### PR TITLE
Clean up original entries

### DIFF
--- a/offline/publication_list.tex
+++ b/offline/publication_list.tex
@@ -2,6 +2,12 @@
 % This file can be rendered by calling 
 % latexmk publication_list.tex
 %
+% NOTE: This file purposely does not allow UTF-8
+% and other unicode characters. This is to catch
+% character combinations (e.g. ``fi'', ``fl'') that
+% do not render as (likely) intended if their unicode
+% counterparts are used.
+%
 
 \documentclass[]{article}
 \usepackage[

--- a/publications-1998.bib
+++ b/publications-1998.bib
@@ -2,7 +2,7 @@
 
 @MastersThesis{1998_0,
   author    = {W. Bangerth},
-  title     = {Adaptive Finite-Elemente-Methoden zur L\&ouml;sung der Wellengleichung mit Anwendung in der Physik der Sonne},
+  title     = {Adaptive Finite-Elemente-Methoden zur L\"{o}sung der Wellengleichung mit Anwendung in der Physik der Sonne},
   school    = {University of Heidelberg},
   year      = {1998},
   owner     = {Jean-Paul Pelteret},

--- a/publications-1999.bib
+++ b/publications-1999.bib
@@ -2,7 +2,7 @@
 
 @Article{1999_0,
   author    = {W. Bangerth and G. Kanschat},
-  title     = {Concepts for object-oriented finite element software - the <CODE>deal.II</CODE> library},
+  title     = {Concepts for object-oriented finite element software - the \texttt{deal.II} library},
   journal   = {Preprint 99-43 (SFB 359), IWR Heidelberg},
   year      = {1999},
   owner     = {Jean-Paul Pelteret},
@@ -22,7 +22,7 @@
 
 @MastersThesis{1999_2,
   author    = {S. Nauber},
-  title     = {Adaptive Finite Elemente Verfahren f\&uuml;r selbstadjungierte Eigenwertprobleme},
+  title     = {Adaptive Finite Elemente Verfahren f\"{u}r selbstadjungierte Eigenwertprobleme},
   school    = {University of Heidelberg},
   year      = {1999},
   owner     = {Jean-Paul Pelteret},

--- a/publications-2001.bib
+++ b/publications-2001.bib
@@ -2,7 +2,7 @@
 
 @Article{2001_0,
   author    = {A. Barinka and T. Barsch and P. Charton and A. Cohen and S. Dahlke and W. Dahmen and K. Urban},
-  title     = {Adaptive wavelet schemes for elliptic problems\&mdash;implementation and numerical experiments},
+  title     = {Adaptive wavelet schemes for elliptic problems -- implementation and numerical experiments},
   journal   = {SIAM J. Sci. Comput.},
   year      = {2001},
   volume    = {23},
@@ -26,6 +26,7 @@
   author    = {R. Becker and R. Rannacher},
   title     = {An optimal control approach to a posteriori error estimation in finite element methods},
   journal   = {Acta Numerica 2001},
+  journal   = {Acta Numerica 2001},
   year      = {2001},
   volume    = {10},
   pages     = {1--102},
@@ -35,7 +36,7 @@
 }
 
 @Article{2001_3,
-  author    = {B. Cockburn and G. Kanschat and Ilaria Perugia and D. Sch\&ouml;tzau},
+  author    = {B. Cockburn and G. Kanschat and Ilaria Perugia and D. Sch\"{o}tzau},
   title     = {Superconvergence of the Local Discontinuous Galerkin Method for Elliptic Problems on Cartesian Grids},
   journal   = {SIAM J. Numer. Anal.},
   year      = {2001},
@@ -48,7 +49,7 @@
 @Article{2001_4,
   author    = {R. Hartmann},
   title     = {Adaptive FE-Methods for Conservation Equations},
-  journal   = {In Heinrich Freist\&uuml;hler and Gerald Warnecke, eds. Hyperbolic problems: theory, numerics, applications: eighth international conference in Magdeburg, 2000. <br> International series of numerical mathematics 141: 495-503. Birkh\&auml;user, Basel},
+  journal   = {In Heinrich Freist\"{u}hler and Gerald Warnecke, eds. Hyperbolic problems: theory, numerics, applications: eighth international conference in Magdeburg, 2000. International series of numerical mathematics 141: 495-503. Birkh\"{a}user, Basel},
   year      = {2001},
   owner     = {Jean-Paul Pelteret},
   timestamp = {2018.11.20},

--- a/publications-2002.bib
+++ b/publications-2002.bib
@@ -1,115 +1,115 @@
 % Encoding: ISO-8859-1
 
 @phdthesis{2002_0,
-   author  = "W. Bangerth",
-   title   = "Adaptive Finite Element Methods for the Identification of Distributed Parameters in Partial Differential Equations",
-   year    = "2002",
-   school  = "University of Heidelberg",
-   url     = ""
+   author  = {W. Bangerth},
+   title   = {Adaptive Finite Element Methods for the Identification of Distributed Parameters in Partial Differential Equations},
+   year    = {2002},
+   school  = {University of Heidelberg},
+   url     = {}
 }
 
 @mastersthesis{2002_1,
-   author  = "S. Benkler",
-   title   = "Numerical solution of the nonlinear Hartree equation.",
-   year    = "2002",
-   school  = "ETH Zurich, Switzerland",
-   url     = ""
+   author  = {S. Benkler},
+   title   = {Numerical solution of the nonlinear Hartree equation.},
+   year    = {2002},
+   school  = {ETH Zurich, Switzerland},
+   url     = {}
 }
 
 @article{2002_2,
-   author  = "B. Cockburn and G. Kanschat and D. Sch&ouml;tzau",
-   title   = "The local discontinuous Galerkin method in incompressible fluid flow",
-   journal = "in Mang, Rammerstorfer, Eberhardsteiner: Proceedings of the Fifth World Congress on Computational Mechanics (WCCM V), Vienna University of Technology",
-   year    = "2002",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
+   title   = {The local discontinuous Galerkin method in incompressible fluid flow},
+   journal = {in Mang, Rammerstorfer, Eberhardsteiner: Proceedings of the Fifth World Congress on Computational Mechanics (WCCM V), Vienna University of Technology},
+   year    = {2002},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2002_3,
-   author  = "B. Cockburn and G. Kanschat and D. Sch&ouml;tzau and C. Schwab",
-   title   = "Local discontinuous Galerkin methods for the Stokes system",
-   journal = "SIAM J. Numer. Anal.",
-   year    = "2002",
-   volume  = "40",
-   pages   = "319--343",
-   url     = "",
-   doi     = ""
+   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau and C. Schwab},
+   title   = {Local discontinuous Galerkin methods for the Stokes system},
+   journal = {SIAM J. Numer. Anal.},
+   year    = {2002},
+   volume  = {40},
+   pages   = {319--343},
+   url     = {},
+   doi     = {}
 }
 
 @article{2002_4,
-   author  = "R. Hartmann and P. Houston",
-   title   = "Adaptive Discontinuous Galerkin Finite Element Methods for Nonlinear Hyperbolic Conservation Laws",
-   journal = "SIAM J. Sci. Comput.",
-   year    = "2002",
-   volume  = "24",
-   pages   = "979--1004",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {Adaptive Discontinuous Galerkin Finite Element Methods for Nonlinear Hyperbolic Conservation Laws},
+   journal = {SIAM J. Sci. Comput.},
+   year    = {2002},
+   volume  = {24},
+   pages   = {979--1004},
+   url     = {},
+   doi     = {}
 }
 
 @article{2002_5,
-   author  = "R. Hartmann and P. Houston",
-   title   = "Adaptive Discontinuous Galerkin Finite Element Methods for the Compressible Euler Equations",
-   journal = "J. Comput. Phys.",
-   year    = "2002",
-   volume  = "183",
-   pages   = "508--532",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {Adaptive Discontinuous Galerkin Finite Element Methods for the Compressible Euler Equations},
+   journal = {J. Comput. Phys.},
+   year    = {2002},
+   volume  = {183},
+   pages   = {508--532},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2002_6,
-   author  = "R. Hartmann",
-   title   = "Adaptive Finite Element Methods for the Compressible Euler Equations",
-   year    = "2002",
-   school  = "University of Heidelberg",
-   url     = ""
+   author  = {R. Hartmann},
+   title   = {Adaptive Finite Element Methods for the Compressible Euler Equations},
+   year    = {2002},
+   school  = {University of Heidelberg},
+   url     = {}
 }
 
 @article{2002_7,
-   author  = "G. Kanschat and Rolf Rannacher",
-   title   = "Local error analysis of the interior penalty discontinuous Galerkin method for second order elliptic problems",
-   journal = "J. Numer. Math.",
-   year    = "2002",
-   volume  = "10",
-   pages   = "249--274",
-   url     = "",
-   doi     = ""
+   author  = {G. Kanschat and Rolf Rannacher},
+   title   = {Local error analysis of the interior penalty discontinuous Galerkin method for second order elliptic problems},
+   journal = {J. Numer. Math.},
+   year    = {2002},
+   volume  = {10},
+   pages   = {249--274},
+   url     = {},
+   doi     = {}
 }
 
 @article{2002_8,
-   author  = "F. Mohamed and M. Troyer and G. Blatter",
-   title   = "Interaction of vortices in superconductors with kappa close to 1/sqrt(2),",
-   journal = "Phys. Rev. B, article 224504",
-   year    = "2002",
-   volume  = "65",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {F. Mohamed and M. Troyer and G. Blatter},
+   title   = {Interaction of vortices in superconductors with kappa close to 1/sqrt(2),},
+   journal = {Phys. Rev. B, article 224504},
+   year    = {2002},
+   volume  = {65},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2002_9,
-   author  = "T. Shardlow",
-   title   = "A coupled Cahn-Hilliard particle system",
-   journal = "Electronic Journal of Differential Equations, No. 73",
-   year    = "2002",
-   volume  = "2002",
-   pages   = "1--21",
-   url     = "",
-   doi     = ""
+   author  = {T. Shardlow},
+   title   = {A coupled Cahn-Hilliard particle system},
+   journal = {Electronic Journal of Differential Equations, No. 73},
+   year    = {2002},
+   volume  = {2002},
+   pages   = {1--21},
+   url     = {},
+   doi     = {}
 }
 
 @article{2002_10,
-   author  = "M. Stadler and G. A. Holzapfel",
-   title   = "A novel approach for smooth contact surfaces using NURBS: application to the FE simulation of stenting",
-   journal = "Proceedings of the 13th Conference of the European Society of Biomechanics, 1-4 September 2002, Wroclaw, Poland",
-   year    = "2002",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Stadler and G. A. Holzapfel},
+   title   = {A novel approach for smooth contact surfaces using NURBS: application to the FE simulation of stenting},
+   journal = {Proceedings of the 13th Conference of the European Society of Biomechanics, 1-4 September 2002, Wroclaw, Poland},
+   year    = {2002},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2003.bib
+++ b/publications-2003.bib
@@ -1,181 +1,181 @@
 % Encoding: ISO-8859-1
 
 @phdthesis{2003_0,
-   author  = "S. Achatz",
-   title   = "Adaptive finite D&uuml;nngitter-Elemente h&ouml;herer Ordnung f&uuml;r elliptische partielle Differentialgleichungen mit variablen Koeffizienten",
-   year    = "2003",
-   school  = "TU Munich",
-   url     = ""
+   author  = {S. Achatz},
+   title   = {Adaptive finite D\"{u}nngitter-Elemente h\"{o}herer Ordnung f\"{u}r elliptische partielle Differentialgleichungen mit variablen Koeffizienten},
+   year    = {2003},
+   school  = {TU Munich},
+   url     = {}
 }
 
 @article{2003_1,
-   author  = "W. Bangerth",
-   title   = "Starting threads in a C++ compatible fashion",
-   journal = "C/C++ Users Journal",
-   year    = "2003",
-   volume  = "",
-   pages   = "21--24",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth},
+   title   = {Starting threads in a C++ compatible fashion},
+   journal = {C/C++ Users Journal},
+   year    = {2003},
+   volume  = {},
+   pages   = {21--24},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_2,
-   author  = "W. Bangerth and R. Rannacher",
-   title   = "Adaptive Finite Element Methods for Solving Differential Equations",
-   journal = "Book, Birkh&auml;user",
-   year    = "2003",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and R. Rannacher},
+   title   = {Adaptive Finite Element Methods for Solving Differential Equations},
+   journal = {Book, Birkh\"{a}user},
+   year    = {2003},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2003_3,
-   author  = "M. Calhoun-Lopez",
-   title   = "Numerical solutions of hyperbolic conservation laws: Incorporating multi-resolution viscosity methods into the finite element framework",
-   year    = "2003",
-   school  = "Iowa State University",
-   url     = ""
+   author  = {M. Calhoun-Lopez},
+   title   = {Numerical solutions of hyperbolic conservation laws: Incorporating multi-resolution viscosity methods into the finite element framework},
+   year    = {2003},
+   school  = {Iowa State University},
+   url     = {}
 }
 
 @phdthesis{2003_4,
-   author  = "B. Carnes",
-   title   = "Adaptive finite elements for nonlinear transport equations",
-   year    = "2003",
-   school  = "ICES, The University of Texas at Austin",
-   url     = ""
+   author  = {B. Carnes},
+   title   = {Adaptive finite elements for nonlinear transport equations},
+   year    = {2003},
+   school  = {ICES, The University of Texas at Austin},
+   url     = {}
 }
 
 @article{2003_5,
-   author  = "B. Cockburn and G. Kanschat and D. Sch&ouml;tzau",
-   title   = "LDG methods for Stokes flow problems",
-   journal = "in Brezzi, Buffa, Corsaro, Murli: Numerical Mathematics and Advanced Applications: ENUMATH 2001, Springer Italia",
-   year    = "2003",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
+   title   = {LDG methods for Stokes flow problems},
+   journal = {in Brezzi, Buffa, Corsaro, Murli: Numerical Mathematics and Advanced Applications: ENUMATH 2001, Springer Italia},
+   year    = {2003},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_6,
-   author  = "B. Cockburn and G. Kanschat and D. Sch&ouml;tzau",
-   title   = "The Local Discontinuous Galerkin Method for the Oseen Equations",
-   journal = "Math. Comput.",
-   year    = "2003",
-   volume  = "73",
-   pages   = "569--593",
-   url     = "",
-   doi     = ""
+   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
+   title   = {The Local Discontinuous Galerkin Method for the Oseen Equations},
+   journal = {Math. Comput.},
+   year    = {2003},
+   volume  = {73},
+   pages   = {569--593},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_7,
-   author  = "J. Gopalakrishnan and G. Kanschat",
-   title   = "A Multilevel Discontinuous Galerkin Method",
-   journal = "Numer. Math.",
-   year    = "2003",
-   volume  = "95",
-   pages   = "527--550",
-   url     = "",
-   doi     = ""
+   author  = {J. Gopalakrishnan and G. Kanschat},
+   title   = {A Multilevel Discontinuous Galerkin Method},
+   journal = {Numer. Math.},
+   year    = {2003},
+   volume  = {95},
+   pages   = {527--550},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_8,
-   author  = "J. Gopalakrishnan and G. Kanschat",
-   title   = "Application of unified DG analysis to preconditioning DG methods",
-   journal = "in Bathe: Computational Fluid and Solid Mechanics",
-   year    = "2003",
-   volume  = "",
-   pages   = "1943--1945",
-   url     = "",
-   doi     = ""
+   author  = {J. Gopalakrishnan and G. Kanschat},
+   title   = {Application of unified DG analysis to preconditioning DG methods},
+   journal = {in Bathe: Computational Fluid and Solid Mechanics},
+   year    = {2003},
+   volume  = {},
+   pages   = {1943--1945},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_9,
-   author  = "J. Gopalakrishnan and G. Kanschat",
-   title   = "Multi-level Preconditioners for the interior penalty method",
-   journal = "in Brezzi, Buffa, Corsaro, Murli: Numerical Mathematics and Advanced Applications: ENUMATH 2001, Springer Italia",
-   year    = "2003",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Gopalakrishnan and G. Kanschat},
+   title   = {Multi-level Preconditioners for the interior penalty method},
+   journal = {in Brezzi, Buffa, Corsaro, Murli: Numerical Mathematics and Advanced Applications: ENUMATH 2001, Springer Italia},
+   year    = {2003},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_10,
-   author  = "R. Hartmann and P. Houston",
-   title   = "Goal-Oriented A Posteriori Error Estimation for Compressible Fluid Flows",
-   journal = "In F. Brezzi, A. Buffa, S. Corsaro and A. Murli, editors, Numerical Mathematics and Advanced Applications, Springer",
-   year    = "2003",
-   volume  = "",
-   pages   = "775--784",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {Goal-Oriented A Posteriori Error Estimation for Compressible Fluid Flows},
+   journal = {In F. Brezzi, A. Buffa, S. Corsaro and A. Murli, editors, Numerical Mathematics and Advanced Applications, Springer},
+   year    = {2003},
+   volume  = {},
+   pages   = {775--784},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_11,
-   author  = "R. Hartmann and P. Houston",
-   title   = "Goal-Oriented A Posteriori Error Estimation for Multiple Target Functionals",
-   journal = "in T. Y. Hou and E. Tadmor, editors, Hyperbolic Problems: Theory, Numerics, Applications, Springer",
-   year    = "2003",
-   volume  = "",
-   pages   = "579--588",
-   url     = "http://link.springer.com/chapter/10.1007/978-3-642-55711-8_54",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {Goal-Oriented A Posteriori Error Estimation for Multiple Target Functionals},
+   journal = {in T. Y. Hou and E. Tadmor, editors, Hyperbolic Problems: Theory, Numerics, Applications, Springer},
+   year    = {2003},
+   volume  = {},
+   pages   = {579--588},
+   url     = {http://link.springer.com/chapter/10.1007/978-3-642-55711-8_54},
+   doi     = {}
 }
 
 @article{2003_12,
-   author  = "G. Kanschat",
-   title   = "Discontinuous Galerkin Finite Element Methods for Advection-Diffusion Problems",
-   journal = "Habilitationsschrift, Universit&auml;t Heidelberg",
-   year    = "2003",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {G. Kanschat},
+   title   = {Discontinuous Galerkin Finite Element Methods for Advection-Diffusion Problems},
+   journal = {Habilitationsschrift, Universit\"{a}t Heidelberg},
+   year    = {2003},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_13,
-   author  = "G. Kanschat",
-   title   = "Preconditioning discontinuous Galerkin saddle point systems",
-   journal = "in Bathe: Computational Fluid and Solid Mechanics",
-   year    = "2003",
-   volume  = "",
-   pages   = "2016--2018",
-   url     = "",
-   doi     = ""
+   author  = {G. Kanschat},
+   title   = {Preconditioning discontinuous Galerkin saddle point systems},
+   journal = {in Bathe: Computational Fluid and Solid Mechanics},
+   year    = {2003},
+   volume  = {},
+   pages   = {2016--2018},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_14,
-   author  = "G. Kanschat",
-   title   = "Preconditioning methods for local discontinuous {G}alerkin Discretizations",
-   journal = "SIAM J. Sci. Comput.",
-   year    = "2003",
-   volume  = "25",
-   pages   = "815--831",
-   url     = "",
-   doi     = ""
+   author  = {G. Kanschat},
+   title   = {Preconditioning methods for local discontinuous {G}alerkin Discretizations},
+   journal = {SIAM J. Sci. Comput.},
+   year    = {2003},
+   volume  = {25},
+   pages   = {815--831},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_15,
-   author  = "A. Schneebeli and D. Sch&ouml;tzau",
-   title   = "Mixed finite elements for incompressible magneto-hydrodynamics",
-   journal = "Comptes Rendus Mathematique",
-   year    = "2003",
-   volume  = "337",
-   pages   = "71--74",
-   url     = "",
-   doi     = ""
+   author  = {A. Schneebeli and D. Sch\"{o}tzau},
+   title   = {Mixed finite elements for incompressible magneto-hydrodynamics},
+   journal = {Comptes Rendus Mathematique},
+   year    = {2003},
+   volume  = {337},
+   pages   = {71--74},
+   url     = {},
+   doi     = {}
 }
 
 @article{2003_16,
-   author  = "M. Stadler and G. A. Holzapfel and J. Korelc",
-   title   = "C<sup>n</sup> continuous modelling of smooth contact surfaces using NURBS and application to 2D problems",
-   journal = "International Journal for Numerical Methods in Engineering",
-   year    = "2003",
-   volume  = "57",
-   pages   = "2177--2203",
-   url     = "",
-   doi     = ""
+   author  = {M. Stadler and G. A. Holzapfel and J. Korelc},
+   title   = {C$^{n}$ continuous modelling of smooth contact surfaces using NURBS and application to 2D problems},
+   journal = {International Journal for Numerical Methods in Engineering},
+   year    = {2003},
+   volume  = {57},
+   pages   = {2177--2203},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2004.bib
+++ b/publications-2004.bib
@@ -1,176 +1,176 @@
 % Encoding: ISO-8859-1
 
 @article{2004_0,
-   author  = "W. Bangerth and ",
-   title   = "A framework for the adaptive finite element solution of large inverse problems. I. Basic techniques",
-   journal = "ICES Report 2004-39",
-   year    = "2004",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and },
+   title   = {A framework for the adaptive finite element solution of large inverse problems. I. Basic techniques},
+   journal = {ICES Report 2004-39},
+   year    = {2004},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_1,
-   author  = "W. Bangerth and M. Grote and C. Hohenegger",
-   title   = "Finite Element Method For Time Dependent Scattering: Nonreflecting Boundary Condition, Adaptivity, and Energy Decay",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2004",
-   volume  = "193",
-   pages   = "2453--2482",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and M. Grote and C. Hohenegger},
+   title   = {Finite Element Method For Time Dependent Scattering: Nonreflecting Boundary Condition, Adaptivity, and Energy Decay},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2004},
+   volume  = {193},
+   pages   = {2453--2482},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_2,
-   author  = "D. Boffi and L. Gastaldi and L. Heltai",
-   title   = "A finite element approach to the immersed boundary method",
-   journal = "Progress in Engineering Computational Technology",
-   year    = "2004",
-   volume  = "12",
-   pages   = "271--298",
-   url     = "",
-   doi     = ""
+   author  = {D. Boffi and L. Gastaldi and L. Heltai},
+   title   = {A finite element approach to the immersed boundary method},
+   journal = {Progress in Engineering Computational Technology},
+   year    = {2004},
+   volume  = {12},
+   pages   = {271--298},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_3,
-   author  = "G. Carey and M. Anderson and B. Carnes and B. Kirk",
-   title   = "Some aspects of adaptive grid technology related to boundary and interior layers",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2004",
-   volume  = "166",
-   pages   = "55--86",
-   url     = "",
-   doi     = ""
+   author  = {G. Carey and M. Anderson and B. Carnes and B. Kirk},
+   title   = {Some aspects of adaptive grid technology related to boundary and interior layers},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2004},
+   volume  = {166},
+   pages   = {55--86},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_4,
-   author  = "G. Carey and W. Barth and J. A. Woods and B. Kirk and M. Anderson and S. Chow and W. Bangerth",
-   title   = "Modeling error and constitutive relations in simulation of flow and transport",
-   journal = "International Journal for Numerical Methods in Fluids",
-   year    = "2004",
-   volume  = "46",
-   pages   = "1211--1236",
-   url     = "",
-   doi     = ""
+   author  = {G. Carey and W. Barth and J. A. Woods and B. Kirk and M. Anderson and S. Chow and W. Bangerth},
+   title   = {Modeling error and constitutive relations in simulation of flow and transport},
+   journal = {International Journal for Numerical Methods in Fluids},
+   year    = {2004},
+   volume  = {46},
+   pages   = {1211--1236},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_5,
-   author  = "S. Chow and G. F. Carey and M. L. Anderson",
-   title   = "Finite element approximations of a glaciology problem.",
-   journal = "ESAIM: Mathematical Modelling and Numerical Analysis (M2AN)",
-   year    = "2004",
-   volume  = "38",
-   pages   = "741--756",
-   url     = "",
-   doi     = ""
+   author  = {S. Chow and G. F. Carey and M. L. Anderson},
+   title   = {Finite element approximations of a glaciology problem.},
+   journal = {ESAIM: Mathematical Modelling and Numerical Analysis (M2AN)},
+   year    = {2004},
+   volume  = {38},
+   pages   = {741--756},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2004_6,
-   author  = "C. Fr&ouml;bel",
-   title   = "Tikhonov-Regularisierung zur Parameteridentifikation bei elliptischen und parabolischen Modellgleichungen.",
-   year    = "2004",
-   school  = "Universit&auml;t Bremen, Germany",
-   url     = ""
+   author  = {C. Fr\"{o}bel},
+   title   = {Tikhonov-Regularisierung zur Parameteridentifikation bei elliptischen und parabolischen Modellgleichungen.},
+   year    = {2004},
+   school  = {Universit\"{a}t Bremen, Germany},
+   url     = {}
 }
 
 @article{2004_7,
-   author  = "U. Hasler and A. Schneebeli and D. Sch&ouml;tzau",
-   title   = "Mixed finite element approximation of incompressible MHD problems based on weighted regularization",
-   journal = "Applied Numerical Mathematics",
-   year    = "2004",
-   volume  = "51",
-   pages   = "19--45",
-   url     = "",
-   doi     = ""
+   author  = {U. Hasler and A. Schneebeli and D. Sch\"{o}tzau},
+   title   = {Mixed finite element approximation of incompressible MHD problems based on weighted regularization},
+   journal = {Applied Numerical Mathematics},
+   year    = {2004},
+   volume  = {51},
+   pages   = {19--45},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_8,
-   author  = "A. Joshi and W. Bangerth and E. Sevick-Muraca",
-   title   = "Adaptive finite element based tomography for fluorescence optical imaging in tissue",
-   journal = "Optics Express, issue 22",
-   year    = "2004",
-   volume  = "12",
-   pages   = "5402--5417",
-   url     = "http://www.opticsinfobase.org/oe/fulltext.cfm?uri=oe-12-22-5402&id=81637",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
+   title   = {Adaptive finite element based tomography for fluorescence optical imaging in tissue},
+   journal = {Optics Express, issue 22},
+   year    = {2004},
+   volume  = {12},
+   pages   = {5402--5417},
+   url     = {http://www.opticsinfobase.org/oe/fulltext.cfm?uri=oe-12-22-5402&id=81637},
+   doi     = {}
 }
 
 @article{2004_9,
-   author  = "A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca",
-   title   = "Adaptive finite element methods for fluorescence enhanced frequency domain optical tomography: Forward imaging problem",
-   journal = "Proceedings of the 2004 IEEE International Symposium on Biomedical Imaging",
-   year    = "2004",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca},
+   title   = {Adaptive finite element methods for fluorescence enhanced frequency domain optical tomography: Forward imaging problem},
+   journal = {Proceedings of the 2004 IEEE International Symposium on Biomedical Imaging},
+   year    = {2004},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_10,
-   author  = "A. Joshi and A. B. Thompson and W. Bangerth and E. Sevick-Muraca",
-   title   = "Adaptive finite element methods for forward modeling in fluorescence enhanced frequency domain optical tomography",
-   journal = "Proceedings of the 2004 OSA Biomedical Topical Meetings",
-   year    = "2004",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and A. B. Thompson and W. Bangerth and E. Sevick-Muraca},
+   title   = {Adaptive finite element methods for forward modeling in fluorescence enhanced frequency domain optical tomography},
+   journal = {Proceedings of the 2004 OSA Biomedical Topical Meetings},
+   year    = {2004},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_11,
-   author  = "G. Kanschat",
-   title   = "Multi-level methods for discontinuous Galerkin FEM on locally refined meshes",
-   journal = "Comput. &amp; Struct.",
-   year    = "2004",
-   volume  = "82",
-   pages   = "2437--2445",
-   url     = "",
-   doi     = ""
+   author  = {G. Kanschat},
+   title   = {Multi-level methods for discontinuous Galerkin FEM on locally refined meshes},
+   journal = {Comput. \& Struct.},
+   year    = {2004},
+   volume  = {82},
+   pages   = {2437--2445},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_12,
-   author  = "G. Kanschat and E. Meinkohn",
-   title   = "Multi-model preconditioning for radiative transfer problems, 2004.",
-   journal = "IWR, University of Heidelberg, Preprint 2004-33",
-   year    = "2004",
-   volume  = "",
-   pages   = "",
-   url     = "http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.87.169&rep=rep1&type=pdf",
-   doi     = ""
+   author  = {G. Kanschat and E. Meinkohn},
+   title   = {Multi-model preconditioning for radiative transfer problems, 2004.},
+   journal = {IWR, University of Heidelberg, Preprint 2004-33},
+   year    = {2004},
+   volume  = {},
+   pages   = {},
+   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.87.169&rep=rep1&type=pdf},
+   doi     = {}
 }
 
 @article{2004_13,
-   author  = "J. Ramirez and M. Laso",
-   title   = "Micro-macro simulations of three-dimensional plane contraction flow",
-   journal = "Modelling Simul. Mater. Sci. Eng.",
-   year    = "2004",
-   volume  = "12",
-   pages   = "1293--1306",
-   url     = "",
-   doi     = ""
+   author  = {J. Ramirez and M. Laso},
+   title   = {Micro-macro simulations of three-dimensional plane contraction flow},
+   journal = {Modelling Simul. Mater. Sci. Eng.},
+   year    = {2004},
+   volume  = {12},
+   pages   = {1293--1306},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_14,
-   author  = "R. B. Schulz and W. Bangerth and J. Peter and W. Semmler",
-   title   = "Independent modeling of fluorescence excitation and emission with the finite element method",
-   journal = "Proceedings of the OSA BIOMED topical meeting, Miami, Florida, 14-18 April ",
-   year    = "2004",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. B. Schulz and W. Bangerth and J. Peter and W. Semmler},
+   title   = {Independent modeling of fluorescence excitation and emission with the finite element method},
+   journal = {Proceedings of the OSA BIOMED topical meeting, Miami, Florida, 14-18 April },
+   year    = {2004},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2004_15,
-   author  = "E. Zander and J. R. Weimar and H. G. Mathies",
-   title   = "Simulation of High-Frequency Atmospheric Gas Discharges",
-   journal = "PAMM",
-   year    = "2004",
-   volume  = "4",
-   pages   = "428--429",
-   url     = "",
-   doi     = ""
+   author  = {E. Zander and J. R. Weimar and H. G. Mathies},
+   title   = {Simulation of High-Frequency Atmospheric Gas Discharges},
+   journal = {PAMM},
+   year    = {2004},
+   volume  = {4},
+   pages   = {428--429},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2005.bib
+++ b/publications-2005.bib
@@ -1,217 +1,217 @@
 % Encoding: ISO-8859-1
 
 @article{2005_0,
-   author  = "M. Anderson and W. Bangerth and G. Carey",
-   title   = "Analysis of parameter sensitivity and experimental design for a class of nonlinear partial differential equations",
-   journal = "International Journal for Numerical Methods in Fluids",
-   year    = "2005",
-   volume  = "48",
-   pages   = "583--605",
-   url     = "",
-   doi     = ""
+   author  = {M. Anderson and W. Bangerth and G. Carey},
+   title   = {Analysis of parameter sensitivity and experimental design for a class of nonlinear partial differential equations},
+   journal = {International Journal for Numerical Methods in Fluids},
+   year    = {2005},
+   volume  = {48},
+   pages   = {583--605},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_1,
-   author  = "W. Bangerth and A. Joshi and E. Sevick-Muraca",
-   title   = "Adaptive finite element methods for increased resolution in fluorescence optical tomography",
-   journal = "Progress in Biomedical Optics and Imaging",
-   year    = "2005",
-   volume  = "6",
-   pages   = "318--329",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and A. Joshi and E. Sevick-Muraca},
+   title   = {Adaptive finite element methods for increased resolution in fluorescence optical tomography},
+   journal = {Progress in Biomedical Optics and Imaging},
+   year    = {2005},
+   volume  = {6},
+   pages   = {318--329},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_2,
-   author  = "D. Boffi and L. Gastaldi and L. Heltai",
-   title   = "The finite element immersed boundary method: model, stability, and numerical results",
-   journal = "In Schrefler Papadrakakis, Onate, eds., Computational Methods for Coupled Problems in Science and Engineering",
-   year    = "2005",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Boffi and L. Gastaldi and L. Heltai},
+   title   = {The finite element immersed boundary method: model, stability, and numerical results},
+   journal = {In Schrefler Papadrakakis, Onate, eds., Computational Methods for Coupled Problems in Science and Engineering},
+   year    = {2005},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_3,
-   author  = "M. Calhoun-Lopez and M. D. Gunzburger",
-   title   = "A Finite Element, Multiresolution Viscosity Method for Hyperbolic Conservation Laws",
-   journal = "SIAM J. Numer. Anal.",
-   year    = "2005",
-   volume  = "43",
-   pages   = "1988--2011",
-   url     = "",
-   doi     = ""
+   author  = {M. Calhoun-Lopez and M. D. Gunzburger},
+   title   = {A Finite Element, Multiresolution Viscosity Method for Hyperbolic Conservation Laws},
+   journal = {SIAM J. Numer. Anal.},
+   year    = {2005},
+   volume  = {43},
+   pages   = {1988--2011},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_4,
-   author  = "B. Carnes and N. Djilali",
-   title   = "Systematic parameter estimation for PEM fuel cell models",
-   journal = "Journal of Power Sources",
-   year    = "2005",
-   volume  = "144",
-   pages   = "83--93",
-   url     = "",
-   doi     = ""
+   author  = {B. Carnes and N. Djilali},
+   title   = {Systematic parameter estimation for PEM fuel cell models},
+   journal = {Journal of Power Sources},
+   year    = {2005},
+   volume  = {144},
+   pages   = {83--93},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_5,
-   author  = "B. Cockburn and G. Kanschat and D. Sch&ouml;tzau",
-   title   = "A locally conservative LDG method for the incompressible Navier-Stokes equations",
-   journal = "Math. Comput.",
-   year    = "2005",
-   volume  = "74",
-   pages   = "1067--1095",
-   url     = "",
-   doi     = ""
+   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
+   title   = {A locally conservative LDG method for the incompressible Navier-Stokes equations},
+   journal = {Math. Comput.},
+   year    = {2005},
+   volume  = {74},
+   pages   = {1067--1095},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_6,
-   author  = "B. Cockburn and G. Kanschat and D. Sch&ouml;tzau",
-   title   = "The Local Discontinuous Galerkin Method for Linear Incomressible Fluid Flow: a Review",
-   journal = "Comput. &amp; Fluids",
-   year    = "2005",
-   volume  = "34",
-   pages   = "491--506",
-   url     = "",
-   doi     = ""
+   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
+   title   = {The Local Discontinuous Galerkin Method for Linear Incomressible Fluid Flow: a Review},
+   journal = {Comput. \& Fluids},
+   year    = {2005},
+   volume  = {34},
+   pages   = {491--506},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_7,
-   author  = "R. Hartmann",
-   title   = "Discontinuous Galerkin methods for compressible flows: higher order accuracy, error estimation and adaptivity",
-   journal = "In H. Deconinck and M. Ricchiuto, editors, VKI LS 2006-01: CFD - Higher Order Discretization Methods, November 14-18, 2005, Rhode Saint Genese, Belgium. von Karman Institute for Fluid Dynamics",
-   year    = "2005",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Discontinuous Galerkin methods for compressible flows: higher order accuracy, error estimation and adaptivity},
+   journal = {In H. Deconinck and M. Ricchiuto, editors, VKI LS 2006-01: CFD - Higher Order Discretization Methods, November 14-18, 2005, Rhode Saint Genese, Belgium. von Karman Institute for Fluid Dynamics},
+   year    = {2005},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2005_8,
-   author  = "A. Joshi",
-   title   = "Adaptive finite element methods for fluorescence enhanced optical tomography",
-   year    = "2005",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {A. Joshi},
+   title   = {Adaptive finite element methods for fluorescence enhanced optical tomography},
+   year    = {2005},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2005_9,
-   author  = "A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca",
-   title   = "Experimental fluorescence optical tomography using adaptive finite elements and planar illumination with modulated excitation light",
-   journal = "Progress in Biomedical Optics and Imaging",
-   year    = "2005",
-   volume  = "6",
-   pages   = "351--358",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca},
+   title   = {Experimental fluorescence optical tomography using adaptive finite elements and planar illumination with modulated excitation light},
+   journal = {Progress in Biomedical Optics and Imaging},
+   year    = {2005},
+   volume  = {6},
+   pages   = {351--358},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_10,
-   author  = "G. Kanschat",
-   title   = "Block Preconditioners for LDG Discretizations of Linear Incompressible Flow Problems",
-   journal = "J. Sci. Comput., -23",
-   year    = "2005",
-   volume  = "22",
-   pages   = "371--384",
-   url     = "http://link.springer.com/article/10.1007/s10915-004-4144-6#page-1",
-   doi     = ""
+   author  = {G. Kanschat},
+   title   = {Block Preconditioners for LDG Discretizations of Linear Incompressible Flow Problems},
+   journal = {J. Sci. Comput., -23},
+   year    = {2005},
+   volume  = {22},
+   pages   = {371--384},
+   url     = {http://link.springer.com/article/10.1007/s10915-004-4144-6#page-1},
+   doi     = {}
 }
 
 @article{2005_11,
-   author  = "O. Kayser-Herold and H. G. Matthies",
-   title   = "Least squares finite element methods for fluid-structure interaction problems",
-   journal = "Computers &amp; Structures",
-   year    = "2005",
-   volume  = "83",
-   pages   = "191--207",
-   url     = "",
-   doi     = ""
+   author  = {O. Kayser-Herold and H. G. Matthies},
+   title   = {Least squares finite element methods for fluid-structure interaction problems},
+   journal = {Computers \& Structures},
+   year    = {2005},
+   volume  = {83},
+   pages   = {191--207},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_12,
-   author  = "R. Li",
-   title   = "On multi-mesh h-adaptive methods",
-   journal = "J. Sci. Comput.",
-   year    = "2005",
-   volume  = "24",
-   pages   = "321--341",
-   url     = "",
-   doi     = ""
+   author  = {R. Li},
+   title   = {On multi-mesh h-adaptive methods},
+   journal = {J. Sci. Comput.},
+   year    = {2005},
+   volume  = {24},
+   pages   = {321--341},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_13,
-   author  = "M. Mu",
-   title   = "PDE.MART: A network-based problem-solving environment for PDEs",
-   journal = "ACM Trans. Math. Software",
-   year    = "2005",
-   volume  = "31",
-   pages   = "508--531",
-   url     = "",
-   doi     = ""
+   author  = {M. Mu},
+   title   = {PDE.MART: A network-based problem-solving environment for PDEs},
+   journal = {ACM Trans. Math. Software},
+   year    = {2005},
+   volume  = {31},
+   pages   = {508--531},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_14,
-   author  = "B. Nestler and D. Danilov and P. Galenko",
-   title   = "Crystal growth of pure substances: Phase-field simulations in comparison with analytical and experimental results",
-   journal = "Journal of Computational Physics",
-   year    = "2005",
-   volume  = "207",
-   pages   = "221--239",
-   url     = "",
-   doi     = ""
+   author  = {B. Nestler and D. Danilov and P. Galenko},
+   title   = {Crystal growth of pure substances: Phase-field simulations in comparison with analytical and experimental results},
+   journal = {Journal of Computational Physics},
+   year    = {2005},
+   volume  = {207},
+   pages   = {221--239},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_15,
-   author  = "T. Nielsen and T. Koehler and M. van der Mark and G. t'Hooft",
-   title   = "Fully 3D reconstruction of attenuation for diffuse optical tomography using a finite element model",
-   journal = "Nuclear Science Symposium Record",
-   year    = "2005",
-   volume  = "4",
-   pages   = "2283--2285",
-   url     = "",
-   doi     = ""
+   author  = {T. Nielsen and T. Koehler and M. van der Mark and G. t'Hooft},
+   title   = {Fully 3D reconstruction of attenuation for diffuse optical tomography using a finite element model},
+   journal = {Nuclear Science Symposium Record},
+   year    = {2005},
+   volume  = {4},
+   pages   = {2283--2285},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_16,
-   author  = "Q. Ouyang and K. Xiu",
-   title   = "Simulation Study of Reduced Self-Heating in Novel Thin-SOI Vertical Bipolar Transistors",
-   journal = "Simulation of Semiconductor Processes and Devices",
-   year    = "2005",
-   volume  = "",
-   pages   = "55--58",
-   url     = "",
-   doi     = ""
+   author  = {Q. Ouyang and K. Xiu},
+   title   = {Simulation Study of Reduced Self-Heating in Novel Thin-SOI Vertical Bipolar Transistors},
+   journal = {Simulation of Semiconductor Processes and Devices},
+   year    = {2005},
+   volume  = {},
+   pages   = {55--58},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2005_17,
-   author  = "M. Polner",
-   title   = "Galerkin least-squares stabilization operators for the Navier-Stokes equations, A unified approach",
-   year    = "2005",
-   school  = "University of Twente, The Netherlands",
-   url     = ""
+   author  = {M. Polner},
+   title   = {Galerkin least-squares stabilization operators for the Navier-Stokes equations, A unified approach},
+   year    = {2005},
+   school  = {University of Twente, The Netherlands},
+   url     = {}
 }
 
 @article{2005_18,
-   author  = "R. B. Schulz and G. Echner and H. Ruehle and W. Stroh and J. Vierling and T. Vogt and J. Peter and W. Semmler",
-   title   = "Development of a fully rotational non-contact fluorescence tomographer for small animals",
-   journal = "IEEE Micro-imaging Conference, IEEE Nuclear Science Symposium Conference Record",
-   year    = "2005",
-   volume  = "",
-   pages   = "2391--2393",
-   url     = "",
-   doi     = ""
+   author  = {R. B. Schulz and G. Echner and H. Ruehle and W. Stroh and J. Vierling and T. Vogt and J. Peter and W. Semmler},
+   title   = {Development of a fully rotational non-contact fluorescence tomographer for small animals},
+   journal = {IEEE Micro-imaging Conference, IEEE Nuclear Science Symposium Conference Record},
+   year    = {2005},
+   volume  = {},
+   pages   = {2391--2393},
+   url     = {},
+   doi     = {}
 }
 
 @article{2005_19,
-   author  = "R. B. Schulz and J. Peter and W. Semmler and C. D'andrea and G. Valentini and R. Cubeddu",
-   title   = "Quantifiability and Image Quality in Noncontact Fluorescence Tomography",
-   journal = "in: Photon Migration and Diffuse-Light Imaging II, K. Licha and R. Cubeddu (eds.), SPIE press",
-   year    = "2005",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. B. Schulz and J. Peter and W. Semmler and C. D'andrea and G. Valentini and R. Cubeddu},
+   title   = {Quantifiability and Image Quality in Noncontact Fluorescence Tomography},
+   journal = {in: Photon Migration and Diffuse-Light Imaging II, K. Licha and R. Cubeddu (eds.), SPIE press},
+   year    = {2005},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2006.bib
+++ b/publications-2006.bib
@@ -1,285 +1,285 @@
 % Encoding: ISO-8859-1
 
 @mastersthesis{2006_0,
-   author  = "M. Allmaras",
-   title   = "Optimal Design of Periodic Microstructures by the Inverse Homogenization Method",
-   year    = "2006",
-   school  = "Technical University Munich, Germany",
-   url     = ""
+   author  = {M. Allmaras},
+   title   = {Optimal Design of Periodic Microstructures by the Inverse Homogenization Method},
+   year    = {2006},
+   school  = {Technical University Munich, Germany},
+   url     = {}
 }
 
 @article{2006_1,
-   author  = "N. Antonic and M. Vrdoljak",
-   title   = "Sequential laminates in multiple state optimal design problems",
-   journal = "Mathematical Problems in Engineering",
-   year    = "2006",
-   volume  = "2006",
-   pages   = "1--14",
-   url     = "",
-   doi     = ""
+   author  = {N. Antonic and M. Vrdoljak},
+   title   = {Sequential laminates in multiple state optimal design problems},
+   journal = {Mathematical Problems in Engineering},
+   year    = {2006},
+   volume  = {2006},
+   pages   = {1--14},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_2,
-   author  = "E. B&auml;ngtsson and B. Lund",
-   title   = "A comparison between two approaches to solve the equations of isostasy",
-   journal = "Institute for Parallel Processing (BIS 21++) Technical Report 2006-03, Bulgarian Academy of Sciences",
-   year    = "2006",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {E. B\"{a}ngtsson and B. Lund},
+   title   = {A comparison between two approaches to solve the equations of isostasy},
+   journal = {Institute for Parallel Processing (BIS 21++) Technical Report 2006-03, Bulgarian Academy of Sciences},
+   year    = {2006},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_3,
-   author  = "E. B&auml;ngtsson and B. Lund",
-   title   = "A comparison between two approaches to solve the equations of isostasy",
-   journal = "Technical Report 2006-051, Uppsala University, Sweden",
-   year    = "2006",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {E. B\"{a}ngtsson and B. Lund},
+   title   = {A comparison between two approaches to solve the equations of isostasy},
+   journal = {Technical Report 2006-051, Uppsala University, Sweden},
+   year    = {2006},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_4,
-   author  = "E. B&auml;ngtsson and M. Neytcheva",
-   title   = "Numerical simulations of glacial rebound using preconditioned iterative solution methods",
-   journal = "Applications of Mathematics",
-   year    = "2006",
-   volume  = "50",
-   pages   = "183--201",
-   url     = "",
-   doi     = ""
+   author  = {E. B\"{a}ngtsson and M. Neytcheva},
+   title   = {Numerical simulations of glacial rebound using preconditioned iterative solution methods},
+   journal = {Applications of Mathematics},
+   year    = {2006},
+   volume  = {50},
+   pages   = {183--201},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_5,
-   author  = "E. B&auml;ngtsson and M. Neytcheva",
-   title   = "An agglomerate multilevel preconditioner for linear isostasy saddle point problems",
-   journal = "Proceedings of Large-Scale Scientific Computing: 5th International Conference (I. Lirkov, S. Margenov, J. Wasniewski, eds)",
-   year    = "2006",
-   volume  = "",
-   pages   = "113--120",
-   url     = "",
-   doi     = ""
+   author  = {E. B\"{a}ngtsson and M. Neytcheva},
+   title   = {An agglomerate multilevel preconditioner for linear isostasy saddle point problems},
+   journal = {Proceedings of Large-Scale Scientific Computing: 5th International Conference (I. Lirkov, S. Margenov, J. Wasniewski, eds)},
+   year    = {2006},
+   volume  = {},
+   pages   = {113--120},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_6,
-   author  = "D. Boffi and L. Gastaldi and L. Heltai",
-   title   = "Stability Results and Algorithmic Strategies for the Finite Element Approach to the Immersed Boundary Method",
-   journal = "Numerical Mathematics and Advanced Applications",
-   year    = "2006",
-   volume  = "",
-   pages   = "575--582",
-   url     = "http://link.springer.com/chapter/10.1007/978-3-540-34288-5_54",
-   doi     = ""
+   author  = {D. Boffi and L. Gastaldi and L. Heltai},
+   title   = {Stability Results and Algorithmic Strategies for the Finite Element Approach to the Immersed Boundary Method},
+   journal = {Numerical Mathematics and Advanced Applications},
+   year    = {2006},
+   volume  = {},
+   pages   = {575--582},
+   url     = {http://link.springer.com/chapter/10.1007/978-3-540-34288-5_54},
+   doi     = {}
 }
 
 @article{2006_7,
-   author  = "D. Danilov and B. Nestler",
-   title   = "Phase-field simulations of eutectic solidification using an adaptive finite element method",
-   journal = "International Journal of Modern Physics B",
-   year    = "2006",
-   volume  = "20",
-   pages   = "853--867",
-   url     = "",
-   doi     = ""
+   author  = {D. Danilov and B. Nestler},
+   title   = {Phase-field simulations of eutectic solidification using an adaptive finite element method},
+   journal = {International Journal of Modern Physics B},
+   year    = {2006},
+   volume  = {20},
+   pages   = {853--867},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_8,
-   author  = "M. Grote and A. Schneebeli and D. Sch&ouml;tzau",
-   title   = "Discontinuous Galerkin Finite Element Method for the Wave Equation",
-   journal = "SIAM J. Numer. Anal",
-   year    = "2006",
-   volume  = "44",
-   pages   = "2408--2431",
-   url     = "",
-   doi     = ""
+   author  = {M. Grote and A. Schneebeli and D. Sch\"{o}tzau},
+   title   = {Discontinuous Galerkin Finite Element Method for the Wave Equation},
+   journal = {SIAM J. Numer. Anal},
+   year    = {2006},
+   volume  = {44},
+   pages   = {2408--2431},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_9,
-   author  = "T. Ha and C. Shin",
-   title   = "Two dimensional magnetotelluric inversion via reverse time migration algorithm",
-   journal = "Abstracts of the SEG Annual Meeting in New Orleans",
-   year    = "2006",
-   volume  = "",
-   pages   = "830--835",
-   url     = "",
-   doi     = ""
+   author  = {T. Ha and C. Shin},
+   title   = {Two dimensional magnetotelluric inversion via reverse time migration algorithm},
+   journal = {Abstracts of the SEG Annual Meeting in New Orleans},
+   year    = {2006},
+   volume  = {},
+   pages   = {830--835},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_10,
-   author  = "R. Hartmann",
-   title   = "Adaptive discontinuous Galerkin methods with shock-capturing for the compressible Navier-Stokes equations",
-   journal = "Int. J. Numer. Meth. Fluids",
-   year    = "2006",
-   volume  = "51",
-   pages   = "1131--1156",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Adaptive discontinuous Galerkin methods with shock-capturing for the compressible Navier-Stokes equations},
+   journal = {Int. J. Numer. Meth. Fluids},
+   year    = {2006},
+   volume  = {51},
+   pages   = {1131--1156},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_11,
-   author  = "R. Hartmann",
-   title   = "Derivation of an adjoint consistent discontinuous Galerkin discretization of the compressible Euler equations",
-   journal = "In G. Lube and G. Rapin, eds., Proceedings of the BAIL 2006 Conference",
-   year    = "2006",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Derivation of an adjoint consistent discontinuous Galerkin discretization of the compressible Euler equations},
+   journal = {In G. Lube and G. Rapin, eds., Proceedings of the BAIL 2006 Conference},
+   year    = {2006},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_12,
-   author  = "R. Hartmann",
-   title   = "Error estimation and adjoint-based adaptation in aerodynamics",
-   journal = "In P. Wesseling, E. Onate, J. Periaux, eds., Proceedings of the ECCOMAS CFD 2006, Sept. 5-8, Egmond aan Zee, The Netherlands",
-   year    = "2006",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Error estimation and adjoint-based adaptation in aerodynamics},
+   journal = {In P. Wesseling, E. Onate, J. Periaux, eds., Proceedings of the ECCOMAS CFD 2006, Sept. 5-8, Egmond aan Zee, The Netherlands},
+   year    = {2006},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_13,
-   author  = "R. Hartmann and P. Houston",
-   title   = "Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations I: Method Formulation",
-   journal = "Int. J. Numer. Anal. Model.",
-   year    = "2006",
-   volume  = "3",
-   pages   = "1--20",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations I: Method Formulation},
+   journal = {Int. J. Numer. Anal. Model.},
+   year    = {2006},
+   volume  = {3},
+   pages   = {1--20},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_14,
-   author  = "R. Hartmann and P. Houston",
-   title   = "Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations II: Goal-Oriented A Posteriori Error Estimation",
-   journal = "Int. J. Numer. Anal. Model.",
-   year    = "2006",
-   volume  = "3",
-   pages   = "141--162",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations II: Goal-Oriented A Posteriori Error Estimation},
+   journal = {Int. J. Numer. Anal. Model.},
+   year    = {2006},
+   volume  = {3},
+   pages   = {141--162},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2006_15,
-   author  = "L. Heltai",
-   title   = "The  Finite Element Immersed Boundary Method",
-   year    = "2006",
-   school  = "Universit&agrave; di Pavia, Dipartimento di Matematica "F. Casorati"",
-   url     = ""
+   author  = {L. Heltai},
+   title   = {The  Finite Element Immersed Boundary Method},
+   year    = {2006},
+   school  = {Universit\`{a} di Pavia, Dipartimento di Matematica ``F. Casorati''},
+   url     = {}
 }
 
 @article{2006_16,
-   author  = "K. Hwang and T. Pan and A. Joshi and J. C. Rasmussen and W. Bangerth and E. Sevick-Muraca",
-   title   = "Influence of excitation light rejection on forward model mismatch in optical tomography",
-   journal = "Phys. Med. Biol.",
-   year    = "2006",
-   volume  = "51",
-   pages   = "5889--5902",
-   url     = "",
-   doi     = ""
+   author  = {K. Hwang and T. Pan and A. Joshi and J. C. Rasmussen and W. Bangerth and E. Sevick-Muraca},
+   title   = {Influence of excitation light rejection on forward model mismatch in optical tomography},
+   journal = {Phys. Med. Biol.},
+   year    = {2006},
+   volume  = {51},
+   pages   = {5889--5902},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_17,
-   author  = "A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca",
-   title   = "Fully adaptive FEM based fluorescence optical tomography from time-dependent measurements with area illumination and detection",
-   journal = "Med. Phys.",
-   year    = "2006",
-   volume  = "33",
-   pages   = "1299--1310",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
+   title   = {Fully adaptive FEM based fluorescence optical tomography from time-dependent measurements with area illumination and detection},
+   journal = {Med. Phys.},
+   year    = {2006},
+   volume  = {33},
+   pages   = {1299--1310},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_18,
-   author  = "A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca",
-   title   = "Plane wave fluorescence tomography with adaptive finite elements",
-   journal = "Optics Letters",
-   year    = "2006",
-   volume  = "31",
-   pages   = "193--195",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
+   title   = {Plane wave fluorescence tomography with adaptive finite elements},
+   journal = {Optics Letters},
+   year    = {2006},
+   volume  = {31},
+   pages   = {193--195},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_19,
-   author  = "A. Joshi and W. Bangerth and E. Sevick-Muraca",
-   title   = "Non-contact fluorescence optical tomography with scanning area illumination",
-   journal = "Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA, 2006",
-   year    = "2006",
-   volume  = "",
-   pages   = "582--585",
-   url     = "http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=1624983",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
+   title   = {Non-contact fluorescence optical tomography with scanning area illumination},
+   journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA, 2006},
+   year    = {2006},
+   volume  = {},
+   pages   = {582--585},
+   url     = {http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=1624983},
+   doi     = {}
 }
 
 @article{2006_20,
-   author  = "A. Joshi and W. Bangerth and E. Sevick-Muraca",
-   title   = "Non-contact fluorescence optical tomography with scanning patterned illumination",
-   journal = "Optics Express",
-   year    = "2006",
-   volume  = "14",
-   pages   = "6516--6534",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
+   title   = {Non-contact fluorescence optical tomography with scanning patterned illumination},
+   journal = {Optics Express},
+   year    = {2006},
+   volume  = {14},
+   pages   = {6516--6534},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2006_21,
-   author  = "O. Kayser-Herold",
-   title   = "Least-Squares Methods for the Solution of Fluid-Structure Interaction Problems",
-   year    = "2006",
-   school  = "TU-Braunschweig, Germany",
-   url     = "http://www.digibib.tu-bs.de/?docid=00000035"
+   author  = {O. Kayser-Herold},
+   title   = {Least-Squares Methods for the Solution of Fluid-Structure Interaction Problems},
+   year    = {2006},
+   school  = {TU-Braunschweig, Germany},
+   url     = {http://www.digibib.tu-bs.de/?docid=00000035}
 }
 
 @mastersthesis{2006_22,
-   author  = "T. Leicht",
-   title   = "Anisotropic Mesh Refinement for Discontinuous Galerkin Methods in Aerodynamic Flow Simulations",
-   year    = "2006",
-   school  = "TU Dresden",
-   url     = "http://ganymed.iwr.uni-heidelberg.de/~hartmann/publications/publications.html#supervised"
+   author  = {T. Leicht},
+   title   = {Anisotropic Mesh Refinement for Discontinuous Galerkin Methods in Aerodynamic Flow Simulations},
+   year    = {2006},
+   school  = {TU Dresden},
+   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/publications/publications.html#supervised}
 }
 
 @article{2006_23,
-   author  = "T. Nielsen and T. Kohler",
-   title   = "Impact of noise on image reconstruction for diffuse optical tomography",
-   journal = "Phys. of Med. Imag., Proceedings of SPIE, doi: 10.1117/12.651297, Vol. 6142, 61420M",
-   year    = "2006",
-   volume  = "",
-   pages   = "",
-   url     = "http://reviews.spiedigitallibrary.org/data/Conferences/SPIEP/3323/61420M_1.pdf",
-   doi     = ""
+   author  = {T. Nielsen and T. Kohler},
+   title   = {Impact of noise on image reconstruction for diffuse optical tomography},
+   journal = {Phys. of Med. Imag., Proceedings of SPIE, doi: 10.1117/12.651297, Vol. 6142, 61420M},
+   year    = {2006},
+   volume  = {},
+   pages   = {},
+   url     = {http://reviews.spiedigitallibrary.org/data/Conferences/SPIEP/3323/61420M_1.pdf},
+   doi     = {}
 }
 
 @phdthesis{2006_24,
-   author  = "D. Oeltz",
-   title   = "Ein Raum-Zeit D&uuml;nngitterverfahren zur Diskretisierung parabolischer Differentialgleichungen",
-   year    = "2006",
-   school  = "University of Bonn, Germany",
-   url     = ""
+   author  = {D. Oeltz},
+   title   = {Ein Raum-Zeit D\"{u}nngitterverfahren zur Diskretisierung parabolischer Differentialgleichungen},
+   year    = {2006},
+   school  = {University of Bonn, Germany},
+   url     = {}
 }
 
 @article{2006_25,
-   author  = "M. Schmidt",
-   title   = "Low-dimensional I/O modeling of distributed parameter systems",
-   journal = "Proc. Appl. Math. Mech.",
-   year    = "2006",
-   volume  = "6",
-   pages   = "15--18",
-   url     = "",
-   doi     = ""
+   author  = {M. Schmidt},
+   title   = {Low-dimensional I/O modeling of distributed parameter systems},
+   journal = {Proc. Appl. Math. Mech.},
+   year    = {2006},
+   volume  = {6},
+   pages   = {15--18},
+   url     = {},
+   doi     = {}
 }
 
 @article{2006_26,
-   author  = "R. Ziegler and T. Kohler and T. Nielsen and O. Steinkellner and D. Grosenick and H. Rinneberg",
-   title   = "Spatial Resolution for Time-Resolved Optical Tomography in Slab Geometry",
-   journal = "Nucl. Sci. Symp. Conf. IEEE,  Vol. 4, pp: 2578 - 2583",
-   year    = "2006",
-   volume  = "",
-   pages   = "",
-   url     = "http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=4179549",
-   doi     = ""
+   author  = {R. Ziegler and T. Kohler and T. Nielsen and O. Steinkellner and D. Grosenick and H. Rinneberg},
+   title   = {Spatial Resolution for Time-Resolved Optical Tomography in Slab Geometry},
+   journal = {Nucl. Sci. Symp. Conf. IEEE,  Vol. 4, pp: 2578 - 2583},
+   year    = {2006},
+   volume  = {},
+   pages   = {},
+   url     = {http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=4179549},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2007.bib
+++ b/publications-2007.bib
@@ -1,408 +1,408 @@
 % Encoding: ISO-8859-1
 
 @article{2007_0,
-   author  = "N. Antonic and M. Vrdoljak",
-   title   = "Gradient methods for multiple state optimal design problems",
-   journal = "Ann. Univ. Ferrara",
-   year    = "2007",
-   volume  = "53",
-   pages   = "177--187",
-   url     = "",
-   doi     = ""
+   author  = {N. Antonic and M. Vrdoljak},
+   title   = {Gradient methods for multiple state optimal design problems},
+   journal = {Ann. Univ. Ferrara},
+   year    = {2007},
+   volume  = {53},
+   pages   = {177--187},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_1,
-   author  = "P. F. Antonietti and L. Heltai",
-   title   = "Numerical validation of a class of mixed discontinuous Galerkin methods for Darcy flow",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2007",
-   volume  = "196",
-   pages   = "4505--4520",
-   url     = "",
-   doi     = ""
+   author  = {P. F. Antonietti and L. Heltai},
+   title   = {Numerical validation of a class of mixed discontinuous Galerkin methods for Darcy flow},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2007},
+   volume  = {196},
+   pages   = {4505--4520},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2007_2,
-   author  = "P. F. Antonietti",
-   title   = "Domain decomposition, spectral correctness and numerical testing of discontinuous Galerkin methods",
-   year    = "2007",
-   school  = "University of Pavia, Italy",
-   url     = ""
+   author  = {P. F. Antonietti},
+   title   = {Domain decomposition, spectral correctness and numerical testing of discontinuous Galerkin methods},
+   year    = {2007},
+   school  = {University of Pavia, Italy},
+   url     = {}
 }
 
 @article{2007_3,
-   author  = "W. Bangerth and R. Hartmann and G. Kanschat",
-   title   = "deal.II &mdash; a general-purpose object-oriented finite element library",
-   journal = "ACM Transactions on Mathematical Software, no. 4, article 24",
-   year    = "2007",
-   volume  = "33",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and R. Hartmann and G. Kanschat},
+   title   = {deal.II -- a general-purpose object-oriented finite element library},
+   journal = {ACM Transactions on Mathematical Software, no. 4, article 24},
+   year    = {2007},
+   volume  = {33},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_4,
-   author  = "W. Bangerth and A. Joshi and E. Sevick",
-   title   = "Inverse biomedical imaging using separately adapted meshes for parameters and forward model variables",
-   journal = "Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA",
-   year    = "2007",
-   volume  = "",
-   pages   = "1368--1371",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and A. Joshi and E. Sevick},
+   title   = {Inverse biomedical imaging using separately adapted meshes for parameters and forward model variables},
+   journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
+   year    = {2007},
+   volume  = {},
+   pages   = {1368--1371},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_5,
-   author  = "E. B&auml;ngtsson and M. Neytcheva",
-   title   = "Finite Element Block-Factorized Preconditioners",
-   journal = "Technical Report 2007-008, Uppsala University, Sweden",
-   year    = "2007",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {E. B\"{a}ngtsson and M. Neytcheva},
+   title   = {Finite Element Block-Factorized Preconditioners},
+   journal = {Technical Report 2007-008, Uppsala University, Sweden},
+   year    = {2007},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_6,
-   author  = "D. Boffi and L. Gastaldi and L. Heltai",
-   title   = "Numerical stability of the finite element immersed boundary method",
-   journal = "Mathematical Models and Methods in Applied Sciences",
-   year    = "2007",
-   volume  = "17",
-   pages   = "1479--1505",
-   url     = "",
-   doi     = ""
+   author  = {D. Boffi and L. Gastaldi and L. Heltai},
+   title   = {Numerical stability of the finite element immersed boundary method},
+   journal = {Mathematical Models and Methods in Applied Sciences},
+   year    = {2007},
+   volume  = {17},
+   pages   = {1479--1505},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_7,
-   author  = "D. Boffi and L. Gastaldi and L. Heltai",
-   title   = "On the CFL condition for the finite element immersed boundary method",
-   journal = "Computers &amp; Structures",
-   year    = "2007",
-   volume  = "85",
-   pages   = "775--783",
-   url     = "",
-   doi     = "10.1016/j.compstruc.2007.01.009"
+   author  = {D. Boffi and L. Gastaldi and L. Heltai},
+   title   = {On the CFL condition for the finite element immersed boundary method},
+   journal = {Computers \& Structures},
+   year    = {2007},
+   volume  = {85},
+   pages   = {775--783},
+   url     = {},
+   doi     = {10.1016/j.compstruc.2007.01.009}
 }
 
 @article{2007_8,
-   author  = "M. Calhoun-Lopez and M. D. Gunzburger",
-   title   = "The efficient implementation of a finite element, multi-resolution viscosity method for hyperbolic conservation laws",
-   journal = "Journal of Computational Physics",
-   year    = "2007",
-   volume  = "225",
-   pages   = "1288--1313",
-   url     = "",
-   doi     = ""
+   author  = {M. Calhoun-Lopez and M. D. Gunzburger},
+   title   = {The efficient implementation of a finite element, multi-resolution viscosity method for hyperbolic conservation laws},
+   journal = {Journal of Computational Physics},
+   year    = {2007},
+   volume  = {225},
+   pages   = {1288--1313},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_9,
-   author  = "B. Carnes and N. Djilali",
-   title   = "Analysis of coupled proton and water transport in a PEM fuel cell using the binary friction membrane model",
-   journal = "Electrochimica Acta",
-   year    = "2007",
-   volume  = "52",
-   pages   = "1038--1052",
-   url     = "",
-   doi     = ""
+   author  = {B. Carnes and N. Djilali},
+   title   = {Analysis of coupled proton and water transport in a PEM fuel cell using the binary friction membrane model},
+   journal = {Electrochimica Acta},
+   year    = {2007},
+   volume  = {52},
+   pages   = {1038--1052},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_10,
-   author  = "B. R. Carnes and G. F. Carey",
-   title   = "Estimating spatial and parameter error in parameterized nonlinear reaction-diffusion equations",
-   journal = "Communications in Numerical Methods in Engineering",
-   year    = "2007",
-   volume  = "23",
-   pages   = "835--854",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/cnm.928/abstract",
-   doi     = ""
+   author  = {B. R. Carnes and G. F. Carey},
+   title   = {Estimating spatial and parameter error in parameterized nonlinear reaction-diffusion equations},
+   journal = {Communications in Numerical Methods in Engineering},
+   year    = {2007},
+   volume  = {23},
+   pages   = {835--854},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/cnm.928/abstract},
+   doi     = {}
 }
 
 @article{2007_11,
-   author  = "B. Cockburn and G. Kanschat and and D. Sch&ouml;tzau",
-   title   = "A note on discontinuous Galerkin divergence-free solutions of the Navier-Stokes equations",
-   journal = "Journal of Scientific Computing",
-   year    = "2007",
-   volume  = "31",
-   pages   = "61--73",
-   url     = "",
-   doi     = ""
+   author  = {B. Cockburn and G. Kanschat and and D. Sch\"{o}tzau},
+   title   = {A note on discontinuous Galerkin divergence-free solutions of the Navier-Stokes equations},
+   journal = {Journal of Scientific Computing},
+   year    = {2007},
+   volume  = {31},
+   pages   = {61--73},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_12,
-   author  = "C. C. Douglas and M. J. Cole and P. Dostert and Y. Efendiev and R. E. Ewing and G. Haase and J. Hatcher and M. Iskandarani and C. R. Johnson and R. A. Lodder",
-   title   = "Dynamically identifying and tracking contaminants in water bodies",
-   journal = "International Conference on Computational Science ICCS 2007, of Springer Lecture Notes in Computer Science",
-   year    = "2007",
-   volume  = "4487",
-   pages   = "1002--1009",
-   url     = "",
-   doi     = ""
+   author  = {C. C. Douglas and M. J. Cole and P. Dostert and Y. Efendiev and R. E. Ewing and G. Haase and J. Hatcher and M. Iskandarani and C. R. Johnson and R. A. Lodder},
+   title   = {Dynamically identifying and tracking contaminants in water bodies},
+   journal = {International Conference on Computational Science ICCS 2007, of Springer Lecture Notes in Computer Science},
+   year    = {2007},
+   volume  = {4487},
+   pages   = {1002--1009},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_13,
-   author  = "F. Freddi and M. Fr&eacute;mond",
-   title   = "Collision and Fractures: a predictive theory",
-   journal = "Proceedings of the EuroSim Conference, Lubiana, Slovenia, 9-13 September",
-   year    = "2007",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and M. Fr\'{e}mond},
+   title   = {Collision and Fractures: a predictive theory},
+   journal = {Proceedings of the EuroSim Conference, Lubiana, Slovenia, 9-13 September},
+   year    = {2007},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_14,
-   author  = "P. K. Galenko and S. Reutzel and D. M. Herlach and D. Danilov and B. Nestler",
-   title   = "Modelling of dendritic solidification in undercooled dilute Ni-Zr melts",
-   journal = "Acta Materialia",
-   year    = "2007",
-   volume  = "55",
-   pages   = "6834--6842",
-   url     = "",
-   doi     = ""
+   author  = {P. K. Galenko and S. Reutzel and D. M. Herlach and D. Danilov and B. Nestler},
+   title   = {Modelling of dendritic solidification in undercooled dilute Ni-Zr melts},
+   journal = {Acta Materialia},
+   year    = {2007},
+   volume  = {55},
+   pages   = {6834--6842},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_15,
-   author  = "T. Ha and C. Shin",
-   title   = "Magnetotelluric inversion via reverse time migration algorithm of seimic data",
-   journal = "J. Comput. Phys.",
-   year    = "2007",
-   volume  = "225",
-   pages   = "237--262",
-   url     = "",
-   doi     = ""
+   author  = {T. Ha and C. Shin},
+   title   = {Magnetotelluric inversion via reverse time migration algorithm of seimic data},
+   journal = {J. Comput. Phys.},
+   year    = {2007},
+   volume  = {225},
+   pages   = {237--262},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_16,
-   author  = "R. Hartmann",
-   title   = "Adjoint consistency analysis of Discontinuous Galerkin discretizations",
-   journal = "SIAM J. Numer. Anal., no. 6",
-   year    = "2007",
-   volume  = "45",
-   pages   = "2671--2696",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Adjoint consistency analysis of Discontinuous Galerkin discretizations},
+   journal = {SIAM J. Numer. Anal., no. 6},
+   year    = {2007},
+   volume  = {45},
+   pages   = {2671--2696},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_17,
-   author  = "R. Hartmann",
-   title   = "Error estimation and adjoint based refinement for an adjoint consistent DG discretization of the compressible Euler equations",
-   journal = "Int. J. Computing Science and Mathematics",
-   year    = "2007",
-   volume  = "1",
-   pages   = "207--220",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Error estimation and adjoint based refinement for an adjoint consistent DG discretization of the compressible Euler equations},
+   journal = {Int. J. Computing Science and Mathematics},
+   year    = {2007},
+   volume  = {1},
+   pages   = {207--220},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_18,
-   author  = "R. Hartmann",
-   title   = "DG discretizations for compressible flows: Adjoint consistency analysis, error estimation and adaptivity",
-   journal = "In R. Rannacher, E. S&uuml;li, and R. Verf&uuml;hrt, eds., Adaptive Numerical Methods for PDEs, Mathematisches Forschungsinstitut Oberwolfach Report 29/2007",
-   year    = "2007",
-   volume  = "",
-   pages   = "26--30",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {DG discretizations for compressible flows: Adjoint consistency analysis, error estimation and adaptivity},
+   journal = {In R. Rannacher, E. S\"{u}li, and R. Verf\"{u}hrt, eds., Adaptive Numerical Methods for PDEs, Mathematisches Forschungsinstitut Oberwolfach Report 29/2007},
+   year    = {2007},
+   volume  = {},
+   pages   = {26--30},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2007_19,
-   author  = "P. Hepperger",
-   title   = "Ein POD-basierter Ansatz zur numerischen L&ouml;sung eines Datenassimilationsproblems am Beispiel einer linearen Diffusions-Konvektions-Gleichung",
-   year    = "2007",
-   school  = "Technical University of Munich, Germany",
-   url     = ""
+   author  = {P. Hepperger},
+   title   = {Ein POD-basierter Ansatz zur numerischen L\"{o}sung eines Datenassimilationsproblems am Beispiel einer linearen Diffusions-Konvektions-Gleichung},
+   year    = {2007},
+   school  = {Technical University of Munich, Germany},
+   url     = {}
 }
 
 @mastersthesis{2007_20,
-   author  = "C. D. Kamm",
-   title   = "A posteriori error estimation in numerical methods for solving self-adjoint eigenvalue problems",
-   year    = "2007",
-   school  = "TU Berlin, Germany",
-   url     = ""
+   author  = {C. D. Kamm},
+   title   = {A posteriori error estimation in numerical methods for solving self-adjoint eigenvalue problems},
+   year    = {2007},
+   school  = {TU Berlin, Germany},
+   url     = {}
 }
 
 @article{2007_21,
-   author  = "O. Kayser-Herold and H.G. Matthies",
-   title   = "A unified least-squares formulation for fluid-structure interaction problems",
-   journal = "Computers and Structures",
-   year    = "2007",
-   volume  = "85",
-   pages   = "998--1011",
-   url     = "",
-   doi     = ""
+   author  = {O. Kayser-Herold and H.G. Matthies},
+   title   = {A unified least-squares formulation for fluid-structure interaction problems},
+   journal = {Computers and Structures},
+   year    = {2007},
+   volume  = {85},
+   pages   = {998--1011},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2007_22,
-   author  = "B. Janssen and ",
-   title   = "Vergleich verschiedener Finite-Elemente-Approximationen zur numerischen L&ouml;sung der Plattengleichung",
-   year    = "2007",
-   school  = "University of Heidelberg, Germany",
-   url     = ""
+   author  = {B. Janssen and },
+   title   = {Vergleich verschiedener Finite-Elemente-Approximationen zur numerischen L\"{o}sung der Plattengleichung},
+   year    = {2007},
+   school  = {University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2007_23,
-   author  = "A. Joshi and W. Bangerth and R. Sharma and J. Rasmussen and W. Wang and E. Sevick",
-   title   = "Molecular tomographic imaging of lymph nodes with NIR fluorescence",
-   journal = "Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA",
-   year    = "2007",
-   volume  = "",
-   pages   = "564--567",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and R. Sharma and J. Rasmussen and W. Wang and E. Sevick},
+   title   = {Molecular tomographic imaging of lymph nodes with NIR fluorescence},
+   journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
+   year    = {2007},
+   volume  = {},
+   pages   = {564--567},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_24,
-   author  = "B. Nestler and D. Danilov and A. Bracchi and Y.-L. Huang and T. Niermann and M. Seibt and S. Schneider",
-   title   = "A metallic glass composite: Phase-field simulations and experimental analysis of microstructure evolution",
-   journal = "Materials Science and Engineering: A, -453",
-   year    = "2007",
-   volume  = "452",
-   pages   = "8--14",
-   url     = "",
-   doi     = ""
+   author  = {B. Nestler and D. Danilov and A. Bracchi and Y.-L. Huang and T. Niermann and M. Seibt and S. Schneider},
+   title   = {A metallic glass composite: Phase-field simulations and experimental analysis of microstructure evolution},
+   journal = {Materials Science and Engineering: A, -453},
+   year    = {2007},
+   volume  = {452},
+   pages   = {8--14},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_25,
-   author  = "T. Nielsen and B. Brendel and T. Koehler and R. Ziegler and A. Ziegler and L. Bakker and M. van Beek and M. van der Mark and M. van der Voort and R. Harbers and K. Licha and M. Pessel and F. Schippers and J. P. Meeuwse and A. Feuerabend and D. van Pijkeren and S. Deckers",
-   title   = "Image reconstruction and evaluation of system performance for optical fluorescence tomography",
-   journal = "Multimodal Biomedical Imaging II, Proc. SPIE ",
-   year    = "2007",
-   volume  = "6431",
-   pages   = "",
-   url     = "http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=1296529",
-   doi     = ""
+   author  = {T. Nielsen and B. Brendel and T. Koehler and R. Ziegler and A. Ziegler and L. Bakker and M. van Beek and M. van der Mark and M. van der Voort and R. Harbers and K. Licha and M. Pessel and F. Schippers and J. P. Meeuwse and A. Feuerabend and D. van Pijkeren and S. Deckers},
+   title   = {Image reconstruction and evaluation of system performance for optical fluorescence tomography},
+   journal = {Multimodal Biomedical Imaging II, Proc. SPIE },
+   year    = {2007},
+   volume  = {6431},
+   pages   = {},
+   url     = {http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=1296529},
+   doi     = {}
 }
 
 @phdthesis{2007_26,
-   author  = "A. Nigro",
-   title   = "Discontinuous Galerkin Methods for inviscid low Mach number flows",
-   year    = "2007",
-   school  = "University of Calabria",
-   url     = ""
+   author  = {A. Nigro},
+   title   = {Discontinuous Galerkin Methods for inviscid low Mach number flows},
+   year    = {2007},
+   school  = {University of Calabria},
+   url     = {}
 }
 
 @article{2007_27,
-   author  = "P. J. Phillips and M. F. Wheeler",
-   title   = "A coupling of mixed and continuous Galerkin finite element methods for poroelasticity II: the discrete-in-time case",
-   journal = "Computational Geosciences",
-   year    = "2007",
-   volume  = "11",
-   pages   = "145--158",
-   url     = "",
-   doi     = ""
+   author  = {P. J. Phillips and M. F. Wheeler},
+   title   = {A coupling of mixed and continuous Galerkin finite element methods for poroelasticity II: the discrete-in-time case},
+   journal = {Computational Geosciences},
+   year    = {2007},
+   volume  = {11},
+   pages   = {145--158},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_28,
-   author  = "H. J. Reinhardt and J. Frohne",
-   title   = "On Multidimensional Inverse Heat Conduction Problems",
-   journal = "International Conference ''Inverse and Ill-Posed Problems of Mathematical Physics'', Russia",
-   year    = "2007",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.math.nsc.ru/conference/ipmp07/abstracts/Section3/ReinhardtHJ.pdf",
-   doi     = ""
+   author  = {H. J. Reinhardt and J. Frohne},
+   title   = {On Multidimensional Inverse Heat Conduction Problems},
+   journal = {International Conference ''Inverse and Ill-Posed Problems of Mathematical Physics'', Russia},
+   year    = {2007},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.math.nsc.ru/conference/ipmp07/abstracts/Section3/ReinhardtHJ.pdf},
+   doi     = {}
 }
 
 @article{2007_29,
-   author  = "H. J. Reinhardt and D. N. H&agrave;o and J. Frohne and F.-T. Suttmeier",
-   title   = "Numerical solution of Inverse Heat Conduction Problems in two spatial dimensions",
-   journal = "J. Inverse and Ill-Posed Problems",
-   year    = "2007",
-   volume  = "5",
-   pages   = "19--36",
-   url     = "",
-   doi     = ""
+   author  = {H. J. Reinhardt and D. N. H\`{a}o and J. Frohne and F.-T. Suttmeier},
+   title   = {Numerical solution of Inverse Heat Conduction Problems in two spatial dimensions},
+   journal = {J. Inverse and Ill-Posed Problems},
+   year    = {2007},
+   volume  = {5},
+   pages   = {19--36},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2007_30,
-   author  = "L. R&ouml;he",
-   title   = "Residuale Stabilisierung f&uuml;r Finite Elemente Verfahren bei inkompressiblen Str&ouml;mungen",
-   year    = "2007",
-   school  = "University of G&ouml;ttingen, Germany",
-   url     = ""
+   author  = {L. R\"{o}he},
+   title   = {Residuale Stabilisierung f\"{u}r Finite Elemente Verfahren bei inkompressiblen Str\"{o}mungen},
+   year    = {2007},
+   school  = {University of G\"{o}ttingen, Germany},
+   url     = {}
 }
 
 @phdthesis{2007_31,
-   author  = "M. Schmidt",
-   title   = "Systematic discretization of input/output maps and other contributions to the control of distributed parameter systems",
-   year    = "2007",
-   school  = "TU Berlin, Germany",
-   url     = ""
+   author  = {M. Schmidt},
+   title   = {Systematic discretization of input/output maps and other contributions to the control of distributed parameter systems},
+   year    = {2007},
+   school  = {TU Berlin, Germany},
+   url     = {}
 }
 
 @article{2007_32,
-   author  = "R. B. Schulz and M. Schweiger and C. D'Andrea and G. Valentini and J. Peter and R. Cubeddu and S. Arridge and W. Semmler",
-   title   = "Applying Time-Dependent Data for Fluorescence Tomography",
-   journal = "European Conference on Biomedical Optics, Munich Germany",
-   year    = "2007",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.osapublishing.org/abstract.cfm?uri=ECBO-2007-6626_19",
-   doi     = "10.1364/ECBO.2007.6626_19"
+   author  = {R. B. Schulz and M. Schweiger and C. D'Andrea and G. Valentini and J. Peter and R. Cubeddu and S. Arridge and W. Semmler},
+   title   = {Applying Time-Dependent Data for Fluorescence Tomography},
+   journal = {European Conference on Biomedical Optics, Munich Germany},
+   year    = {2007},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.osapublishing.org/abstract.cfm?uri=ECBO-2007-6626_19},
+   doi     = {10.1364/ECBO.2007.6626_19}
 }
 
 @article{2007_33,
-   author  = "M. Secanell and B. Carnes and A. Suleman and N. Djilali",
-   title   = "Numerical optimization of proton exchange membrane fuel cell cathodes",
-   journal = "Electrochimica Acta",
-   year    = "2007",
-   volume  = "52",
-   pages   = "2668--2682",
-   url     = "",
-   doi     = ""
+   author  = {M. Secanell and B. Carnes and A. Suleman and N. Djilali},
+   title   = {Numerical optimization of proton exchange membrane fuel cell cathodes},
+   journal = {Electrochimica Acta},
+   year    = {2007},
+   volume  = {52},
+   pages   = {2668--2682},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_34,
-   author  = "M. Secanell and K. Karan and A. Suleman and N. Djilali",
-   title   = "Multi-variable optimization of PEMFC cathodes using an agglomerate model",
-   journal = "Electrochimica Acta",
-   year    = "2007",
-   volume  = "52",
-   pages   = "6318--6337",
-   url     = "",
-   doi     = ""
+   author  = {M. Secanell and K. Karan and A. Suleman and N. Djilali},
+   title   = {Multi-variable optimization of PEMFC cathodes using an agglomerate model},
+   journal = {Electrochimica Acta},
+   year    = {2007},
+   volume  = {52},
+   pages   = {6318--6337},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_35,
-   author  = "M. Steigemann and M. Fulland",
-   title   = "On the computation of the pure Neumann problem in 2-dimensional elasticity",
-   journal = "International Journal of Fracture",
-   year    = "2007",
-   volume  = "146",
-   pages   = "265--277",
-   url     = "",
-   doi     = ""
+   author  = {M. Steigemann and M. Fulland},
+   title   = {On the computation of the pure Neumann problem in 2-dimensional elasticity},
+   journal = {International Journal of Fracture},
+   year    = {2007},
+   volume  = {146},
+   pages   = {265--277},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_36,
-   author  = "M. Steigemann and M. Fulland and M. Specovius-Neugebauer and H. A. Richard",
-   title   = "Simulation of crack paths in functionally graded materials",
-   journal = "PAMM",
-   year    = "2007",
-   volume  = "7",
-   pages   = "4030029--4030030",
-   url     = "",
-   doi     = ""
+   author  = {M. Steigemann and M. Fulland and M. Specovius-Neugebauer and H. A. Richard},
+   title   = {Simulation of crack paths in functionally graded materials},
+   journal = {PAMM},
+   year    = {2007},
+   volume  = {7},
+   pages   = {4030029--4030030},
+   url     = {},
+   doi     = {}
 }
 
 @article{2007_37,
-   author  = "R. Ziegler and T. Nielsen and T. Koehler and D. Grosenick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg",
-   title   = "Reconstruction of absorption and fluorescence contrast for scanning time-domain fluorescence mammography",
-   journal = "Optical Tomography and Spectroscopy of Tissue VII, Proc. SPIE 64340H/1-11",
-   year    = "2007",
-   volume  = "6434",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Ziegler and T. Nielsen and T. Koehler and D. Grosenick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg},
+   title   = {Reconstruction of absorption and fluorescence contrast for scanning time-domain fluorescence mammography},
+   journal = {Optical Tomography and Spectroscopy of Tissue VII, Proc. SPIE 64340H/1-11},
+   year    = {2007},
+   volume  = {6434},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2007_64,
-   author  = "S. M. Renda",
-   title   = "Discontinuous Galerkin Methods for all speed flows",
-   year    = "2007",
-   school  = "University of Calabria",
-   url     = ""
+   author  = {S. M. Renda},
+   title   = {Discontinuous Galerkin Methods for all speed flows},
+   year    = {2007},
+   school  = {University of Calabria},
+   url     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -1,378 +1,386 @@
 % Encoding: ISO-8859-1
 
 @article{2008_0,
-   author  = "W. Bangerth",
-   title   = "A framework for the adaptive finite element solution of large-scale inverse problems",
-   journal = "SIAM J. Sci. Comput",
-   year    = "2008",
-   volume  = "30",
-   pages   = "2965--2989",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth},
+   title   = {A framework for the adaptive finite element solution of large-scale inverse problems},
+   journal = {SIAM J. Sci. Comput},
+   year    = {2008},
+   volume  = {30},
+   pages   = {2965--2989},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_1,
-   author  = "W. Bangerth and A. Joshi",
-   title   = "Adaptive finite element methods for the solution of inverse problems in optical tomography",
-   journal = "Inverse Problems, article 034011 (23 pages)",
-   year    = "2008",
-   volume  = "24",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and A. Joshi},
+   title   = {Adaptive finite element methods for the solution of inverse problems in optical tomography},
+   journal = {Inverse Problems, article 034011 (23 pages)},
+   year    = {2008},
+   volume  = {24},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_2,
-   author  = "E. B&auml;ngtsson and B. Lund",
-   title   = "A comparison between two solution techniques to solve the equations of glacially induced deformation of an elastic Earth",
-   journal = "Int. J. Numer. Meth. Engrg.",
-   year    = "2008",
-   volume  = "75",
-   pages   = "479--502",
-   url     = "",
-   doi     = ""
+   author  = {E. B\"{a}ngtsson and B. Lund},
+   title   = {A comparison between two solution techniques to solve the equations of glacially induced deformation of an elastic Earth},
+   journal = {Int. J. Numer. Meth. Engrg.},
+   year    = {2008},
+   volume  = {75},
+   pages   = {479--502},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_3,
-   author  = "M. Bartels and A. Joshi and J. C. Rasmussen and E. M. Sevick-Muraca and W. Bangerth",
-   title   = "Post-image acquisition excitation light mitigation in NIR fluorescent tomography",
-   journal = "Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA",
-   year    = "2008",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Bartels and A. Joshi and J. C. Rasmussen and E. M. Sevick-Muraca and W. Bangerth},
+   title   = {Post-image acquisition excitation light mitigation in NIR fluorescent tomography},
+   journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
+   year    = {2008},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_4,
-   author  = "B. Brendel and R. Ziegler and T. Nielsen",
-   title   = "Algebraic reconstruction techniques for spectral reconstruction in diffuse optical tomography",
-   journal = "Applied Optics",
-   year    = "2008",
-   volume  = "47",
-   pages   = "6392--6403",
-   url     = "",
-   doi     = ""
+   author  = {B. Brendel and R. Ziegler and T. Nielsen},
+   title   = {Algebraic reconstruction techniques for spectral reconstruction in diffuse optical tomography},
+   journal = {Applied Optics},
+   year    = {2008},
+   volume  = {47},
+   pages   = {6392--6403},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_5,
-   author  = "D. Boffi and L. Gastaldi and L. Heltai and C. S. Peskin",
-   title   = "On the hyper-elastic formulation of the immersed boundary method",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2008",
-   volume  = "197",
-   pages   = "2210--2231",
-   url     = "",
-   doi     = ""
+   author  = {D. Boffi and L. Gastaldi and L. Heltai and C. S. Peskin},
+   title   = {On the hyper-elastic formulation of the immersed boundary method},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2008},
+   volume  = {197},
+   pages   = {2210--2231},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_6,
-   author  = "B. Carnes and G. F. Carey",
-   title   = "Local boundary value problems for the error in FE approximation of non-linear diffusion systems",
-   journal = "Int. J. for Numer. Methods Engrg.",
-   year    = "2008",
-   volume  = "73",
-   pages   = "665--684",
-   url     = "",
-   doi     = ""
+   author  = {B. Carnes and G. F. Carey},
+   title   = {Local boundary value problems for the error in FE approximation of non-linear diffusion systems},
+   journal = {Int. J. for Numer. Methods Engrg.},
+   year    = {2008},
+   volume  = {73},
+   pages   = {665--684},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_7,
-   author  = "N. Djilali and P. C. Sui",
-   title   = "Transport phenomena in fuel cells: from microscale to macroscale",
-   journal = "Int. J. of Comput. Fluid Dynam.",
-   year    = "2008",
-   volume  = "22",
-   pages   = "115--133",
-   url     = "",
-   doi     = ""
+   author  = {N. Djilali and P. C. Sui},
+   title   = {Transport phenomena in fuel cells: from microscale to macroscale},
+   journal = {Int. J. of Comput. Fluid Dynam.},
+   year    = {2008},
+   volume  = {22},
+   pages   = {115--133},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_8,
-   author  = "R. Fosdick and F. Freddi and G. Royer-Carfagni",
-   title   = "Bifurcation instability in linear elasticity with the constraint of local injectivity",
-   journal = "J. of Elasticity",
-   year    = "2008",
-   volume  = "90",
-   pages   = "99--126",
-   url     = "",
-   doi     = ""
+   author  = {R. Fosdick and F. Freddi and G. Royer-Carfagni},
+   title   = {Bifurcation instability in linear elasticity with the constraint of local injectivity},
+   journal = {J. of Elasticity},
+   year    = {2008},
+   volume  = {90},
+   pages   = {99--126},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2008_9,
-   author  = "M. Geiger",
-   title   = "Vergleich dreier Zeitschrittverahren zur numerischen L&ouml;sung der akustischen Wellengleichung",
-   year    = "2008",
-   school  = "University of Heidelberg, Germany",
-   url     = ""
+   author  = {M. Geiger},
+   title   = {Vergleich dreier Zeitschrittverahren zur numerischen L\"{o}sung der akustischen Wellengleichung},
+   year    = {2008},
+   school  = {University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2008_10,
-   author  = "P. Ghysels and G. Samaey and B. Tijskens and H. Ramon and D. Roose",
-   title   = "Multi-scale simulation of plant tissue deformation using a model for individual cell behavior",
-   journal = "Report TW 522, Department of Computer Science, K.U. Leuven, Belgium, 2008. <br> <li> C. Giavarini, M.L. Santarelli, R. Natalini, F. Freddi <br> A non-linear model of sulphation of porous stones: Numerical simulations and preliminary laboratory assessments <br> J. of Cultural Heritage",
-   year    = "2008",
-   volume  = "9",
-   pages   = "14--22",
-   url     = "http://www.sciencedirect.com/science/article/pii/S1296207407001422",
-   doi     = ""
+   author  = {P. Ghysels and G. Samaey and B. Tijskens and H. Ramon and D. Roose},
+   title   = {Multi-scale simulation of plant tissue deformation using a model for individual cell behavior},
+   journal = {Report TW 522, Department of Computer Science, K.U. Leuven, Belgium, 2008.}
+}
+
+@article{2008_10a,
+   author  = {C. Giavarini, M.L. Santarelli, R. Natalini and F. Freddi},
+   title   = {A non-linear model of sulphation of porous stones: Numerical simulations and preliminary laboratory assessments},
+   journal = {J. of Cultural Heritage},
+   year    = {2008},
+   volume  = {9},
+   pages   = {14--22},
+   url     = {http://www.sciencedirect.com/science/article/pii/S1296207407001422},
+   doi     = {}
 }
 
 @article{2008_11,
-   author  = "M. Grote and A. Schneebeli and D. Sch&ouml;tzau",
-   title   = "Interior penalty discontinuous Galerkin method for Maxwell's equations: optimal L<sup>2</sup>-norm estimates",
-   journal = "IMA J. Numer. Anal.",
-   year    = "2008",
-   volume  = "28",
-   pages   = "440--468",
-   url     = "",
-   doi     = ""
+   author  = {M. Grote and A. Schneebeli and D. Sch\"{o}tzau},
+   title   = {Interior penalty discontinuous Galerkin method for Maxwell's equations: optimal L$^{2}$-norm estimates},
+   journal = {IMA J. Numer. Anal.},
+   year    = {2008},
+   volume  = {28},
+   pages   = {440--468},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_12,
-   author  = "R. Hartmann",
-   title   = "Error estimation and adjoint-based refinement for multiple force coefficients in aerodynamic flow simulations",
-   journal = "8th. World Congress on Computational Mechanics (WCCM8)",
-   year    = "2008",
-   volume  = "",
-   pages   = "",
-   url     = "http://elib.dlr.de/57075",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Error estimation and adjoint-based refinement for multiple force coefficients in aerodynamic flow simulations},
+   journal = {8th. World Congress on Computational Mechanics (WCCM8)},
+   year    = {2008},
+   volume  = {},
+   pages   = {},
+   url     = {http://elib.dlr.de/57075},
+   doi     = {}
 }
 
 @article{2008_13,
-   author  = "R. Hartmann",
-   title   = "Multitarget error estimation and adaptivity in aerodynamic flow simulations",
-   journal = "SIAM J. Sci. Comput., no. 1",
-   year    = "2008",
-   volume  = "31",
-   pages   = "708--731",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Multitarget error estimation and adaptivity in aerodynamic flow simulations},
+   journal = {SIAM J. Sci. Comput., no. 1},
+   year    = {2008},
+   volume  = {31},
+   pages   = {708--731},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_14,
-   author  = "R. Hartmann",
-   title   = "Numerical Analysis of Higher Order Discontinuous Galerkin Finite Element Methods",
-   journal = "In H. Deconinck, editor, VKI LS 2008-08: 35th CFD/ADIGMA course on very high order discretization methods, Oct. 13-17, 2008. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium",
-   year    = "2008",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Numerical Analysis of Higher Order Discontinuous Galerkin Finite Element Methods},
+   journal = {In H. Deconinck, editor, VKI LS 2008-08: 35th CFD/ADIGMA course on very high order discretization methods, Oct. 13-17, 2008. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium},
+   year    = {2008},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_15,
-   author  = "R. Hartmann and P. Houston",
-   title   = "An optimal order interior penalty discontinuous Galerkin discretization of the compressible Navier-Stokes equations",
-   journal = "J. Comput. Phys., no. 22",
-   year    = "2008",
-   volume  = "227",
-   pages   = "9670--9685",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {An optimal order interior penalty discontinuous Galerkin discretization of the compressible Navier-Stokes equations},
+   journal = {J. Comput. Phys., no. 22},
+   year    = {2008},
+   volume  = {227},
+   pages   = {9670--9685},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2008_16,
-   author  = "T. Heister",
-   title   = "Vorkonditionierunsstrategien f&uuml;r das stabilisierte Oseen-Problem",
-   year    = "2008",
-   school  = "University of G&ouml;ttingen, Germany",
-   url     = ""
+   author  = {T. Heister},
+   title   = {Vorkonditionierunsstrategien f\"{u}r das stabilisierte Oseen-Problem},
+   year    = {2008},
+   school  = {University of G\"{o}ttingen, Germany},
+   url     = {}
 }
 
 @article{2008_17,
-   author  = "L. Heltai",
-   title   = "On the stability of the finite element immersed boundary method",
-   journal = "Computers and Structures",
-   year    = "2008",
-   volume  = "86",
-   pages   = "598--617",
-   url     = "",
-   doi     = ""
+   author  = {L. Heltai},
+   title   = {On the stability of the finite element immersed boundary method},
+   journal = {Computers and Structures},
+   year    = {2008},
+   volume  = {86},
+   pages   = {598--617},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_18,
-   author  = "A. Joshi and W. Bangerth and E. Sevick",
-   title   = "Non-Contact Fluorescence Optical Tomography with Adaptive Finite Element Methods",
-   journal = "In: Mathematical Methods in Biomedical Imaging and Intensity-Modulated Radiation Therapy (IMRT), Y. Censor, M. Jiang and A.K. Louis (eds.), Birkh&auml;user",
-   year    = "2008",
-   volume  = "",
-   pages   = "185--200",
-   url     = "",
-   doi     = ""
+   author  = {A. Joshi and W. Bangerth and E. Sevick},
+   title   = {Non-Contact Fluorescence Optical Tomography with Adaptive Finite Element Methods},
+   journal = {In: Mathematical Methods in Biomedical Imaging and Intensity-Modulated Radiation Therapy (IMRT), Y. Censor, M. Jiang and A.K. Louis (eds.), Birkh\"{a}user},
+   year    = {2008},
+   volume  = {},
+   pages   = {185--200},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_19,
-   author  = "G. Kanschat",
-   title   = "Robust smoothers for high order discontinuous Galerkin discretizations of advection-diffusion problems",
-   journal = "J. Comput. Appl. Math.",
-   year    = "2008",
-   volume  = "218",
-   pages   = "53--60",
-   url     = "http://www.isc.tamu.edu/publications-reports/tr/0701.pdf",
-   doi     = ""
+   author  = {G. Kanschat},
+   title   = {Robust smoothers for high order discontinuous Galerkin discretizations of advection-diffusion problems},
+   journal = {J. Comput. Appl. Math.},
+   year    = {2008},
+   volume  = {218},
+   pages   = {53--60},
+   url     = {http://www.isc.tamu.edu/publications-reports/tr/0701.pdf},
+   doi     = {}
 }
 
 @article{2008_20,
-   author  = "G. Kanschat and D. Sch&ouml;tzau",
-   title   = "Energy norm a-posteriori error estimation for divergence-free discontinuous Galerkin approximations of the Navier-Stokes equations",
-   journal = "Int. J. Numer. Methods Fluids",
-   year    = "2008",
-   volume  = "57",
-   pages   = "1093--1113",
-   url     = "",
-   doi     = "10.1002/fld.1795"
+   author  = {G. Kanschat and D. Sch\"{o}tzau},
+   title   = {Energy norm a-posteriori error estimation for divergence-free discontinuous Galerkin approximations of the Navier-Stokes equations},
+   journal = {Int. J. Numer. Methods Fluids},
+   year    = {2008},
+   volume  = {57},
+   pages   = {1093--1113},
+   url     = {},
+   doi     = {10.1002/fld.1795}
 }
 
 @article{2008_21,
-   author  = "D. K. Khalmanova and F. Costanzo",
-   title   = "A space-time discontinuous Galerkin finite element method for fully coupled linear thermo-elasto-dynamic problems with strain and heat flux discontinuities",
-   journal = "Comput. Meth. Appl. Mech. Engrg.",
-   year    = "2008",
-   volume  = "197",
-   pages   = "1323--1342",
-   url     = "",
-   doi     = ""
+   author  = {D. K. Khalmanova and F. Costanzo},
+   title   = {A space-time discontinuous Galerkin finite element method for fully coupled linear thermo-elasto-dynamic problems with strain and heat flux discontinuities},
+   journal = {Comput. Meth. Appl. Mech. Engrg.},
+   year    = {2008},
+   volume  = {197},
+   pages   = {1323--1342},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2008_22,
-   author  = "L. Khasina",
-   title   = "Mathematische Behandlung von Mischungen elastoplastischer Substanzen",
-   year    = "2008",
-   school  = "University of Bonn, Germany",
-   url     = ""
+   author  = {L. Khasina},
+   title   = {Mathematische Behandlung von Mischungen elastoplastischer Substanzen},
+   year    = {2008},
+   school  = {University of Bonn, Germany},
+   url     = {}
 }
 
 @article{2008_23,
-   author  = "M. Kronbichler and G. Kreiss",
-   title   = "A hybrid level&ndash;set&ndash;Cahn&ndash;Hilliard model for two-phase flow",
-   journal = "Proceedings of the 1st European Conference on Microfluidics, accepted for publication. Microfluidics 2008, Bologna, Italy, December 10&ndash;12",
-   year    = "2008",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Kronbichler and G. Kreiss},
+   title   = {A hybrid level--set--Cahn--Hilliard model for two-phase flow},
+   journal = {Proceedings of the 1st European Conference on Microfluidics, accepted for publication. Microfluidics 2008, Bologna, Italy, December 10--12},
+   year    = {2008},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_24,
-   author  = "T. Leicht and R. Hartmann",
-   title   = "Anisotropic mesh refinement for discontinuous Galerkin methods in two-dimensional aerodynamic flow simulations",
-   journal = "Int. J. Numer. Meth. Fluids, no. 11",
-   year    = "2008",
-   volume  = "56",
-   pages   = "2111--2138",
-   url     = "",
-   doi     = ""
+   author  = {T. Leicht and R. Hartmann},
+   title   = {Anisotropic mesh refinement for discontinuous Galerkin methods in two-dimensional aerodynamic flow simulations},
+   journal = {Int. J. Numer. Meth. Fluids, no. 11},
+   year    = {2008},
+   volume  = {56},
+   pages   = {2111--2138},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2008_25,
-   author  = "J. L&ouml;we",
-   title   = "Stabilisierung durch lokale Projektion f&uuml;r inkompressible Str&ouml;mungsprobleme",
-   year    = "2008",
-   school  = "University of G&ouml;ttingen, Germany",
-   url     = ""
+   author  = {J. L\"{o}we},
+   title   = {Stabilisierung durch lokale Projektion f\"{u}r inkompressible Str\"{o}mungsprobleme},
+   year    = {2008},
+   school  = {University of G\"{o}ttingen, Germany},
+   url     = {}
 }
 
 @article{2008_26,
-   author  = "M. Neytcheva and E. B&auml;ngtsson",
-   title   = "Preconditioning of nonsymmetric saddle point systems as arising in modelling of viscoelastic problems",
-   journal = "ETNA",
-   year    = "2008",
-   volume  = "29",
-   pages   = "193--211",
-   url     = "",
-   doi     = ""
+   author  = {M. Neytcheva and E. B\"{a}ngtsson},
+   title   = {Preconditioning of nonsymmetric saddle point systems as arising in modelling of viscoelastic problems},
+   journal = {ETNA},
+   year    = {2008},
+   volume  = {29},
+   pages   = {193--211},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_27,
-   author  = "J. S. Pitt and F. Costanzo",
-   title   = "Theory and simulation of a brittle damage model in thermoelastodynamics",
-   journal = "Proceedings of the 8th World Congress on Computational Mechanics (WCCM 8), Venice, Italy",
-   year    = "2008",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. S. Pitt and F. Costanzo},
+   title   = {Theory and simulation of a brittle damage model in thermoelastodynamics},
+   journal = {Proceedings of the 8th World Congress on Computational Mechanics (WCCM 8), Venice, Italy},
+   year    = {2008},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2008_28,
-   author  = "K. Schmid",
-   title   = "Theory and numerics of a reconstruction algorithm for a problem from acoustic microscopy",
-   year    = "2008",
-   school  = "Technical University of Munich, Germany",
-   url     = ""
+   author  = {K. Schmid},
+   title   = {Theory and numerics of a reconstruction algorithm for a problem from acoustic microscopy},
+   year    = {2008},
+   school  = {Technical University of Munich, Germany},
+   url     = {}
 }
 
 @article{2008_29,
-   author  = "M. Secanell and K. Karan and A. Suleman and N. Djilali",
-   title   = "Optimal design of ultralow-platinum PEMFC anode electrodes",
-   journal = "Journal of The Electrochemical Society, pp. B125-B134",
-   year    = "2008",
-   volume  = "155",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Secanell and K. Karan and A. Suleman and N. Djilali},
+   title   = {Optimal design of ultralow-platinum PEMFC anode electrodes},
+   journal = {Journal of The Electrochemical Society, pp. B125-B134},
+   year    = {2008},
+   volume  = {155},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_30,
-   author  = "M. Secanell and R. Songprakorp and A. Suleman and N. Djilali",
-   title   = "Multi-objective optimization of a polymer electrolyte fuel cell membrane electrode assembly",
-   journal = "Energy &amp; Environmental Science",
-   year    = "2008",
-   volume  = "1",
-   pages   = "378--388",
-   url     = "",
-   doi     = ""
+   author  = {M. Secanell and R. Songprakorp and A. Suleman and N. Djilali},
+   title   = {Multi-objective optimization of a polymer electrolyte fuel cell membrane electrode assembly},
+   journal = {Energy \& Environmental Science},
+   year    = {2008},
+   volume  = {1},
+   pages   = {378--388},
+   url     = {},
+   doi     = {}
 }
 
 @article{2008_31,
-   author  = "J. A. White and R. I. Borja",
-   title   = "Stabilized low-order finite elements for coupled solid-deformation/fluid-diffusion and their application to fault zone transients",
-   journal = "Comput. Meth. Appl. Mech. Engrg.",
-   year    = "2008",
-   volume  = "197",
-   pages   = "4353--4366",
-   url     = "",
-   doi     = ""
+   author  = {J. A. White and R. I. Borja},
+   title   = {Stabilized low-order finite elements for coupled solid-deformation/fluid-diffusion and their application to fault zone transients},
+   journal = {Comput. Meth. Appl. Mech. Engrg.},
+   year    = {2008},
+   volume  = {197},
+   pages   = {4353--4366},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2008_32,
-   author  = "T. Wick",
-   title   = "Untersuchung von Kopplungsmechanismen von Fluid-Struktur-Interaktion",
-   year    = "2008",
-   school  = "Universit&auml;t Siegen, Germany",
-   url     = ""
+   author  = {T. Wick},
+   title   = {Untersuchung von Kopplungsmechanismen von Fluid-Struktur-Interaktion},
+   year    = {2008},
+   school  = {Universit\"{a}t Siegen, Germany},
+   url     = {}
 }
 
 @phdthesis{2008_33,
-   author  = "R. Ziegler",
-   title   = "Modeling photon transport and reconstruction of optical properties for performance assessment of laser and fluorescence mammographs and analysis of clinical data",
-   year    = "2008",
-   school  = "Freie Universit&auml;t Berlin",
-   url     = ""
+   author  = {R. Ziegler},
+   title   = {Modeling photon transport and reconstruction of optical properties for performance assessment of laser and fluorescence mammographs and analysis of clinical data},
+   year    = {2008},
+   school  = {Freie Universit\"{a}t Berlin},
+   url     = {}
 }
 
 @article{2008_34,
-   author  = "R. Ziegler and B. Brendel and A. Ziegler and T. Nielsen and H. Rinneberg",
-   title   = "Nonlinear Reconstruction of Continuous Wave Diffuse Optical Tomography Using Fitted Diffusion Coefficients",
-   journal = "Doi: 10.1364/BIOMED.2008.BSuE44,  Biomedical Optics . Florida, USA",
-   year    = "2008",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.osapublishing.org/abstract.cfm?uri=BIOMED-2008-BSuE44",
-   doi     = ""
+   author  = {R. Ziegler and B. Brendel and A. Ziegler and T. Nielsen and H. Rinneberg},
+   title   = {Nonlinear Reconstruction of Continuous Wave Diffuse Optical Tomography Using Fitted Diffusion Coefficients},
+   journal = {Doi: 10.1364/BIOMED.2008.BSuE44,  Biomedical Optics . Florida, USA},
+   year    = {2008},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.osapublishing.org/abstract.cfm?uri=BIOMED-2008-BSuE44},
+   doi     = {}
 }
 
 @article{2008_41,
-   author  = "G. Lube and B. Tews",
-   title   = "Optimal control of singularly perturbed advection-diffusion-reaction problems",
-   journal = "Math. Model. Meths. Appl. Sc., Vol. 20, No. 3, 375-395, 2010. (<a href="http://dx.doi.org/10.1142/S0218202510004271">DOI</a>)<br> Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G&ouml;ttingen, Germany",
-   year    = "2008",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {G. Lube and B. Tews},
+   title   = {Optimal control of singularly perturbed advection-diffusion-reaction problems},
+   journal = {Math. Model. Meths. Appl. Sc.},
+   year    = {2010},
+   volume  = {20},
+   number  = {3},
+   pages   = {375--395},
+   url     = {},
+   doi     = {10.1142/S0218202510004271},
+   comment = {Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G\"{o}ttingen, Germany}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2009.bib
+++ b/publications-2009.bib
@@ -1,558 +1,558 @@
 % Encoding: ISO-8859-1
 
 @article{2009_0,
-   author  = "S. G. Abaimov and A. Roy and J.P. Cusumano",
-   title   = "Damage nucleation phenomena: Statistics of times to failure",
-   journal = "arXiv:0910.5179",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/0910.5179",
-   doi     = ""
+   author  = {S. G. Abaimov and A. Roy and J.P. Cusumano},
+   title   = {Damage nucleation phenomena: Statistics of times to failure},
+   journal = {arXiv:0910.5179},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/0910.5179},
+   doi     = {}
 }
 
 @article{2009_1,
-   author  = "W. Bangerth and A. Joshi",
-   title   = "Adaptive finite element methods for nonlinear inverse problems",
-   journal = "Proceedings of the 2009 ACM Symposium on Applied Computing",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and A. Joshi},
+   title   = {Adaptive finite element methods for nonlinear inverse problems},
+   journal = {Proceedings of the 2009 ACM Symposium on Applied Computing},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_2,
-   author  = "W. Bangerth and O. Kayser-Herold",
-   title   = "Data Structures and Requirements for hp Finite Element Software",
-   journal = "ACM Trans. Math. Softw., pp. 4/1-31",
-   year    = "2009",
-   volume  = "36",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and O. Kayser-Herold},
+   title   = {Data Structures and Requirements for hp Finite Element Software},
+   journal = {ACM Trans. Math. Softw., pp. 4/1-31},
+   year    = {2009},
+   volume  = {36},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_3,
-   author  = "S. Bartle",
-   title   = "Shell finite elements with applications in biomechanics",
-   year    = "2009",
-   school  = "University of Cape Town, South Africa",
-   url     = ""
+   author  = {S. Bartle},
+   title   = {Shell finite elements with applications in biomechanics},
+   year    = {2009},
+   school  = {University of Cape Town, South Africa},
+   url     = {}
 }
 
 @article{2009_4,
-   author  = "S. Bartle and A. McBride and B. D. Reddy",
-   title   = "A discontinuous Galerkin formulation of a model of gradient plasticity at finite strains",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2009",
-   volume  = "198",
-   pages   = "1805--1820",
-   url     = "",
-   doi     = ""
+   author  = {S. Bartle and A. McBride and B. D. Reddy},
+   title   = {A discontinuous Galerkin formulation of a model of gradient plasticity at finite strains},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2009},
+   volume  = {198},
+   pages   = {1805--1820},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_5,
-   author  = "F. Bassi and C. De Bartolo and R. Hartmann and A. Nigro",
-   title   = "A discontinuous Galerkin method for inviscid low Mach number flows",
-   journal = "J. Comput. Phys., no. 11",
-   year    = "2009",
-   volume  = "228",
-   pages   = "3996--4011",
-   url     = "",
-   doi     = ""
+   author  = {F. Bassi and C. De Bartolo and R. Hartmann and A. Nigro},
+   title   = {A discontinuous Galerkin method for inviscid low Mach number flows},
+   journal = {J. Comput. Phys., no. 11},
+   year    = {2009},
+   volume  = {228},
+   pages   = {3996--4011},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_6,
-   author  = "B. Brendel and T. Nielsen",
-   title   = "Selection of optimal wavelengths for spectral reconstruction in diffuse optical tomography",
-   journal = "J. Biomed. Optics, 034041/1-034041/10",
-   year    = "2009",
-   volume  = "14",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Brendel and T. Nielsen},
+   title   = {Selection of optimal wavelengths for spectral reconstruction in diffuse optical tomography},
+   journal = {J. Biomed. Optics, 034041/1-034041/10},
+   year    = {2009},
+   volume  = {14},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_7,
-   author  = "M. Čapek",
-   title   = "Metoda vrstevnic a modelování proudění nemísitelných nestlačitelných tekutin",
-   journal = "PhD dissertation, Charles University, Prague, Czech Republic",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "https://dspace.cuni.cz/handle/20.500.11956/22847",
-   doi     = ""
+   author  = {\v{C}apek, Marek},
+   title   = {Metoda vrstevnic a modelov\'{a}n\'{i} proud\v{e}n\'{i} nem\'{i}siteln\'{y}ch nestla\v{c}iteln\'{y}ch tekutin},
+   journal = {PhD dissertation, Charles University, Prague, Czech Republic},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {https://dspace.cuni.cz/handle/20.500.11956/22847},
+   doi     = {}
 }
 
 @article{2009_8,
-   author  = "C. Clason and P. Hepperger",
-   title   = "A forward approach to numerical data assimilation",
-   journal = "SIAM J. Sc. Comput.",
-   year    = "2009",
-   volume  = "31",
-   pages   = "3090--3115",
-   url     = "",
-   doi     = ""
+   author  = {C. Clason and P. Hepperger},
+   title   = {A forward approach to numerical data assimilation},
+   journal = {SIAM J. Sc. Comput.},
+   year    = {2009},
+   volume  = {31},
+   pages   = {3090--3115},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_9,
-   author  = "B. Cockburn and G. Kanschat and and D. Sch&ouml;tzau",
-   title   = "An equal-order DG method for the incompressible Navier-Stokes equations",
-   journal = "J. Sci. Comput.",
-   year    = "2009",
-   volume  = "40",
-   pages   = "188--210",
-   url     = "",
-   doi     = "10.1007/s10915-008-9261-1"
+   author  = {B. Cockburn and G. Kanschat and and D. Sch\"{o}tzau},
+   title   = {An equal-order DG method for the incompressible Navier-Stokes equations},
+   journal = {J. Sci. Comput.},
+   year    = {2009},
+   volume  = {40},
+   pages   = {188--210},
+   url     = {},
+   doi     = {10.1007/s10915-008-9261-1}
 }
 
 @article{2009_10,
-   author  = "A. DeSimone and L. Heltai and C. Manigrasso",
-   title   = "Tools for the Solution of PDEs Defined on Curved Manifolds with the deal.II Library",
-   journal = "Prep. SISSA 42/2009/M",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. DeSimone and L. Heltai and C. Manigrasso},
+   title   = {Tools for the Solution of PDEs Defined on Curved Manifolds with the deal.II Library},
+   journal = {Prep. SISSA 42/2009/M},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_11,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "From Non-Linear Elasticity to Linearized Theory: Examples Defying Intuition",
-   journal = "J. of Elasticity",
-   year    = "2009",
-   volume  = "96",
-   pages   = "1--26",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {From Non-Linear Elasticity to Linearized Theory: Examples Defying Intuition},
+   journal = {J. of Elasticity},
+   year    = {2009},
+   volume  = {96},
+   pages   = {1--26},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_12,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "Variational models for cleavage and shear fractures",
-   journal = "Proceedings of the XIX Congresso Aimeta, Ancona",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {Variational models for cleavage and shear fractures},
+   journal = {Proceedings of the XIX Congresso Aimeta, Ancona},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_13,
-   author  = "J. Frohne",
-   title   = "Numerische L&ouml;sung des inversen W&auml;rmeleitproblems in zwei Ortsdimensionen zur Identifizierung von Randbedingungen",
-   year    = "2009",
-   school  = "Universit&auml;t Siegen, Germany",
-   url     = ""
+   author  = {J. Frohne},
+   title   = {Numerische L\"{o}sung des inversen W\"{a}rmeleitproblems in zwei Ortsdimensionen zur Identifizierung von Randbedingungen},
+   year    = {2009},
+   school  = {Universit\"{a}t Siegen, Germany},
+   url     = {}
 }
 
 @article{2009_14,
-   author  = "T. George and A. Gupta and V. Sarin",
-   title   = "An empirical analysis of the performance of iterative solvers for SPD systems",
-   journal = "IBM TJ Watson Research Center, Tech. Rep. RC24737",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. George and A. Gupta and V. Sarin},
+   title   = {An empirical analysis of the performance of iterative solvers for SPD systems},
+   journal = {IBM TJ Watson Research Center, Tech. Rep. RC24737},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_15,
-   author  = "P. Ghysels and G. Samaey and B. Tijskens and P. Van Liedekerke and H. Ramon and D. Roose",
-   title   = "Multi-scale simulation of plant tissue deformation using a model for individual cell mechanics",
-   journal = "Phys. Biol., pp. 016009/1-14",
-   year    = "2009",
-   volume  = "6",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {P. Ghysels and G. Samaey and B. Tijskens and P. Van Liedekerke and H. Ramon and D. Roose},
+   title   = {Multi-scale simulation of plant tissue deformation using a model for individual cell mechanics},
+   journal = {Phys. Biol., pp. 016009/1-14},
+   year    = {2009},
+   volume  = {6},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_16,
-   author  = "S. Gladkov and M. Stiemer and B. Svendsen",
-   title   = "Phase-field-based modeling and simulation of solidification and deformation behavior of technological alloys",
-   journal = "PAMM",
-   year    = "2009",
-   volume  = "8",
-   pages   = "10547--10548",
-   url     = "",
-   doi     = ""
+   author  = {S. Gladkov and M. Stiemer and B. Svendsen},
+   title   = {Phase-field-based modeling and simulation of solidification and deformation behavior of technological alloys},
+   journal = {PAMM},
+   year    = {2009},
+   volume  = {8},
+   pages   = {10547--10548},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_17,
-   author  = "R. Hartmann and M. Lukacova-Medvidova and F. Prill",
-   title   = "Efficient preconditioning for the discontinuous Galerkin finite element method by low-order elements",
-   journal = "Appl. Numer. Math., no. 8",
-   year    = "2009",
-   volume  = "59",
-   pages   = "1737--1753",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and M. Lukacova-Medvidova and F. Prill},
+   title   = {Efficient preconditioning for the discontinuous Galerkin finite element method by low-order elements},
+   journal = {Appl. Numer. Math., no. 8},
+   year    = {2009},
+   volume  = {59},
+   pages   = {1737--1753},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_18,
-   author  = "C. Henke",
-   title   = "Nichtlineare, mehrskalige kunstliche Diffusion und L1(L1)-Beschranktheit bei DG-L̈osungen ḧoherer Ordnung von Erhaltungsgleichungen",
-   journal = "PhD dissertation, Technischen Universitat Clausthal",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "http://d-nb.info/1001190246/34/",
-   doi     = ""
+   author  = {C. Henke},
+   title   = {Nichtlineare, mehrskalige kunstliche Diffusion und L$^{\infty}$(L$^{\infty}$)-Beschr\"{a}nktheit bei DG-L\"{o}sungen h\"{o}herer Ordnung von Erhaltungsgleichungen},
+   journal = {PhD dissertation, Technischen Universit\"{a}t Clausthal},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {http://d-nb.info/1001190246/34/},
+   doi     = {}
 }
 
 @article{2009_19,
-   author  = "H. K. Hesse and G. Kanschat",
-   title   = "Mesh Adaptive Multiple Shooting for Partial Differential Equations. Part I: Linear Quadratic Optimal Control Problems",
-   journal = "Journal of Numerical Mathematics",
-   year    = "2009",
-   volume  = "17",
-   pages   = "195--217",
-   url     = "",
-   doi     = ""
+   author  = {H. K. Hesse and G. Kanschat},
+   title   = {Mesh Adaptive Multiple Shooting for Partial Differential Equations. Part I: Linear Quadratic Optimal Control Problems},
+   journal = {Journal of Numerical Mathematics},
+   year    = {2009},
+   volume  = {17},
+   pages   = {195--217},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_20,
-   author  = "D. Hyde and R. Schulz and D. Brooks and E. Miller and V. Ntziachristos",
-   title   = "Performance dependence of hybrid x-ray computed tomography/fluorescence molecular tomography on the optical forward problem",
-   journal = "J. Optical Soc. Amer.",
-   year    = "2009",
-   volume  = "26",
-   pages   = "919--923",
-   url     = "",
-   doi     = ""
+   author  = {D. Hyde and R. Schulz and D. Brooks and E. Miller and V. Ntziachristos},
+   title   = {Performance dependence of hybrid x-ray computed tomography/fluorescence molecular tomography on the optical forward problem},
+   journal = {J. Optical Soc. Amer.},
+   year    = {2009},
+   volume  = {26},
+   pages   = {919--923},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_21,
-   author  = "T. Jetzfellner and D. Razansky and A. Rosenthal and R. Schulz and K.-H. Englmeier and V. Ntziachristos",
-   title   = "Performance of iterative optoacoustic tomography with experimental data",
-   journal = "Appl. Phys. Lett., pp. 013703/1-3",
-   year    = "2009",
-   volume  = "95",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Jetzfellner and D. Razansky and A. Rosenthal and R. Schulz and K.-H. Englmeier and V. Ntziachristos},
+   title   = {Performance of iterative optoacoustic tomography with experimental data},
+   journal = {Appl. Phys. Lett., pp. 013703/1-3},
+   year    = {2009},
+   volume  = {95},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_22,
-   author  = "J. Jung",
-   title   = "Mehrgitterverfahren f&uuml;r FE-Modelle 4. Ordnung",
-   year    = "2009",
-   school  = "Universit&auml;t Siegen, Germany",
-   url     = ""
+   author  = {J. Jung},
+   title   = {Mehrgitterverfahren f\"{u}r FE-Modelle 4. Ordnung},
+   year    = {2009},
+   school  = {Universit\"{a}t Siegen, Germany},
+   url     = {}
 }
 
 @phdthesis{2009_23,
-   author  = "S. Kim",
-   title   = "Analysis of a PML method applied to computation of resonances in open systems and acoustic scattering problems",
-   year    = "2009",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {S. Kim},
+   title   = {Analysis of a PML method applied to computation of resonances in open systems and acoustic scattering problems},
+   year    = {2009},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2009_24,
-   author  = "S. Kim and J. E. Pasciak",
-   title   = "The computation of resonances in open systems using a perfectly matched layer",
-   journal = "Math. Comp.",
-   year    = "2009",
-   volume  = "78",
-   pages   = "1375--1398",
-   url     = "",
-   doi     = ""
+   author  = {S. Kim and J. E. Pasciak},
+   title   = {The computation of resonances in open systems using a perfectly matched layer},
+   journal = {Math. Comp.},
+   year    = {2009},
+   volume  = {78},
+   pages   = {1375--1398},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_25,
-   author  = "N. Klein",
-   title   = "Modelladaptive FE-Techniken bei Elastizit&auml;tsproblemen mit gro&szlig;en Verformungen",
-   year    = "2009",
-   school  = "Universit&auml;t Siegen, Germany",
-   url     = ""
+   author  = {N. Klein},
+   title   = {Modelladaptive FE-Techniken bei Elastizit\"{a}tsproblemen mit gro{\ss}en Verformungen},
+   year    = {2009},
+   school  = {Universit\"{a}t Siegen, Germany},
+   url     = {}
 }
 
 @article{2009_26,
-   author  = "M. Kronbichler",
-   title   = "Numerical Methods for the Navier–Stokes Equations applied to Turbulent Flow and to Multi-Phase Flow",
-   journal = "Dissertation for the degree of Licentiate of Philosophy in Scientific Computing with specialization in Numerical Analysis, Uppsala University",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "http://uu.diva-portal.org/smash/get/diva2:275573/FULLTEXT01.pdf",
-   doi     = ""
+   author  = {M. Kronbichler},
+   title   = {Numerical Methods for the Navier-Stokes Equations applied to Turbulent Flow and to Multi-Phase Flow},
+   journal = {Dissertation for the degree of Licentiate of Philosophy in Scientific Computing with specialization in Numerical Analysis, Uppsala University},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {http://uu.diva-portal.org/smash/get/diva2:275573/FULLTEXT01.pdf},
+   doi     = {}
 }
 
 @mastersthesis{2009_27,
-   author  = "J. Lorentzon",
-   title   = "Fluid-structure interaction (FSI) case study of a cantilever using OpenFOAM and DEAL.II with application to VIV",
-   year    = "2009",
-   school  = "Lunds Institute of Technology, Sweden",
-   url     = ""
+   author  = {J. Lorentzon},
+   title   = {Fluid-structure interaction (FSI) case study of a cantilever using OpenFOAM and DEAL.II with application to VIV},
+   year    = {2009},
+   school  = {Lunds Institute of Technology, Sweden},
+   url     = {}
 }
 
 @article{2009_28,
-   author  = "G. Matthies and G. Lube and L. R&ouml;he",
-   title   = "Some remarks on streamline-diffusion methods for inf-sup stable discretisations of the generalised Oseen problem",
-   journal = "Comp. Meths. Appl. Math. Vol. 9 ",
-   year    = "2009",
-   volume  = "",
-   pages   = "1--23",
-   url     = "",
-   doi     = ""
+   author  = {G. Matthies and G. Lube and L. R\"{o}he},
+   title   = {Some remarks on streamline-diffusion methods for inf-sup stable discretisations of the generalised Oseen problem},
+   journal = {Comp. Meths. Appl. Math. Vol. 9 },
+   year    = {2009},
+   volume  = {},
+   pages   = {1--23},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_29,
-   author  = "A. M. McMahon",
-   title   = "Modelling the Flow Behaviour of Gas Bubbles in a Bubble Column",
-   year    = "2009",
-   school  = "University of Cape Town, South Africa",
-   url     = ""
+   author  = {A. M. McMahon},
+   title   = {Modelling the Flow Behaviour of Gas Bubbles in a Bubble Column},
+   year    = {2009},
+   school  = {University of Cape Town, South Africa},
+   url     = {}
 }
 
 @article{2009_30,
-   author  = "S. T. Miller and F. Costanzo",
-   title   = "A numerical verification for an unconditionally stable FEM for elastodynamics",
-   journal = "Comp. Mech.",
-   year    = "2009",
-   volume  = "43",
-   pages   = "223--237",
-   url     = "",
-   doi     = ""
+   author  = {S. T. Miller and F. Costanzo},
+   title   = {A numerical verification for an unconditionally stable FEM for elastodynamics},
+   journal = {Comp. Mech.},
+   year    = {2009},
+   volume  = {43},
+   pages   = {223--237},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_31,
-   author  = "M. Olshanskii and G. Lube and T. Heister and J. L&ouml;we",
-   title   = "Grad-div stabilization and subgrid pressure models for the incompressible Navier–Stokes equations",
-   journal = "Comp. Meth. Appl. Mech. Eng. V. 198",
-   year    = "2009",
-   volume  = "",
-   pages   = "3975--3988",
-   url     = "",
-   doi     = ""
+   author  = {M. Olshanskii and G. Lube and T. Heister and J. L\"{o}we},
+   title   = {Grad-div stabilization and subgrid pressure models for the incompressible Navier--Stokes equations},
+   journal = {Comp. Meth. Appl. Mech. Eng. V. 198},
+   year    = {2009},
+   volume  = {},
+   pages   = {3975--3988},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_32,
-   author  = "J. S. Pitt and F. Costanzo",
-   title   = "An adaptive h-refinement algorithm for local damage models",
-   journal = "Algorithms",
-   year    = "2009",
-   volume  = "2",
-   pages   = "1281--1300",
-   url     = "",
-   doi     = ""
+   author  = {J. S. Pitt and F. Costanzo},
+   title   = {An adaptive h-refinement algorithm for local damage models},
+   journal = {Algorithms},
+   year    = {2009},
+   volume  = {2},
+   pages   = {1281--1300},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_33,
-   author  = "L. Plagne and F. H&uuml;lsemann and D. Barthou and J. Jaeger",
-   title   = "Parallel expression template for large vectors",
-   journal = "Proceedings of the 8th workshop on Parallel/High-Performance Object-Oriented Scientific Computing, European Conference on Object-Oriented Programming",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {L. Plagne and F. H\"{u}lsemann and D. Barthou and J. Jaeger},
+   title   = {Parallel expression template for large vectors},
+   journal = {Proceedings of the 8th workshop on Parallel/High-Performance Object-Oriented Scientific Computing, European Conference on Object-Oriented Programming},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_34,
-   author  = "F. Prill and M. Lukacova-Medvidova and R. Hartmann",
-   title   = "A multilevel discontinuous Galerkin method for the compressible Navier-Stokes equations",
-   journal = "In A. Handlovicova, P. Frolkovic, K. Mikula and D. Sevcovic, eds., Proceedings of ALGORITMY 2009. 18th Conference on Scientific Computing Vysoke Tatry - Podbanske, Slovakia, March 15 - 20",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {F. Prill and M. Lukacova-Medvidova and R. Hartmann},
+   title   = {A multilevel discontinuous Galerkin method for the compressible Navier-Stokes equations},
+   journal = {In A. Handlovicova, P. Frolkovic, K. Mikula and D. Sevcovic, eds., Proceedings of ALGORITMY 2009. 18th Conference on Scientific Computing Vysoke Tatry - Podbanske, Slovakia, March 15 - 20},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_35,
-   author  = "F. Prill and M. Lukacova-Medvidova and R. Hartmann",
-   title   = "Smoothed aggregation multigrid for the discontinuous Galerkin method",
-   journal = "SIAM J. Sci. Comput., no. 5",
-   year    = "2009",
-   volume  = "31",
-   pages   = "3503--3528",
-   url     = "",
-   doi     = ""
+   author  = {F. Prill and M. Lukacova-Medvidova and R. Hartmann},
+   title   = {Smoothed aggregation multigrid for the discontinuous Galerkin method},
+   journal = {SIAM J. Sci. Comput., no. 5},
+   year    = {2009},
+   volume  = {31},
+   pages   = {3503--3528},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_36,
-   author  = "A. Q. Raeini",
-   title   = "Fractured reservoir simulation using finite element method with logarithmic shape functions (in Persian)",
-   year    = "2009",
-   school  = "Sharif University of Technology, Iran",
-   url     = ""
+   author  = {A. Q. Raeini},
+   title   = {Fractured reservoir simulation using finite element method with logarithmic shape functions (in Persian)},
+   year    = {2009},
+   school  = {Sharif University of Technology, Iran},
+   url     = {}
 }
 
 @article{2009_37,
-   author  = "H. R. Ramay and M. Vendelin",
-   title   = "Diffusion restrictions surrounding mitochondria: a mathematical model of heart muscle fibers",
-   journal = "Biophys. J.",
-   year    = "2009",
-   volume  = "97",
-   pages   = "443--452",
-   url     = "",
-   doi     = ""
+   author  = {H. R. Ramay and M. Vendelin},
+   title   = {Diffusion restrictions surrounding mitochondria: a mathematical model of heart muscle fibers},
+   journal = {Biophys. J.},
+   year    = {2009},
+   volume  = {97},
+   pages   = {443--452},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_38,
-   author  = "R. Rannacher",
-   title   = "Adaptive Finite Element Discretization of Flow Problems for Goal-Oriented Model Reduction",
-   journal = "In: Computational Fluid Dynamics 2008 (H. Choi, H. G. Choi and J. Y. Yoo, eds.), Springer",
-   year    = "2009",
-   volume  = "",
-   pages   = "31--45",
-   url     = "",
-   doi     = ""
+   author  = {R. Rannacher},
+   title   = {Adaptive Finite Element Discretization of Flow Problems for Goal-Oriented Model Reduction},
+   journal = {In: Computational Fluid Dynamics 2008 (H. Choi, H. G. Choi and J. Y. Yoo, eds.), Springer},
+   year    = {2009},
+   volume  = {},
+   pages   = {31--45},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_39,
-   author  = "B. R&uuml;ger and J. Joos and T. Carraro and A. Weber and E. Ivers-Tiff&eacute;e",
-   title   = "3D Electrode Microstructure Reconstruction and Modelling",
-   journal = "ECS Trans. 25",
-   year    = "2009",
-   volume  = "",
-   pages   = "1211--1220",
-   url     = "",
-   doi     = ""
+   author  = {B. R\"{u}ger and J. Joos and T. Carraro and A. Weber and E. Ivers-Tiff\'{e}e},
+   title   = {3D Electrode Microstructure Reconstruction and Modelling},
+   journal = {ECS Trans. 25},
+   year    = {2009},
+   volume  = {},
+   pages   = {1211--1220},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_40,
-   author  = "D. Sch&ouml;tzau and L. Zhu",
-   title   = "A robust a-posteriori error estimator for discontinuous Galerkin methods for convection-diffusion equations",
-   journal = "Appl. Numer. Math.",
-   year    = "2009",
-   volume  = "59",
-   pages   = "2236--2255",
-   url     = "",
-   doi     = ""
+   author  = {D. Sch\"{o}tzau and L. Zhu},
+   title   = {A robust a-posteriori error estimator for discontinuous Galerkin methods for convection-diffusion equations},
+   journal = {Appl. Numer. Math.},
+   year    = {2009},
+   volume  = {59},
+   pages   = {2236--2255},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_41,
-   author  = "N. Schr&ouml;der",
-   title   = "Simulation eines mikrofluidischen Kanals mit deal.II",
-   year    = "2009",
-   school  = "Universit&auml;t Siegen, Germany",
-   url     = ""
+   author  = {N. Schr\"{o}der},
+   title   = {Simulation eines mikrofluidischen Kanals mit deal.II},
+   year    = {2009},
+   school  = {Universit\"{a}t Siegen, Germany},
+   url     = {}
 }
 
 @phdthesis{2009_42,
-   author  = "Y. Wang",
-   title   = "Adaptive mesh refinement solution techniques for the multigrid S<sub>N</sub> transport equation using a higher-order discontinuous finite element method",
-   year    = "2009",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {Y. Wang},
+   title   = {Adaptive mesh refinement solution techniques for the multigrid S$_{\textnormal{N}}$ transport equation using a higher-order discontinuous finite element method},
+   year    = {2009},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2009_43,
-   author  = "Y. Wang and W. Bangerth and J. Ragusa",
-   title   = "Three-dimensional h-adaptivity for the multigroup neutron diffusion equations",
-   journal = "Progress in Nuclear Energy",
-   year    = "2009",
-   volume  = "51",
-   pages   = "543--555",
-   url     = "",
-   doi     = ""
+   author  = {Y. Wang and W. Bangerth and J. Ragusa},
+   title   = {Three-dimensional h-adaptivity for the multigroup neutron diffusion equations},
+   journal = {Progress in Nuclear Energy},
+   year    = {2009},
+   volume  = {51},
+   pages   = {543--555},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2009_44,
-   author  = "S. Wanka",
-   title   = "Grundkonzepte zur Modelladaptivit&auml;t bei Hindernisproblemen",
-   year    = "2009",
-   school  = "Universit&auml;t Siegen, Germany",
-   url     = ""
+   author  = {S. Wanka},
+   title   = {Grundkonzepte zur Modelladaptivit\"{a}t bei Hindernisproblemen},
+   year    = {2009},
+   school  = {Universit\"{a}t Siegen, Germany},
+   url     = {}
 }
 
 @phdthesis{2009_45,
-   author  = "J. White",
-   title   = "Stabilized finite element methods for coupled flow and geomechanics",
-   year    = "2009",
-   school  = "Stanford University",
-   url     = ""
+   author  = {J. White},
+   title   = {Stabilized finite element methods for coupled flow and geomechanics},
+   year    = {2009},
+   school  = {Stanford University},
+   url     = {}
 }
 
 @article{2009_46,
-   author  = "J. Willems",
-   title   = "Numerical Upscaling for Multiscale Flow Problems - Analysis and Algorithms",
-   journal = "S&uuml;dwestdeutscher Verlag f&uuml;r Hochschulschriften",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Willems},
+   title   = {Numerical Upscaling for Multiscale Flow Problems - Analysis and Algorithms},
+   journal = {S\"{u}dwestdeutscher Verlag f\"{u}r Hochschulschriften},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2009_47,
-   author  = "J. Willems",
-   title   = "Numerical upscaling for multiscale flow problems",
-   year    = "2009",
-   school  = "University of Kaiserslautern, Germany",
-   url     = ""
+   author  = {J. Willems},
+   title   = {Numerical upscaling for multiscale flow problems},
+   year    = {2009},
+   school  = {University of Kaiserslautern, Germany},
+   url     = {}
 }
 
 @article{2009_48,
-   author  = "T. D. Young and E. Romero and and J. E. Roman",
-   title   = "Finite element solution of the stationary Schr&ouml;dinger equation using standard computational tools",
-   journal = "In Proceedings of the International Conference on Computational and Mathematical Methods in Science and Engineering 2009, Gijon Asturias, Spain, July ",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. D. Young and E. Romero and and J. E. Roman},
+   title   = {Finite element solution of the stationary Schr\"{o}dinger equation using standard computational tools},
+   journal = {In Proceedings of the International Conference on Computational and Mathematical Methods in Science and Engineering 2009, Gijon Asturias, Spain, July },
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_49,
-   author  = "T. D. Young",
-   title   = "Exemplifying quantum systems in a finite element basis",
-   journal = "AIP Conf. Proc.",
-   year    = "2009",
-   volume  = "1148",
-   pages   = "285--289",
-   url     = "",
-   doi     = ""
+   author  = {T. D. Young},
+   title   = {Exemplifying quantum systems in a finite element basis},
+   journal = {AIP Conf. Proc.},
+   year    = {2009},
+   volume  = {1148},
+   pages   = {285--289},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_50,
-   author  = "R. Ziegler and B. Brendel and A. Schipper and R. Harbers and M. van Beek and H. Rinneberg and T. Nielsen",
-   title   = "Investigation of detection limits for diffuse optical tomography systems: I. Theory and experiment",
-   journal = "Phys. Med. Biol.",
-   year    = "2009",
-   volume  = "54",
-   pages   = "399--412",
-   url     = "",
-   doi     = ""
+   author  = {R. Ziegler and B. Brendel and A. Schipper and R. Harbers and M. van Beek and H. Rinneberg and T. Nielsen},
+   title   = {Investigation of detection limits for diffuse optical tomography systems: I. Theory and experiment},
+   journal = {Phys. Med. Biol.},
+   year    = {2009},
+   volume  = {54},
+   pages   = {399--412},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_51,
-   author  = "R. Ziegler and B. Brendel and H. Rinneberg and T. Nielsen",
-   title   = "Investigation of detection limits for diffuse optical tomography systems: II. Analysis of slab and cup geometry for breast imaging",
-   journal = "Phys. Med. Biol.",
-   year    = "2009",
-   volume  = "54",
-   pages   = "413--431",
-   url     = "",
-   doi     = ""
+   author  = {R. Ziegler and B. Brendel and H. Rinneberg and T. Nielsen},
+   title   = {Investigation of detection limits for diffuse optical tomography systems: II. Analysis of slab and cup geometry for breast imaging},
+   journal = {Phys. Med. Biol.},
+   year    = {2009},
+   volume  = {54},
+   pages   = {413--431},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_52,
-   author  = "R. Ziegler and T. Nielsen and T. Koehler and D. Grosnick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg",
-   title   = "Nonlinear reconstruction of absorption and fluorescence contrast from measured diffuse transmittance and reflectance of a compressed-breast-simulating phantom",
-   journal = "Applied Optics",
-   year    = "2009",
-   volume  = "48",
-   pages   = "4651--4662",
-   url     = "",
-   doi     = ""
+   author  = {R. Ziegler and T. Nielsen and T. Koehler and D. Grosnick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg},
+   title   = {Nonlinear reconstruction of absorption and fluorescence contrast from measured diffuse transmittance and reflectance of a compressed-breast-simulating phantom},
+   journal = {Applied Optics},
+   year    = {2009},
+   volume  = {48},
+   pages   = {4651--4662},
+   url     = {},
+   doi     = {}
 }
 
 @article{2009_53,
-   author  = "V. N. Zingan",
-   title   = "Discontinuous Galerkin Finite Element Method for the Nonlinear Hyperbolic Problems with Entropy-Bases Artificial Viscosity Stabilization",
-   journal = "PhD dissertation, Texas A&M University",
-   year    = "2009",
-   volume  = "",
-   pages   = "",
-   url     = "http://repository.tamu.edu/bitstream/handle/1969.1/ETD-TAMU-2009-12-7280/TRENEV-DISSERTATION.pdf?sequence=3",
-   doi     = ""
+   author  = {V. N. Zingan},
+   title   = {Discontinuous Galerkin Finite Element Method for the Nonlinear Hyperbolic Problems with Entropy-Bases Artificial Viscosity Stabilization},
+   journal = {PhD dissertation, Texas A \& M University},
+   year    = {2009},
+   volume  = {},
+   pages   = {},
+   url     = {http://repository.tamu.edu/bitstream/handle/1969.1/ETD-TAMU-2009-12-7280/TRENEV-DISSERTATION.pdf?sequence=3},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -1,672 +1,672 @@
 % Encoding: ISO-8859-1
 
 @article{2010_0,
-   author  = "M. Alexe and A. Sandu",
-   title   = "Space-time adaptive solution of inverse problems with the discrete adjoint method",
-   journal = "Technical Report TR-10-14, Computational Science Laboratory, Department of Computer Science, Virginia Tech",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Alexe and A. Sandu},
+   title   = {Space-time adaptive solution of inverse problems with the discrete adjoint method},
+   journal = {Technical Report TR-10-14, Computational Science Laboratory, Department of Computer Science, Virginia Tech},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_1,
-   author  = "M. S. Aln&aelig;s and K.-A. Mardal",
-   title   = "On the efficiency of symbolic computations combined with code generation for finite element methods",
-   journal = "ACM Transactions on Mathematical Software, 8/1-26",
-   year    = "2010",
-   volume  = "37",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. S. Aln\ae{}s and K.-A. Mardal},
+   title   = {On the efficiency of symbolic computations combined with code generation for finite element methods},
+   journal = {ACM Transactions on Mathematical Software, 8/1-26},
+   year    = {2010},
+   volume  = {37},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_2,
-   author  = "M. Arroyo and A. DeSimone and L. Heltai",
-   title   = "The role of membrane viscosity in the dynamics of fluid membranes",
-   journal = "arXiv:1007.4934",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1007.4934",
-   doi     = ""
+   author  = {M. Arroyo and A. DeSimone and L. Heltai},
+   title   = {The role of membrane viscosity in the dynamics of fluid membranes},
+   journal = {arXiv:1007.4934},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1007.4934},
+   doi     = {}
 }
 
 @article{2010_3,
-   author  = "J. Balzera and S. Werlingb",
-   title   = "Principles of Shape from Specular Reflection",
-   journal = "Measurement, issue 10, pp. 1305–1317",
-   year    = "2010",
-   volume  = "43",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0263224110001570",
-   doi     = ""
+   author  = {J. Balzera and S. Werlingb},
+   title   = {Principles of Shape from Specular Reflection},
+   journal = {Measurement, issue 10, pp. 1305--1317},
+   year    = {2010},
+   volume  = {43},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0263224110001570},
+   doi     = {}
 }
 
 @article{2010_4,
-   author  = "W. Bangerth and M. Geiger and R. Rannacher",
-   title   = "Adaptive Galerkin finite element methods for the wave equation",
-   journal = "Computational Methods in Applied Mathematics",
-   year    = "2010",
-   volume  = "10",
-   pages   = "3--48",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and M. Geiger and R. Rannacher},
+   title   = {Adaptive Galerkin finite element methods for the wave equation},
+   journal = {Computational Methods in Applied Mathematics},
+   year    = {2010},
+   volume  = {10},
+   pages   = {3--48},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_5,
-   author  = "S. Bartle and A. McBride and B. D. Reddy",
-   title   = "Shell finite elements, with applications in biomechanics",
-   journal = "In: Kok, S. (Ed.): Proceedings of 7th South African Conference on Computational and Applied Mechanics (University of Pretoria, Pretoria, South Africa)",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Bartle and A. McBride and B. D. Reddy},
+   title   = {Shell finite elements, with applications in biomechanics},
+   journal = {In: Kok, S. (Ed.): Proceedings of 7th South African Conference on Computational and Applied Mechanics (University of Pretoria, Pretoria, South Africa)},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_6,
-   author  = "A. Cangiani and R. Natalini",
-   title   = "A spatial model of cellular molecular trafficking including active transport along microtubules",
-   journal = "Journal of Theoretical Biology",
-   year    = "2010",
-   volume  = "267",
-   pages   = "614--625",
-   url     = "",
-   doi     = ""
+   author  = {A. Cangiani and R. Natalini},
+   title   = {A spatial model of cellular molecular trafficking including active transport along microtubules},
+   journal = {Journal of Theoretical Biology},
+   year    = {2010},
+   volume  = {267},
+   pages   = {614--625},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_7,
-   author  = "C. Chauvin and P. Saramito and C. Trophime",
-   title   = "Convergence properties and numerical simulation by an adaptive FEM of the thermistor problem",
-   journal = "hal-00449960, version 1",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "https://hal.archives-ouvertes.fr/hal-00449960/",
-   doi     = ""
+   author  = {C. Chauvin and P. Saramito and C. Trophime},
+   title   = {Convergence properties and numerical simulation by an adaptive FEM of the thermistor problem},
+   journal = {hal-00449960, version 1},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {https://hal.archives-ouvertes.fr/hal-00449960/},
+   doi     = {}
 }
 
 @phdthesis{2010_8,
-   author  = "C. C. Chueh",
-   title   = "Integrated adaptive numerical methods for transient two-phase flow in heterogeneous porous medi",
-   year    = "2010",
-   school  = "University of Victoria",
-   url     = ""
+   author  = {C. C. Chueh},
+   title   = {Integrated adaptive numerical methods for transient two-phase flow in heterogeneous porous medi},
+   year    = {2010},
+   school  = {University of Victoria},
+   url     = {}
 }
 
 @article{2010_9,
-   author  = "C. C. Chueh and M. Secanell and W. Bangerth and N. Djilali",
-   title   = "Multi-level Adaptive Simulation of Transient Two-phase Flow in Heterogeneous Porous Media",
-   journal = "Computers and Fluids",
-   year    = "2010",
-   volume  = "39",
-   pages   = "1585--1596",
-   url     = "",
-   doi     = ""
+   author  = {C. C. Chueh and M. Secanell and W. Bangerth and N. Djilali},
+   title   = {Multi-level Adaptive Simulation of Transient Two-phase Flow in Heterogeneous Porous Media},
+   journal = {Computers and Fluids},
+   year    = {2010},
+   volume  = {39},
+   pages   = {1585--1596},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2010_10,
-   author  = "T. Dally",
-   title   = "FE-Modelladaptivit&auml;t f&uuml;r P-Laplace",
-   year    = "2010",
-   school  = "Universit&auml;t Siegen, Germany",
-   url     = ""
+   author  = {T. Dally},
+   title   = {FE-Modelladaptivit\"{a}t f\"{u}r P-Laplace},
+   year    = {2010},
+   school  = {Universit\"{a}t Siegen, Germany},
+   url     = {}
 }
 
 @article{2010_11,
-   author  = "F. Freddi and M. Fr&eacute;mond",
-   title   = "Collision and Fractures: a predictive theory",
-   journal = "European Journal of Mechanics - A/Solids",
-   year    = "2010",
-   volume  = "29",
-   pages   = "998--1007",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and M. Fr\'{e}mond},
+   title   = {Collision and Fractures: a predictive theory},
+   journal = {European Journal of Mechanics - A/Solids},
+   year    = {2010},
+   volume  = {29},
+   pages   = {998--1007},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_12,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "Regularized Variational Theories of Fracture: a Unified Approach",
-   journal = "Journal of the Mechanics and Physics of Solids",
-   year    = "2010",
-   volume  = "58",
-   pages   = "1154--1174",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {Regularized Variational Theories of Fracture: a Unified Approach},
+   journal = {Journal of the Mechanics and Physics of Solids},
+   year    = {2010},
+   volume  = {58},
+   pages   = {1154--1174},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_13,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "A variational formulation for smeared fixed-crack models",
-   journal = "Proceedings of the IGF Workshop "Problematiche di Frattura nei Materiali per l'Ingegneria", Giornata IGF Forni di Sopra",
-   year    = "2010",
-   volume  = "",
-   pages   = "133--142",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {A variational formulation for smeared fixed-crack models},
+   journal = {Proceedings of the IGF Workshop ``Problematiche di Frattura nei Materiali per l'Ingegneria'', Giornata IGF Forni di Sopra},
+   year    = {2010},
+   volume  = {},
+   pages   = {133--142},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_14,
-   author  = "M. Freyer and A. Ale and R. Schulz and M. Zientkowska and V. Ntziachristos and K.-H. Englmeier",
-   title   = "Fast automatic segmentation of anatomical structures in x-ray computed tomography images to improve fluorescence molecular tomography reconstruction",
-   journal = "Journal of Biomedical Optics, pp. 036006/1-8",
-   year    = "2010",
-   volume  = "15",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Freyer and A. Ale and R. Schulz and M. Zientkowska and V. Ntziachristos and K.-H. Englmeier},
+   title   = {Fast automatic segmentation of anatomical structures in x-ray computed tomography images to improve fluorescence molecular tomography reconstruction},
+   journal = {Journal of Biomedical Optics, pp. 036006/1-8},
+   year    = {2010},
+   volume  = {15},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_15,
-   author  = "A. Garny and J. Cooper and P. J. Hunt",
-   title   = "Toward a VPH/Physiome ToolKit",
-   journal = "Wiley Interdisciplinary Reviews: Systems Biology and Medicine",
-   year    = "2010",
-   volume  = "2",
-   pages   = "134--147",
-   url     = "",
-   doi     = ""
+   author  = {A. Garny and J. Cooper and P. J. Hunt},
+   title   = {Toward a VPH/Physiome ToolKit},
+   journal = {Wiley Interdisciplinary Reviews: Systems Biology and Medicine},
+   year    = {2010},
+   volume  = {2},
+   pages   = {134--147},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_16,
-   author  = "P. Ghysels and G. Samaey and P. Van Liedekerke and E. Tijskens and H. Ramon and D. Roose",
-   title   = "Coarse implicit time integration of a cellular scale particle model for plant tissue deformation",
-   journal = "Int. J. Multisc. Comput. Engrg.",
-   year    = "2010",
-   volume  = "8",
-   pages   = "411--422",
-   url     = "",
-   doi     = ""
+   author  = {P. Ghysels and G. Samaey and P. Van Liedekerke and E. Tijskens and H. Ramon and D. Roose},
+   title   = {Coarse implicit time integration of a cellular scale particle model for plant tissue deformation},
+   journal = {Int. J. Multisc. Comput. Engrg.},
+   year    = {2010},
+   volume  = {8},
+   pages   = {411--422},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_17,
-   author  = "P. Ghysels and G. Samaey and P. Van Liedekerke and E. Tijskens and H. Ramon and D. Roose",
-   title   = "Multiscale modeling of viscoelastic plant tissue",
-   journal = "Int. J. Multisc. Comput. Engrg.",
-   year    = "2010",
-   volume  = "8",
-   pages   = "379--396",
-   url     = "",
-   doi     = ""
+   author  = {P. Ghysels and G. Samaey and P. Van Liedekerke and E. Tijskens and H. Ramon and D. Roose},
+   title   = {Multiscale modeling of viscoelastic plant tissue},
+   journal = {Int. J. Multisc. Comput. Engrg.},
+   year    = {2010},
+   volume  = {8},
+   pages   = {379--396},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_18,
-   author  = "V. Girault and F. Murat and A. Salgado",
-   title   = "Finite element discretization of Darcy's equations with pressure dependent porosity.",
-   journal = "M2AN",
-   year    = "2010",
-   volume  = "44",
-   pages   = "1155--1191",
-   url     = "",
-   doi     = ""
+   author  = {V. Girault and F. Murat and A. Salgado},
+   title   = {Finite element discretization of Darcy's equations with pressure dependent porosity.},
+   journal = {M2AN},
+   year    = {2010},
+   volume  = {44},
+   pages   = {1155--1191},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_19,
-   author  = "M. Guven and L. Reilly-Raska and L. Zhou and B. Yazici",
-   title   = "Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography: Part I",
-   journal = "IEEE Trans. Medical Imaging",
-   year    = "2010",
-   volume  = "29",
-   pages   = "217--229",
-   url     = "",
-   doi     = ""
+   author  = {M. Guven and L. Reilly-Raska and L. Zhou and B. Yazici},
+   title   = {Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography: Part I},
+   journal = {IEEE Trans. Medical Imaging},
+   year    = {2010},
+   volume  = {29},
+   pages   = {217--229},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_20,
-   author  = "M. Guven and L. Zhou and L. Reilly-Raska and B. Yazici",
-   title   = "Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography: Part II",
-   journal = "IEEE Trans. Medical Imaging",
-   year    = "2010",
-   volume  = "29",
-   pages   = "230--245",
-   url     = "",
-   doi     = ""
+   author  = {M. Guven and L. Zhou and L. Reilly-Raska and B. Yazici},
+   title   = {Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography: Part II},
+   journal = {IEEE Trans. Medical Imaging},
+   year    = {2010},
+   volume  = {29},
+   pages   = {230--245},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_21,
-   author  = "R. Hartmann and J. Held and T. Leicht and F. Prill",
-   title   = "Discontinuous Galerkin methods for computational aerodynamics &mdash; 3D adaptive flow simulation with the DLR PADGE code",
-   journal = "Aerospace Science and Technology",
-   year    = "2010",
-   volume  = "14",
-   pages   = "512--519",
-   url     = "http://www.sciencedirect.com/science/article/pii/S1270963810000441",
-   doi     = ""
+   author  = {R. Hartmann and J. Held and T. Leicht and F. Prill},
+   title   = {Discontinuous Galerkin methods for computational aerodynamics -- 3D adaptive flow simulation with the DLR PADGE code},
+   journal = {Aerospace Science and Technology},
+   year    = {2010},
+   volume  = {14},
+   pages   = {512--519},
+   url     = {http://www.sciencedirect.com/science/article/pii/S1270963810000441},
+   doi     = {}
 }
 
 @article{2010_22,
-   author  = "R. Hartmann and J. Held and T. Leicht and F. Prill",
-   title   = "Error estimation and adaptive mesh refinement for aerodynamic flows",
-   journal = "In N. Kroll, H. Bieler, H. Deconinck, V. Couallier, H. van der Ven and K. Sorensen, editors, ADIGMA - A European Initiative on the Development of Adaptive Higher-Order Variational Methods for Aerospace Applications, <br> of Notes on numerical fluid mechanics and multidisciplinary design, Springer",
-   year    = "2010",
-   volume  = "113",
-   pages   = "339--353",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and J. Held and T. Leicht and F. Prill},
+   title   = {Error estimation and adaptive mesh refinement for aerodynamic flows},
+   journal = {In N. Kroll, H. Bieler, H. Deconinck, V. Couallier, H. van der Ven and K. Sorensen, editors, ADIGMA - A European Initiative on the Development of Adaptive Higher-Order Variational Methods for Aerospace Applications, of Notes on numerical fluid mechanics and multidisciplinary design, Springer},
+   year    = {2010},
+   volume  = {113},
+   pages   = {339--353},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_23,
-   author  = "R. Hartmann and P. Houston",
-   title   = "Error estimation and adaptive mesh refinement for aerodynamic flows",
-   journal = "In H. Deconinck, editor, VKI LS 2010-01: 36th CFD/ADIGMA course on hp-adaptive and hp-multigrid methods, Oct. 26-30, 2009. <br> Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and P. Houston},
+   title   = {Error estimation and adaptive mesh refinement for aerodynamic flows},
+   journal = {In H. Deconinck, editor, VKI LS 2010-01: 36th CFD/ADIGMA course on hp-adaptive and hp-multigrid methods, Oct. 26-30, 2009. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_24,
-   author  = "R. Hartmann and T. Leicht",
-   title   = "Discontinuous Galerkin Verfahren in der Aerodynamik: H&ouml;here Ordnung, Fehlersch&auml;tzung und Gitteradaption",
-   journal = "STAB Mitteilungen. 17. DGLR-Fach-Symposium der STAB, 9.-10. Nov. 2010, Berlin",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and T. Leicht},
+   title   = {Discontinuous Galerkin Verfahren in der Aerodynamik: H\"{o}here Ordnung, Fehlersch\"{a}tzung und Gitteradaption},
+   journal = {STAB Mitteilungen. 17. DGLR-Fach-Symposium der STAB, 9.-10. Nov. 2010, Berlin},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_25,
-   author  = "T. Heister and G. Lube and G. Rapin",
-   title   = "On robust parallel preconditioning for incompressible flow problems",
-   journal = "In Numerical Mathematics and Advanced Applications, ENUMATH 2009. Springer, Berlin",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Heister and G. Lube and G. Rapin},
+   title   = {On robust parallel preconditioning for incompressible flow problems},
+   journal = {In Numerical Mathematics and Advanced Applications, ENUMATH 2009. Springer, Berlin},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_26,
-   author  = "T. Heister and M. Kronbichler and W. Bangerth",
-   title   = "Generic Finite Element programming for massively parallel flow simulations",
-   journal = "Eccomas CFD 2010 proceedings",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Heister and M. Kronbichler and W. Bangerth},
+   title   = {Generic Finite Element programming for massively parallel flow simulations},
+   journal = {Eccomas CFD 2010 proceedings},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_27,
-   author  = "T. Heister and M. Kronbichler and W. Bangerth",
-   title   = "Massively Parallel Finite Element Programming",
-   journal = "Recent Advances in the Message Passing Interface, Lecture Notes in Computer Science, /2010",
-   year    = "2010",
-   volume  = "6305",
-   pages   = "122--131",
-   url     = "",
-   doi     = ""
+   author  = {T. Heister and M. Kronbichler and W. Bangerth},
+   title   = {Massively Parallel Finite Element Programming},
+   journal = {Recent Advances in the Message Passing Interface, Lecture Notes in Computer Science, /2010},
+   year    = {2010},
+   volume  = {6305},
+   pages   = {122--131},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_28,
-   author  = "M. Hinze and M. Kunkel",
-   title   = "Residual Based Sampling in POD Model Order Reduction of Drift-Diffusion Equations in Parametrized Electrical Networks",
-   journal = "arXiv:1003.0551v1 [math.NA]",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinze and M. Kunkel},
+   title   = {Residual Based Sampling in POD Model Order Reduction of Drift-Diffusion Equations in Parametrized Electrical Networks},
+   journal = {arXiv:1003.0551v1 [math.NA]},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_29,
-   author  = "O. P. Iliev and R. D. Lazarov and J. Willems",
-   title   = "Discontinuous Galerkin Subgrid Finite Element Method for Heterogeneous Brinkman Equations",
-   journal = "Large-Scale Scientific Computing, Lectures Notes in Computer Science",
-   year    = "2010",
-   volume  = "5910",
-   pages   = "14--25",
-   url     = "",
-   doi     = ""
+   author  = {O. P. Iliev and R. D. Lazarov and J. Willems},
+   title   = {Discontinuous Galerkin Subgrid Finite Element Method for Heterogeneous Brinkman Equations},
+   journal = {Large-Scale Scientific Computing, Lectures Notes in Computer Science},
+   year    = {2010},
+   volume  = {5910},
+   pages   = {14--25},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_30,
-   author  = "O. P. Iliev and R. D. Lazarov and J. Willems",
-   title   = "Fast numerical upscaling of heat equation for fibrous materials",
-   journal = "J. Computing and Visualization in Science",
-   year    = "2010",
-   volume  = "13",
-   pages   = "275--285",
-   url     = "",
-   doi     = ""
+   author  = {O. P. Iliev and R. D. Lazarov and J. Willems},
+   title   = {Fast numerical upscaling of heat equation for fibrous materials},
+   journal = {J. Computing and Visualization in Science},
+   year    = {2010},
+   volume  = {13},
+   pages   = {275--285},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_31,
-   author  = "B. Janssen and T. Wick",
-   title   = "Block preconditioning with Schur complements for monolithic fluid-structure interactions",
-   journal = "Proceedings of the Eccomas CFD 2010 conference, J. C. F. Pereira and A. Sequeira (eds.)",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Janssen and T. Wick},
+   title   = {Block preconditioning with Schur complements for monolithic fluid-structure interactions},
+   journal = {Proceedings of the Eccomas CFD 2010 conference, J. C. F. Pereira and A. Sequeira (eds.)},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_32,
-   author  = "J. Joos and B. R&uuml;ger and T. Carraro and A. Weber and E. Ivers-Tiff&eacute;e",
-   title   = "Electrode Reconstruction by FIB/SEM and Microstructure Modeling",
-   journal = "ECS Trans. 28",
-   year    = "2010",
-   volume  = "",
-   pages   = "81--91",
-   url     = "",
-   doi     = ""
+   author  = {J. Joos and B. R\"{u}ger and T. Carraro and A. Weber and E. Ivers-Tiff\'{e}e},
+   title   = {Electrode Reconstruction by FIB/SEM and Microstructure Modeling},
+   journal = {ECS Trans. 28},
+   year    = {2010},
+   volume  = {},
+   pages   = {81--91},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_33,
-   author  = "G. Kanschat and B. Rivière",
-   title   = "A strongly conservative finite element method for the coupling of Stokes and Darcy flow",
-   journal = "J. Computational Physics",
-   year    = "2010",
-   volume  = "229",
-   pages   = "5933--5943",
-   url     = "",
-   doi     = ""
+   author  = {G. Kanschat and B. Rivi\`{e}re},
+   title   = {A strongly conservative finite element method for the coupling of Stokes and Darcy flow},
+   journal = {J. Computational Physics},
+   year    = {2010},
+   volume  = {229},
+   pages   = {5933--5943},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_34,
-   author  = "F. Keller and M. Feist and H. Nirschl and W. D&ouml;rfler",
-   title   = "Investigation of the nonlinear effects during the sedimentation process of a charged colloidal particle by direct numerical simulation",
-   journal = "Journal of Colloid and Interface Science",
-   year    = "2010",
-   volume  = "344",
-   pages   = "228--236",
-   url     = "",
-   doi     = ""
+   author  = {F. Keller and M. Feist and H. Nirschl and W. D\"{o}rfler},
+   title   = {Investigation of the nonlinear effects during the sedimentation process of a charged colloidal particle by direct numerical simulation},
+   journal = {Journal of Colloid and Interface Science},
+   year    = {2010},
+   volume  = {344},
+   pages   = {228--236},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_35,
-   author  = "S. Kim and J. E. Pasciak",
-   title   = "Analysis of a Cartesian PML approximation to acoustic scattering problems in R<sup>2</sup>",
-   journal = "J. Math. Anal. Appl.",
-   year    = "2010",
-   volume  = "370",
-   pages   = "168--186",
-   url     = "",
-   doi     = ""
+   author  = {S. Kim and J. E. Pasciak},
+   title   = {Analysis of a Cartesian PML approximation to acoustic scattering problems in R$^{2}$},
+   journal = {J. Math. Anal. Appl.},
+   year    = {2010},
+   volume  = {370},
+   pages   = {168--186},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_36,
-   author  = "R. King and V. Mehrmann and W. Nitsche",
-   title   = "Active Flow Control&mdash;A Mathematical Challenge",
-   journal = "Production Factor Mathematics, Part 1",
-   year    = "2010",
-   volume  = "",
-   pages   = "73--80",
-   url     = "",
-   doi     = ""
+   author  = {R. King and V. Mehrmann and W. Nitsche},
+   title   = {Active Flow Control--A Mathematical Challenge},
+   journal = {Production Factor Mathematics, Part 1},
+   year    = {2010},
+   volume  = {},
+   pages   = {73--80},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_37,
-   author  = "R. King and V. Mehrmann and W. Nitsche",
-   title   = "Aktive Str&ouml;mungsbeeinflussung &mdash; Eine Mathematische Herausforderung",
-   journal = "Produktionsfaktor Mathematik, Part 2",
-   year    = "2010",
-   volume  = "",
-   pages   = "99--109",
-   url     = "",
-   doi     = ""
+   author  = {R. King and V. Mehrmann and W. Nitsche},
+   title   = {Aktive Str\"{o}mungsbeeinflussung -- Eine Mathematische Herausforderung},
+   journal = {Produktionsfaktor Mathematik, Part 2},
+   year    = {2010},
+   volume  = {},
+   pages   = {99--109},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_38,
-   author  = "P. Krakowian and T. Lekszycki",
-   title   = "Investigation and Modeling of Bone Fracture Healing",
-   journal = "5th International Conference on Advances in Mechanical Engineering and Mechanics, ICAMEM 2010, Tunisia",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.ippt.pan.pl/Repository/o462.pdf",
-   doi     = ""
+   author  = {P. Krakowian and T. Lekszycki},
+   title   = {Investigation and Modeling of Bone Fracture Healing},
+   journal = {5th International Conference on Advances in Mechanical Engineering and Mechanics, ICAMEM 2010, Tunisia},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.ippt.pan.pl/Repository/o462.pdf},
+   doi     = {}
 }
 
 @article{2010_39,
-   author  = "T. Leicht and R. Hartmann",
-   title   = "Error estimation and anisotropic mesh refinement for 3d laminar aerodynamic flow simulations",
-   journal = "J. Comput. Phys.",
-   year    = "2010",
-   volume  = "229",
-   pages   = "7344--7360",
-   url     = "",
-   doi     = ""
+   author  = {T. Leicht and R. Hartmann},
+   title   = {Error estimation and anisotropic mesh refinement for 3d laminar aerodynamic flow simulations},
+   journal = {J. Comput. Phys.},
+   year    = {2010},
+   volume  = {229},
+   pages   = {7344--7360},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_40,
-   author  = "T. Leicht and R. Hartmann",
-   title   = "Error estimation and anisotropic mesh refinement for aerodynamic flow simulations",
-   journal = "In Numerical Mathematics and Advanced Applications, ENUMATH 2009, . Springer, Berlin",
-   year    = "2010",
-   volume  = "",
-   pages   = "579--587",
-   url     = "",
-   doi     = ""
+   author  = {T. Leicht and R. Hartmann},
+   title   = {Error estimation and anisotropic mesh refinement for aerodynamic flow simulations},
+   journal = {In Numerical Mathematics and Advanced Applications, ENUMATH 2009, . Springer, Berlin},
+   year    = {2010},
+   volume  = {},
+   pages   = {579--587},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_42,
-   author  = "C. E. Michoski and J. A. Evans and P. G. Schmitz",
-   title   = "Modeling Chemical Reactors I: Quiescent Reactors",
-   journal = "arXiv:1012.5682",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1012.5682",
-   doi     = ""
+   author  = {C. E. Michoski and J. A. Evans and P. G. Schmitz},
+   title   = {Modeling Chemical Reactors I: Quiescent Reactors},
+   journal = {arXiv:1012.5682},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1012.5682},
+   doi     = {}
 }
 
 @phdthesis{2010_43,
-   author  = "J. K. Muehl",
-   title   = "Techniques for Interdisciplinary Validation by Visualization in Physiological Modeling Liver Radiofrequency Ablation",
-   year    = "2010",
-   school  = "Graz University of Technology",
-   url     = "http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.419.3812&rep=rep1&type=pdf"
+   author  = {J. K. Muehl},
+   title   = {Techniques for Interdisciplinary Validation by Visualization in Physiological Modeling Liver Radiofrequency Ablation},
+   year    = {2010},
+   school  = {Graz University of Technology},
+   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.419.3812&rep=rep1&type=pdf}
 }
 
 @article{2010_44,
-   author  = "M. Myers and E.G. Fu and Michelle Myers and H. Wang and G. Xie and X. Wang and W-K. Chue and L. Shao",
-   title   = "An experimental and modeling study on the role of damage cascade formation in nanocrystalization of ion-irradiated Ni52.5Nb10Zr15Ti15Pt7.5 metallic glass",
-   journal = "Scripta Materialia, Vol. 63 (11), pp: 1045–1048",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S1359646210005002",
-   doi     = ""
+   author  = {M. Myers and E.G. Fu and Michelle Myers and H. Wang and G. Xie and X. Wang and W-K. Chue and L. Shao},
+   title   = {An experimental and modeling study on the role of damage cascade formation in nanocrystalization of ion-irradiated Ni52.5Nb10Zr15Ti15Pt7.5 metallic glass},
+   journal = {Scripta Materialia, Vol. 63 (11), pp: 1045--1048},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S1359646210005002},
+   doi     = {}
 }
 
 @mastersthesis{2010_45,
-   author  = "C. P. T. Neuen",
-   title   = "A multiscale approach to the Poisson-Nernst-Planck equation",
-   year    = "2010",
-   school  = "University of Bonn, Germany",
-   url     = ""
+   author  = {C. P. T. Neuen},
+   title   = {A multiscale approach to the Poisson-Nernst-Planck equation},
+   year    = {2010},
+   school  = {University of Bonn, Germany},
+   url     = {}
 }
 
 @article{2010_46,
-   author  = "A. Nigro and C. De Bartolo and R. Hartmann and F. Bassi",
-   title   = "Discontinuous Galerkin solution of preconditioned Euler equations for very low Mach number flows",
-   journal = "Int. J. Numer. Meth. Fluids, no. 4",
-   year    = "2010",
-   volume  = "63",
-   pages   = "449--467",
-   url     = "",
-   doi     = ""
+   author  = {A. Nigro and C. De Bartolo and R. Hartmann and F. Bassi},
+   title   = {Discontinuous Galerkin solution of preconditioned Euler equations for very low Mach number flows},
+   journal = {Int. J. Numer. Meth. Fluids, no. 4},
+   year    = {2010},
+   volume  = {63},
+   pages   = {449--467},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2010_47,
-   author  = "F. Prill",
-   title   = "Diskontinuierliche Galerkin-Methoden und schnelle iterative L&ouml;ser zur Simulation kompressibler Str&ouml;mungen",
-   year    = "2010",
-   school  = "TU Hamburg-Harburg",
-   url     = ""
+   author  = {F. Prill},
+   title   = {Diskontinuierliche Galerkin-Methoden und schnelle iterative L\"{o}ser zur Simulation kompressibler Str\"{o}mungen},
+   year    = {2010},
+   school  = {TU Hamburg-Harburg},
+   url     = {}
 }
 
 @article{2010_48,
-   author  = "M. J. Rapson and J. C. Tapson",
-   title   = "Capturing low-frequency cochlear impedance in time domain models: The role of viscosity",
-   journal = "J. Acoust. Soc. Am. Vol. 127, Issue 3",
-   year    = "2010",
-   volume  = "",
-   pages   = "1869--1869",
-   url     = "",
-   doi     = ""
+   author  = {M. J. Rapson and J. C. Tapson},
+   title   = {Capturing low-frequency cochlear impedance in time domain models: The role of viscosity},
+   journal = {J. Acoust. Soc. Am. Vol. 127, Issue 3},
+   year    = {2010},
+   volume  = {},
+   pages   = {1869--1869},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_49,
-   author  = "K. Rupp",
-   title   = "Symbolic integration at compile time in finite element methods",
-   journal = "Proceedings of the 2010 International Symposium on Symbolic and Algebraic Computation, 347-354",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {K. Rupp},
+   title   = {Symbolic integration at compile time in finite element methods},
+   journal = {Proceedings of the 2010 International Symposium on Symbolic and Algebraic Computation, 347-354},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_50,
-   author  = "T. Rees and M. Stoll and A. Wathen",
-   title   = "All-at-once preconditioning in PDE-constrained optimization",
-   journal = "Kybernetica",
-   year    = "2010",
-   volume  = "46",
-   pages   = "341--360",
-   url     = "",
-   doi     = ""
+   author  = {T. Rees and M. Stoll and A. Wathen},
+   title   = {All-at-once preconditioning in PDE-constrained optimization},
+   journal = {Kybernetica},
+   year    = {2010},
+   volume  = {46},
+   pages   = {341--360},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_51,
-   author  = "T. Richter and T. Wick",
-   title   = "Finite Elements for Fluid-Structure Interaction in ALE and Fully Eulerian Coordinates",
-   journal = "Comput. Meth. Appl. Mech. Engrg.",
-   year    = "2010",
-   volume  = "199",
-   pages   = "2633--2642",
-   url     = "",
-   doi     = ""
+   author  = {T. Richter and T. Wick},
+   title   = {Finite Elements for Fluid-Structure Interaction in ALE and Fully Eulerian Coordinates},
+   journal = {Comput. Meth. Appl. Mech. Engrg.},
+   year    = {2010},
+   volume  = {199},
+   pages   = {2633--2642},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_52,
-   author  = "L. R&ouml;he and G. Lube",
-   title   = "Analysis of a variational multiscale method for large-eddy simulation and its application to homogeneous isotropic turbulence",
-   journal = "Comput. Meth. Appl. Mech. Engrg.",
-   year    = "2010",
-   volume  = "199",
-   pages   = "2331--2342",
-   url     = "",
-   doi     = ""
+   author  = {L. R\"{o}he and G. Lube},
+   title   = {Analysis of a variational multiscale method for large-eddy simulation and its application to homogeneous isotropic turbulence},
+   journal = {Comput. Meth. Appl. Mech. Engrg.},
+   year    = {2010},
+   volume  = {199},
+   pages   = {2331--2342},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2010_53,
-   author  = "A. J. Salgado",
-   title   = "Approximation Techniques for Incompressible Flows with Heterogeneous Properties",
-   year    = "2010",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {A. J. Salgado},
+   title   = {Approximation Techniques for Incompressible Flows with Heterogeneous Properties},
+   year    = {2010},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2010_54,
-   author  = "R. Schulz and A. Ale and A. Sarantopoulos and M. Freyer and E. Soehngen and M. Zientkowska and V. Ntziachristos",
-   title   = "Hybrid System for Simultaneous Fluorescence and X-Ray Computed Tomography",
-   journal = "IEEE Trans. Medical Imaging",
-   year    = "2010",
-   volume  = "29",
-   pages   = "465--473",
-   url     = "",
-   doi     = ""
+   author  = {R. Schulz and A. Ale and A. Sarantopoulos and M. Freyer and E. Soehngen and M. Zientkowska and V. Ntziachristos},
+   title   = {Hybrid System for Simultaneous Fluorescence and X-Ray Computed Tomography},
+   journal = {IEEE Trans. Medical Imaging},
+   year    = {2010},
+   volume  = {29},
+   pages   = {465--473},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_55,
-   author  = "M. Secanell and R. Songprakorp and N. Djilali and A. Suleman",
-   title   = "Optimization of a proton exchange membrane fuel cell membrane electrode assembly",
-   journal = "Structural and Multidisciplinary Optimization, issue 1-6, pp 563-583",
-   year    = "2010",
-   volume  = "40",
-   pages   = "",
-   url     = "http://link.springer.com/article/10.1007/s00158-009-0387-z",
-   doi     = ""
+   author  = {M. Secanell and R. Songprakorp and N. Djilali and A. Suleman},
+   title   = {Optimization of a proton exchange membrane fuel cell membrane electrode assembly},
+   journal = {Structural and Multidisciplinary Optimization, issue 1-6, pp 563-583},
+   year    = {2010},
+   volume  = {40},
+   pages   = {},
+   url     = {http://link.springer.com/article/10.1007/s00158-009-0387-z},
+   doi     = {}
 }
 
 @article{2010_56,
-   author  = "M. Steigemann and M. Specovius-Neugebauer and M. Fulland and H. A. Richard",
-   title   = "Simulation of crack paths in functionally graded materials",
-   journal = "Engineering Fracture Mechanics",
-   year    = "2010",
-   volume  = "77",
-   pages   = "2145--2157",
-   url     = "",
-   doi     = ""
+   author  = {M. Steigemann and M. Specovius-Neugebauer and M. Fulland and H. A. Richard},
+   title   = {Simulation of crack paths in functionally graded materials},
+   journal = {Engineering Fracture Mechanics},
+   year    = {2010},
+   volume  = {77},
+   pages   = {2145--2157},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_57,
-   author  = "M. Stoll and A. Wathen",
-   title   = "All-at-once preconditioning of time-dependent PDE-constrained optimization problems",
-   journal = "Preprint 1017, University of Oxford",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Stoll and A. Wathen},
+   title   = {All-at-once preconditioning of time-dependent PDE-constrained optimization problems},
+   journal = {Preprint 1017, University of Oxford},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_58,
-   author  = "B. Turcksin and J. C. Ragusa and W. Bangerth",
-   title   = "Goal-oriented h-adaptivity for the multigroup SP<sub>N</sub> equations",
-   journal = "Nuclear Science and Engineering",
-   year    = "2010",
-   volume  = "165",
-   pages   = "305--319",
-   url     = "",
-   doi     = ""
+   author  = {B. Turcksin and J. C. Ragusa and W. Bangerth},
+   title   = {Goal-oriented h-adaptivity for the multigroup SP$_{\textnormal{N}}$ equations},
+   journal = {Nuclear Science and Engineering},
+   year    = {2010},
+   volume  = {165},
+   pages   = {305--319},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_59,
-   author  = "M. Vdroljak",
-   title   = "On Hashin-Shtrikman bounds for mixtures of two isotropic materials",
-   journal = "Nonlinear Analysis: Real world applications",
-   year    = "2010",
-   volume  = "11",
-   pages   = "4597--4606",
-   url     = "",
-   doi     = ""
+   author  = {M. Vdroljak},
+   title   = {On Hashin-Shtrikman bounds for mixtures of two isotropic materials},
+   journal = {Nonlinear Analysis: Real world applications},
+   year    = {2010},
+   volume  = {11},
+   pages   = {4597--4606},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2010_60,
-   author  = "C. Weiler",
-   title   = "Stromfunktionsformulierung der Navier-Stokes-Gleichungen und Methoden der Druckrekonstruktion",
-   year    = "2010",
-   school  = "University of Heidelberg, Germany",
-   url     = ""
+   author  = {C. Weiler},
+   title   = {Stromfunktionsformulierung der Navier-Stokes-Gleichungen und Methoden der Druckrekonstruktion},
+   year    = {2010},
+   school  = {University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2010_61,
-   author  = "T. D. Young and R. Armiento",
-   title   = "Strategies for <i>h</i>-adaptive refinement for a finite element treatment of harmonic oscillator Schr&ouml;dinger eigenproblem",
-   journal = "Commun. Theor. Phys. (Beijing, China), (6)",
-   year    = "2010",
-   volume  = "53",
-   pages   = "1017--1023",
-   url     = "",
-   doi     = ""
+   author  = {T. D. Young and R. Armiento},
+   title   = {Strategies for $h$-adaptive refinement for a finite element treatment of harmonic oscillator Schr\"{o}dinger eigenproblem},
+   journal = {Commun. Theor. Phys. (Beijing, China), (6)},
+   year    = {2010},
+   volume  = {53},
+   pages   = {1017--1023},
+   url     = {},
+   doi     = {}
 }
 
 @article{2010_62,
-   author  = "L. Zhou",
-   title   = "Adaptive finite element methods for fluorescence diffuse optical tomography",
-   journal = "PhD dissertation, Rensselaer Polytechnic Institute",
-   year    = "2010",
-   volume  = "",
-   pages   = "",
-   url     = "http://gradworks.umi.com/34/35/3435879.html",
-   doi     = ""
+   author  = {L. Zhou},
+   title   = {Adaptive finite element methods for fluorescence diffuse optical tomography},
+   journal = {PhD dissertation, Rensselaer Polytechnic Institute},
+   year    = {2010},
+   volume  = {},
+   pages   = {},
+   url     = {http://gradworks.umi.com/34/35/3435879.html},
+   doi     = {}
 }
 
 @phdthesis{2010_63,
-   author  = "L. Zhu",
-   title   = "Robust a posteriori error estimation for discontinuous Galerkin methods for convection-diffusion equations",
-   year    = "2010",
-   school  = "University of British Columbia",
-   url     = ""
+   author  = {L. Zhu},
+   title   = {Robust a posteriori error estimation for discontinuous Galerkin methods for convection-diffusion equations},
+   year    = {2010},
+   school  = {University of British Columbia},
+   url     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2011.bib
+++ b/publications-2011.bib
@@ -1,671 +1,671 @@
 % Encoding: ISO-8859-1
 
 @article{2011_0,
-   author  = "I. Adeniran and M. J. McPate and H. J. Wichtel and J. C. Hancox and H. Zhang",
-   title   = "Increased vulnerability of human ventricle to re-entrant excitation in hERG-linked variant 1 short QT syndrome",
-   journal = "PLoS Computational Biology, e1002313",
-   year    = "2011",
-   volume  = "7",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {I. Adeniran and M. J. McPate and H. J. Wichtel and J. C. Hancox and H. Zhang},
+   title   = {Increased vulnerability of human ventricle to re-entrant excitation in hERG-linked variant 1 short QT syndrome},
+   journal = {PLoS Computational Biology, e1002313},
+   year    = {2011},
+   volume  = {7},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2011_1,
-   author  = "M. Allmaras",
-   title   = "Modeling aspects and computational methods for some recent problems of tomographic imaging",
-   year    = "2011",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {M. Allmaras},
+   title   = {Modeling aspects and computational methods for some recent problems of tomographic imaging},
+   year    = {2011},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2011_2,
-   author  = "M. Allmaras and W. Bangerth",
-   title   = "Reconstructions in ultrasound modulated optical tomography",
-   journal = "J. Inverse and Ill-posed Problems",
-   year    = "2011",
-   volume  = "19",
-   pages   = "801--823",
-   url     = "",
-   doi     = ""
+   author  = {M. Allmaras and W. Bangerth},
+   title   = {Reconstructions in ultrasound modulated optical tomography},
+   journal = {J. Inverse and Ill-posed Problems},
+   year    = {2011},
+   volume  = {19},
+   pages   = {801--823},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_3,
-   author  = "F. Alouges and A. DeSimone and L. Heltai",
-   title   = "Numerical strategies for stroke optimization of axisymmetric microswimmers",
-   journal = "Mathematical Models and Methods in Applied Sciences",
-   year    = "2011",
-   volume  = "21",
-   pages   = "361--387",
-   url     = "",
-   doi     = ""
+   author  = {F. Alouges and A. DeSimone and L. Heltai},
+   title   = {Numerical strategies for stroke optimization of axisymmetric microswimmers},
+   journal = {Mathematical Models and Methods in Applied Sciences},
+   year    = {2011},
+   volume  = {21},
+   pages   = {361--387},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_4,
-   author  = "W. Bangerth and C. Burstedde and T. Heister and M. Kronbichler",
-   title   = "Algorithms and Data Structures for Massively Parallel Generic Finite Element Codes",
-   journal = "ACM Transactions on Mathematical Software, article 124",
-   year    = "2011",
-   volume  = "38",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and C. Burstedde and T. Heister and M. Kronbichler},
+   title   = {Algorithms and Data Structures for Massively Parallel Generic Finite Element Codes},
+   journal = {ACM Transactions on Mathematical Software, article 124},
+   year    = {2011},
+   volume  = {38},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_5,
-   author  = "K. Benzarti and F. Freddi and M. Fr&eacute;mond",
-   title   = "A damage model to predict the durability of bonded assemblies. Part I: Debonding behavior of FRP strengthened concrete structures",
-   journal = "Construction and Building Materials, 25(2), 547-555",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {K. Benzarti and F. Freddi and M. Fr\'{e}mond},
+   title   = {A damage model to predict the durability of bonded assemblies. Part I: Debonding behavior of FRP strengthened concrete structures},
+   journal = {Construction and Building Materials, 25(2), 547-555},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_6,
-   author  = "A. Buehler and A. Rosenthal and T. Jetzfellner and A. Dima and D. Razansky and V. Ntziachristos",
-   title   = "Model-based optoacoustic inversions with incomplete projection data",
-   journal = "Med. Phys.",
-   year    = "2011",
-   volume  = "38",
-   pages   = "1694--1704",
-   url     = "",
-   doi     = ""
+   author  = {A. Buehler and A. Rosenthal and T. Jetzfellner and A. Dima and D. Razansky and V. Ntziachristos},
+   title   = {Model-based optoacoustic inversions with incomplete projection data},
+   journal = {Med. Phys.},
+   year    = {2011},
+   volume  = {38},
+   pages   = {1694--1704},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_7,
-   author  = "M. B&uuml;rg",
-   title   = "An hp-Efficient Residual-Based A Posteriori Error Estimator for Maxwell's Equations",
-   journal = "Proc. Appl. Math. Mech. Vol. 11, pp: 869 – 870",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/pamm.201110421/abstract",
-   doi     = ""
+   author  = {M. B\"{u}rg},
+   title   = {An hp-Efficient Residual-Based A Posteriori Error Estimator for Maxwell's Equations},
+   journal = {Proc. Appl. Math. Mech. Vol. 11, pp: 869 -- 870},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201110421/abstract},
+   doi     = {}
 }
 
 @article{2011_8,
-   author  = "M. B&uuml;rg and W. D&ouml;rfler",
-   title   = "Convergence of an adaptive hp finite element strategy in higher space-dimensions",
-   journal = "Appl. Numer. Math. 61",
-   year    = "2011",
-   volume  = "",
-   pages   = "1132--1146",
-   url     = "",
-   doi     = ""
+   author  = {M. B\"{u}rg and W. D\"{o}rfler},
+   title   = {Convergence of an adaptive hp finite element strategy in higher space-dimensions},
+   journal = {Appl. Numer. Math. 61},
+   year    = {2011},
+   volume  = {},
+   pages   = {1132--1146},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_9,
-   author  = "A. Cangiani and E. Georgoulis and M. Jensen",
-   title   = "Discontinuous Galerkin methods for convection-diffusion problems modelling mass transfer through semipermeable membranes.",
-   journal = "Proceedings of the Congress on Numerical Methods in Engineering, Coimbra",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Cangiani and E. Georgoulis and M. Jensen},
+   title   = {Discontinuous Galerkin methods for convection-diffusion problems modelling mass transfer through semipermeable membranes.},
+   journal = {Proceedings of the Congress on Numerical Methods in Engineering, Coimbra},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_10,
-   author  = "P. Carrara and D. Ferretti and F. Freddi and G. Rosati",
-   title   = "Shear tests of carbon fiber plates bonded to concrete with control of snap-back",
-   journal = "Engineering Fracture Mechanics",
-   year    = "2011",
-   volume  = "78",
-   pages   = "2663--2678",
-   url     = "",
-   doi     = ""
+   author  = {P. Carrara and D. Ferretti and F. Freddi and G. Rosati},
+   title   = {Shear tests of carbon fiber plates bonded to concrete with control of snap-back},
+   journal = {Engineering Fracture Mechanics},
+   year    = {2011},
+   volume  = {78},
+   pages   = {2663--2678},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_11,
-   author  = "S. Chandrasekaran and K. R. Jayaraman and M. Gu and H. N. Mhaskar and J. Moffitt",
-   title   = "MSNFD: A Higher Order Finite Difference Method for Solving Elliptic PDEs on scattered points (An Extended version of our paper submitted to ICCS 2011)",
-   journal = "submitted",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "http://scg.ece.ucsb.edu/msnpub.html",
-   doi     = ""
+   author  = {S. Chandrasekaran and K. R. Jayaraman and M. Gu and H. N. Mhaskar and J. Moffitt},
+   title   = {MSNFD: A Higher Order Finite Difference Method for Solving Elliptic PDEs on scattered points (An Extended version of our paper submitted to ICCS 2011)},
+   journal = {submitted},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {http://scg.ece.ucsb.edu/msnpub.html},
+   doi     = {}
 }
 
 @phdthesis{2011_12,
-   author  = "B. Crestel",
-   title   = "Moving meshes on general surfaces",
-   year    = "2011",
-   school  = "Simon Fraser University",
-   url     = ""
+   author  = {B. Crestel},
+   title   = {Moving meshes on general surfaces},
+   year    = {2011},
+   school  = {Simon Fraser University},
+   url     = {}
 }
 
 @mastersthesis{2011_13,
-   author  = "P. Dobson",
-   title   = "Investigation of the polymer electrolyte membrane fuel cell catalyst layer microstructure ",
-   year    = "2011",
-   school  = "University of Alberta",
-   url     = "https://era.library.ualberta.ca/public/datastream/get/uuid:30e76f20-e819-4c0e-b3e4-063dbdca6319/DS1/Dobson_Peter_Fall_2011.pdf"
+   author  = {P. Dobson},
+   title   = {Investigation of the polymer electrolyte membrane fuel cell catalyst layer microstructure },
+   year    = {2011},
+   school  = {University of Alberta},
+   url     = {https://era.library.ualberta.ca/public/datastream/get/uuid:30e76f20-e819-4c0e-b3e4-063dbdca6319/DS1/Dobson_Peter_Fall_2011.pdf}
 }
 
 @article{2011_14,
-   author  = "E. Emmrich and D. &Scaron;i&scaron;ka",
-   title   = "Full discretization of second-order nonlinear evolution equations: Strong convergence and applications",
-   journal = "Preprint, University of Bielefeld",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {E. Emmrich and D. \v{S}i\v{s}ka},
+   title   = {Full discretization of second-order nonlinear evolution equations: Strong convergence and applications},
+   journal = {Preprint, University of Bielefeld},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_15,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "A variational approach to plasticity. Numerical experiments",
-   journal = "Proceedings, Atti XX Congresso Nazionale AIMETA, Bologna, Italy",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {A variational approach to plasticity. Numerical experiments},
+   journal = {Proceedings, Atti XX Congresso Nazionale AIMETA, Bologna, Italy},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_16,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "Variational fracture mechanics for compressive splitting of masonry-like materials",
-   journal = "Annals of Solid and Structural Mechanics",
-   year    = "2011",
-   volume  = "2",
-   pages   = "57--67",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {Variational fracture mechanics for compressive splitting of masonry-like materials},
+   journal = {Annals of Solid and Structural Mechanics},
+   year    = {2011},
+   volume  = {2},
+   pages   = {57--67},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2011_17,
-   author  = "M. Freyer",
-   title   = "Automatische Segmentierung anatomischer Strukturen in CT-Bildern eines hybriden FMT/XCT-Systems zur Verbesserung der optischen Bildgebung",
-   year    = "2011",
-   school  = "Ludwig-Maximilians-University Munich, Germany",
-   url     = ""
+   author  = {M. Freyer},
+   title   = {Automatische Segmentierung anatomischer Strukturen in CT-Bildern eines hybriden FMT/XCT-Systems zur Verbesserung der optischen Bildgebung},
+   year    = {2011},
+   school  = {Ludwig-Maximilians-University Munich, Germany},
+   url     = {}
 }
 
 @phdthesis{2011_18,
-   author  = "J. Frohne",
-   title   = "FEM-Simulation der Umformtechnik metallischer Oberfl&auml;chen im Mikrokosmos",
-   year    = "2011",
-   school  = "University of Siegen, Germany",
-   url     = ""
+   author  = {J. Frohne},
+   title   = {FEM-Simulation der Umformtechnik metallischer Oberfl\"{a}chen im Mikrokosmos},
+   year    = {2011},
+   school  = {University of Siegen, Germany},
+   url     = {}
 }
 
 @article{2011_19,
-   author  = "T. George and A. Gupta and V. Sarin",
-   title   = "An empirical analysis of the performance of iterative solvers for SPD systems",
-   journal = "Submitted to ACM Trans. Math. Softw., 2011. IBM Research Report RC 24737",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. George and A. Gupta and V. Sarin},
+   title   = {An empirical analysis of the performance of iterative solvers for SPD systems},
+   journal = {Submitted to ACM Trans. Math. Softw., 2011. IBM Research Report RC 24737},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_20,
-   author  = "A. Ginzburg",
-   title   = "Introduction to Geophysics (in Hebrew)",
-   journal = "The Open University of Israel",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Ginzburg},
+   title   = {Introduction to Geophysics (in Hebrew)},
+   journal = {The Open University of Israel},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_21,
-   author  = "S. Gladkov and T. Kayser and B. Svendsen",
-   title   = "FE-modeling of ideal grain growth based on preprocessed EBSD data",
-   journal = "PAMM",
-   year    = "2011",
-   volume  = "11",
-   pages   = "471--472",
-   url     = "",
-   doi     = ""
+   author  = {S. Gladkov and T. Kayser and B. Svendsen},
+   title   = {FE-modeling of ideal grain growth based on preprocessed EBSD data},
+   journal = {PAMM},
+   year    = {2011},
+   volume  = {11},
+   pages   = {471--472},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_22,
-   author  = "J. L. Guermond and A. Salgado",
-   title   = "Error analysis of a fractional time-stepping technique for incompressible flows with variable density.",
-   journal = "SIAM J. of Numerical Analysis",
-   year    = "2011",
-   volume  = "49",
-   pages   = "917--944",
-   url     = "",
-   doi     = ""
+   author  = {J. L. Guermond and A. Salgado},
+   title   = {Error analysis of a fractional time-stepping technique for incompressible flows with variable density.},
+   journal = {SIAM J. of Numerical Analysis},
+   year    = {2011},
+   volume  = {49},
+   pages   = {917--944},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_23,
-   author  = "R. Hartmann and J. Held and T. Leicht",
-   title   = "Adjoint-based error estimation and adaptive mesh refinement for the RANS and k-&#969; turbulence model equations",
-   journal = "J. Comput. Phys.",
-   year    = "2011",
-   volume  = "230",
-   pages   = "4268--4284",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann and J. Held and T. Leicht},
+   title   = {Adjoint-based error estimation and adaptive mesh refinement for the RANS and k-$\omega$ turbulence model equations},
+   journal = {J. Comput. Phys.},
+   year    = {2011},
+   volume  = {230},
+   pages   = {4268--4284},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2011_24,
-   author  = "T. Heister",
-   title   = "A Massively Parallel Finite Element Framework with Application to Incompressible Flows",
-   year    = "2011",
-   school  = "University of G&ouml;ttingen, Germany",
-   url     = ""
+   author  = {T. Heister},
+   title   = {A Massively Parallel Finite Element Framework with Application to Incompressible Flows},
+   year    = {2011},
+   school  = {University of G\"{o}ttingen, Germany},
+   url     = {}
 }
 
 @article{2011_25,
-   author  = "P. T. Hepperger",
-   title   = "Pricing and Hedging under High-Dimensional Jump-Diffusion Models using Partial Dierential Equations",
-   journal = "PhD dissertation, Technische Universit at Munchen",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "http://mediatum.ub.tum.de/doc/1006896/1006896.pdf",
-   doi     = ""
+   author  = {P. T. Hepperger},
+   title   = {Pricing and Hedging under High-Dimensional Jump-Diffusion Models using Partial Dierential Equations},
+   journal = {PhD dissertation, Technische Universit at Munchen},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {http://mediatum.ub.tum.de/doc/1006896/1006896.pdf},
+   doi     = {}
 }
 
 @article{2011_26,
-   author  = "M. Hinze and M. Kunkel and U. Matthes and M. Vierling",
-   title   = "Model order reduction of integrated circuits in electrical networks",
-   journal = "Hamburger Beitr&auml;ge zur Angewandten Mathematik, Nr. 2011-14",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinze and M. Kunkel and U. Matthes and M. Vierling},
+   title   = {Model order reduction of integrated circuits in electrical networks},
+   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik, Nr. 2011-14},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_27,
-   author  = "M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel",
-   title   = "Model order reduction of coupled circuit-device systems",
-   journal = "Hamburger Beitr&auml;ge zur Angewandten Mathematik, Nr. 2011-08",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel},
+   title   = {Model order reduction of coupled circuit-device systems},
+   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik, Nr. 2011-08},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_28,
-   author  = "M. Hinze and M. Kunkel and M. Vierling",
-   title   = "POD model order reduction of drift-diffusion equations in electrical networks",
-   journal = "in: Model Reduction for Circuit Simulation, P. Benner, M. Hinze, and J. ter Maten (eds.), Lecture Notes in Electrical Engineering, Berlin-Heidelberg: Springer-Verlag, p. 177–192",
-   year    = "2011",
-   volume  = "74",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinze and M. Kunkel and M. Vierling},
+   title   = {POD model order reduction of drift-diffusion equations in electrical networks},
+   journal = {in: Model Reduction for Circuit Simulation, P. Benner, M. Hinze, and J. ter Maten (eds.), Lecture Notes in Electrical Engineering, Berlin-Heidelberg: Springer-Verlag, p. 177--192},
+   year    = {2011},
+   volume  = {74},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_29,
-   author  = "O. P. Iliev and R. D. Lazarov and J. Willems",
-   title   = "Variational multiscale finite element method for flows in highly porous media",
-   journal = "Multiscale Modeling and Simulation",
-   year    = "2011",
-   volume  = "4",
-   pages   = "1350--1372",
-   url     = "",
-   doi     = ""
+   author  = {O. P. Iliev and R. D. Lazarov and J. Willems},
+   title   = {Variational multiscale finite element method for flows in highly porous media},
+   journal = {Multiscale Modeling and Simulation},
+   year    = {2011},
+   volume  = {4},
+   pages   = {1350--1372},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_30,
-   author  = "B. Janssen and G. Kanschat",
-   title   = "Adaptive multilevel methods with local smoothing",
-   journal = "SIAM J. Sci. Comput. 33(4) 2095-2114",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Janssen and G. Kanschat},
+   title   = {Adaptive multilevel methods with local smoothing},
+   journal = {SIAM J. Sci. Comput. 33(4) 2095-2114},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_31,
-   author  = "G. Jegert and A. Kersch and W. Weinreich and P. Lugli",
-   title   = "Monte Carlo Simulation of Leakage Currents in TiN/ZrO<sub>2</sub>/TiN Capacitors",
-   journal = "IEEE Transactions on Electron Devices",
-   year    = "2011",
-   volume  = "58",
-   pages   = "327--334",
-   url     = "",
-   doi     = ""
+   author  = {G. Jegert and A. Kersch and W. Weinreich and P. Lugli},
+   title   = {Monte Carlo Simulation of Leakage Currents in TiN/ZrO$_{2}$/TiN Capacitors},
+   journal = {IEEE Transactions on Electron Devices},
+   year    = {2011},
+   volume  = {58},
+   pages   = {327--334},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_32,
-   author  = "N. Jepihhina and N. Beraud and M. Sepp and R. Birkedal and M. Vendelin",
-   title   = "Permeabilized Rat Cardiomyocyte Response Demonstrates Intracellular Origin of Diffusion Obstacles",
-   journal = "Biophysical Journal , Vol. 101(9), pp: 2112–2121",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S000634951101085X",
-   doi     = ""
+   author  = {N. Jepihhina and N. Beraud and M. Sepp and R. Birkedal and M. Vendelin},
+   title   = {Permeabilized Rat Cardiomyocyte Response Demonstrates Intracellular Origin of Diffusion Obstacles},
+   journal = {Biophysical Journal , Vol. 101(9), pp: 2112--2121},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S000634951101085X},
+   doi     = {}
 }
 
 @mastersthesis{2011_33,
-   author  = "N. Johansson",
-   title   = "Implementation of a standard level set method for incompressible two-phase flow simulations",
-   year    = "2011",
-   school  = "Uppsala University, Uppsala, Sweden",
-   url     = ""
+   author  = {N. Johansson},
+   title   = {Implementation of a standard level set method for incompressible two-phase flow simulations},
+   year    = {2011},
+   school  = {Uppsala University, Uppsala, Sweden},
+   url     = {}
 }
 
 @article{2011_34,
-   author  = "J. Joos and T. Carraro and M. Ender and B. R&uuml;ger and A. Weber and E. Ivers-Tiff&eacute;e",
-   title   = "Detailed Microstructure Analysis and 3D Simulations of Porous Electrodes",
-   journal = "ECS Trans. 35",
-   year    = "2011",
-   volume  = "",
-   pages   = "2357--2368",
-   url     = "",
-   doi     = ""
+   author  = {J. Joos and T. Carraro and M. Ender and B. R\"{u}ger and A. Weber and E. Ivers-Tiff\'{e}e},
+   title   = {Detailed Microstructure Analysis and 3D Simulations of Porous Electrodes},
+   journal = {ECS Trans. 35},
+   year    = {2011},
+   volume  = {},
+   pages   = {2357--2368},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_35,
-   author  = "F. Keller and H. Nirschl and W. D&ouml;rfler",
-   title   = "Primary charge effects on prolate spheroids with moderate aspect ratios",
-   journal = "Journal of Colloid and Interface Science",
-   year    = "2011",
-   volume  = "363",
-   pages   = "690--702",
-   url     = "",
-   doi     = ""
+   author  = {F. Keller and H. Nirschl and W. D\"{o}rfler},
+   title   = {Primary charge effects on prolate spheroids with moderate aspect ratios},
+   journal = {Journal of Colloid and Interface Science},
+   year    = {2011},
+   volume  = {363},
+   pages   = {690--702},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_36,
-   author  = "K. Kormann and M. Kronbichler",
-   title   = "Parallel finite element operator application: Graph partitioning and coloring",
-   journal = "In proceedings of the 2011 IEEE 7th international conference on e-Science",
-   year    = "2011",
-   volume  = "",
-   pages   = "332--339",
-   url     = "",
-   doi     = ""
+   author  = {K. Kormann and M. Kronbichler},
+   title   = {Parallel finite element operator application: Graph partitioning and coloring},
+   journal = {In proceedings of the 2011 IEEE 7th international conference on e-Science},
+   year    = {2011},
+   volume  = {},
+   pages   = {332--339},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2011_37,
-   author  = "M. Kronbichler",
-   title   = "Computational Techniques for Coupled Flow-Transport Problems",
-   year    = "2011",
-   school  = "Uppsala University, Uppsala, Sweden",
-   url     = ""
+   author  = {M. Kronbichler},
+   title   = {Computational Techniques for Coupled Flow-Transport Problems},
+   year    = {2011},
+   school  = {Uppsala University, Uppsala, Sweden},
+   url     = {}
 }
 
 @article{2011_38,
-   author  = "M. Kronbichler and C. Walker and G. Kreiss and B. M&uuml;ller",
-   title   = "Multiscale modeling of capillary-driven contact line dynamics",
-   journal = "submitted",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Kronbichler and C. Walker and G. Kreiss and B. M\"{u}ller},
+   title   = {Multiscale modeling of capillary-driven contact line dynamics},
+   journal = {submitted},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_39,
-   author  = "W. Layton and L. R&ouml;he and H. Tran",
-   title   = "Explicitly uncoupled VMS stabilization of fluid flow",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2011",
-   volume  = "200",
-   pages   = "3183--3199",
-   url     = "",
-   doi     = ""
+   author  = {W. Layton and L. R\"{o}he and H. Tran},
+   title   = {Explicitly uncoupled VMS stabilization of fluid flow},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2011},
+   volume  = {200},
+   pages   = {3183--3199},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_40,
-   author  = "T. Leicht and R. Hartmann",
-   title   = "Error estimation and hp-adaptive mesh refinement for discontinuous Galerkin methods",
-   journal = "In Z. J. Wang, editor, Adaptive High-Order Methods in Computational Fluid Dynamics - with applications in aerospace engineering, World Science Books",
-   year    = "2011",
-   volume  = "",
-   pages   = "67--94",
-   url     = "",
-   doi     = ""
+   author  = {T. Leicht and R. Hartmann},
+   title   = {Error estimation and hp-adaptive mesh refinement for discontinuous Galerkin methods},
+   journal = {In Z. J. Wang, editor, Adaptive High-Order Methods in Computational Fluid Dynamics - with applications in aerospace engineering, World Science Books},
+   year    = {2011},
+   volume  = {},
+   pages   = {67--94},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_41,
-   author  = "T. Leicht and R. Hartmann",
-   title   = "Goal-oriented error estimation and hp-adaptive mesh refinement for aerodynamic flows.",
-   journal = "49<sup>th</sup> AIAA Aerospace Sciences Meeting AIAA 2011-212",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Leicht and R. Hartmann},
+   title   = {Goal-oriented error estimation and hp-adaptive mesh refinement for aerodynamic flows.},
+   journal = {49$^{\textnormal{th}}$ AIAA Aerospace Sciences Meeting AIAA 2011-212},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_42,
-   author  = "K. Leonard",
-   title   = "Multiphase Modelling of Tissue Engineering",
-   journal = "Proceedings of the University of Oxford Department of Computer Science Student Conference 2011",
-   year    = "2011",
-   volume  = "",
-   pages   = "18--19",
-   url     = "",
-   doi     = ""
+   author  = {K. Leonard},
+   title   = {Multiphase Modelling of Tissue Engineering},
+   journal = {Proceedings of the University of Oxford Department of Computer Science Student Conference 2011},
+   year    = {2011},
+   volume  = {},
+   pages   = {18--19},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_43,
-   author  = "J. L&ouml;we and G. Lube and L. R&ouml;he",
-   title   = "A Projection-Based Variational Multiscale Method for the Incompressible Navier–Stokes/Fourier Model",
-   journal = "BAIL 2010 - Boundary and Interior Layers, Computational and Asymptitic Methods. Lecture Notes in Computational Science and Engineering, Vol. 81",
-   year    = "2011",
-   volume  = "",
-   pages   = "165--175",
-   url     = "",
-   doi     = ""
+   author  = {J. L\"{o}we and G. Lube and L. R\"{o}he},
+   title   = {A Projection-Based Variational Multiscale Method for the Incompressible Navier--Stokes/Fourier Model},
+   journal = {BAIL 2010 - Boundary and Interior Layers, Computational and Asymptitic Methods. Lecture Notes in Computational Science and Engineering, Vol. 81},
+   year    = {2011},
+   volume  = {},
+   pages   = {165--175},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2011_44,
-   author  = "J. Löwe",
-   title   = "Eine Finite-Elemente-Methode für nicht-isotherme inkompressible Strömungsprobleme ",
-   year    = "2011",
-   school  = "Gottingen University",
-   url     = "http://num.math.uni-goettingen.de/picap/pdf/E675.pdf"
+   author  = {J. L\"{o}we},
+   title   = {Eine Finite-Elemente-Methode f\"{u}r nicht-isotherme inkompressible Str\"{o}mungsprobleme },
+   year    = {2011},
+   school  = {Gottingen University},
+   url     = {http://num.math.uni-goettingen.de/picap/pdf/E675.pdf}
 }
 
 @article{2011_45,
-   author  = "M. T. Myers and B. H. Sencer and L. Shao",
-   title   = "Multi-scale modeling of localized heating caused by ion bombardment",
-   journal = "Nuclear Instruments and Methods in Physics Research Section B: Beam Interactions with Materials and Atoms, in press",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0168583X11000760",
-   doi     = ""
+   author  = {M. T. Myers and B. H. Sencer and L. Shao},
+   title   = {Multi-scale modeling of localized heating caused by ion bombardment},
+   journal = {Nuclear Instruments and Methods in Physics Research Section B: Beam Interactions with Materials and Atoms, in press},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0168583X11000760},
+   doi     = {}
 }
 
 @article{2011_46,
-   author  = "A. Nigro and S. Renda and C. De Bartolo and R. Hartmann and F. Bassi",
-   title   = "A discontinuous Galerkin method for laminar low Mach number flows",
-   journal = "66th National Congress ATI in Rende, Italy, 5-9 Sept. 2011. University of Calabria",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Nigro and S. Renda and C. De Bartolo and R. Hartmann and F. Bassi},
+   title   = {A discontinuous Galerkin method for laminar low Mach number flows},
+   journal = {66th National Congress ATI in Rende, Italy, 5-9 Sept. 2011. University of Calabria},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_47,
-   author  = "J. A. Norato and A. J. Wagoner Johnson",
-   title   = "A Computational and Cellular Solids Approach to the Stiffness-Based Design of Bone Scaffolds",
-   journal = "J. Biomech. Eng., 091003/1-8",
-   year    = "2011",
-   volume  = "133",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. A. Norato and A. J. Wagoner Johnson},
+   title   = {A Computational and Cellular Solids Approach to the Stiffness-Based Design of Bone Scaffolds},
+   journal = {J. Biomech. Eng., 091003/1-8},
+   year    = {2011},
+   volume  = {133},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_48,
-   author  = "D. Pilipenko and M. Fleck and H. Emmerich",
-   title   = "On numerical aspects of phase field fracture modelling",
-   journal = "European Phys. J. Plus, 100/1-16",
-   year    = "2011",
-   volume  = "126",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Pilipenko and M. Fleck and H. Emmerich},
+   title   = {On numerical aspects of phase field fracture modelling},
+   journal = {European Phys. J. Plus, 100/1-16},
+   year    = {2011},
+   volume  = {126},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2011_49,
-   author  = "K. J. Raghuram",
-   title   = "Higher Order Numerical Discretization on Scattered Grids",
-   year    = "2011",
-   school  = "University of California, Santa Barbara",
-   url     = ""
+   author  = {K. J. Raghuram},
+   title   = {Higher Order Numerical Discretization on Scattered Grids},
+   year    = {2011},
+   school  = {University of California, Santa Barbara},
+   url     = {}
 }
 
 @article{2011_50,
-   author  = "M. J. Rapson and J. C. Tapson",
-   title   = "Emulating the theoretical bifurcation diagram of a cochlear model in computation",
-   journal = "Second African Conference on Computational Mechanics - AfriCOMP11",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. J. Rapson and J. C. Tapson},
+   title   = {Emulating the theoretical bifurcation diagram of a cochlear model in computation},
+   journal = {Second African Conference on Computational Mechanics - AfriCOMP11},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_51,
-   author  = "M. J. Rapson and J. C. Tapson",
-   title   = "Investigations into Time Stepping Methods for Cochlear Models",
-   journal = "International Journal for Numerical Methods in Biomedical Engineering, accepted",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. J. Rapson and J. C. Tapson},
+   title   = {Investigations into Time Stepping Methods for Cochlear Models},
+   journal = {International Journal for Numerical Methods in Biomedical Engineering, accepted},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_52,
-   author  = "T. Richter and T. Wick",
-   title   = "Fluid-Structure Interactions in ALE and Fully Eulerian Coordinates",
-   journal = "PAMM",
-   year    = "2011",
-   volume  = "10",
-   pages   = "487--488",
-   url     = "",
-   doi     = ""
+   author  = {T. Richter and T. Wick},
+   title   = {Fluid-Structure Interactions in ALE and Fully Eulerian Coordinates},
+   journal = {PAMM},
+   year    = {2011},
+   volume  = {10},
+   pages   = {487--488},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2011_53,
-   author  = "D. Riedlbauer",
-   title   = "Thermomechanical Modelling and Simulation of Electron Beam Melting",
-   year    = "2011",
-   school  = "Friedrich-Alexander-University, Erlangen-Nuremberg",
-   url     = ""
+   author  = {D. Riedlbauer},
+   title   = {Thermomechanical Modelling and Simulation of Electron Beam Melting},
+   year    = {2011},
+   school  = {Friedrich-Alexander-University, Erlangen-Nuremberg},
+   url     = {}
 }
 
 @article{2011_54,
-   author  = "L. R&ouml;he and G. Lube",
-   title   = "Large-Eddy Simulation of Wall-Bounded Turbulent Flows: Layer-Adapted Meshes vs. Weak Dirichlet Boundary Conditions",
-   journal = "BAIL 2010 - Boundary and Interior Layers, Computational and Asymptitic Methods. Lecture Notes in Computational Science and Engineering, Vol. 81",
-   year    = "2011",
-   volume  = "",
-   pages   = "197--205",
-   url     = "",
-   doi     = ""
+   author  = {L. R\"{o}he and G. Lube},
+   title   = {Large-Eddy Simulation of Wall-Bounded Turbulent Flows: Layer-Adapted Meshes vs. Weak Dirichlet Boundary Conditions},
+   journal = {BAIL 2010 - Boundary and Interior Layers, Computational and Asymptitic Methods. Lecture Notes in Computational Science and Engineering, Vol. 81},
+   year    = {2011},
+   volume  = {},
+   pages   = {197--205},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_55,
-   author  = "M. Steigemann",
-   title   = "Simulation of Quasi-static Crack Propagation in Functionally Graded Materials",
-   journal = "Dept. of Math. and Natural Sci., Inst. of Anal. and Appl. Math., University of Kassel",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.martin-steigemann.net/downloads/preprint_steigemann_simulation_of_quasi-static_crack_propagation_in_fgms.pdf",
-   doi     = ""
+   author  = {M. Steigemann},
+   title   = {Simulation of Quasi-static Crack Propagation in Functionally Graded Materials},
+   journal = {Dept. of Math. and Natural Sci., Inst. of Anal. and Appl. Math., University of Kassel},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.martin-steigemann.net/downloads/preprint_steigemann_simulation_of_quasi-static_crack_propagation_in_fgms.pdf},
+   doi     = {}
 }
 
 @article{2011_56,
-   author  = "M. Stoll and J. Pearson and A. Wathen",
-   title   = "Preconditioners for state constrained optimal control problems with Moreau-Yosida penalty function",
-   journal = "Submitted to Numerical Linear Algebra with Applications",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.mpi-magdeburg.mpg.de/people/stollm/pub.html",
-   doi     = ""
+   author  = {M. Stoll and J. Pearson and A. Wathen},
+   title   = {Preconditioners for state constrained optimal control problems with Moreau-Yosida penalty function},
+   journal = {Submitted to Numerical Linear Algebra with Applications},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.mpi-magdeburg.mpg.de/people/stollm/pub.html},
+   doi     = {}
 }
 
 @article{2011_57,
-   author  = "J. White and R. I. Borja",
-   title   = "Block-preconditioned Newton–Krylov solvers for fully coupled flow and geomechanics",
-   journal = "Comp. Geosc.",
-   year    = "2011",
-   volume  = "15",
-   pages   = "647--659",
-   url     = "",
-   doi     = ""
+   author  = {J. White and R. I. Borja},
+   title   = {Block-preconditioned Newton--Krylov solvers for fully coupled flow and geomechanics},
+   journal = {Comp. Geosc.},
+   year    = {2011},
+   volume  = {15},
+   pages   = {647--659},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_58,
-   author  = "T. Wick",
-   title   = "Fluid-structure interactions using different mesh motion techniques",
-   journal = "Computers and Structures",
-   year    = "2011",
-   volume  = "89",
-   pages   = "1456--1467",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Fluid-structure interactions using different mesh motion techniques},
+   journal = {Computers and Structures},
+   year    = {2011},
+   volume  = {89},
+   pages   = {1456--1467},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2011_59,
-   author  = "T. Wick",
-   title   = "Adaptive finite element simulation of fluid-structure interaction",
-   year    = "2011",
-   school  = "University of Heidelberg, Germany",
-   url     = ""
+   author  = {T. Wick},
+   title   = {Adaptive finite element simulation of fluid-structure interaction},
+   year    = {2011},
+   school  = {University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2011_60,
-   author  = "T. D. Young",
-   title   = "A qualitative semi-classical treatment of an isolated semi-polar quantum dot",
-   journal = "J. Phys.: Conf. Ser., 28(10)",
-   year    = "2011",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. D. Young},
+   title   = {A qualitative semi-classical treatment of an isolated semi-polar quantum dot},
+   journal = {J. Phys.: Conf. Ser., 28(10)},
+   year    = {2011},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_61,
-   author  = "S. Zahedi and M. Kronbichler and G. Kreiss",
-   title   = "Spurious currents in finite element based level set methods for two-phase flow",
-   journal = "Int. J. Numer. Meth. Fluids.",
-   year    = "2011",
-   volume  = "67",
-   pages   = "1433--1456",
-   url     = "",
-   doi     = ""
+   author  = {S. Zahedi and M. Kronbichler and G. Kreiss},
+   title   = {Spurious currents in finite element based level set methods for two-phase flow},
+   journal = {Int. J. Numer. Meth. Fluids.},
+   year    = {2011},
+   volume  = {67},
+   pages   = {1433--1456},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_62,
-   author  = "L. Zhou and B. Yazici",
-   title   = "Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography in the Presence of Measurement Noise",
-   journal = "IEEE Trans. Image Processing",
-   year    = "2011",
-   volume  = "20",
-   pages   = "1094--1111",
-   url     = "",
-   doi     = ""
+   author  = {L. Zhou and B. Yazici},
+   title   = {Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography in the Presence of Measurement Noise},
+   journal = {IEEE Trans. Image Processing},
+   year    = {2011},
+   volume  = {20},
+   pages   = {1094--1111},
+   url     = {},
+   doi     = {}
 }
 
 @article{2011_63,
-   author  = "L. Zhu and D. Sch&ouml;tzau",
-   title   = "A robust a posteriori error estimate for hp-adaptive DG methods for convection-diffusion equations",
-   journal = "IMA J. Numer. Math.",
-   year    = "2011",
-   volume  = "31",
-   pages   = "971--1005",
-   url     = "",
-   doi     = ""
+   author  = {L. Zhu and D. Sch\"{o}tzau},
+   title   = {A robust a posteriori error estimate for hp-adaptive DG methods for convection-diffusion equations},
+   journal = {IMA J. Numer. Math.},
+   year    = {2011},
+   volume  = {31},
+   pages   = {971--1005},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -1,774 +1,774 @@
 % Encoding: ISO-8859-1
 
 @phdthesis{2012_0,
-   author  = "I. Adeniran",
-   title   = "Biophysically detailed modelling of the functional impact of gene mutations associated with the "short QT syndrome"",
-   year    = "2012",
-   school  = "University of Manchester",
-   url     = ""
+   author  = {I. Adeniran},
+   title   = {Biophysically detailed modelling of the functional impact of gene mutations associated with the ``short QT syndrome''},
+   year    = {2012},
+   school  = {University of Manchester},
+   url     = {}
 }
 
 @article{2012_1,
-   author  = "T. A. Albring",
-   title   = "Optimal Control of PDEs solved by Fixed Point Iterations using Algorithmic Differentiation",
-   journal = "Bachelor of Science in Computational Engineering Science, RWTH Aachen University",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.mathcces.rwth-aachen.de/_media/5people/albring/thesis_bsc.pdf",
-   doi     = ""
+   author  = {T. A. Albring},
+   title   = {Optimal Control of PDEs solved by Fixed Point Iterations using Algorithmic Differentiation},
+   journal = {Bachelor of Science in Computational Engineering Science, RWTH Aachen University},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.mathcces.rwth-aachen.de/_media/5people/albring/thesis_bsc.pdf},
+   doi     = {}
 }
 
 @article{2012_2,
-   author  = "M. Alexe and A. Sandu",
-   title   = "A fully discrete framework for the adaptive solution of inverse problems ",
-   journal = "Technical report, Computer Science Department, Virginia Tech.",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "https://vtechworks.lib.vt.edu/handle/10919/19441",
-   doi     = ""
+   author  = {M. Alexe and A. Sandu},
+   title   = {A fully discrete framework for the adaptive solution of inverse problems },
+   journal = {Technical report, Computer Science Department, Virginia Tech.},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {https://vtechworks.lib.vt.edu/handle/10919/19441},
+   doi     = {}
 }
 
 @article{2012_3,
-   author  = "M. Bause and U. K&ouml;cher",
-   title   = "Numerical simulation of elastic wave propagation in composite material",
-   journal = "Proceedings of the European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS 2012) J. Eberhardsteiner et.al. (eds.) Vienna, Austria, September 10-14",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "http://link.springer.com/article/10.1007/s10915-014-9831-3",
-   doi     = ""
+   author  = {M. Bause and U. K\"{o}cher},
+   title   = {Numerical simulation of elastic wave propagation in composite material},
+   journal = {Proceedings of the European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS 2012) J. Eberhardsteiner et.al. (eds.) Vienna, Austria, September 10-14},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {http://link.springer.com/article/10.1007/s10915-014-9831-3},
+   doi     = {}
 }
 
 @article{2012_4,
-   author  = "M. Besier and W. Wollner",
-   title   = "On the pressure approximation in nonstationary incompressible flow simulations on dynamically varying spatial meshes",
-   journal = "International Journal for Numerical Methods in Fluids",
-   year    = "2012",
-   volume  = "69",
-   pages   = "1045--1064",
-   url     = "",
-   doi     = ""
+   author  = {M. Besier and W. Wollner},
+   title   = {On the pressure approximation in nonstationary incompressible flow simulations on dynamically varying spatial meshes},
+   journal = {International Journal for Numerical Methods in Fluids},
+   year    = {2012},
+   volume  = {69},
+   pages   = {1045--1064},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_5,
-   author  = "L. Blank and L. Sarbu and M. Stoll",
-   title   = "Preconditioning for Allen-Cahn variational inequalities with non-local constraints",
-   journal = "Journal of Computational Physics",
-   year    = "2012",
-   volume  = "231",
-   pages   = "5406--5402",
-   url     = "",
-   doi     = ""
+   author  = {L. Blank and L. Sarbu and M. Stoll},
+   title   = {Preconditioning for Allen-Cahn variational inequalities with non-local constraints},
+   journal = {Journal of Computational Physics},
+   year    = {2012},
+   volume  = {231},
+   pages   = {5406--5402},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_6,
-   author  = "C. Boehm and M. Ulbrich",
-   title   = "A Newton-CG method for full-waveform inversion in a coupled solid-fluid system",
-   journal = "submitted",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "http://www-m1.ma.tum.de/bin/view/Lehrstuhl/PublikationenUlbrich",
-   doi     = ""
+   author  = {C. Boehm and M. Ulbrich},
+   title   = {A Newton-CG method for full-waveform inversion in a coupled solid-fluid system},
+   journal = {submitted},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {http://www-m1.ma.tum.de/bin/view/Lehrstuhl/PublikationenUlbrich},
+   doi     = {}
 }
 
 @phdthesis{2012_7,
-   author  = "P. Boyanova",
-   title   = "On Numerical Solution Methods for Block-Structured Discrete Systems",
-   year    = "2012",
-   school  = "University of Uppsala",
-   url     = ""
+   author  = {P. Boyanova},
+   title   = {On Numerical Solution Methods for Block-Structured Discrete Systems},
+   year    = {2012},
+   school  = {University of Uppsala},
+   url     = {}
 }
 
 @article{2012_8,
-   author  = "M. Braack and G. Lube and L. R&ouml;he",
-   title   = "Divergence preserving interpolation on anisotropic quadrilateral meshes",
-   journal = "Comput. Methods Appl. Math., Vol. 12",
-   year    = "2012",
-   volume  = "",
-   pages   = "123--138",
-   url     = "",
-   doi     = ""
+   author  = {M. Braack and G. Lube and L. R\"{o}he},
+   title   = {Divergence preserving interpolation on anisotropic quadrilateral meshes},
+   journal = {Comput. Methods Appl. Math., Vol. 12},
+   year    = {2012},
+   volume  = {},
+   pages   = {123--138},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_9,
-   author  = "M. B&uuml;rg",
-   title   = "A Residual-Based A Posteriori Error Estimator for the <i>hp</i>-Finite Element Method for Maxwell's Equations",
-   journal = "Appl. Numer. Math.",
-   year    = "2012",
-   volume  = "62",
-   pages   = "922--940",
-   url     = "",
-   doi     = ""
+   author  = {M. B\"{u}rg},
+   title   = {A Residual-Based A Posteriori Error Estimator for the $hp$-Finite Element Method for Maxwell's Equations},
+   journal = {Appl. Numer. Math.},
+   year    = {2012},
+   volume  = {62},
+   pages   = {922--940},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2012_10,
-   author  = "M. B&uuml;rg",
-   title   = "A Fully Automatic <i>hp</i>-Adaptive Refinement Strategy",
-   year    = "2012",
-   school  = "Karlsruhe Institute of Technology (KIT)",
-   url     = ""
+   author  = {M. B\"{u}rg},
+   title   = {A Fully Automatic $hp$-Adaptive Refinement Strategy},
+   year    = {2012},
+   school  = {Karlsruhe Institute of Technology (KIT)},
+   url     = {}
 }
 
 @article{2012_11,
-   author  = "A. Cangiani and E. Georgoulis and S. Metcalfe",
-   title   = "An a posteriori error estimator for discontinuous Galerkin methods for non-stationary convection-diffusion problems",
-   journal = "submitted",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
+   title   = {An a posteriori error estimator for discontinuous Galerkin methods for non-stationary convection-diffusion problems},
+   journal = {submitted},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_12,
-   author  = "A. Cangiani and E. Georgoulis and M. Jensen",
-   title   = "Discontinuous Galerkin methods for mass transfer through semi-permeable membranes",
-   journal = "submitted",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "http://www2.le.ac.uk/departments/mathematics/extranet/staff-material/staff-profiles/eg64/publications",
-   doi     = ""
+   author  = {A. Cangiani and E. Georgoulis and M. Jensen},
+   title   = {Discontinuous Galerkin methods for mass transfer through semi-permeable membranes},
+   journal = {submitted},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {http://www2.le.ac.uk/departments/mathematics/extranet/staff-material/staff-profiles/eg64/publications},
+   doi     = {}
 }
 
 @article{2012_13,
-   author  = "T. Carraro and J. Joos and B. R&uuml;ger and A. Weber and E. Ivers-Tiff&eacute;e",
-   title   = "3D finite element model for reconstructed mixed-conducting cathodes: I. Performance quantification",
-   journal = "Electrochimica Acta, Vol. 77",
-   year    = "2012",
-   volume  = "",
-   pages   = "315--323",
-   url     = "",
-   doi     = ""
+   author  = {T. Carraro and J. Joos and B. R\"{u}ger and A. Weber and E. Ivers-Tiff\'{e}e},
+   title   = {3D finite element model for reconstructed mixed-conducting cathodes: I. Performance quantification},
+   journal = {Electrochimica Acta, Vol. 77},
+   year    = {2012},
+   volume  = {},
+   pages   = {315--323},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_14,
-   author  = "T. Carraro and J. Joos and B. R&uuml;ger and A. Weber and E. Ivers-Tiff&eacute;e",
-   title   = "3D finite element model for reconstructed mixed-conducting cathodes: II. Parameter sensitivity analysis",
-   journal = "Electrochimica Acta, Vol. 77",
-   year    = "2012",
-   volume  = "",
-   pages   = "309--314",
-   url     = "",
-   doi     = ""
+   author  = {T. Carraro and J. Joos and B. R\"{u}ger and A. Weber and E. Ivers-Tiff\'{e}e},
+   title   = {3D finite element model for reconstructed mixed-conducting cathodes: II. Parameter sensitivity analysis},
+   journal = {Electrochimica Acta, Vol. 77},
+   year    = {2012},
+   volume  = {},
+   pages   = {309--314},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2012_15,
-   author  = "J. Chapman",
-   title   = "On Discontinuous Galerkin Methods for Singularly Perturbed and Incompressible Miscible Displacement Problems ",
-   year    = "2012",
-   school  = "Durham University",
-   url     = "http://etheses.dur.ac.uk/5886/1/JRChapman_thesis_final.pdf?DDD21"
+   author  = {J. Chapman},
+   title   = {On Discontinuous Galerkin Methods for Singularly Perturbed and Incompressible Miscible Displacement Problems },
+   year    = {2012},
+   school  = {Durham University},
+   url     = {http://etheses.dur.ac.uk/5886/1/JRChapman_thesis_final.pdf?DDD21}
 }
 
 @article{2012_16,
-   author  = "A. Demlow and A. H. Georgoulis",
-   title   = "Pointwise a posteriori error control for discontinuous Galerkin methods for elliptic problems",
-   journal = "SIAM Journal on Numerical Analysis",
-   year    = "2012",
-   volume  = "50",
-   pages   = "2159--2181",
-   url     = "",
-   doi     = ""
+   author  = {A. Demlow and A. H. Georgoulis},
+   title   = {Pointwise a posteriori error control for discontinuous Galerkin methods for elliptic problems},
+   journal = {SIAM Journal on Numerical Analysis},
+   year    = {2012},
+   volume  = {50},
+   pages   = {2159--2181},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_17,
-   author  = "P. Dobson and C. Lei and T. Navessin and M. Secanell",
-   title   = "Characterization of the PEM Fuel Cell Catalyst Layer Microstructure by Nonlinear Least-Squares Parameter Estimation",
-   journal = "Journal of the Electrochemical Society, 159(5), B1-B10",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {P. Dobson and C. Lei and T. Navessin and M. Secanell},
+   title   = {Characterization of the PEM Fuel Cell Catalyst Layer Microstructure by Nonlinear Least-Squares Parameter Estimation},
+   journal = {Journal of the Electrochemical Society, 159(5), B1-B10},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2012_18,
-   author  = "B. S. M. Ebna Hai",
-   title   = "Numerical approximation of fluid structure interaction (FSI) problem and simplified model for the vertical vibrations of the aircraft wing",
-   year    = "2012",
-   school  = "University of Hamburg, Germany and University of L'Aquila, Italy",
-   url     = ""
+   author  = {B. S. M. Ebna Hai},
+   title   = {Numerical approximation of fluid structure interaction (FSI) problem and simplified model for the vertical vibrations of the aircraft wing},
+   year    = {2012},
+   school  = {University of Hamburg, Germany and University of L'Aquila, Italy},
+   url     = {}
 }
 
 @article{2012_19,
-   author  = "B. S. M. Ebna Hai",
-   title   = "Numerical approximation of fluid structure interaction (FSI) problem: simplified model for the vertical vibrations of the aircraft wing",
-   journal = "Lambert Academic Publishing, ISBN: 978-3-659-30284-8",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai},
+   title   = {Numerical approximation of fluid structure interaction (FSI) problem: simplified model for the vertical vibrations of the aircraft wing},
+   journal = {Lambert Academic Publishing, ISBN: 978-3-659-30284-8},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_20,
-   author  = "Y. Efendiev and J. Galvis and R. Lazarov and J. Willems",
-   title   = "Robust domain decomposition preconditioners for abstract symmetric positive definite bilinear forms",
-   journal = "ESAIM: Mathematical Modelling and Numerical Analysis",
-   year    = "2012",
-   volume  = "46",
-   pages   = "1175--1199",
-   url     = "",
-   doi     = ""
+   author  = {Y. Efendiev and J. Galvis and R. Lazarov and J. Willems},
+   title   = {Robust domain decomposition preconditioners for abstract symmetric positive definite bilinear forms},
+   journal = {ESAIM: Mathematical Modelling and Numerical Analysis},
+   year    = {2012},
+   volume  = {46},
+   pages   = {1175--1199},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_21,
-   author  = "Y. Efendiev and J. Galvis and R. Lazarov and J. Willems",
-   title   = "Robust solvers for symmetric positive definite operators and weighted Poincar&eacute; inequalities",
-   journal = "In I. Lirkov, S. Margenov, and J. Wasniewski, editors, Large-Scale Scientific Computing: 8th International Conference, LSSC 2011, Sozopol, Bulgaria, 43-51, Lecture Notes in Computer Science, Springer",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {Y. Efendiev and J. Galvis and R. Lazarov and J. Willems},
+   title   = {Robust solvers for symmetric positive definite operators and weighted Poincar\'{e} inequalities},
+   journal = {In I. Lirkov, S. Margenov, and J. Wasniewski, editors, Large-Scale Scientific Computing: 8th International Conference, LSSC 2011, Sozopol, Bulgaria, 43-51, Lecture Notes in Computer Science, Springer},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_22,
-   author  = "J. Fang and X. Gao and A. Zhou",
-   title   = "A Kohn-Sham equation solver based on hexahedral finite elements",
-   journal = "Journal of Computational Physics, pp. 3166–3180",
-   year    = "2012",
-   volume  = "231",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Fang and X. Gao and A. Zhou},
+   title   = {A Kohn-Sham equation solver based on hexahedral finite elements},
+   journal = {Journal of Computational Physics, pp. 3166--3180},
+   year    = {2012},
+   volume  = {231},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2012_23,
-   author  = "T. Fankhauser",
-   title   = "An hp-adaptive strategy based on smoothness estimation in 2d",
-   year    = "2012",
-   school  = "University of Bern, Switzerland",
-   url     = ""
+   author  = {T. Fankhauser},
+   title   = {An hp-adaptive strategy based on smoothness estimation in 2d},
+   year    = {2012},
+   school  = {University of Bern, Switzerland},
+   url     = {}
 }
 
 @article{2012_24,
-   author  = "T. Fankhauser and T. P. Wihler and M. Wirz",
-   title   = "hp-adaptive FEM based on continuous Sobolev embeddings: isotropic refinements",
-   journal = "Research report 2012-10, University of Bern, Switzerland",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Fankhauser and T. P. Wihler and M. Wirz},
+   title   = {hp-adaptive FEM based on continuous Sobolev embeddings: isotropic refinements},
+   journal = {Research report 2012-10, University of Bern, Switzerland},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2012_25,
-   author  = "L. Ferguson",
-   title   = "Brittle fracture modeling with a surface tension excess property",
-   year    = "2012",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {L. Ferguson},
+   title   = {Brittle fracture modeling with a surface tension excess property},
+   year    = {2012},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2012_26,
-   author  = "A. Frisani and Y. A. Hassan",
-   title   = "On the Immersed Boundary Method: Finite Element Versus Finite Volume Approach",
-   journal = "2012 20th International Conference on Nuclear Engineering and the ASME 2012 Power Conference",
-   year    = "2012",
-   volume  = "",
-   pages   = "535--547",
-   url     = "http://proceedings.asmedigitalcollection.asme.org/proceeding.aspx?articleid=1764417",
-   doi     = ""
+   author  = {A. Frisani and Y. A. Hassan},
+   title   = {On the Immersed Boundary Method: Finite Element Versus Finite Volume Approach},
+   journal = {2012 20th International Conference on Nuclear Engineering and the ASME 2012 Power Conference},
+   year    = {2012},
+   volume  = {},
+   pages   = {535--547},
+   url     = {http://proceedings.asmedigitalcollection.asme.org/proceeding.aspx?articleid=1764417},
+   doi     = {}
 }
 
 @article{2012_27,
-   author  = "J. J. Gaitero and J. S. Dolado and C. Neuen and F. Heber and E. Koenders",
-   title   = "Computational 3d simulation of Calcium leaching in cement matrices",
-   journal = "Institut f&uuml;r numerische Simulation, Rheinische Friedrich-Wilhelms-Universit&auml;t Bonn, INS Preprint 1203",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. J. Gaitero and J. S. Dolado and C. Neuen and F. Heber and E. Koenders},
+   title   = {Computational 3d simulation of Calcium leaching in cement matrices},
+   journal = {Institut f\"{u}r numerische Simulation, Rheinische Friedrich-Wilhelms-Universit\"{a}t Bonn, INS Preprint 1203},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_28,
-   author  = "C. Goll and R. Rannacher and W. Wollner",
-   title   = "On the adjoint to the damped Crank-Nicolson time marching scheme: applications to goal-oriented mesh adaptation for the Black-Scholes equations",
-   journal = "Preprint, Institut f&uuml;r Wissenschaftliches Rechnen, accepted for publication in Journal of Computational Finance",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {C. Goll and R. Rannacher and W. Wollner},
+   title   = {On the adjoint to the damped Crank-Nicolson time marching scheme: applications to goal-oriented mesh adaptation for the Black-Scholes equations},
+   journal = {Preprint, Institut f\"{u}r Wissenschaftliches Rechnen, accepted for publication in Journal of Computational Finance},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_29,
-   author  = "C. Goll and T. Wick and W. Wollner",
-   title   = "DOpElib: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving PDEs and Optimization Problems with PDEs",
-   journal = "submitted in Dec ",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {C. Goll and T. Wick and W. Wollner},
+   title   = {DOpElib: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving PDEs and Optimization Problems with PDEs},
+   journal = {submitted in Dec },
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_30,
-   author  = "R. Hartmann",
-   title   = "Higher-order and adaptive discontinuous Galerkin methods with shock-capturing applied to transonic turbulent delta wing flow",
-   journal = "50th AIAA Aerospace Sciences Meeting, AIAA 2012-459",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Higher-order and adaptive discontinuous Galerkin methods with shock-capturing applied to transonic turbulent delta wing flow},
+   journal = {50th AIAA Aerospace Sciences Meeting, AIAA 2012-459},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_31,
-   author  = "L. Heltai and F. Costanzo",
-   title   = "Variational implementation of immersed finite element methods",
-   journal = "Computer Methods in Applied Mechanics and Engineering, –232, pp. 110–127",
-   year    = "2012",
-   volume  = "229",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {L. Heltai and F. Costanzo},
+   title   = {Variational implementation of immersed finite element methods},
+   journal = {Computer Methods in Applied Mechanics and Engineering, --232, pp. 110--127},
+   year    = {2012},
+   volume  = {229},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_32,
-   author  = "L. Heltai and S. Roy and F. Costanzo",
-   title   = "A Fully Coupled Immersed Finite Element Method for Fluid Structure Interaction via the Deal.II Library",
-   journal = "arXiv:1209.2811 [math.NA]",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {L. Heltai and S. Roy and F. Costanzo},
+   title   = {A Fully Coupled Immersed Finite Element Method for Fluid Structure Interaction via the Deal.II Library},
+   journal = {arXiv:1209.2811 [math.NA]},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_33,
-   author  = "M. Hinterm&uuml;ller and A. Schiela and W. Wollner",
-   title   = "The length of the primal-dual path in Moreau-Yosida-based path-following for state constrained optimal control",
-   journal = "Hamburger Beitr&auml;ge zur Angewandten Mathematik, 2012-03",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinterm\"{u}ller and A. Schiela and W. Wollner},
+   title   = {The length of the primal-dual path in Moreau-Yosida-based path-following for state constrained optimal control},
+   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik, 2012-03},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_34,
-   author  = "M. Hinze and M. Kunkel",
-   title   = "Discrete empirical interpolation in POD Model Order Reduction of Drift-Diffusion Equations in Electrical Networks",
-   journal = "Scientific Computing in Electrical Engineering, SCEE 2010 Mathematics in Industry, part 5",
-   year    = "2012",
-   volume  = "16",
-   pages   = "423--431",
-   url     = "http://link.springer.com/chapter/10.1007%2F978-3-642-22453-9_45",
-   doi     = ""
+   author  = {M. Hinze and M. Kunkel},
+   title   = {Discrete empirical interpolation in POD Model Order Reduction of Drift-Diffusion Equations in Electrical Networks},
+   journal = {Scientific Computing in Electrical Engineering, SCEE 2010 Mathematics in Industry, part 5},
+   year    = {2012},
+   volume  = {16},
+   pages   = {423--431},
+   url     = {http://link.springer.com/chapter/10.1007%2F978-3-642-22453-9_45},
+   doi     = {}
 }
 
 @article{2012_35,
-   author  = "M. Hinze and M. Kunkel and U. Matthes",
-   title   = "POD Model Order Reduction of electrical networks with semiconductors modeled by the transient Drift–Diffusion equations",
-   journal = "Progress in Industrial Mathematics at ECMI 2010 Mathematics in Industry, pp 161-168",
-   year    = "2012",
-   volume  = "17",
-   pages   = "",
-   url     = "http://link.springer.com/chapter/10.1007/978-3-642-25100-9_19",
-   doi     = ""
+   author  = {M. Hinze and M. Kunkel and U. Matthes},
+   title   = {POD Model Order Reduction of electrical networks with semiconductors modeled by the transient Drift--Diffusion equations},
+   journal = {Progress in Industrial Mathematics at ECMI 2010 Mathematics in Industry, pp 161-168},
+   year    = {2012},
+   volume  = {17},
+   pages   = {},
+   url     = {http://link.springer.com/chapter/10.1007/978-3-642-25100-9_19},
+   doi     = {}
 }
 
 @article{2012_36,
-   author  = "M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel",
-   title   = "Model order reduction of coupled circuit-device systems",
-   journal = "International Journal of Numerical Modelling: Electronic Networks, Devices and Fields",
-   year    = "2012",
-   volume  = "25",
-   pages   = "362--377",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel},
+   title   = {Model order reduction of coupled circuit-device systems},
+   journal = {International Journal of Numerical Modelling: Electronic Networks, Devices and Fields},
+   year    = {2012},
+   volume  = {25},
+   pages   = {362--377},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_37,
-   author  = "O. Jirousek and P. Zlamal",
-   title   = "Large-scale micro-finite element simulation of compressive behavior of trabecular bone microstructure",
-   journal = "Proceedings of the 18th Conference on Engineering Mechanics, Svratka, Czech Republic, May 14-17, 2012; paper #206",
-   year    = "2012",
-   volume  = "",
-   pages   = "543--549",
-   url     = "",
-   doi     = ""
+   author  = {O. Jirousek and P. Zlamal},
+   title   = {Large-scale micro-finite element simulation of compressive behavior of trabecular bone microstructure},
+   journal = {Proceedings of the 18th Conference on Engineering Mechanics, Svratka, Czech Republic, May 14-17, 2012; paper \#206},
+   year    = {2012},
+   volume  = {},
+   pages   = {543--549},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_38,
-   author  = "J. Joos and M. Ender and T. Carraro and A. Weber and E. Ivers-Tiff&eacute;e",
-   title   = "Representative Volume Element Size for Accurate Solid Oxide Fuel Cell Cathode Reconstructions from Focused Ion Beam Tomography Data",
-   journal = "Electrochimica Acta, in press",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S001346861200761X",
-   doi     = ""
+   author  = {J. Joos and M. Ender and T. Carraro and A. Weber and E. Ivers-Tiff\'{e}e},
+   title   = {Representative Volume Element Size for Accurate Solid Oxide Fuel Cell Cathode Reconstructions from Focused Ion Beam Tomography Data},
+   journal = {Electrochimica Acta, in press},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S001346861200761X},
+   doi     = {}
 }
 
 @phdthesis{2012_39,
-   author  = "S. Joshi",
-   title   = "A model for the estimation of residual stresses in soft tissues",
-   year    = "2012",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {S. Joshi},
+   title   = {A model for the estimation of residual stresses in soft tissues},
+   year    = {2012},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @phdthesis{2012_40,
-   author  = "K. Kormann",
-   title   = "On Numerical Solution Methods for Block-Structured Discrete Systems",
-   year    = "2012",
-   school  = "University of Uppsala",
-   url     = ""
+   author  = {K. Kormann},
+   title   = {On Numerical Solution Methods for Block-Structured Discrete Systems},
+   year    = {2012},
+   school  = {University of Uppsala},
+   url     = {}
 }
 
 @article{2012_41,
-   author  = "K. Kormann",
-   title   = "A time-space adaptive method for the Schr&ouml;dinger equation",
-   journal = "University of Uppsala, research report",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.cambridge.org/core/journals/communications-in-computational-physics/article/timespace-adaptive-method-for-the-schrodinger-equation/92B29B2C22440E091DD4DB7149E9140D",
-   doi     = ""
+   author  = {K. Kormann},
+   title   = {A time-space adaptive method for the Schr\"{o}dinger equation},
+   journal = {University of Uppsala, research report},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.cambridge.org/core/journals/communications-in-computational-physics/article/timespace-adaptive-method-for-the-schrodinger-equation/92B29B2C22440E091DD4DB7149E9140D},
+   doi     = {}
 }
 
 @phdthesis{2012_42,
-   author  = "K. Kormann",
-   title   = "Efficient and Reliable Simulation of Quantum Molecular Dynamics",
-   year    = "2012",
-   school  = "Doctoral thesis, Uppsala University",
-   url     = "http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A549981&dswid=6393"
+   author  = {K. Kormann},
+   title   = {Efficient and Reliable Simulation of Quantum Molecular Dynamics},
+   year    = {2012},
+   school  = {Doctoral thesis, Uppsala University},
+   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A549981&dswid=6393}
 }
 
 @phdthesis{2012_43,
-   author  = "S. Kramer",
-   title   = "CUDA-based scientific computing tools and selected applications",
-   year    = "2012",
-   school  = "G&ouml;ttingen University, Germany",
-   url     = ""
+   author  = {S. Kramer},
+   title   = {CUDA-based scientific computing tools and selected applications},
+   year    = {2012},
+   school  = {G\"{o}ttingen University, Germany},
+   url     = {}
 }
 
 @article{2012_44,
-   author  = "M. Kronbichler and T. Heister and W. Bangerth",
-   title   = "High Accuracy Mantle Convection Simulation through Modern Numerical Methods",
-   journal = "Geophysical Journal International",
-   year    = "2012",
-   volume  = "191",
-   pages   = "12--29",
-   url     = "",
-   doi     = ""
+   author  = {M. Kronbichler and T. Heister and W. Bangerth},
+   title   = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods},
+   journal = {Geophysical Journal International},
+   year    = {2012},
+   volume  = {191},
+   pages   = {12--29},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2012_45,
-   author  = "M. Kunkel",
-   title   = "Nonsmooth Newton Methods and Convergence of Discretized Optimal Control Problems subject to DAEs",
-   year    = "2012",
-   school  = "Universit&auml;t der Bundeswehr M&uuml;nchen",
-   url     = ""
+   author  = {M. Kunkel},
+   title   = {Nonsmooth Newton Methods and Convergence of Discretized Optimal Control Problems subject to DAEs},
+   year    = {2012},
+   school  = {Universit\"{a}t der Bundeswehr M\"{u}nchen},
+   url     = {}
 }
 
 @article{2012_46,
-   author  = "J. L&ouml;we and G. Lube",
-   title   = "A projection-based variational multiscale method for large-eddy simulation with application to non-isothermal free convection problems",
-   journal = "Math. Models Methods Appl. Sci., article 1150011",
-   year    = "2012",
-   volume  = "22",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. L\"{o}we and G. Lube},
+   title   = {A projection-based variational multiscale method for large-eddy simulation with application to non-isothermal free convection problems},
+   journal = {Math. Models Methods Appl. Sci., article 1150011},
+   year    = {2012},
+   volume  = {22},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_47,
-   author  = "A. T. McBride and J. Mergheim and A. Javili and P. Steinmann and S. Bargmann",
-   title   = "Micro-to-macro transitions for heterogeneous material layers accounting for in-plane stretch",
-   journal = "Journal of the Mechanics and Physics of Solids",
-   year    = "2012",
-   volume  = "60",
-   pages   = "1221--1239",
-   url     = "",
-   doi     = ""
+   author  = {A. T. McBride and J. Mergheim and A. Javili and P. Steinmann and S. Bargmann},
+   title   = {Micro-to-macro transitions for heterogeneous material layers accounting for in-plane stretch},
+   journal = {Journal of the Mechanics and Physics of Solids},
+   year    = {2012},
+   volume  = {60},
+   pages   = {1221--1239},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2012_48,
-   author  = "M. Moore",
-   title   = "Investigation of the Double-Trap Intrinsic Kinetic Equation for the Oxygen Reduction Reaction and its implementation into a Membrane Electrode Assembly model",
-   year    = "2012",
-   school  = "Department of Mechanical Engineering",
-   url     = "https://era.library.ualberta.ca/public/view/item/uuid:79f8832e-b550-49fd-8160-9b055147ee6d/"
+   author  = {M. Moore},
+   title   = {Investigation of the Double-Trap Intrinsic Kinetic Equation for the Oxygen Reduction Reaction and its implementation into a Membrane Electrode Assembly model},
+   year    = {2012},
+   school  = {Department of Mechanical Engineering},
+   url     = {https://era.library.ualberta.ca/public/view/item/uuid:79f8832e-b550-49fd-8160-9b055147ee6d/}
 }
 
 @article{2012_49,
-   author  = "C. Neuen and M. Griebel and J. Hamaekers",
-   title   = "Multiscale simulation of ion migration for battery system",
-   journal = "Institut f&uuml;r numerische Simulation, Rheinische Friedrich-Wilhelms-Universit&auml;t Bonn, INS Preprint 1208",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {C. Neuen and M. Griebel and J. Hamaekers},
+   title   = {Multiscale simulation of ion migration for battery system},
+   journal = {Institut f\"{u}r numerische Simulation, Rheinische Friedrich-Wilhelms-Universit\"{a}t Bonn, INS Preprint 1208},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_50,
-   author  = "J. Pearson and M. Stoll and A. Wathen",
-   title   = "Regularization-robust preconditioners for time-dependent PDE constrained optimization problems",
-   journal = "SIAM J. Matrix Analysis and Applications",
-   year    = "2012",
-   volume  = "33",
-   pages   = "1126--1152",
-   url     = "",
-   doi     = ""
+   author  = {J. Pearson and M. Stoll and A. Wathen},
+   title   = {Regularization-robust preconditioners for time-dependent PDE constrained optimization problems},
+   journal = {SIAM J. Matrix Analysis and Applications},
+   year    = {2012},
+   volume  = {33},
+   pages   = {1126--1152},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_51,
-   author  = "J. P. V. Pelteret and B. D. Reddy",
-   title   = "Computational model of soft tissues in the human upper airway",
-   journal = "International Journal for Numerical Methods in Biomedical Engineering, Vol. 28, pp. 111–132",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. P. V. Pelteret and B. D. Reddy},
+   title   = {Computational model of soft tissues in the human upper airway},
+   journal = {International Journal for Numerical Methods in Biomedical Engineering, Vol. 28, pp. 111--132},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_52,
-   author  = "M. J. Rapson and J. C. Tapson and D. Karpul",
-   title   = "Unification and Extension of Monolithic State Space and Iterative Cochlear Models",
-   journal = "Journal of the Acoustical Society of America",
-   year    = "2012",
-   volume  = "131",
-   pages   = "3935--3952",
-   url     = "",
-   doi     = ""
+   author  = {M. J. Rapson and J. C. Tapson and D. Karpul},
+   title   = {Unification and Extension of Monolithic State Space and Iterative Cochlear Models},
+   journal = {Journal of the Acoustical Society of America},
+   year    = {2012},
+   volume  = {131},
+   pages   = {3935--3952},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_53,
-   author  = "T. Reis and W. Wollner",
-   title   = "Finite-Rank ADI Iteration for Operator Lyapunov Equations",
-   journal = "Hamburger Beitr&auml;ge zur Angewandten Mathematik, 2012-09",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Reis and W. Wollner},
+   title   = {Finite-Rank ADI Iteration for Operator Lyapunov Equations},
+   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik, 2012-09},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2012_54,
-   author  = "N. Richardson",
-   title   = "An Investigation into Aspects of Rate-Independent Single Crystal Plasticity",
-   year    = "2012",
-   school  = "University of Cape Town, South Africa",
-   url     = ""
+   author  = {N. Richardson},
+   title   = {An Investigation into Aspects of Rate-Independent Single Crystal Plasticity},
+   year    = {2012},
+   school  = {University of Cape Town, South Africa},
+   url     = {}
 }
 
 @article{2012_55,
-   author  = "D. Riedlbauer and J. Mergheim and A. McBride and P. Steinmann",
-   title   = "Macroscopic modelling of the selective beam melting process",
-   journal = "PAMM, p. 381-382",
-   year    = "2012",
-   volume  = "12",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Riedlbauer and J. Mergheim and A. McBride and P. Steinmann},
+   title   = {Macroscopic modelling of the selective beam melting process},
+   journal = {PAMM, p. 381-382},
+   year    = {2012},
+   volume  = {12},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2012_56,
-   author  = "E. Romero Alcalde",
-   title   = "Parallel implementation of Davidson-type methods for large-scale eigenvalue problems",
-   year    = "2012",
-   school  = "Universitat Politecnica de Valencia",
-   url     = ""
+   author  = {E. Romero Alcalde},
+   title   = {Parallel implementation of Davidson-type methods for large-scale eigenvalue problems},
+   year    = {2012},
+   school  = {Universitat Politecnica de Valencia},
+   url     = {}
 }
 
 @phdthesis{2012_57,
-   author  = "S. Roy",
-   title   = "Numerical simulation using the generalized immersed boundary method: An application to Hydrocephalus",
-   year    = "2012",
-   school  = "The Pennsylvania State University",
-   url     = ""
+   author  = {S. Roy},
+   title   = {Numerical simulation using the generalized immersed boundary method: An application to Hydrocephalus},
+   year    = {2012},
+   school  = {The Pennsylvania State University},
+   url     = {}
 }
 
 @article{2012_58,
-   author  = "J. Sauter",
-   title   = "A Multiscale Method for Interacting Particle Systems",
-   journal = "Diplomarbeit, Westfalische Wilhelms-Universitat Munster",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "http://wwwmath.uni-muenster.de/num/Arbeitsgruppen/ag_burger/organization/burger/pictures/DA%20Sauter.pdf",
-   doi     = ""
+   author  = {J. Sauter},
+   title   = {A Multiscale Method for Interacting Particle Systems},
+   journal = {Diplomarbeit, Westfalische Wilhelms-Universitat Munster},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {http://wwwmath.uni-muenster.de/num/Arbeitsgruppen/ag_burger/organization/burger/pictures/DA%20Sauter.pdf},
+   doi     = {}
 }
 
 @article{2012_59,
-   author  = "D. Sch&ouml;tzau and C. Schwab and T. Wihler and M. Wirz",
-   title   = "Exponential convergence of the hp-DGFEM for elliptic problems in polyhedral domains",
-   journal = "Research Report 2012-40, Seminar f&uuml;r Angewandte Mathematik, ETH Zurich",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
+   title   = {Exponential convergence of the hp-DGFEM for elliptic problems in polyhedral domains},
+   journal = {Research Report 2012-40, Seminar f\"{u}r Angewandte Mathematik, ETH Zurich},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2012_60,
-   author  = "J. Sheldon",
-   title   = "A comparison of fluid-structure interaction coupling algorithms using the finite element method",
-   year    = "2012",
-   school  = "The Pennsylvania State University",
-   url     = ""
+   author  = {J. Sheldon},
+   title   = {A comparison of fluid-structure interaction coupling algorithms using the finite element method},
+   year    = {2012},
+   school  = {The Pennsylvania State University},
+   url     = {}
 }
 
 @article{2012_61,
-   author  = "M. Stoll and A. Wathen",
-   title   = "Preconditioning for partial differential equation constrained optimization with control constraints",
-   journal = "Numerical Linear Algebra with Applications",
-   year    = "2012",
-   volume  = "19",
-   pages   = "53--71",
-   url     = "",
-   doi     = ""
+   author  = {M. Stoll and A. Wathen},
+   title   = {Preconditioning for partial differential equation constrained optimization with control constraints},
+   journal = {Numerical Linear Algebra with Applications},
+   year    = {2012},
+   volume  = {19},
+   pages   = {53--71},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_62,
-   author  = "M. Stoll and A. Wathen",
-   title   = "All-at-once solution of time-dependent Stokes control",
-   journal = "Journal of Computational Physics",
-   year    = "2012",
-   volume  = "232",
-   pages   = "498--515",
-   url     = "",
-   doi     = ""
+   author  = {M. Stoll and A. Wathen},
+   title   = {All-at-once solution of time-dependent Stokes control},
+   journal = {Journal of Computational Physics},
+   year    = {2012},
+   volume  = {232},
+   pages   = {498--515},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_63,
-   author  = "W. Symes and X. Wang",
-   title   = "Harmonic coordinate finite element method for acoustic waves",
-   journal = "SEG Technical Program Expanded Abstracts 2012",
-   year    = "2012",
-   volume  = "",
-   pages   = "1--5",
-   url     = "",
-   doi     = ""
+   author  = {W. Symes and X. Wang},
+   title   = {Harmonic coordinate finite element method for acoustic waves},
+   journal = {SEG Technical Program Expanded Abstracts 2012},
+   year    = {2012},
+   volume  = {},
+   pages   = {1--5},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_64,
-   author  = "S. Taylor and K. Dontsova and S. Bigl and C. Richardson and J. Lever and J. Pitt and J. P. Bradley and M. Walsh. J. Simunek",
-   title   = "Dissolution Rate of Propellant Energetics from Nitrocellulose Matrices",
-   journal = "Engineer Research and Development Center, Cold Regions Research and Engineering Laboratory, US Army Corps of Engineers, Technical Report ER-1691",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Taylor and K. Dontsova and S. Bigl and C. Richardson and J. Lever and J. Pitt and J. P. Bradley and M. Walsh. J. Simunek},
+   title   = {Dissolution Rate of Propellant Energetics from Nitrocellulose Matrices},
+   journal = {Engineer Research and Development Center, Cold Regions Research and Engineering Laboratory, US Army Corps of Engineers, Technical Report ER-1691},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_65,
-   author  = "M. Thalhammer and J. Abhau",
-   title   = "A numerical study of adaptive space and time discretisations for Gross–Pitaevskii equations",
-   journal = "Journal of Computational Physics",
-   year    = "2012",
-   volume  = "231",
-   pages   = "6665--6681",
-   url     = "",
-   doi     = ""
+   author  = {M. Thalhammer and J. Abhau},
+   title   = {A numerical study of adaptive space and time discretisations for Gross--Pitaevskii equations},
+   journal = {Journal of Computational Physics},
+   year    = {2012},
+   volume  = {231},
+   pages   = {6665--6681},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_66,
-   author  = "J. Trangenstein",
-   title   = "Numerical Solution of Elliptic and Parabolic Partial Differential Equations",
-   journal = "Cambridge University Press",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Trangenstein},
+   title   = {Numerical Solution of Elliptic and Parabolic Partial Differential Equations},
+   journal = {Cambridge University Press},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_67,
-   author  = "M. Vavalis and M. Mu and G. Sarailidis",
-   title   = "Finite element simulations of window Josephson junctions",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2012",
-   volume  = "236",
-   pages   = "3186--3197",
-   url     = "",
-   doi     = ""
+   author  = {M. Vavalis and M. Mu and G. Sarailidis},
+   title   = {Finite element simulations of window Josephson junctions},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2012},
+   volume  = {236},
+   pages   = {3186--3197},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_68,
-   author  = "M. Wallraff and T. Leicht and M. Lange-Hegermann",
-   title   = "Numerical flux functions for RANS-k&#969; computations with a line-implicit p-multigrid DG solver",
-   journal = "50<sup>th</sup> AIAA Aerospace Sciences Meeting, AIAA 2012-458",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Wallraff and T. Leicht and M. Lange-Hegermann},
+   title   = {Numerical flux functions for RANS-k$\omega$ computations with a line-implicit p-multigrid DG solver},
+   journal = {50$^{\textnormal{th}}$ AIAA Aerospace Sciences Meeting, AIAA 2012-458},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_69,
-   author  = "X. Wang",
-   title   = "Transfer-of-approximation Approaches for Subgrid Modeling",
-   journal = "PhD dissertation, Rice University",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.trip.caam.rice.edu/reports/2012/ThesisFinal_XWang.pdf",
-   doi     = ""
+   author  = {X. Wang},
+   title   = {Transfer-of-approximation Approaches for Subgrid Modeling},
+   journal = {PhD dissertation, Rice University},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.trip.caam.rice.edu/reports/2012/ThesisFinal_XWang.pdf},
+   doi     = {}
 }
 
 @article{2012_70,
-   author  = "T. Wick",
-   title   = "Goal-oriented mesh adaptivity for fluid-structure interaction with application to heart-valve settings",
-   journal = "Arch. Mech. Engrg.",
-   year    = "2012",
-   volume  = "59",
-   pages   = "73--99",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Goal-oriented mesh adaptivity for fluid-structure interaction with application to heart-valve settings},
+   journal = {Arch. Mech. Engrg.},
+   year    = {2012},
+   volume  = {59},
+   pages   = {73--99},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_71,
-   author  = "J. Willems",
-   title   = "Robust multilevel methods for general symmetric positive definite operators",
-   journal = "RICAM Report 2012-06",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Willems},
+   title   = {Robust multilevel methods for general symmetric positive definite operators},
+   journal = {RICAM Report 2012-06},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2012_72,
-   author  = "J. A. Worthen",
-   title   = "Inverse problems in mantle convection : models, algorithms, and applications ",
-   year    = "2012",
-   school  = "- University of Texas",
-   url     = "http://repositories.lib.utexas.edu/handle/2152/19458"
+   author  = {J. A. Worthen},
+   title   = {Inverse problems in mantle convection : models, algorithms, and applications },
+   year    = {2012},
+   school  = {- University of Texas},
+   url     = {http://repositories.lib.utexas.edu/handle/2152/19458}
 }
 
 @article{2012_73,
-   author  = "S. Yoon and M. A. Walkley and O. G. Harlen",
-   title   = "Two particle interactions in a confined viscoelastic fluid under shear",
-   journal = "Journal of Non-Newtonian Fluid Mechanics, /186",
-   year    = "2012",
-   volume  = "185",
-   pages   = "39--48",
-   url     = "",
-   doi     = ""
+   author  = {S. Yoon and M. A. Walkley and O. G. Harlen},
+   title   = {Two particle interactions in a confined viscoelastic fluid under shear},
+   journal = {Journal of Non-Newtonian Fluid Mechanics, /186},
+   year    = {2012},
+   volume  = {185},
+   pages   = {39--48},
+   url     = {},
+   doi     = {}
 }
 
 @article{2012_74,
-   author  = "S. Zhang and X. Lin and H. Zhang and D. A. Yuen and Y. Shi",
-   title   = "A new method for calculating displacements from elastic dislocation over arbitrary 3-D fault surface with extended FEM and Adaptive Mesh Refinement (AMR)",
-   journal = "Proceedings of the International Workshop on Deep Geothermal Systems, Wuhan, China, June 29-30",
-   year    = "2012",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Zhang and X. Lin and H. Zhang and D. A. Yuen and Y. Shi},
+   title   = {A new method for calculating displacements from elastic dislocation over arbitrary 3-D fault surface with extended FEM and Adaptive Mesh Refinement (AMR)},
+   journal = {Proceedings of the International Workshop on Deep Geothermal Systems, Wuhan, China, June 29-30},
+   year    = {2012},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -1,994 +1,994 @@
 % Encoding: ISO-8859-1
 
 @mastersthesis{2013_0,
-   author  = "G. Alam",
-   title   = "Fast iterative solution of large scale statistical inverse problems",
-   year    = "2013",
-   school  = "Stockholm University",
-   url     = ""
+   author  = {G. Alam},
+   title   = {Fast iterative solution of large scale statistical inverse problems},
+   year    = {2013},
+   school  = {Stockholm University},
+   url     = {}
 }
 
 @article{2013_1,
-   author  = "F. Alouges and A. DeSimone and L. Heltai and A. Lefebvre-Lepot and B. Merlet",
-   title   = "Optimally swimming Stokesian robots",
-   journal = "Discrete Contin. Dyn. Syst. Ser. B, pp. 1189–1215",
-   year    = "2013",
-   volume  = "18",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {F. Alouges and A. DeSimone and L. Heltai and A. Lefebvre-Lepot and B. Merlet},
+   title   = {Optimally swimming Stokesian robots},
+   journal = {Discrete Contin. Dyn. Syst. Ser. B, pp. 1189--1215},
+   year    = {2013},
+   volume  = {18},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2013_2,
-   author  = "J. C. Araujo-Cabarcas",
-   title   = "Numerical methods for glacial isostatic adjustment models",
-   year    = "2013",
-   school  = "Uppsala University, Uppsala, Sweden",
-   url     = ""
+   author  = {J. C. Araujo-Cabarcas},
+   title   = {Numerical methods for glacial isostatic adjustment models},
+   year    = {2013},
+   school  = {Uppsala University, Uppsala, Sweden},
+   url     = {}
 }
 
 @article{2013_3,
-   author  = "P. Argoul and G. Ruocci and F. Freddi and K. Benzarti",
-   title   = "An improved damage modelling to deal with the variability of fracture mechanisms in FRP reinforced concrete structures",
-   journal = "International Journal of Adhesion and Adhesives 45 , 7-20",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {P. Argoul and G. Ruocci and F. Freddi and K. Benzarti},
+   title   = {An improved damage modelling to deal with the variability of fracture mechanisms in FRP reinforced concrete structures},
+   journal = {International Journal of Adhesion and Adhesives 45 , 7-20},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2013_4,
-   author  = "D. Arndt",
-   title   = "Augmented Taylor-Hood Elements for Incompressible Flow",
-   year    = "2013",
-   school  = "University of G&ouml;ttingen, Germany",
-   url     = ""
+   author  = {D. Arndt},
+   title   = {Augmented Taylor-Hood Elements for Incompressible Flow},
+   year    = {2013},
+   school  = {University of G\"{o}ttingen, Germany},
+   url     = {}
 }
 
 @article{2013_5,
-   author  = "O. Axelsson and P. Boyanova and M. Kronbichler and M. Neytcheva and X. Wu",
-   title   = "Numerical and computational efficiency of solvers for two-phase problems",
-   journal = "Comput. Math. Appl., 65, 301-314",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {O. Axelsson and P. Boyanova and M. Kronbichler and M. Neytcheva and X. Wu},
+   title   = {Numerical and computational efficiency of solvers for two-phase problems},
+   journal = {Comput. Math. Appl., 65, 301-314},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_6,
-   author  = "W. Bangerth and T. Heister",
-   title   = "What makes computational open source software libraries successful?",
-   journal = "Computational Science &amp; Discovery, article 015010",
-   year    = "2013",
-   volume  = "6",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and T. Heister},
+   title   = {What makes computational open source software libraries successful?},
+   journal = {Computational Science \& Discovery, article 015010},
+   year    = {2013},
+   volume  = {6},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_7,
-   author  = "W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young",
-   title   = "The <abbr>deal.II</abbr> Library, Version 8.1",
-   journal = "<a href="http://arxiv.org/abs/1312.2266v4" target="_top">arxiv:1312.2266v4</a>",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
+   title   = {The \texttt{deal.II} Library, Version 8.1},
+   journal = {arXiv.org preprint 1312.2266v4},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1312.2266v4},
+   doi     = {}
 }
 
 @article{2013_8,
-   author  = "W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young",
-   title   = "The <abbr>deal.II</abbr> Library, Version 8.0",
-   journal = "<a href="http://arxiv.org/abs/1312.2266v3" target="_top">arxiv:1312.2266v3</a>",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
+   title   = {The \texttt{deal.II} Library, Version 8.0},
+   journal = {arXiv.org preprint 1312.2266v3},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1312.2266v3},
+   doi     = {}
 }
 
 @article{2013_9,
-   author  = "P. Benner and M. Stoll",
-   title   = "Optimal control for Allen-Cahn equations enhanced by model predictive control",
-   journal = "Preprint, MPI Magdeburg",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {P. Benner and M. Stoll},
+   title   = {Optimal control for Allen-Cahn equations enhanced by model predictive control},
+   journal = {Preprint, MPI Magdeburg},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_10,
-   author  = "A. Bonito and R. DeVore and R. H. Nochetto",
-   title   = "Adaptive Finite Element Methods for Elliptic Problems with Discontinuous Coefficients",
-   journal = "SIAM Journal on Numerical Analysis",
-   year    = "2013",
-   volume  = "51",
-   pages   = "3106--3134",
-   url     = "",
-   doi     = ""
+   author  = {A. Bonito and R. DeVore and R. H. Nochetto},
+   title   = {Adaptive Finite Element Methods for Elliptic Problems with Discontinuous Coefficients},
+   journal = {SIAM Journal on Numerical Analysis},
+   year    = {2013},
+   volume  = {51},
+   pages   = {3106--3134},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_11,
-   author  = "A. Bonito and I. Kyza and R. H. Nochetto",
-   title   = "A dG Approach to Higher Order ALE Formulations in Time",
-   journal = "2012 Barrett Lectures, The IMA Volume in Mathematics and its Applications, Vol. 157, 36 pages, Springer",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Bonito and I. Kyza and R. H. Nochetto},
+   title   = {A dG Approach to Higher Order ALE Formulations in Time},
+   journal = {2012 Barrett Lectures, The IMA Volume in Mathematics and its Applications, Vol. 157, 36 pages, Springer},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_12,
-   author  = "A. Bonito and I. Kyza and R. H. Nochetto",
-   title   = "Time-discrete higher order ALE formulations: A priori error analysis",
-   journal = "Numer. Math., vol, 125",
-   year    = "2013",
-   volume  = "",
-   pages   = "225--257",
-   url     = "",
-   doi     = ""
+   author  = {A. Bonito and I. Kyza and R. H. Nochetto},
+   title   = {Time-discrete higher order ALE formulations: A priori error analysis},
+   journal = {Numer. Math., vol, 125},
+   year    = {2013},
+   volume  = {},
+   pages   = {225--257},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_13,
-   author  = "A. Bonito and I. Kyza and R. H. Nochetto",
-   title   = "Time-discrete higher order ALE formulations: Stability",
-   journal = "SIAM J. Numer. Anal., 51(1), 577-608",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Bonito and I. Kyza and R. H. Nochetto},
+   title   = {Time-discrete higher order ALE formulations: Stability},
+   journal = {SIAM J. Numer. Anal., 51(1), 577-608},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2013_14,
-   author  = "J. A. Bramwell",
-   title   = "A discontinuous Petrov-Galerkin method for seismic tomography problems",
-   year    = "2013",
-   school  = "University of Texas at Austin",
-   url     = ""
+   author  = {J. A. Bramwell},
+   title   = {A discontinuous Petrov-Galerkin method for seismic tomography problems},
+   year    = {2013},
+   school  = {University of Texas at Austin},
+   url     = {}
 }
 
 @article{2013_15,
-   author  = "M. B&uuml;rg",
-   title   = "Convergence of an automatic <i>hp</i>-adaptive finite element strategy for Maxwell's equations",
-   journal = "Applied Numerical Mathematics",
-   year    = "2013",
-   volume  = "72",
-   pages   = "188--204",
-   url     = "",
-   doi     = ""
+   author  = {M. B\"{u}rg},
+   title   = {Convergence of an automatic $hp$-adaptive finite element strategy for Maxwell's equations},
+   journal = {Applied Numerical Mathematics},
+   year    = {2013},
+   volume  = {72},
+   pages   = {188--204},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_16,
-   author  = "A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen",
-   title   = "Implementation of the Continuous-Discontinuous Galerkin Finite Element Method",
-   journal = "Numerical Mathematics and Advanced Applications 2011",
-   year    = "2013",
-   volume  = "",
-   pages   = "315--322",
-   url     = "",
-   doi     = ""
+   author  = {A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen},
+   title   = {Implementation of the Continuous-Discontinuous Galerkin Finite Element Method},
+   journal = {Numerical Mathematics and Advanced Applications 2011},
+   year    = {2013},
+   volume  = {},
+   pages   = {315--322},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_17,
-   author  = "T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikelic",
-   title   = "Pressure jump interface law for the Stokes-Darcy coupling: Confirmation by direct numerical simulation",
-   journal = "Journal of Fluid Mechanics",
-   year    = "2013",
-   volume  = "732",
-   pages   = "510--536",
-   url     = "",
-   doi     = ""
+   author  = {T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikelic},
+   title   = {Pressure jump interface law for the Stokes-Darcy coupling: Confirmation by direct numerical simulation},
+   journal = {Journal of Fluid Mechanics},
+   year    = {2013},
+   volume  = {732},
+   pages   = {510--536},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_18,
-   author  = "T. Carraro and J. Joos",
-   title   = "Parameter estimation for a reconstructed SOFC mixed-conducting LSCF-cathode",
-   journal = "Model Based Parameter Estimation, H. G. Bock et al., eds., Springer",
-   year    = "2013",
-   volume  = "",
-   pages   = "267--285",
-   url     = "",
-   doi     = ""
+   author  = {T. Carraro and J. Joos},
+   title   = {Parameter estimation for a reconstructed SOFC mixed-conducting LSCF-cathode},
+   journal = {Model Based Parameter Estimation, H. G. Bock et al., eds., Springer},
+   year    = {2013},
+   volume  = {},
+   pages   = {267--285},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_19,
-   author  = "C. C. Chueh and N. Djilali and W. Bangerth",
-   title   = "An h-adaptive Operator Splitting Method for Two-phase Flow in 3D Heterogeneous Porous Media",
-   journal = "SIAM Journal on Scientific Computing, pp. B149-175",
-   year    = "2013",
-   volume  = "35",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {C. C. Chueh and N. Djilali and W. Bangerth},
+   title   = {An h-adaptive Operator Splitting Method for Two-phase Flow in 3D Heterogeneous Porous Media},
+   journal = {SIAM Journal on Scientific Computing, pp. B149-175},
+   year    = {2013},
+   volume  = {35},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2013_20,
-   author  = "D. Devaud",
-   title   = "Adaptive Methods for the Stokes System with Discontinuous Viscosities",
-   year    = "2013",
-   school  = "EPFL",
-   url     = ""
+   author  = {D. Devaud},
+   title   = {Adaptive Methods for the Stokes System with Discontinuous Viscosities},
+   year    = {2013},
+   school  = {EPFL},
+   url     = {}
 }
 
 @article{2013_21,
-   author  = "T. Dohnal and W. D&ouml;rfler",
-   title   = "Coupled Mode Equation Modeling for Out-of-Plane Gap Solitons in 2D Photonic Crystals",
-   journal = "Multiscale Modeling and Simulation",
-   year    = "2013",
-   volume  = "11",
-   pages   = "162--191",
-   url     = "",
-   doi     = ""
+   author  = {T. Dohnal and W. D\"{o}rfler},
+   title   = {Coupled Mode Equation Modeling for Out-of-Plane Gap Solitons in 2D Photonic Crystals},
+   journal = {Multiscale Modeling and Simulation},
+   year    = {2013},
+   volume  = {11},
+   pages   = {162--191},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2013_22,
-   author  = "I. Donev",
-   title   = "Time Dependent Finite Element Simulations of a Generalized Oldroyd-B Fluid",
-   year    = "2013",
-   school  = "University of Cape Town",
-   url     = ""
+   author  = {I. Donev},
+   title   = {Time Dependent Finite Element Simulations of a Generalized Oldroyd-B Fluid},
+   year    = {2013},
+   school  = {University of Cape Town},
+   url     = {}
 }
 
 @mastersthesis{2013_23,
-   author  = "K. Dugan",
-   title   = "Dynamic adaptive multimesh refinement for coupled physics applicable to nuclear engineering",
-   year    = "2013",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {K. Dugan},
+   title   = {Dynamic adaptive multimesh refinement for coupled physics applicable to nuclear engineering},
+   year    = {2013},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2013_24,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Numerical Approximation of Fluid Structure Interaction (FSI) Problem",
-   journal = "In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2013-16013, pp. V01AT02A001/1-10, July 7–11, Incline Village, Nevada, USA",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Numerical Approximation of Fluid Structure Interaction (FSI) Problem},
+   journal = {In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2013-16013, pp. V01AT02A001/1-10, July 7--11, Incline Village, Nevada, USA},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_25,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Adaptive Multigrid Methods for Fluid-Structure Interaction (FSI) Optimization in an Aircraft and Design of Integrated Structural Health Monitoring (SHM) Systems",
-   journal = "Proceedings of The 2nd ECCOMAS Young Investigators Conference (YIC2013), At Bordeaux, France",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Adaptive Multigrid Methods for Fluid-Structure Interaction (FSI) Optimization in an Aircraft and Design of Integrated Structural Health Monitoring (SHM) Systems},
+   journal = {Proceedings of The 2nd ECCOMAS Young Investigators Conference (YIC2013), At Bordeaux, France},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_26,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Finite Element Approximation of Fluid Structure Interaction (FSI) Optimization in Arbitrary Lagrangian-Eulerian Coordinates",
-   journal = "In proceedings of: the ASME International Mechanical Engineering Congress &amp; Exposition, Vol. 7B, No. IMECE2013-62291, pp. V07BT08A034/1–8, Nov 13–21, San Diego, California, USA",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Finite Element Approximation of Fluid Structure Interaction (FSI) Optimization in Arbitrary Lagrangian-Eulerian Coordinates},
+   journal = {In proceedings of: the ASME International Mechanical Engineering Congress \& Exposition, Vol. 7B, No. IMECE2013-62291, pp. V07BT08A034/1--8, Nov 13--21, San Diego, California, USA},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_27,
-   author  = "Y. Efendiev and J. Galvis and S. Pauletti",
-   title   = "Multiscale finite element methods for flows on rough surfaces",
-   journal = "Communications in Computational Physics",
-   year    = "2013",
-   volume  = "14",
-   pages   = "979--1000",
-   url     = "",
-   doi     = ""
+   author  = {Y. Efendiev and J. Galvis and S. Pauletti},
+   title   = {Multiscale finite element methods for flows on rough surfaces},
+   journal = {Communications in Computational Physics},
+   year    = {2013},
+   volume  = {14},
+   pages   = {979--1000},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_28,
-   author  = "E. Emmrich and A. Wr&#243;blewska-Kami&#324;ska",
-   title   = "Convergence of a Full Discretization of Quasi-linear Parabolic Equations in Isotropic and Anisotropic Orlicz Spaces",
-   journal = "SIAM Journal on Numerical Analysis",
-   year    = "2013",
-   volume  = "51",
-   pages   = "1163--1184",
-   url     = "",
-   doi     = ""
+   author  = {E. Emmrich and A. Wr\'{o}blewska-Kami\'{n}ska},
+   title   = {Convergence of a Full Discretization of Quasi-linear Parabolic Equations in Isotropic and Anisotropic Orlicz Spaces},
+   journal = {SIAM Journal on Numerical Analysis},
+   year    = {2013},
+   volume  = {51},
+   pages   = {1163--1184},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_29,
-   author  = "J. Fang and X. Gao and A. Zhou",
-   title   = "A finite element recovery approach to eigenvalue approximations with applications to electronic structure calculations",
-   journal = "Journal of Scientific Computing",
-   year    = "2013",
-   volume  = "55",
-   pages   = "432--454",
-   url     = "",
-   doi     = ""
+   author  = {J. Fang and X. Gao and A. Zhou},
+   title   = {A finite element recovery approach to eigenvalue approximations with applications to electronic structure calculations},
+   journal = {Journal of Scientific Computing},
+   year    = {2013},
+   volume  = {55},
+   pages   = {432--454},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_30,
-   author  = "H. P. Flath",
-   title   = "Hessian-based response surface approximations for uncertainty quantification in large-scale statistical inverse problems, with applications to groundwater flow",
-   journal = "PhD dissertation, University of Texas at Austin",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://repositories.lib.utexas.edu/handle/2152/21157",
-   doi     = ""
+   author  = {H. P. Flath},
+   title   = {Hessian-based response surface approximations for uncertainty quantification in large-scale statistical inverse problems, with applications to groundwater flow},
+   journal = {PhD dissertation, University of Texas at Austin},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://repositories.lib.utexas.edu/handle/2152/21157},
+   doi     = {}
 }
 
 @article{2013_31,
-   author  = "S. Frei and T. Richter and T. Wick",
-   title   = "Eulerian Techniques for Fluid-Structure Interactions - Part I: Modeling and Simulation",
-   journal = "ENUMATH Proc., submitted Nov ",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Frei and T. Richter and T. Wick},
+   title   = {Eulerian Techniques for Fluid-Structure Interactions - Part I: Modeling and Simulation},
+   journal = {ENUMATH Proc., submitted Nov },
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_32,
-   author  = "S. Frei and T. Richter and T. Wick",
-   title   = "Eulerian Techniques for Fluid-Structure Interactions - Part II: Applications",
-   journal = "ENUMATH Proc., submitted Nov ",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Frei and T. Richter and T. Wick},
+   title   = {Eulerian Techniques for Fluid-Structure Interactions - Part II: Applications},
+   journal = {ENUMATH Proc., submitted Nov },
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_33,
-   author  = "A. Geringer and B. Lenhof and S. Diebels",
-   title   = "Macroscopic modeling of foams: an order-parameter approach vs. a micropolar model",
-   journal = "Technische Mechanik",
-   year    = "2013",
-   volume  = "33",
-   pages   = "87--96",
-   url     = "http://www.uni-magdeburg.de/ifme/zeitschrift_tm/2013_Heft2/01_Geringer_Lenhof_Diebels.pdf",
-   doi     = ""
+   author  = {A. Geringer and B. Lenhof and S. Diebels},
+   title   = {Macroscopic modeling of foams: an order-parameter approach vs. a micropolar model},
+   journal = {Technische Mechanik},
+   year    = {2013},
+   volume  = {33},
+   pages   = {87--96},
+   url     = {http://www.uni-magdeburg.de/ifme/zeitschrift_tm/2013_Heft2/01_Geringer_Lenhof_Diebels.pdf},
+   doi     = {}
 }
 
 @phdthesis{2013_34,
-   author  = "F. Gimbel",
-   title   = "Modelling and numerical simulation of contact and lubrication",
-   year    = "2013",
-   school  = "University of Siegen, Germany",
-   url     = ""
+   author  = {F. Gimbel},
+   title   = {Modelling and numerical simulation of contact and lubrication},
+   year    = {2013},
+   school  = {University of Siegen, Germany},
+   url     = {}
 }
 
 @mastersthesis{2013_35,
-   author  = "N. Giuliani",
-   title   = "An hybrid boundary element method for free surface flows",
-   year    = "2013",
-   school  = "Politecnico di Milano",
-   url     = "https://www.politesi.polimi.it/handle/10589/81430"
+   author  = {N. Giuliani},
+   title   = {An hybrid boundary element method for free surface flows},
+   year    = {2013},
+   school  = {Politecnico di Milano},
+   url     = {https://www.politesi.polimi.it/handle/10589/81430}
 }
 
 @article{2013_36,
-   author  = "C. Goll and R. Rannacher and W. Wollner",
-   title   = "Goal-Oriented Mesh Adaptation in the Space-Time Finite Element Approximation of the Black-Scholes Equation",
-   journal = "Journal of Computational Finance, accepted",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {C. Goll and R. Rannacher and W. Wollner},
+   title   = {Goal-Oriented Mesh Adaptation in the Space-Time Finite Element Approximation of the Black-Scholes Equation},
+   journal = {Journal of Computational Finance, accepted},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_37,
-   author  = "B. J. Grieshaber",
-   title   = "Locking-free discontinuous Galerkin methods for problems in elasticity, using linear and multilinear approximations",
-   journal = "PhD disseration, University of Cape Town",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://link.springer.com/article/10.1007/s00419-014-0943-x",
-   doi     = ""
+   author  = {B. J. Grieshaber},
+   title   = {Locking-free discontinuous Galerkin methods for problems in elasticity, using linear and multilinear approximations},
+   journal = {PhD disseration, University of Cape Town},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://link.springer.com/article/10.1007/s00419-014-0943-x},
+   doi     = {}
 }
 
 @article{2013_38,
-   author  = "N. Gupta and N. Nataraj",
-   title   = "A posteriori error estimates for an optimal control problem of laser surface hardening of steel",
-   journal = "Adv. Comp. Math.",
-   year    = "2013",
-   volume  = "39",
-   pages   = "69--99",
-   url     = "http://link.springer.com/article/10.1007%2Fs10444-011-9270-8",
-   doi     = ""
+   author  = {N. Gupta and N. Nataraj},
+   title   = {A posteriori error estimates for an optimal control problem of laser surface hardening of steel},
+   journal = {Adv. Comp. Math.},
+   year    = {2013},
+   volume  = {39},
+   pages   = {69--99},
+   url     = {http://link.springer.com/article/10.1007%2Fs10444-011-9270-8},
+   doi     = {}
 }
 
 @article{2013_39,
-   author  = "R. Hartmann",
-   title   = "Higher-order and adaptive discontinuous Galerkin methods with shock-capturing applied to transonic turbulent delta wing flow",
-   journal = "International Journal for Numerical Methods in Fluids",
-   year    = "2013",
-   volume  = "72",
-   pages   = "883--894",
-   url     = "",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Higher-order and adaptive discontinuous Galerkin methods with shock-capturing applied to transonic turbulent delta wing flow},
+   journal = {International Journal for Numerical Methods in Fluids},
+   year    = {2013},
+   volume  = {72},
+   pages   = {883--894},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_40,
-   author  = "R. Hartmann",
-   title   = "Higher-order and adaptive Discontinuous Galerkin methods applied to turbulent delta wing flow",
-   journal = "New Results in Numerical and Experimental Fluid Mechanics VIII, Notes on Numerical Fluid Mechanics and Multidisciplinary Design, pp 497-505",
-   year    = "2013",
-   volume  = "121",
-   pages   = "",
-   url     = "http://link.springer.com/chapter/10.1007/978-3-642-35680-3_59",
-   doi     = ""
+   author  = {R. Hartmann},
+   title   = {Higher-order and adaptive Discontinuous Galerkin methods applied to turbulent delta wing flow},
+   journal = {New Results in Numerical and Experimental Fluid Mechanics VIII, Notes on Numerical Fluid Mechanics and Multidisciplinary Design, pp 497-505},
+   year    = {2013},
+   volume  = {121},
+   pages   = {},
+   url     = {http://link.springer.com/chapter/10.1007/978-3-642-35680-3_59},
+   doi     = {}
 }
 
 @article{2013_41,
-   author  = "T. Heister and G. Rapin",
-   title   = "Efficient augmented Lagrangian-type preconditioning for the Oseen problem using Grad-Div stabilization",
-   journal = "Int. J. Num. Meth. Fluids, 71, 118–134",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1002/fld.3654"
+   author  = {T. Heister and G. Rapin},
+   title   = {Efficient augmented Lagrangian-type preconditioning for the Oseen problem using Grad-Div stabilization},
+   journal = {Int. J. Num. Meth. Fluids, 71, 118--134},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1002/fld.3654}
 }
 
 @article{2013_42,
-   author  = "M. Hinze and U. Mathes",
-   title   = "Model order reduction for networks of ODE and PDE systems",
-   journal = "System Modeling and Optimization, IFIP Advances in Information and Communication Technology Vol. 391, pp 92-101",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinze and U. Mathes},
+   title   = {Model order reduction for networks of ODE and PDE systems},
+   journal = {System Modeling and Optimization, IFIP Advances in Information and Communication Technology Vol. 391, pp 92-101},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_43,
-   author  = "S. Joshi and J and Walton",
-   title   = "Reconstruction of the residual stresses in a hyperelastic body using ultrasound techniques",
-   journal = "International Journal on Engineering Science",
-   year    = "2013",
-   volume  = "70",
-   pages   = "46--72",
-   url     = "",
-   doi     = ""
+   author  = {S. Joshi and J and Walton},
+   title   = {Reconstruction of the residual stresses in a hyperelastic body using ultrasound techniques},
+   journal = {International Journal on Engineering Science},
+   year    = {2013},
+   volume  = {70},
+   pages   = {46--72},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_44,
-   author  = "J. A. Kallen-Brown",
-   title   = "Computational methods for ice flow simulation",
-   journal = "PhD dissertation, ETH Z&uuml;rich",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://e-collection.library.ethz.ch/eserv/eth:5692/eth-5692-02.pdf?pid=eth:5692&dsID=eth-5692-02.pdf",
-   doi     = ""
+   author  = {J. A. Kallen-Brown},
+   title   = {Computational methods for ice flow simulation},
+   journal = {PhD dissertation, ETH Z\"{u}rich},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://e-collection.library.ethz.ch/eserv/eth:5692/eth-5692-02.pdf?pid=eth:5692&dsID=eth-5692-02.pdf},
+   doi     = {}
 }
 
 @article{2013_45,
-   author  = "S. Kim",
-   title   = "Analysis of the convected Helmholtz equation with a uniform mean flow in a waveguide with complete radiation boundary conditions",
-   journal = "Journal of Mathematical Analysis and Applications, in press",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0022247X1300749X",
-   doi     = ""
+   author  = {S. Kim},
+   title   = {Analysis of the convected Helmholtz equation with a uniform mean flow in a waveguide with complete radiation boundary conditions},
+   journal = {Journal of Mathematical Analysis and Applications, in press},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0022247X1300749X},
+   doi     = {}
 }
 
 @phdthesis{2013_46,
-   author  = "N. Klein",
-   title   = "Consistent FE-Analysis of elliptic Variational Inequalities",
-   year    = "2013",
-   school  = "University of Siegen, Germany",
-   url     = ""
+   author  = {N. Klein},
+   title   = {Consistent FE-Analysis of elliptic Variational Inequalities},
+   year    = {2013},
+   school  = {University of Siegen, Germany},
+   url     = {}
 }
 
 @article{2013_47,
-   author  = "S. Kramer",
-   title   = "CUDA-based parallel preconditioning for RANS simulation of indoor airflow",
-   journal = "Numerical Mathematics and Advanced Applications (Proceedings of the ENUMATH 2011 conference), Springer",
-   year    = "2013",
-   volume  = "",
-   pages   = "663--671",
-   url     = "",
-   doi     = ""
+   author  = {S. Kramer},
+   title   = {CUDA-based parallel preconditioning for RANS simulation of indoor airflow},
+   journal = {Numerical Mathematics and Advanced Applications (Proceedings of the ENUMATH 2011 conference), Springer},
+   year    = {2013},
+   volume  = {},
+   pages   = {663--671},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_48,
-   author  = "S. Kramer",
-   title   = "Finite-element methods for spatially resolved mesoscopic electron transport",
-   journal = "Physical Review B 88, 125308",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://link.aps.org/doi/10.1103/PhysRevB.88.125308",
-   doi     = "10.1103/PhysRevB.88.125308"
+   author  = {S. Kramer},
+   title   = {Finite-element methods for spatially resolved mesoscopic electron transport},
+   journal = {Physical Review B 88, 125308},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://link.aps.org/doi/10.1103/PhysRevB.88.125308},
+   doi     = {10.1103/PhysRevB.88.125308}
 }
 
 @phdthesis{2013_49,
-   author  = "T. Kr&uuml;ger",
-   title   = "Regularization-based fictitious domain methods",
-   year    = "2013",
-   school  = "University of Siegen, Germany",
-   url     = ""
+   author  = {T. Kr\"{u}ger},
+   title   = {Regularization-based fictitious domain methods},
+   year    = {2013},
+   school  = {University of Siegen, Germany},
+   url     = {}
 }
 
 @article{2013_50,
-   author  = "K. Kumar and T. van Noorden and M. F. Wheeler and T. Wick",
-   title   = "An ALE-based method for reaction-induced boundary movement towards clogging",
-   journal = "ENUMATH Proc., submitted Nov ",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {K. Kumar and T. van Noorden and M. F. Wheeler and T. Wick},
+   title   = {An ALE-based method for reaction-induced boundary movement towards clogging},
+   journal = {ENUMATH Proc., submitted Nov },
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_51,
-   author  = "K. Kumar and M. F. Wheeler and T. Wick",
-   title   = "Reactive flow reaction-induced boundary movement in a thin channel",
-   journal = "SIAM J. Sci. Comput. 35(6), pp. B1235-B1266",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {K. Kumar and M. F. Wheeler and T. Wick},
+   title   = {Reactive flow reaction-induced boundary movement in a thin channel},
+   journal = {SIAM J. Sci. Comput. 35(6), pp. B1235-B1266},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_52,
-   author  = "B. Lenhof and A. Geringer and S. Diebels",
-   title   = "Macroscopic modeling of size effects in foams using an order parameter",
-   journal = "Generalized Continua as Models for Materials, Advanced Structured Materials",
-   year    = "2013",
-   volume  = "22",
-   pages   = "237--254",
-   url     = "",
-   doi     = ""
+   author  = {B. Lenhof and A. Geringer and S. Diebels},
+   title   = {Macroscopic modeling of size effects in foams using an order parameter},
+   journal = {Generalized Continua as Models for Materials, Advanced Structured Materials},
+   year    = {2013},
+   volume  = {22},
+   pages   = {237--254},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2013_53,
-   author  = "S. H. Lim",
-   title   = "Numerical Simulation of Two-phase Heat Flow and Transient Partial Melting in the Lower Crust with Adaptive Mesh Refinement",
-   year    = "2013",
-   school  = "Undergraduate honors thesis, University of Michigan, Ann Arbor",
-   url     = ""
+   author  = {S. H. Lim},
+   title   = {Numerical Simulation of Two-phase Heat Flow and Transient Partial Melting in the Lower Crust with Adaptive Mesh Refinement},
+   year    = {2013},
+   school  = {Undergraduate honors thesis, University of Michigan, Ann Arbor},
+   url     = {}
 }
 
 @article{2013_54,
-   author  = "A. Mikelic and M. F. Wheeler and T. Wick",
-   title   = "A phase field approach to the fluid filled fracture surrounded by a poroelastic medium",
-   journal = "ICES preprint 13-15",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.ices.utexas.edu/research/reports/",
-   doi     = ""
+   author  = {A. Mikelic and M. F. Wheeler and T. Wick},
+   title   = {A phase field approach to the fluid filled fracture surrounded by a poroelastic medium},
+   journal = {ICES preprint 13-15},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.ices.utexas.edu/research/reports/},
+   doi     = {}
 }
 
 @article{2013_55,
-   author  = "A. Mola and L. Heltai and A. DeSimone",
-   title   = "A stable and adaptive semi-Lagrangian potential model for unsteady and nonlinear ship-wave interactions",
-   journal = "Engineering Analysis with Boundary Elements",
-   year    = "2013",
-   volume  = "37",
-   pages   = "128--143",
-   url     = "",
-   doi     = ""
+   author  = {A. Mola and L. Heltai and A. DeSimone},
+   title   = {A stable and adaptive semi-Lagrangian potential model for unsteady and nonlinear ship-wave interactions},
+   journal = {Engineering Analysis with Boundary Elements},
+   year    = {2013},
+   volume  = {37},
+   pages   = {128--143},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_56,
-   author  = "M. Neytcheva and B. Lund",
-   title   = "Efficient numerical solution methods for isostatic adjustment of visco- poroelastic Earth models",
-   journal = "Joint project with Dept. of Info. Tech. and Earth Sci., Uppsala University",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.math.uu.se/digitalAssets/157/157344_3gia_project_cim_2013_bl.pdf",
-   doi     = ""
+   author  = {M. Neytcheva and B. Lund},
+   title   = {Efficient numerical solution methods for isostatic adjustment of visco- poroelastic Earth models},
+   journal = {Joint project with Dept. of Info. Tech. and Earth Sci., Uppsala University},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.math.uu.se/digitalAssets/157/157344_3gia_project_cim_2013_bl.pdf},
+   doi     = {}
 }
 
 @article{2013_57,
-   author  = "M. R. Opmeer and T. Reis and W. Wollner",
-   title   = "Finite-Rank ADI Iteration for Operator Lyapunov Equations",
-   journal = "SIAM Journal on Control and Optimization, no. 5",
-   year    = "2013",
-   volume  = "51",
-   pages   = "4084--4117",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/120885310",
-   doi     = ""
+   author  = {M. R. Opmeer and T. Reis and W. Wollner},
+   title   = {Finite-Rank ADI Iteration for Operator Lyapunov Equations},
+   journal = {SIAM Journal on Control and Optimization, no. 5},
+   year    = {2013},
+   volume  = {51},
+   pages   = {4084--4117},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/120885310},
+   doi     = {}
 }
 
 @article{2013_58,
-   author  = "J. Pearson and M. Stoll",
-   title   = "Fast Iterative Solution of Reaction-Diffusion Control Problems Arising from Chemical Processes",
-   journal = "SIAM Journal on Scientific Computing, pp. B987-B1009",
-   year    = "2013",
-   volume  = "35",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Pearson and M. Stoll},
+   title   = {Fast Iterative Solution of Reaction-Diffusion Control Problems Arising from Chemical Processes},
+   journal = {SIAM Journal on Scientific Computing, pp. B987-B1009},
+   year    = {2013},
+   volume  = {35},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2013_59,
-   author  = "J. P. V. Pelteret",
-   title   = "A computational neuromuscular model of the human upper airway with application to the study of obstructive sleep apnoea",
-   year    = "2013",
-   school  = "University of Cape Town, South Africa",
-   url     = ""
+   author  = {J. P. V. Pelteret},
+   title   = {A computational neuromuscular model of the human upper airway with application to the study of obstructive sleep apnoea},
+   year    = {2013},
+   school  = {University of Cape Town, South Africa},
+   url     = {}
 }
 
 @mastersthesis{2013_60,
-   author  = "T. Povall",
-   title   = "Single Crystal Plasticity at Finite Strains: A Computational Investigation of Hardening Relations",
-   year    = "2013",
-   school  = "University of Cape Town",
-   url     = ""
+   author  = {T. Povall},
+   title   = {Single Crystal Plasticity at Finite Strains: A Computational Investigation of Hardening Relations},
+   year    = {2013},
+   school  = {University of Cape Town},
+   url     = {}
 }
 
 @article{2013_61,
-   author  = "A. Redlund and G. Cheng",
-   title   = "Implementation and performance studies of a three-phase model solver",
-   journal = "Technical report, University of Uppsala",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Redlund and G. Cheng},
+   title   = {Implementation and performance studies of a three-phase model solver},
+   journal = {Technical report, University of Uppsala},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_62,
-   author  = "J. Reinhardt and F. Weysser and J. M. Brader",
-   title   = "Density functional approach to nonlinear rheology",
-   journal = "Europhysics Letters, article 28011",
-   year    = "2013",
-   volume  = "102",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Reinhardt and F. Weysser and J. M. Brader},
+   title   = {Density functional approach to nonlinear rheology},
+   journal = {Europhysics Letters, article 28011},
+   year    = {2013},
+   volume  = {102},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_63,
-   author  = "T. Reis and W. Wollner",
-   title   = "Iterative solution of operator Lyapunov equations arising in heat transfer",
-   journal = "2013 European Control Conference, Zurich Switzerland",
-   year    = "2013",
-   volume  = "",
-   pages   = "41--46",
-   url     = "",
-   doi     = ""
+   author  = {T. Reis and W. Wollner},
+   title   = {Iterative solution of operator Lyapunov equations arising in heat transfer},
+   journal = {2013 European Control Conference, Zurich Switzerland},
+   year    = {2013},
+   volume  = {},
+   pages   = {41--46},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_65,
-   author  = "T. Richter and T. Wick",
-   title   = "Solid growth and clogging in fluid-structure interaction computed in ALE and fully Eulerian coordinates",
-   journal = "submitted",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Richter and T. Wick},
+   title   = {Solid growth and clogging in fluid-structure interaction computed in ALE and fully Eulerian coordinates},
+   journal = {submitted},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_66,
-   author  = "T. Richter and T. Wick",
-   title   = "On time discretizations of fluid-structure interactions",
-   journal = "submitted",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Richter and T. Wick},
+   title   = {On time discretizations of fluid-structure interactions},
+   journal = {submitted},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_67,
-   author  = "T. Richter and T. Wick",
-   title   = "Optimal Control and Parameter Estimation for Stationary Fluid-Structure Interaction Problems",
-   journal = "SIAM J. Sci. Comput., pp. B1085-B1104",
-   year    = "2013",
-   volume  = "35",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Richter and T. Wick},
+   title   = {Optimal Control and Parameter Estimation for Stationary Fluid-Structure Interaction Problems},
+   journal = {SIAM J. Sci. Comput., pp. B1085-B1104},
+   year    = {2013},
+   volume  = {35},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2013_68,
-   author  = "N. V. Roberts",
-   title   = "A discontinuous Petrov-Galerkin methodology for incompressible flow problems",
-   year    = "2013",
-   school  = "University of Texas at Austin",
-   url     = "http://repositories.lib.utexas.edu/handle/2152/21174"
+   author  = {N. V. Roberts},
+   title   = {A discontinuous Petrov-Galerkin methodology for incompressible flow problems},
+   year    = {2013},
+   school  = {University of Texas at Austin},
+   url     = {http://repositories.lib.utexas.edu/handle/2152/21174}
 }
 
 @article{2013_69,
-   author  = "S. Roy and L. Heltai and D. Drapaca and F. Costanzo",
-   title   = "An immersed finite element method approach for brain biomechanics",
-   journal = "Mechanics of Biological Systems and Materials, Vol. 5, Conference Proceedings of the Society for Experimental Mechanics Series",
-   year    = "2013",
-   volume  = "",
-   pages   = "79--86",
-   url     = "",
-   doi     = ""
+   author  = {S. Roy and L. Heltai and D. Drapaca and F. Costanzo},
+   title   = {An immersed finite element method approach for brain biomechanics},
+   journal = {Mechanics of Biological Systems and Materials, Vol. 5, Conference Proceedings of the Society for Experimental Mechanics Series},
+   year    = {2013},
+   volume  = {},
+   pages   = {79--86},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_70,
-   author  = "S. Rudraraju and K. L. Mills and R. Kemkemer and K. Garikipati",
-   title   = "Multiphysics Modeling of Reactions, Mass Transport and Mechanics of Tumor Growth",
-   journal = "Computer Models in Biomechanics, G. Holzapfel and E. Kuhl (eds.), Spinger Verlag",
-   year    = "2013",
-   volume  = "",
-   pages   = "293--303",
-   url     = "",
-   doi     = ""
+   author  = {S. Rudraraju and K. L. Mills and R. Kemkemer and K. Garikipati},
+   title   = {Multiphysics Modeling of Reactions, Mass Transport and Mechanics of Tumor Growth},
+   journal = {Computer Models in Biomechanics, G. Holzapfel and E. Kuhl (eds.), Spinger Verlag},
+   year    = {2013},
+   volume  = {},
+   pages   = {293--303},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_71,
-   author  = "A. Sabouni and A. Venkateswaran and A. Shmuel and P. Pouliot and F. Lesage",
-   title   = "An automated technique to determine the induced current in transcranial magnetic stimulation",
-   journal = "Proceedings, Antennas and Propagation Society International Symposium (APSURSI), 2013 IEEE",
-   year    = "2013",
-   volume  = "",
-   pages   = "2050--2051",
-   url     = "",
-   doi     = ""
+   author  = {A. Sabouni and A. Venkateswaran and A. Shmuel and P. Pouliot and F. Lesage},
+   title   = {An automated technique to determine the induced current in transcranial magnetic stimulation},
+   journal = {Proceedings, Antennas and Propagation Society International Symposium (APSURSI), 2013 IEEE},
+   year    = {2013},
+   volume  = {},
+   pages   = {2050--2051},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_72,
-   author  = "M. Sagebaum and N. R. Gauger and U. Naumann and J. Lotz and K. Leppkes",
-   title   = "Algorithmic differentiation of a complex C++ code with underlying libraries",
-   journal = "Procedia Computer Science",
-   year    = "2013",
-   volume  = "18",
-   pages   = "208--217",
-   url     = "",
-   doi     = ""
+   author  = {M. Sagebaum and N. R. Gauger and U. Naumann and J. Lotz and K. Leppkes},
+   title   = {Algorithmic differentiation of a complex C++ code with underlying libraries},
+   journal = {Procedia Computer Science},
+   year    = {2013},
+   volume  = {18},
+   pages   = {208--217},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_73,
-   author  = "A. J. Salgado",
-   title   = "A framework for the implementation of coupled multiphase flow problems using the deal.II library and its application to electrowetting",
-   journal = "Archive of Numerical Software, article 2",
-   year    = "2013",
-   volume  = "1",
-   pages   = "1--19",
-   url     = "",
-   doi     = ""
+   author  = {A. J. Salgado},
+   title   = {A framework for the implementation of coupled multiphase flow problems using the deal.II library and its application to electrowetting},
+   journal = {Archive of Numerical Software, article 2},
+   year    = {2013},
+   volume  = {1},
+   pages   = {1--19},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_74,
-   author  = "A. J. Salgado",
-   title   = "A diffuse interface fractional time-stepping technique for incompressible two-phase flows with moving contact lines",
-   journal = "ESAIM Math. Model. Numer. Anal., pp. 743–769",
-   year    = "2013",
-   volume  = "47",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. J. Salgado},
+   title   = {A diffuse interface fractional time-stepping technique for incompressible two-phase flows with moving contact lines},
+   journal = {ESAIM Math. Model. Numer. Anal., pp. 743--769},
+   year    = {2013},
+   volume  = {47},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_75,
-   author  = "D. Schillinger and J. A. Evans and A.  Reali and M. A. Scott and T. J.R. Hughes",
-   title   = "Isogeometric Collocation: Cost Comparison with Galerkin Methods and Extension to Adaptive Hierarchical NURBS Discretizations",
-   journal = "ICES Report, Austin, TX",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.ticam.utexas.edu/media/reports/2013/1303.pdf",
-   doi     = ""
+   author  = {D. Schillinger and J. A. Evans and A.  Reali and M. A. Scott and T. J.R. Hughes},
+   title   = {Isogeometric Collocation: Cost Comparison with Galerkin Methods and Extension to Adaptive Hierarchical NURBS Discretizations},
+   journal = {ICES Report, Austin, TX},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.ticam.utexas.edu/media/reports/2013/1303.pdf},
+   doi     = {}
 }
 
 @phdthesis{2013_76,
-   author  = "P. Siehr",
-   title   = "Stabilisierungsmethoden für die Stokes-Gleichungen",
-   year    = "2013",
-   school  = "Bachelor thesis, University of Heidelberg, Germany",
-   url     = ""
+   author  = {P. Siehr},
+   title   = {Stabilisierungsmethoden f\"{u}r die Stokes-Gleichungen},
+   year    = {2013},
+   school  = {Bachelor thesis, University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2013_77,
-   author  = "J. Stapf and C. Garbe",
-   title   = "Partikelbasierte Str&ouml;mungsmessung unter Ausnutzung typischer Bewegungsmuster",
-   journal = "Proceedings, Fachtagung ``Lasermethoden in der Str&ouml;mungsmesstechnik, Munich, September 3-5, 2013, C. J. K&auml;hler, R. Hain, C. Cierpka, B. Ruck, A. Leder, D. Dopheide (eds.), article 1",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Stapf and C. Garbe},
+   title   = {Partikelbasierte Str\"{o}mungsmessung unter Ausnutzung typischer Bewegungsmuster},
+   journal = {Proceedings, Fachtagung ``Lasermethoden in der Str\"{o}mungsmesstechnik, Munich, September 3-5, 2013, C. J. K\"{a}hler, R. Hain, C. Cierpka, B. Ruck, A. Leder, D. Dopheide (eds.), article 1},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_78,
-   author  = "M. Steigemann and B. Schramm",
-   title   = "Precise computation and error control of stress intensity factors and certain integral characteristics in anisotropic inhomogeneous materials",
-   journal = "International Journal of Fracture",
-   year    = "2013",
-   volume  = "182",
-   pages   = "67--91",
-   url     = "",
-   doi     = ""
+   author  = {M. Steigemann and B. Schramm},
+   title   = {Precise computation and error control of stress intensity factors and certain integral characteristics in anisotropic inhomogeneous materials},
+   journal = {International Journal of Fracture},
+   year    = {2013},
+   volume  = {182},
+   pages   = {67--91},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_79,
-   author  = "M. Stoll and A. Wathen",
-   title   = "All-at-once solution of time-dependent PDE-constrained optimization problems",
-   journal = "Journal of Computational Physics",
-   year    = "2013",
-   volume  = "232",
-   pages   = "498--515",
-   url     = "",
-   doi     = ""
+   author  = {M. Stoll and A. Wathen},
+   title   = {All-at-once solution of time-dependent PDE-constrained optimization problems},
+   journal = {Journal of Computational Physics},
+   year    = {2013},
+   volume  = {232},
+   pages   = {498--515},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2013_80,
-   author  = "O. Sutton",
-   title   = "Numerical methods for reaction diffusion systems arising in Mathematical Biology",
-   year    = "2013",
-   school  = "University of Leicester",
-   url     = ""
+   author  = {O. Sutton},
+   title   = {Numerical methods for reaction diffusion systems arising in Mathematical Biology},
+   year    = {2013},
+   school  = {University of Leicester},
+   url     = {}
 }
 
 @mastersthesis{2013_81,
-   author  = "Q. Tong",
-   title   = "An exactly divergence-free finite element method for non-isothermal flow problems",
-   year    = "2013",
-   school  = "University of British Columbia",
-   url     = ""
+   author  = {Q. Tong},
+   title   = {An exactly divergence-free finite element method for non-isothermal flow problems},
+   year    = {2013},
+   school  = {University of British Columbia},
+   url     = {}
 }
 
 @article{2013_82,
-   author  = "H. A. Tran",
-   title   = "Partitioned Methods for Coupled Fluid Flow Problems",
-   journal = "PhD dissertation, University of Pittsburgh",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "http://d-scholarship.pitt.edu/18509/",
-   doi     = ""
+   author  = {H. A. Tran},
+   title   = {Partitioned Methods for Coupled Fluid Flow Problems},
+   journal = {PhD dissertation, University of Pittsburgh},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {http://d-scholarship.pitt.edu/18509/},
+   doi     = {}
 }
 
 @article{2013_83,
-   author  = "N. Vakulin and R. Shaw and T. Livingston",
-   title   = "ELEC 490, final report: High performance computing with GPUs",
-   journal = "Semester project for ELEC 490, final report. Queen's University",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {N. Vakulin and R. Shaw and T. Livingston},
+   title   = {ELEC 490, final report: High performance computing with GPUs},
+   journal = {Semester project for ELEC 490, final report. Queen's University},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_84,
-   author  = "M. Wallraff and T. Leicht and M. Lange-Hegermann",
-   title   = "Numerical flux functions for Reynolds-averaged Navier-Stokes and k&#969; turbulence model computations with a line-preconditioned p-multigrid discontinuous Galerkin solver",
-   journal = "Int. J. Numer. Meth. Fluids",
-   year    = "2013",
-   volume  = "71",
-   pages   = "1055--1072",
-   url     = "",
-   doi     = ""
+   author  = {M. Wallraff and T. Leicht and M. Lange-Hegermann},
+   title   = {Numerical flux functions for Reynolds-averaged Navier-Stokes and k$\omega$ turbulence model computations with a line-preconditioned p-multigrid discontinuous Galerkin solver},
+   journal = {Int. J. Numer. Meth. Fluids},
+   year    = {2013},
+   volume  = {71},
+   pages   = {1055--1072},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_85,
-   author  = "T. Wick and A. H. Elsheikh and M. F. Wheeler",
-   title   = "Parameter Estimation for the Coupled Biot-Lame-Navier Problem in Subsurface Modeling",
-   journal = "ARMA Conference in San Francisco, Jun 23-26",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick and A. H. Elsheikh and M. F. Wheeler},
+   title   = {Parameter Estimation for the Coupled Biot-Lame-Navier Problem in Subsurface Modeling},
+   journal = {ARMA Conference in San Francisco, Jun 23-26},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_86,
-   author  = "T. Wick",
-   title   = "Coupling of fully Eulerian and arbitrary Lagrangian-Eulerian methods for fluid-structure interaction computations",
-   journal = "Computational Mechanics, DOI: 10.1007/s00466-013-0866-3",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Coupling of fully Eulerian and arbitrary Lagrangian-Eulerian methods for fluid-structure interaction computations},
+   journal = {Computational Mechanics, DOI: 10.1007/s00466-013-0866-3},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_87,
-   author  = "T. Wick",
-   title   = "Flapping and Contact FSI Computations with the Fluid-Solid Interface-Tracking/Interface-Capturing Technique and Mesh Adaptivity",
-   journal = "Computational Mechanics, DOI: 10.1007/s00466-013-0890-3",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Flapping and Contact FSI Computations with the Fluid-Solid Interface-Tracking/Interface-Capturing Technique and Mesh Adaptivity},
+   journal = {Computational Mechanics, DOI: 10.1007/s00466-013-0890-3},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_88,
-   author  = "T. Wick",
-   title   = "Solving Monolithic Fluid-Structure Interaction Problems in Arbitrary Lagrangian Eulerian Coordinates with the deal.II Library",
-   journal = "Archive of Numerical Software, article 1",
-   year    = "2013",
-   volume  = "1",
-   pages   = "1--19",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Solving Monolithic Fluid-Structure Interaction Problems in Arbitrary Lagrangian Eulerian Coordinates with the deal.II Library},
+   journal = {Archive of Numerical Software, article 1},
+   year    = {2013},
+   volume  = {1},
+   pages   = {1--19},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_89,
-   author  = "T. Wick",
-   title   = "Fully Eulerian fluid-structure interaction for time-dependent problems",
-   journal = "Comp. Methods Appl. Mech. Engrg.",
-   year    = "2013",
-   volume  = "255",
-   pages   = "14--26",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Fully Eulerian fluid-structure interaction for time-dependent problems},
+   journal = {Comp. Methods Appl. Mech. Engrg.},
+   year    = {2013},
+   volume  = {255},
+   pages   = {14--26},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_90,
-   author  = "J. Willems",
-   title   = "Robust Multilevel Solvers for High-Contrast Anisotropic Multiscale Problems",
-   journal = "Journal of Computational and Applied Mathematics, 251:47-60",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1016/j.cam.2013.03.030"
+   author  = {J. Willems},
+   title   = {Robust Multilevel Solvers for High-Contrast Anisotropic Multiscale Problems},
+   journal = {Journal of Computational and Applied Mathematics, 251:47-60},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1016/j.cam.2013.03.030}
 }
 
 @article{2013_91,
-   author  = "J. Willems",
-   title   = "Spectral Coarse Spaces in Robust Two-Level Schwartz Methods",
-   journal = "O. Iliev, S. Margenov, P. Minev, P. Vassilevski, L. Zikatanov, editors, Numerical Solution of Partial Differential Equations: Theory, Algorithms and their Applications, 303-326, Springer Proceedings in Mathematics &amp; Statistics, Springer",
-   year    = "2013",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Willems},
+   title   = {Spectral Coarse Spaces in Robust Two-Level Schwartz Methods},
+   journal = {O. Iliev, S. Margenov, P. Minev, P. Vassilevski, L. Zikatanov, editors, Numerical Solution of Partial Differential Equations: Theory, Algorithms and their Applications, 303-326, Springer Proceedings in Mathematics \& Statistics, Springer},
+   year    = {2013},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_92,
-   author  = "S. Yoon and Y. T. Kang",
-   title   = "Mass transfer enhancement in non-Brownian particle suspension under a confined shear",
-   journal = "International Journal of Heat and Mass Transfer",
-   year    = "2013",
-   volume  = "60",
-   pages   = "114--124",
-   url     = "",
-   doi     = ""
+   author  = {S. Yoon and Y. T. Kang},
+   title   = {Mass transfer enhancement in non-Brownian particle suspension under a confined shear},
+   journal = {International Journal of Heat and Mass Transfer},
+   year    = {2013},
+   volume  = {60},
+   pages   = {114--124},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_93,
-   author  = "T. D. Young",
-   title   = "A finite basis grid analysis of the Hartree-Fock wavefunction method for one- and two-electron atoms",
-   journal = "AIP Conf. Proc., pp. 1524",
-   year    = "2013",
-   volume  = "1558",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. D. Young},
+   title   = {A finite basis grid analysis of the Hartree-Fock wavefunction method for one- and two-electron atoms},
+   journal = {AIP Conf. Proc., pp. 1524},
+   year    = {2013},
+   volume  = {1558},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_94,
-   author  = "T. D. Young and E. Romero and J. E. Roman",
-   title   = "Parallel finite element density functional theory exploiting grid refinement and subspace recycling",
-   journal = "Comput. Phys. Commun., 1",
-   year    = "2013",
-   volume  = "184",
-   pages   = "66--72",
-   url     = "",
-   doi     = ""
+   author  = {T. D. Young and E. Romero and J. E. Roman},
+   title   = {Parallel finite element density functional theory exploiting grid refinement and subspace recycling},
+   journal = {Comput. Phys. Commun., 1},
+   year    = {2013},
+   volume  = {184},
+   pages   = {66--72},
+   url     = {},
+   doi     = {}
 }
 
 @article{2013_95,
-   author  = "V. Zingan and J.-L. Guermond and J. Morel and B. Popov",
-   title   = "Implementation of the entropy viscosity method with the Discontinuous Galerkin Method",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2013",
-   volume  = "253",
-   pages   = "479--490",
-   url     = "",
-   doi     = ""
+   author  = {V. Zingan and J.-L. Guermond and J. Morel and B. Popov},
+   title   = {Implementation of the entropy viscosity method with the Discontinuous Galerkin Method},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2013},
+   volume  = {253},
+   pages   = {479--490},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -1,1374 +1,1374 @@
 % Encoding: ISO-8859-1
 
 @article{2014_0,
-   author  = "S. G. Abaimov and J. P. Cusumano",
-   title   = "Nucleation phenomena in an annealed damage model: Statistics of times to failure",
-   journal = "Phys. Rev. E 90",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://journals.aps.org/pre/abstract/10.1103/PhysRevE.90.062401",
-   doi     = ""
+   author  = {S. G. Abaimov and J. P. Cusumano},
+   title   = {Nucleation phenomena in an annealed damage model: Statistics of times to failure},
+   journal = {Phys. Rev. E 90},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://journals.aps.org/pre/abstract/10.1103/PhysRevE.90.062401},
+   doi     = {}
 }
 
 @article{2014_1,
-   author  = "I. Adeniran",
-   title   = "Modeling the Short QT Syndrome Gene Mutations",
-   journal = "Springer Theses",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {I. Adeniran},
+   title   = {Modeling the Short QT Syndrome Gene Mutations},
+   journal = {Springer Theses},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_2,
-   author  = "J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan",
-   title   = "Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects",
-   journal = "arXiv:1407.3197",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan},
+   title   = {Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects},
+   journal = {arXiv:1407.3197},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_3,
-   author  = "J. H. Adler and L. Dorfmann and D. Han and S. P. MacLachlan and C. Paetsch",
-   title   = "Mathematical and computational models of incompressible materials subject to shear",
-   journal = "IMA Journal of Applied Mathematics",
-   year    = "2014",
-   volume  = "79",
-   pages   = "889--914",
-   url     = "",
-   doi     = ""
+   author  = {J. H. Adler and L. Dorfmann and D. Han and S. P. MacLachlan and C. Paetsch},
+   title   = {Mathematical and computational models of incompressible materials subject to shear},
+   journal = {IMA Journal of Applied Mathematics},
+   year    = {2014},
+   volume  = {79},
+   pages   = {889--914},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_4,
-   author  = "J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel",
-   title   = "Constrained Optimization for Liquid Crystal Equilibria: Extended Results",
-   journal = "arXiv:1412.8056",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1412.8056",
-   doi     = ""
+   author  = {J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel},
+   title   = {Constrained Optimization for Liquid Crystal Equilibria: Extended Results},
+   journal = {arXiv:1412.8056},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1412.8056},
+   doi     = {}
 }
 
 @article{2014_5,
-   author  = "M. Alexe and A. Sandu",
-   title   = "Space–time adaptive solution of inverse problems with the discrete adjoint method",
-   journal = "Journal of Computational Physics, pp. 21–39",
-   year    = "2014",
-   volume  = "270",
-   pages   = "",
-   url     = "http://link.springer.com/article/10.1007/s10208-014-9208-x",
-   doi     = ""
+   author  = {M. Alexe and A. Sandu},
+   title   = {Space--time adaptive solution of inverse problems with the discrete adjoint method},
+   journal = {Journal of Computational Physics, pp. 21--39},
+   year    = {2014},
+   volume  = {270},
+   pages   = {},
+   url     = {http://link.springer.com/article/10.1007/s10208-014-9208-x},
+   doi     = {}
 }
 
 @article{2014_6,
-   author  = "A. I. Avila and A. Meister and M. Steigemann",
-   title   = "On numerical methods for nonlinear singularly perturbed Schr&ouml;dinger problems",
-   journal = "Applied Numerical Mathematics",
-   year    = "2014",
-   volume  = "86",
-   pages   = "22--42",
-   url     = "",
-   doi     = ""
+   author  = {A. I. Avila and A. Meister and M. Steigemann},
+   title   = {On numerical methods for nonlinear singularly perturbed Schr\"{o}dinger problems},
+   journal = {Applied Numerical Mathematics},
+   year    = {2014},
+   volume  = {86},
+   pages   = {22--42},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_7,
-   author  = "W. Bangerth and T. Heister",
-   title   = "Quo Vadis, Scientific Software?",
-   journal = "SIAM News, January 2014",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Bangerth and T. Heister},
+   title   = {Quo Vadis, Scientific Software?},
+   journal = {SIAM News, January 2014},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_8,
-   author  = "S. Bartels and R. H. Nochetto and A. J. Salgado",
-   title   = "Discrete total variation flows without regularization",
-   journal = "SIAM Journal on Numerical Analysis",
-   year    = "2014",
-   volume  = "52",
-   pages   = "363--385",
-   url     = "",
-   doi     = ""
+   author  = {S. Bartels and R. H. Nochetto and A. J. Salgado},
+   title   = {Discrete total variation flows without regularization},
+   journal = {SIAM Journal on Numerical Analysis},
+   year    = {2014},
+   volume  = {52},
+   pages   = {363--385},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_9,
-   author  = "A. Bertei and C.-C. Chueh and J. Pharoah and C. Nicolella",
-   title   = "Modified collective rearrangement sphere-assembly algorithm for random packings of nonspherical particles: Towards engineering applications",
-   journal = "Powder Technology",
-   year    = "2014",
-   volume  = "253",
-   pages   = "311--324",
-   url     = "",
-   doi     = ""
+   author  = {A. Bertei and C.-C. Chueh and J. Pharoah and C. Nicolella},
+   title   = {Modified collective rearrangement sphere-assembly algorithm for random packings of nonspherical particles: Towards engineering applications},
+   journal = {Powder Technology},
+   year    = {2014},
+   volume  = {253},
+   pages   = {311--324},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_10,
-   author  = "M. Bhaiya",
-   title   = "An open-source two-phase non-isothermal mathematical model of a polymer electrolyte membrane fuel cell",
-   year    = "2014",
-   school  = "University of Alberta, Edmonton",
-   url     = ""
+   author  = {M. Bhaiya},
+   title   = {An open-source two-phase non-isothermal mathematical model of a polymer electrolyte membrane fuel cell},
+   year    = {2014},
+   school  = {University of Alberta, Edmonton},
+   url     = {}
 }
 
 @article{2014_11,
-   author  = "M. Bhaiya and A. Putz and M. Secanell",
-   title   = "Analysis of non-isothermal effects on polymer electrolyte fuel cell electrode assemblies",
-   journal = "Electrochimica Acta",
-   year    = "2014",
-   volume  = "147",
-   pages   = "294--309",
-   url     = "",
-   doi     = ""
+   author  = {M. Bhaiya and A. Putz and M. Secanell},
+   title   = {Analysis of non-isothermal effects on polymer electrolyte fuel cell electrode assemblies},
+   journal = {Electrochimica Acta},
+   year    = {2014},
+   volume  = {147},
+   pages   = {294--309},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_12,
-   author  = "A. Bonito and R. Glowinski",
-   title   = "On the Nodal Set of the Eigenfunctions of the Laplace-Beltrami Operator for Bounded Surfaces in R<sup>3</sup>: A Computational Approach",
-   journal = "Communications on Pure and Applied Mathematics",
-   year    = "2014",
-   volume  = "13",
-   pages   = "2115--2126",
-   url     = "",
-   doi     = ""
+   author  = {A. Bonito and R. Glowinski},
+   title   = {On the Nodal Set of the Eigenfunctions of the Laplace-Beltrami Operator for Bounded Surfaces in R$^{3}$: A Computational Approach},
+   journal = {Communications on Pure and Applied Mathematics},
+   year    = {2014},
+   volume  = {13},
+   pages   = {2115--2126},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_13,
-   author  = "J. Bosch and D. Kay and M. Stoll and A. J. Wathen",
-   title   = "Fast solvers for Cahn-Hilliard inpainting",
-   journal = "SIAM Journal on Imaging Science",
-   year    = "2014",
-   volume  = "7",
-   pages   = "67--97",
-   url     = "",
-   doi     = ""
+   author  = {J. Bosch and D. Kay and M. Stoll and A. J. Wathen},
+   title   = {Fast solvers for Cahn-Hilliard inpainting},
+   journal = {SIAM Journal on Imaging Science},
+   year    = {2014},
+   volume  = {7},
+   pages   = {67--97},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_14,
-   author  = "J. Bosch and M. Stoll and P. Benner",
-   title   = "Fast solution of Cahn-Hilliard variational inequalities using implicit time discretizations and finite elements",
-   journal = "Journal of Computational Physics",
-   year    = "2014",
-   volume  = "262",
-   pages   = "38--57",
-   url     = "",
-   doi     = ""
+   author  = {J. Bosch and M. Stoll and P. Benner},
+   title   = {Fast solution of Cahn-Hilliard variational inequalities using implicit time discretizations and finite elements},
+   journal = {Journal of Computational Physics},
+   year    = {2014},
+   volume  = {262},
+   pages   = {38--57},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_15,
-   author  = "K. D. Brauss",
-   title   = "An implementation of the finite element method for the velocity-current magnetohydrodynamics equations",
-   year    = "2014",
-   school  = "University of Texas at Austin",
-   url     = ""
+   author  = {K. D. Brauss},
+   title   = {An implementation of the finite element method for the velocity-current magnetohydrodynamics equations},
+   year    = {2014},
+   school  = {University of Texas at Austin},
+   url     = {}
 }
 
 @article{2014_16,
-   author  = "A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen",
-   title   = "On local super-penalization of interior penalty discontinuous Galerkin methods",
-   journal = "International Journal of Numerical Analysis &amp; Modeling",
-   year    = "2014",
-   volume  = "11",
-   pages   = "478--495",
-   url     = "",
-   doi     = ""
+   author  = {A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen},
+   title   = {On local super-penalization of interior penalty discontinuous Galerkin methods},
+   journal = {International Journal of Numerical Analysis \& Modeling},
+   year    = {2014},
+   volume  = {11},
+   pages   = {478--495},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_17,
-   author  = "A. Cangiani and E. Georgoulis and S. Metcalfe",
-   title   = "Adaptive discontinuous Galerkin methods for nonstationary convection–diffusion problems",
-   journal = "IMA Journal of Numerical Analysis, Vol. 34, Issue 4",
-   year    = "2014",
-   volume  = "",
-   pages   = "1578--1597",
-   url     = "http://imajna.oxfordjournals.org/content/34/4/1578.short",
-   doi     = ""
+   author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
+   title   = {Adaptive discontinuous Galerkin methods for nonstationary convection--diffusion problems},
+   journal = {IMA Journal of Numerical Analysis, Vol. 34, Issue 4},
+   year    = {2014},
+   volume  = {},
+   pages   = {1578--1597},
+   url     = {http://imajna.oxfordjournals.org/content/34/4/1578.short},
+   doi     = {}
 }
 
 @article{2014_18,
-   author  = "N. Castelletto and J. A. White and H. A. Tchelepi",
-   title   = "A unified framework for fully-implicit and sequential-implicit schemes for coupled poroelasticity",
-   journal = "Proceedings, ECMOR XIV - 14th European conference on the mathematics of oil recovery",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {N. Castelletto and J. A. White and H. A. Tchelepi},
+   title   = {A unified framework for fully-implicit and sequential-implicit schemes for coupled poroelasticity},
+   journal = {Proceedings, ECMOR XIV - 14th European conference on the mathematics of oil recovery},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_19,
-   author  = "F. Cattoglio",
-   title   = "Multigrid preconditioning techniques for saddle point problems with highly variable coefficients",
-   year    = "2014",
-   school  = "Politecnico di Milano",
-   url     = ""
+   author  = {F. Cattoglio},
+   title   = {Multigrid preconditioning techniques for saddle point problems with highly variable coefficients},
+   year    = {2014},
+   school  = {Politecnico di Milano},
+   url     = {}
 }
 
 @article{2014_20,
-   author  = "C. C. Chueh and A. Bertei and J. Pharoah and C. Nicolella",
-   title   = "Effective Conductivity in Random Porous Media with Convex and Non-Convex Porosity",
-   journal = "International Journal of Heat and Mass Transfer",
-   year    = "2014",
-   volume  = "71",
-   pages   = "183--188",
-   url     = "",
-   doi     = ""
+   author  = {C. C. Chueh and A. Bertei and J. Pharoah and C. Nicolella},
+   title   = {Effective Conductivity in Random Porous Media with Convex and Non-Convex Porosity},
+   journal = {International Journal of Heat and Mass Transfer},
+   year    = {2014},
+   volume  = {71},
+   pages   = {183--188},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_21,
-   author  = "W. Dahmen and V. Gerber and T. Gotzen and S. Muller and M. Rom and C. Windisch",
-   title   = "Numerical Simulation of Transpiration Cooling with a Mixture of Thermally Perfect Gases",
-   journal = "11th World Congress on Computational Mechanics (WCCM XI), Spain",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://wccm-eccm-ecfd2014.org/admin/files/filePaper/p1331.pdf",
-   doi     = ""
+   author  = {W. Dahmen and V. Gerber and T. Gotzen and S. Muller and M. Rom and C. Windisch},
+   title   = {Numerical Simulation of Transpiration Cooling with a Mixture of Thermally Perfect Gases},
+   journal = {11th World Congress on Computational Mechanics (WCCM XI), Spain},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://wccm-eccm-ecfd2014.org/admin/files/filePaper/p1331.pdf},
+   doi     = {}
 }
 
 @article{2014_22,
-   author  = "W. Dahmen and T. Gotzen and S. Müller and M. Rom",
-   title   = "Numerical simulation of transpiration cooling through porous material",
-   journal = "Int. J. Numer. Meth. Fluids.  Vol. 76, pp:331–365",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/fld.3935/full",
-   doi     = ""
+   author  = {W. Dahmen and T. Gotzen and S. M\"{u}ller and M. Rom},
+   title   = {Numerical simulation of transpiration cooling through porous material},
+   journal = {Int. J. Numer. Meth. Fluids.  Vol. 76, pp:331--365},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.3935/full},
+   doi     = {}
 }
 
 @article{2014_23,
-   author  = "D. Davydov and J.-P. Pelteret and P. Steinmann",
-   title   = "Comparison of several staggered atomistic-to-continuum concurrent coupling strategies",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2014",
-   volume  = "277",
-   pages   = "260--280",
-   url     = "",
-   doi     = ""
+   author  = {D. Davydov and J.-P. Pelteret and P. Steinmann},
+   title   = {Comparison of several staggered atomistic-to-continuum concurrent coupling strategies},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2014},
+   volume  = {277},
+   pages   = {260--280},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_24,
-   author  = "D. Davydov and E. Voyiatzis and G. Chatzigeorgiou and S. Liu and P. Steinmann and M. C. B&ouml;hm and F. M&uuml;ller-Plathe",
-   title   = "Size Effects in a Silica-Polystyrene Nanocomposite: Molecular Dynamics and Surface-enhanced Continuum Approaches",
-   journal = "Soft Materials, pp. S142-S151",
-   year    = "2014",
-   volume  = "12",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Davydov and E. Voyiatzis and G. Chatzigeorgiou and S. Liu and P. Steinmann and M. C. B\"{o}hm and F. M\"{u}ller-Plathe},
+   title   = {Size Effects in a Silica-Polystyrene Nanocomposite: Molecular Dynamics and Surface-enhanced Continuum Approaches},
+   journal = {Soft Materials, pp. S142-S151},
+   year    = {2014},
+   volume  = {12},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_25,
-   author  = "I. G. Donev and B. D. Reddy",
-   title   = "Time-dependent finite element simulations of a shear-thinning viscoelastic fluid with application to blood flow",
-   journal = "International Journal for Numerical Methods in Fluids, pp. 668–686",
-   year    = "2014",
-   volume  = "75",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {I. G. Donev and B. D. Reddy},
+   title   = {Time-dependent finite element simulations of a shear-thinning viscoelastic fluid with application to blood flow},
+   journal = {International Journal for Numerical Methods in Fluids, pp. 668--686},
+   year    = {2014},
+   volume  = {75},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_26,
-   author  = "A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt",
-   title   = "Parallel performance study of block-preconditioned iterative methods on multicore computer systems",
-   journal = "Technical Report 2014-007, Department of Information Technology, Uppsala University",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt},
+   title   = {Parallel performance study of block-preconditioned iterative methods on multicore computer systems},
+   journal = {Technical Report 2014-007, Department of Information Technology, Uppsala University},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_27,
-   author  = "A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt",
-   title   = "CPU and GPU Performance of Large Scale Numerical Simulations in Geophysics",
-   journal = "Lecture Notes in Computer Science,  Vol. 8805, pp: 12-23",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://link.springer.com/chapter/10.1007/978-3-319-14325-5_2#page-1",
-   doi     = ""
+   author  = {A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt},
+   title   = {CPU and GPU Performance of Large Scale Numerical Simulations in Geophysics},
+   journal = {Lecture Notes in Computer Science,  Vol. 8805, pp: 12-23},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://link.springer.com/chapter/10.1007/978-3-319-14325-5_2#page-1},
+   doi     = {}
 }
 
 @article{2014_28,
-   author  = "A. Ebrahimi and M. Monavari and T. Hochrainer",
-   title   = "Numerical implementation of continuum dislocation dynamics with discontinuous-Galerkin method",
-   journal = "MRS Proceedings",
-   year    = "2014",
-   volume  = "1651",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Ebrahimi and M. Monavari and T. Hochrainer},
+   title   = {Numerical implementation of continuum dislocation dynamics with discontinuous-Galerkin method},
+   journal = {MRS Proceedings},
+   year    = {2014},
+   volume  = {1651},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_29,
-   author  = "Y. El-Kurdi and W. J. Gross and D. Giannacopoulos",
-   title   = "Parallel Multigrid Acceleration for the Finite-Element Gaussian Belief Propagation Algorithm",
-   journal = "IEEE Transactions on Magnetics, article 7014304",
-   year    = "2014",
-   volume  = "50",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {Y. El-Kurdi and W. J. Gross and D. Giannacopoulos},
+   title   = {Parallel Multigrid Acceleration for the Finite-Element Gaussian Belief Propagation Algorithm},
+   journal = {IEEE Transactions on Magnetics, article 7014304},
+   year    = {2014},
+   volume  = {50},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_30,
-   author  = "A. Evgrafov",
-   title   = "State space Newton's method for topology optimization",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2014",
-   volume  = "278",
-   pages   = "272--290",
-   url     = "",
-   doi     = ""
+   author  = {A. Evgrafov},
+   title   = {State space Newton's method for topology optimization},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2014},
+   volume  = {278},
+   pages   = {272--290},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_31,
-   author  = "B. Faigle and R. Helmig and I. Aavatsmark and B. Flemisch",
-   title   = "Efficient multiphysics modelling with adaptive grid refinement using a MPFA method",
-   journal = "Comput. Geosci. Vol. 18, pp. 625–636",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://link.springer.com/article/10.1007/s10596-014-9407-1#page",
-   doi     = ""
+   author  = {B. Faigle and R. Helmig and I. Aavatsmark and B. Flemisch},
+   title   = {Efficient multiphysics modelling with adaptive grid refinement using a MPFA method},
+   journal = {Comput. Geosci. Vol. 18, pp. 625--636},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://link.springer.com/article/10.1007/s10596-014-9407-1#page},
+   doi     = {}
 }
 
 @article{2014_32,
-   author  = "T. Fankhauser and T. Wihler and M. Wirz",
-   title   = "The hp-adaptive FEM based on continuous Sobolev embeddings: Isotropic refinements",
-   journal = "Computers &amp; Mathematics with Applications",
-   year    = "2014",
-   volume  = "67",
-   pages   = "854--868",
-   url     = "",
-   doi     = ""
+   author  = {T. Fankhauser and T. Wihler and M. Wirz},
+   title   = {The hp-adaptive FEM based on continuous Sobolev embeddings: Isotropic refinements},
+   journal = {Computers \& Mathematics with Applications},
+   year    = {2014},
+   volume  = {67},
+   pages   = {854--868},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_33,
-   author  = "R. Fayez and A. Vidal-Ferrandiz and D. Ginestar and G. Verdu",
-   title   = "h-p finite element method for the Lambda modes problem in hexagonal geometries",
-   journal = "40 Annual Meeting of Spanish Nuclear Society, Volume 46, Issue 13",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "https://inis.iaea.org/search/searchsinglerecord.aspx?recordsFor=SingleRecord&RN=46032323",
-   doi     = ""
+   author  = {R. Fayez and A. Vidal-Ferrandiz and D. Ginestar and G. Verdu},
+   title   = {h-p finite element method for the Lambda modes problem in hexagonal geometries},
+   journal = {40 Annual Meeting of Spanish Nuclear Society, Volume 46, Issue 13},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {https://inis.iaea.org/search/searchsinglerecord.aspx?recordsFor=SingleRecord&RN=46032323},
+   doi     = {}
 }
 
 @article{2014_34,
-   author  = "L. Ferguson and T. D. Breitzman",
-   title   = "Implementation and experimental validation of the Sendova-Walton theory for mode-I fracture",
-   journal = "Proceedings of the 11th World Congress on Computationa Mechnics (WCCM XI)",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {L. Ferguson and T. D. Breitzman},
+   title   = {Implementation and experimental validation of the Sendova-Walton theory for mode-I fracture},
+   journal = {Proceedings of the 11th World Congress on Computationa Mechnics (WCCM XI)},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2014_35,
-   author  = "M. Fraters",
-   title   = "Thermo-mechanically coupled subduction modelling with ASPECT",
-   year    = "2014",
-   school  = "Utrecht University",
-   url     = ""
+   author  = {M. Fraters},
+   title   = {Thermo-mechanically coupled subduction modelling with ASPECT},
+   year    = {2014},
+   school  = {Utrecht University},
+   url     = {}
 }
 
 @article{2014_36,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "Plastic flow as an energy minimization problem. Numerical Experiments",
-   journal = "Journal of Elasticity",
-   year    = "2014",
-   volume  = "115",
-   pages   = "53--74",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {Plastic flow as an energy minimization problem. Numerical Experiments},
+   journal = {Journal of Elasticity},
+   year    = {2014},
+   volume  = {115},
+   pages   = {53--74},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_37,
-   author  = "F. Freddi and E. Sacco",
-   title   = "An interface damage model accounting for in-plane effects",
-   journal = "International Journal of Solids and Structures",
-   year    = "2014",
-   volume  = "51",
-   pages   = "4230--4244",
-   url     = "",
-   doi     = ""
+   author  = {F. Freddi and E. Sacco},
+   title   = {An interface damage model accounting for in-plane effects},
+   journal = {International Journal of Solids and Structures},
+   year    = {2014},
+   volume  = {51},
+   pages   = {4230--4244},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_38,
-   author  = "S. Frei and T. Richter and T. Wick",
-   title   = "Solid growth and clogging in fluid-structure interaction using ALE and fully Eulerian coordinates",
-   journal = "RICAM, research report",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.ricam.oeaw.ac.at/people/member/?firstname=Thomas&lastname=Wick&show=publications",
-   doi     = ""
+   author  = {S. Frei and T. Richter and T. Wick},
+   title   = {Solid growth and clogging in fluid-structure interaction using ALE and fully Eulerian coordinates},
+   journal = {RICAM, research report},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.ricam.oeaw.ac.at/people/member/?firstname=Thomas&lastname=Wick&show=publications},
+   doi     = {}
 }
 
 @article{2014_39,
-   author  = "S. Frei and T. Richter and T. Wick",
-   title   = "Eulerian Techniques for Fluid-Structure Interactions - Part I: Modeling and Simulation",
-   journal = "ENUMATH Proc",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Frei and T. Richter and T. Wick},
+   title   = {Eulerian Techniques for Fluid-Structure Interactions - Part I: Modeling and Simulation},
+   journal = {ENUMATH Proc},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_40,
-   author  = "S. Frei and T. Richter and T. Wick",
-   title   = "Eulerian Techniques for Fluid-Structure Interactions - Part II: Applications",
-   journal = "ENUMATH Proc",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Frei and T. Richter and T. Wick},
+   title   = {Eulerian Techniques for Fluid-Structure Interactions - Part II: Applications},
+   journal = {ENUMATH Proc},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_41,
-   author  = "R. R. Fu and B. H. Hager and A. I. Ermakov and M. T. Zuber",
-   title   = "Efficient early global relaxation of asteroid Vesta",
-   journal = "Icarus",
-   year    = "2014",
-   volume  = "240",
-   pages   = "133--145",
-   url     = "",
-   doi     = ""
+   author  = {R. R. Fu and B. H. Hager and A. I. Ermakov and M. T. Zuber},
+   title   = {Efficient early global relaxation of asteroid Vesta},
+   journal = {Icarus},
+   year    = {2014},
+   volume  = {240},
+   pages   = {133--145},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_42,
-   author  = "J. J. Gaitero and J. S. Dolado and C. Neuen and F. Heber and E. Koenders",
-   title   = "3D Computational Simulation of Calcium Leaching in Cement Matrices",
-   journal = "Materiales de Construcción, Vol 64, article e035",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. J. Gaitero and J. S. Dolado and C. Neuen and F. Heber and E. Koenders},
+   title   = {3D Computational Simulation of Calcium Leaching in Cement Matrices},
+   journal = {Materiales de Construcci\'{o}n, Vol 64, article e035},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_43,
-   author  = "K. George and H. Thomas",
-   title   = "Simulation of groundwater flow based on adaptive mesh refinement",
-   journal = "Proceedings of the 7th International Congress on Environmental Modelling and Software, San Diego, International Environmental Modelling and Software Society (iEMSs)",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {K. George and H. Thomas},
+   title   = {Simulation of groundwater flow based on adaptive mesh refinement},
+   journal = {Proceedings of the 7th International Congress on Environmental Modelling and Software, San Diego, International Environmental Modelling and Software Society (iEMSs)},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_44,
-   author  = "S. Sh. Ghorashi and J. Amani and A. S. Bagherzadeh and T. Rabczuk",
-   title   = "Goal-oriented error estimation and mesh adaptivity in three-dimensional elasticity problems",
-   journal = "Proceedings of the 11th World Congress on Computational Mechnics (WCCM XI)",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Sh. Ghorashi and J. Amani and A. S. Bagherzadeh and T. Rabczuk},
+   title   = {Goal-oriented error estimation and mesh adaptivity in three-dimensional elasticity problems},
+   journal = {Proceedings of the 11th World Congress on Computational Mechnics (WCCM XI)},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_45,
-   author  = "M. C. Giestas and J. P. Milhazes and H. L. Pina",
-   title   = "Numerical Modeling of Solar Ponds",
-   journal = "Energy Procedia, pp. 2416–2425",
-   year    = "2014",
-   volume  = "57",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S1876610214016178",
-   doi     = ""
+   author  = {M. C. Giestas and J. P. Milhazes and H. L. Pina},
+   title   = {Numerical Modeling of Solar Ponds},
+   journal = {Energy Procedia, pp. 2416--2425},
+   year    = {2014},
+   volume  = {57},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S1876610214016178},
+   doi     = {}
 }
 
 @article{2014_46,
-   author  = "V. Girault and G. Kanschat and B. Rivière",
-   title   = "Error analysis for a monolithic discretization of coupled Darcy and Stokes problems",
-   journal = "Journal of Numerical Mathematics, no. 2",
-   year    = "2014",
-   volume  = "22",
-   pages   = "109--142",
-   url     = "",
-   doi     = "10.1515/jnma-2014-0005"
+   author  = {V. Girault and G. Kanschat and B. Rivi\`{e}re},
+   title   = {Error analysis for a monolithic discretization of coupled Darcy and Stokes problems},
+   journal = {Journal of Numerical Mathematics, no. 2},
+   year    = {2014},
+   volume  = {22},
+   pages   = {109--142},
+   url     = {},
+   doi     = {10.1515/jnma-2014-0005}
 }
 
 @article{2014_47,
-   author  = "A. Grayver and M. B&uuml;rg",
-   title   = "Robust and scalable 3-D geo-electromagnetic modelling approach using the finite element method",
-   journal = "Geophysical Journal International 2014, published online (DOI 10.1093/gji/ggu119)",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://gji.oxfordjournals.org/content/early/2014/04/29/gji.ggu119.abstract?keytype=ref&ijkey=gkyDCSgpUEOjqWw",
-   doi     = ""
+   author  = {A. Grayver and M. B\"{u}rg},
+   title   = {Robust and scalable 3-D geo-electromagnetic modelling approach using the finite element method},
+   journal = {Geophysical Journal International 2014, published online (DOI 10.1093/gji/ggu119)},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://gji.oxfordjournals.org/content/early/2014/04/29/gji.ggu119.abstract?keytype=ref&ijkey=gkyDCSgpUEOjqWw},
+   doi     = {}
 }
 
 @article{2014_48,
-   author  = "N. Gupta and N. Nataraj",
-   title   = "A dual weighted residual method for an optimal control problem of laser surface hardening of steel",
-   journal = "Mathematics and Computers in Simulation, pp. 12–32",
-   year    = "2014",
-   volume  = "103",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0378475414000494",
-   doi     = ""
+   author  = {N. Gupta and N. Nataraj},
+   title   = {A dual weighted residual method for an optimal control problem of laser surface hardening of steel},
+   journal = {Mathematics and Computers in Simulation, pp. 12--32},
+   year    = {2014},
+   volume  = {103},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0378475414000494},
+   doi     = {}
 }
 
 @article{2014_49,
-   author  = "D.H. Ha and A. H. Caldwell and M. J. Ward and S.s Honrao and K. Mathew and R. Hovden and M. K. A. Koker and D. A. Muller and R. G. Hennig and R. D. Robinson",
-   title   = "Solid–Solid Phase Transformations Induced through Cation Exchange and Strain in 2D Heterostructured Copper Sulfide Nanocrystals",
-   journal = "NANO Letters, 14(12)",
-   year    = "2014",
-   volume  = "",
-   pages   = "7090--7099",
-   url     = "http://pubs.acs.org/doi/abs/10.1021/nl5035607",
-   doi     = ""
+   author  = {D.H. Ha and A. H. Caldwell and M. J. Ward and S.s Honrao and K. Mathew and R. Hovden and M. K. A. Koker and D. A. Muller and R. G. Hennig and R. D. Robinson},
+   title   = {Solid--Solid Phase Transformations Induced through Cation Exchange and Strain in 2D Heterostructured Copper Sulfide Nanocrystals},
+   journal = {NANO Letters, 14(12)},
+   year    = {2014},
+   volume  = {},
+   pages   = {7090--7099},
+   url     = {http://pubs.acs.org/doi/abs/10.1021/nl5035607},
+   doi     = {}
 }
 
 @article{2014_50,
-   author  = "J. S. Hale and P. Kerfriden and J. J. R. Garcia and and S. P. A. Bordas",
-   title   = "Parallel Simulations of Soft-Tissue using an Adaptive Quadtree/Octree Implicit Bounadry Finite Element Method",
-   journal = "11th World Congress on Computational Mechanics (WCCM XI), Spain",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://journals.aps.org/pre/abstract/10.1103/PhysRevE.90.062401",
-   doi     = ""
+   author  = {J. S. Hale and P. Kerfriden and J. J. R. Garcia and and S. P. A. Bordas},
+   title   = {Parallel Simulations of Soft-Tissue using an Adaptive Quadtree/Octree Implicit Bounadry Finite Element Method},
+   journal = {11th World Congress on Computational Mechanics (WCCM XI), Spain},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://journals.aps.org/pre/abstract/10.1103/PhysRevE.90.062401},
+   doi     = {}
 }
 
 @article{2014_51,
-   author  = "S. H&auml;rting and A. Marciniak-Czochra",
-   title   = "Spike patterns in a reaction-diffusion-ode model with Turing instability",
-   journal = "Mathematical Methods in the Applied Sciences, Issue 9",
-   year    = "2014",
-   volume  = "37",
-   pages   = "1377--1391",
-   url     = "",
-   doi     = ""
+   author  = {S. H\"{a}rting and A. Marciniak-Czochra},
+   title   = {Spike patterns in a reaction-diffusion-ode model with Turing instability},
+   journal = {Mathematical Methods in the Applied Sciences, Issue 9},
+   year    = {2014},
+   volume  = {37},
+   pages   = {1377--1391},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_52,
-   author  = "R. Hartmann and T. Leicht",
-   title   = "Higher order and adaptive DG methods for compressible flows",
-   journal = "In H. Deconinck and R. Abgrall, editors, VKI LS 2014-03: 37th Advanced VKI CFD Lecture Series: Recent developments in higher order methods and industrial application in aeronautics, Dec. 9-12, 2013. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://ganymed.iwr.uni-heidelberg.de/~hartmann/",
-   doi     = ""
+   author  = {R. Hartmann and T. Leicht},
+   title   = {Higher order and adaptive DG methods for compressible flows},
+   journal = {In H. Deconinck and R. Abgrall, editors, VKI LS 2014-03: 37th Advanced VKI CFD Lecture Series: Recent developments in higher order methods and industrial application in aeronautics, Dec. 9-12, 2013. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/},
+   doi     = {}
 }
 
 @article{2014_53,
-   author  = "L. Heltai and S. Roy and F. Costanzo",
-   title   = "A Fully Coupled Immersed Finite Element Method for Fluid Structure Interaction via the Deal.II Library",
-   journal = "Archive of Numerical Software, article 1",
-   year    = "2014",
-   volume  = "2",
-   pages   = "1--27",
-   url     = "",
-   doi     = ""
+   author  = {L. Heltai and S. Roy and F. Costanzo},
+   title   = {A Fully Coupled Immersed Finite Element Method for Fluid Structure Interaction via the Deal.II Library},
+   journal = {Archive of Numerical Software, article 1},
+   year    = {2014},
+   volume  = {2},
+   pages   = {1--27},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_54,
-   author  = "M. Hinterm&uuml;ller and A. Schiela and W. Wollner",
-   title   = "The length of the primal-dual path in Moreau-Yosida-based path-following for state constrained optimal control",
-   journal = "SIAM J. Optim.",
-   year    = "2014",
-   volume  = "24",
-   pages   = "108--126",
-   url     = "",
-   doi     = ""
+   author  = {M. Hinterm\"{u}ller and A. Schiela and W. Wollner},
+   title   = {The length of the primal-dual path in Moreau-Yosida-based path-following for state constrained optimal control},
+   journal = {SIAM J. Optim.},
+   year    = {2014},
+   volume  = {24},
+   pages   = {108--126},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_55,
-   author  = "B. Janssen and T. Wihler",
-   title   = "Existence Results for the Continuous and Discontinuous Galerkin Time Stepping Methods for Nonlinear Initial Value Problems",
-   journal = "arXiv:1407.5520",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Janssen and T. Wihler},
+   title   = {Existence Results for the Continuous and Discontinuous Galerkin Time Stepping Methods for Nonlinear Initial Value Problems},
+   journal = {arXiv:1407.5520},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_56,
-   author  = "A. Javili and A. T. McBride and P. Steinmann and B. D. Reddy",
-   title   = "A unified computational framework for bulk and surface elasticity theory: a curvilinear-coordinate-based finite element methodology",
-   journal = "Computational Mechanics",
-   year    = "2014",
-   volume  = "54",
-   pages   = "745--762",
-   url     = "",
-   doi     = ""
+   author  = {A. Javili and A. T. McBride and P. Steinmann and B. D. Reddy},
+   title   = {A unified computational framework for bulk and surface elasticity theory: a curvilinear-coordinate-based finite element methodology},
+   journal = {Computational Mechanics},
+   year    = {2014},
+   volume  = {54},
+   pages   = {745--762},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_57,
-   author  = "G. Kanschat and J. V. Ragusa",
-   title   = "A Robust Multigrid Preconditioner for <i>S<sub>N</sub></i>DG Approximation of Monochromatic, Isotropic Radiation Transport Problems",
-   journal = "SIAM J. Sci. Comput. no. 5",
-   year    = "2014",
-   volume  = "36",
-   pages   = "2326--2345",
-   url     = "",
-   doi     = "10.1137/13091600X"
+   author  = {G. Kanschat and J. V. Ragusa},
+   title   = {A Robust Multigrid Preconditioner for S$S_{\textnormal{N}}$DG Approximation of Monochromatic, Isotropic Radiation Transport Problems},
+   journal = {SIAM J. Sci. Comput. no. 5},
+   year    = {2014},
+   volume  = {36},
+   pages   = {2326--2345},
+   url     = {},
+   doi     = {10.1137/13091600X}
 }
 
 @article{2014_58,
-   author  = "G. Kanschat and N. Sharma",
-   title   = "Divergence-conforming Discontinuous Galerkin Methods and C<sup>0</sup> Interior Penalty Methods",
-   journal = "SIAM J. Numer. Anal., no. 4",
-   year    = "2014",
-   volume  = "52",
-   pages   = "1822--1842",
-   url     = "",
-   doi     = "10.1137/120902975"
+   author  = {G. Kanschat and N. Sharma},
+   title   = {Divergence-conforming Discontinuous Galerkin Methods and C$^{0}$ Interior Penalty Methods},
+   journal = {SIAM J. Numer. Anal., no. 4},
+   year    = {2014},
+   volume  = {52},
+   pages   = {1822--1842},
+   url     = {},
+   doi     = {10.1137/120902975}
 }
 
 @article{2014_59,
-   author  = "S. Kim",
-   title   = "Cartesian PML approximation to resonances in open systems in R<sup>2</sup>",
-   journal = "Applied Numerical Mathematics",
-   year    = "2014",
-   volume  = "81",
-   pages   = "50--75",
-   url     = "",
-   doi     = ""
+   author  = {S. Kim},
+   title   = {Cartesian PML approximation to resonances in open systems in R$^{2}$},
+   journal = {Applied Numerical Mathematics},
+   year    = {2014},
+   volume  = {81},
+   pages   = {50--75},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_60,
-   author  = "S. Kim",
-   title   = "Analysis of the convected Helmholtz equation with a uniform mean flow in a waveguide with complete radiation boundary conditions",
-   journal = "Journal of Mathematical Analysis and Applications",
-   year    = "2014",
-   volume  = "410",
-   pages   = "275--291",
-   url     = "",
-   doi     = ""
+   author  = {S. Kim},
+   title   = {Analysis of the convected Helmholtz equation with a uniform mean flow in a waveguide with complete radiation boundary conditions},
+   journal = {Journal of Mathematical Analysis and Applications},
+   year    = {2014},
+   volume  = {410},
+   pages   = {275--291},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_61,
-   author  = "U. K&ouml;cher and M. Bause",
-   title   = "Variational Space-Time Methods for the Wave Equation",
-   journal = "Journal of Scientific Computing, Vol 61, issue 2",
-   year    = "2014",
-   volume  = "",
-   pages   = "424--453",
-   url     = "http://link.springer.com/article/10.1007/s10915-014-9831-3",
-   doi     = ""
+   author  = {U. K\"{o}cher and M. Bause},
+   title   = {Variational Space-Time Methods for the Wave Equation},
+   journal = {Journal of Scientific Computing, Vol 61, issue 2},
+   year    = {2014},
+   volume  = {},
+   pages   = {424--453},
+   url     = {http://link.springer.com/article/10.1007/s10915-014-9831-3},
+   doi     = {}
 }
 
 @article{2014_62,
-   author  = "G. Kourakos and T. Harter",
-   title   = "Simulation of Groundwater Flow based on Adaptive Mesh Refinement",
-   journal = "In: Ames, D.P., Quinn, N.W.T., Rizzoli, A.E. (Eds.), Proceedings of the 7th International Congress on Environmental Modelling and Software, June 15-19, San Diego, California, USA; ",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {G. Kourakos and T. Harter},
+   title   = {Simulation of Groundwater Flow based on Adaptive Mesh Refinement},
+   journal = {In: Ames, D.P., Quinn, N.W.T., Rizzoli, A.E. (Eds.), Proceedings of the 7th International Congress on Environmental Modelling and Software, June 15-19, San Diego, California, USA; },
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_63,
-   author  = "S. Kramer and G. Lube",
-   title   = "Finite Element-Boundary Element Methods for Accurate Modeling of Excluded Volume Effects in Dielectric Relaxation Spectroscopy",
-   journal = "Preprint",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Kramer and G. Lube},
+   title   = {Finite Element-Boundary Element Methods for Accurate Modeling of Excluded Volume Effects in Dielectric Relaxation Spectroscopy},
+   journal = {Preprint},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_64,
-   author  = "O. Krehel",
-   title   = "Aggregation and fragmentation in reaction-diffusion systems posed in heterogeneous domains",
-   year    = "2014",
-   school  = "Friedrich Alexander University ErlangenNuremberg, Germany Oct",
-   url     = "http://alexandria.tue.nl/extra2/780944.pdf"
+   author  = {O. Krehel},
+   title   = {Aggregation and fragmentation in reaction-diffusion systems posed in heterogeneous domains},
+   year    = {2014},
+   school  = {Friedrich Alexander University ErlangenNuremberg, Germany Oct},
+   url     = {http://alexandria.tue.nl/extra2/780944.pdf}
 }
 
 @article{2014_65,
-   author  = "O. Krehel and A. Muntean and P. Knabner",
-   title   = "Multiscale modeling of colloidal dynamics in porous media: Capturing aggregation and deposition effects",
-   journal = "<a href="http://arxiv.org/abs/1404.4207">arxiv:1404.4207</a>",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {O. Krehel and A. Muntean and P. Knabner},
+   title   = {Multiscale modeling of colloidal dynamics in porous media: Capturing aggregation and deposition effects},
+   journal = {arXiv.org preprint 1404.4207},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1404.4207},
+   doi     = {}
 }
 
 @article{2014_66,
-   author  = "K. Kumar and T. van Noorden and M. F. Wheeler and T. Wick",
-   title   = "An ALE-based method for reaction-induced boundary movement towards clogging",
-   journal = "ENUMATH Proceedings",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {K. Kumar and T. van Noorden and M. F. Wheeler and T. Wick},
+   title   = {An ALE-based method for reaction-induced boundary movement towards clogging},
+   journal = {ENUMATH Proceedings},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_67,
-   author  = "K. Leonard",
-   title   = "Mathematical and Computational Modelling of Tissue Engineered Bone in a Hydrostatic Bioreactor",
-   year    = "2014",
-   school  = "University of Oxford",
-   url     = ""
+   author  = {K. Leonard},
+   title   = {Mathematical and Computational Modelling of Tissue Engineered Bone in a Hydrostatic Bioreactor},
+   year    = {2014},
+   school  = {University of Oxford},
+   url     = {}
 }
 
 @article{2014_68,
-   author  = "G. Lube and D. Arndt and H. Dallmann",
-   title   = "Understanding the limits of inf-sup stable Galerkin-FEM for incompressible flows",
-   journal = "BAIL 2014 - Boundary and Interior Layers",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.mathsim.eu/~darndt/",
-   doi     = "10.1007/978-3-319-25727-3"
+   author  = {G. Lube and D. Arndt and H. Dallmann},
+   title   = {Understanding the limits of inf-sup stable Galerkin-FEM for incompressible flows},
+   journal = {BAIL 2014 - Boundary and Interior Layers},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.mathsim.eu/~darndt/},
+   doi     = {10.1007/978-3-319-25727-3}
 }
 
 @article{2014_69,
-   author  = "S. Liebenstein and S. Sandfeld and M. Zaiser",
-   title   = "Higher Order Continuum Modelling for Predicting the Mechanical Behaviour of Solid Foams",
-   journal = "PAMM · Proc. Appl. Math. Mech., pp. 315–316",
-   year    = "2014",
-   volume  = "14",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410145/abstract",
-   doi     = ""
+   author  = {S. Liebenstein and S. Sandfeld and M. Zaiser},
+   title   = {Higher Order Continuum Modelling for Predicting the Mechanical Behaviour of Solid Foams},
+   journal = {PAMM: Proc. Appl. Math. Mech., pp. 315--316},
+   year    = {2014},
+   volume  = {14},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410145/abstract},
+   doi     = {}
 }
 
 @article{2014_70,
-   author  = "A. Madzvamuse and A. H. W. Chung",
-   title   = "Fully implicit time-stepping schemes and non-linear solvers for systems of reaction–diffusion equations",
-   journal = "Applied Mathematics and Computation",
-   year    = "2014",
-   volume  = "244",
-   pages   = "361--374",
-   url     = "",
-   doi     = ""
+   author  = {A. Madzvamuse and A. H. W. Chung},
+   title   = {Fully implicit time-stepping schemes and non-linear solvers for systems of reaction--diffusion equations},
+   journal = {Applied Mathematics and Computation},
+   year    = {2014},
+   volume  = {244},
+   pages   = {361--374},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_71,
-   author  = "D. Malhotra and A. Gholami and G. Biros",
-   title   = "A volume integral equation Stokes solver for problems with variable coefficients",
-   journal = "SC14: International Conference for High Performance Computing, Network, Storage and Analysis",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://dl.acm.org/citation.cfm?id=2683604",
-   doi     = ""
+   author  = {D. Malhotra and A. Gholami and G. Biros},
+   title   = {A volume integral equation Stokes solver for problems with variable coefficients},
+   journal = {SC14: International Conference for High Performance Computing, Network, Storage and Analysis},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://dl.acm.org/citation.cfm?id=2683604},
+   doi     = {}
 }
 
 @article{2014_72,
-   author  = "M. S. Mallikarjunaiah and J. Walton",
-   title   = "On the direct numerical simulation (DNS) of an anti-plane shear crack in a new class of strain-limiting elastic bodies",
-   journal = "Proceedings of the US National Congress on Theoretical and Applied Mechanics (USNTAM-14) to be held in Michigan State University-East Lansing, June 15-20",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. S. Mallikarjunaiah and J. Walton},
+   title   = {On the direct numerical simulation (DNS) of an anti-plane shear crack in a new class of strain-limiting elastic bodies},
+   journal = {Proceedings of the US National Congress on Theoretical and Applied Mechanics (USNTAM-14) to be held in Michigan State University-East Lansing, June 15-20},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2014_73,
-   author  = "J. Y. Merten",
-   title   = "Entwicklung eines adaptiven Finite-Elemente-Verfahrens f&uuml;r ein Lithium-Ionen-Akkumulator Modell",
-   year    = "2014",
-   school  = "University of Heidelberg",
-   url     = ""
+   author  = {J. Y. Merten},
+   title   = {Entwicklung eines adaptiven Finite-Elemente-Verfahrens f\"{u}r ein Lithium-Ionen-Akkumulator Modell},
+   year    = {2014},
+   school  = {University of Heidelberg},
+   url     = {}
 }
 
 @phdthesis{2014_74,
-   author  = "S. A. Metcalfe",
-   title   = "Adaptive discontinuous Galerkin methods for nonlinear parabolic problems",
-   year    = "2014",
-   school  = "University of Leicester",
-   url     = "http://arXiv.org/abs/1504.02646"
+   author  = {S. A. Metcalfe},
+   title   = {Adaptive discontinuous Galerkin methods for nonlinear parabolic problems},
+   year    = {2014},
+   school  = {University of Leicester},
+   url     = {http://arXiv.org/abs/1504.02646}
 }
 
 @article{2014_75,
-   author  = "C. E. Michoski and J. A. Evans and P. G. Schmitz",
-   title   = "Discontinuous Galerkin hp-adaptive methods for multiscale chemical reactors: Quiescent reactors",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2014",
-   volume  = "279",
-   pages   = "163--197",
-   url     = "",
-   doi     = ""
+   author  = {C. E. Michoski and J. A. Evans and P. G. Schmitz},
+   title   = {Discontinuous Galerkin hp-adaptive methods for multiscale chemical reactors: Quiescent reactors},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2014},
+   volume  = {279},
+   pages   = {163--197},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_76,
-   author  = "K. L. Mills and S. Rudraraju and R. Kemkemer and K. Garikipati",
-   title   = "Elastic free energy drives the shape of prevascular tumors",
-   journal = "PLoS ONE",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1405.3293",
-   doi     = ""
+   author  = {K. L. Mills and S. Rudraraju and R. Kemkemer and K. Garikipati},
+   title   = {Elastic free energy drives the shape of prevascular tumors},
+   journal = {PLoS ONE},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1405.3293},
+   doi     = {}
 }
 
 @article{2014_77,
-   author  = "A. Mola and L. Heltai and A. DeSimone",
-   title   = "A fully nonlinear potential model for ship hydrodynamics directly interfaced with CAD data structures",
-   journal = "The Twenty-fourth International Ocean and Polar Engineering Conference, Busan, Korea",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.onepetro.org/conference-paper/ISOPE-I-14-475",
-   doi     = ""
+   author  = {A. Mola and L. Heltai and A. DeSimone},
+   title   = {A fully nonlinear potential model for ship hydrodynamics directly interfaced with CAD data structures},
+   journal = {The Twenty-fourth International Ocean and Polar Engineering Conference, Busan, Korea},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.onepetro.org/conference-paper/ISOPE-I-14-475},
+   doi     = {}
 }
 
 @mastersthesis{2014_78,
-   author  = "C. M&uuml;ller",
-   title   = "An explicit formulation of the hybridizable discontinuous Galerkin method for the acoustic wave equation",
-   year    = "2014",
-   school  = "Technische Universit&auml;t M&uuml;nchen",
-   url     = ""
+   author  = {C. M\"{u}ller},
+   title   = {An explicit formulation of the hybridizable discontinuous Galerkin method for the acoustic wave equation},
+   year    = {2014},
+   school  = {Technische Universit\"{a}t M\"{u}nchen},
+   url     = {}
 }
 
 @article{2014_79,
-   author  = "N. Nama and P.-H. Huang and T. J. Huang and F. Costanzo",
-   title   = "Investigation of acoustic streaming patterns around oscillating sharp edges",
-   journal = "Lab Chip",
-   year    = "2014",
-   volume  = "14",
-   pages   = "2824--2836",
-   url     = "",
-   doi     = ""
+   author  = {N. Nama and P.-H. Huang and T. J. Huang and F. Costanzo},
+   title   = {Investigation of acoustic streaming patterns around oscillating sharp edges},
+   journal = {Lab Chip},
+   year    = {2014},
+   volume  = {14},
+   pages   = {2824--2836},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_80,
-   author  = "M. Neytcheva and B. Lund",
-   title   = "Numerical solution methods for algebraic systems arising in discrete coupled visco-/poroelastic models",
-   journal = "Joint project with Dept. of Info. Tech. and Earth Sci., Uppsala University",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://user.it.uu.se/~maya/Projects/GIA/GIA_project_TDB_2014.pdf",
-   doi     = ""
+   author  = {M. Neytcheva and B. Lund},
+   title   = {Numerical solution methods for algebraic systems arising in discrete coupled visco-/poroelastic models},
+   journal = {Joint project with Dept. of Info. Tech. and Earth Sci., Uppsala University},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://user.it.uu.se/~maya/Projects/GIA/GIA_project_TDB_2014.pdf},
+   doi     = {}
 }
 
 @article{2014_81,
-   author  = "R. H. Nochetto and A. J. Salgado and I. Tomas",
-   title   = "The micropolar Navier-Stokes equations: A priori error analysis",
-   journal = "Mathematical Models and Methods in Applied Sciences",
-   year    = "2014",
-   volume  = "24",
-   pages   = "1237--1264",
-   url     = "",
-   doi     = ""
+   author  = {R. H. Nochetto and A. J. Salgado and I. Tomas},
+   title   = {The micropolar Navier-Stokes equations: A priori error analysis},
+   journal = {Mathematical Models and Methods in Applied Sciences},
+   year    = {2014},
+   volume  = {24},
+   pages   = {1237--1264},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_82,
-   author  = "R. H. Nochetto and A. J. Salgado and S. W. Walker",
-   title   = "A diffuse interface model for electrowetting with moving contact lines",
-   journal = "Mathematical Models and Methods in Applied Sciences, article 67",
-   year    = "2014",
-   volume  = "24",
-   pages   = "",
-   url     = "http://www.worldscientific.com/doi/abs/10.1142/S0218202513500474?journalCode=m3as",
-   doi     = ""
+   author  = {R. H. Nochetto and A. J. Salgado and S. W. Walker},
+   title   = {A diffuse interface model for electrowetting with moving contact lines},
+   journal = {Mathematical Models and Methods in Applied Sciences, article 67},
+   year    = {2014},
+   volume  = {24},
+   pages   = {},
+   url     = {http://www.worldscientific.com/doi/abs/10.1142/S0218202513500474?journalCode=m3as},
+   doi     = {}
 }
 
 @article{2014_83,
-   author  = "J. Pearson and M. Stoll and A. Wathen",
-   title   = "Preconditioners for state-constrained optimal control problems with Moreau–Yosida penalty function",
-   journal = "Numerical Linear Algebra",
-   year    = "2014",
-   volume  = "21",
-   pages   = "81--97",
-   url     = "",
-   doi     = ""
+   author  = {J. Pearson and M. Stoll and A. Wathen},
+   title   = {Preconditioners for state-constrained optimal control problems with Moreau--Yosida penalty function},
+   journal = {Numerical Linear Algebra},
+   year    = {2014},
+   volume  = {21},
+   pages   = {81--97},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_84,
-   author  = "J. P. V. Pelteret and B. D. Reddy",
-   title   = "Development of a computational biomechanical model of the human upper-airway soft-tissues toward simulating obstructive sleep apnea",
-   journal = "Clinical Anatomy",
-   year    = "2014",
-   volume  = "27",
-   pages   = "182--200",
-   url     = "",
-   doi     = ""
+   author  = {J. P. V. Pelteret and B. D. Reddy},
+   title   = {Development of a computational biomechanical model of the human upper-airway soft-tissues toward simulating obstructive sleep apnea},
+   journal = {Clinical Anatomy},
+   year    = {2014},
+   volume  = {27},
+   pages   = {182--200},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_85,
-   author  = "M. Pernach and K. Bzowski and M. Pietrzyk",
-   title   = "Numerical modelling of phase transformation in DP steel after hot rolling and laminar cooling",
-   journal = "International Journal for Multiscale Computational Engineering",
-   year    = "2014",
-   volume  = "12",
-   pages   = "397--410",
-   url     = "",
-   doi     = ""
+   author  = {M. Pernach and K. Bzowski and M. Pietrzyk},
+   title   = {Numerical modelling of phase transformation in DP steel after hot rolling and laminar cooling},
+   journal = {International Journal for Multiscale Computational Engineering},
+   year    = {2014},
+   volume  = {12},
+   pages   = {397--410},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_86,
-   author  = "E. G. Phillips",
-   title   = "Fast Solvers and Uncertainty Quantification for Models of Magnetohydrodynamics",
-   year    = "2014",
-   school  = "University of Maryland",
-   url     = ""
+   author  = {E. G. Phillips},
+   title   = {Fast Solvers and Uncertainty Quantification for Models of Magnetohydrodynamics},
+   year    = {2014},
+   school  = {University of Maryland},
+   url     = {}
 }
 
 @article{2014_87,
-   author  = "T. Povall and A. T. McBride and B. D. Reddy",
-   title   = "Finite element simulation of large-strain single-crystal viscoplasticity: An investigation of various hardening relations",
-   journal = "Computational Materials Science",
-   year    = "2014",
-   volume  = "81",
-   pages   = "386--396",
-   url     = "",
-   doi     = ""
+   author  = {T. Povall and A. T. McBride and B. D. Reddy},
+   title   = {Finite element simulation of large-strain single-crystal viscoplasticity: An investigation of various hardening relations},
+   journal = {Computational Materials Science},
+   year    = {2014},
+   volume  = {81},
+   pages   = {386--396},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_88,
-   author  = "M. J. Rapson and T. J. Hamilton and J. C. Tapson",
-   title   = "On the fluid-structure interaction in the cochlea",
-   journal = "J. Acoust. Soc. Am.",
-   year    = "2014",
-   volume  = "136",
-   pages   = "284--300",
-   url     = "",
-   doi     = ""
+   author  = {M. J. Rapson and T. J. Hamilton and J. C. Tapson},
+   title   = {On the fluid-structure interaction in the cochlea},
+   journal = {J. Acoust. Soc. Am.},
+   year    = {2014},
+   volume  = {136},
+   pages   = {284--300},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_89,
-   author  = "H. Rahemi and N. Nigam and J. M. Wakeling",
-   title   = "Regionalizing muscle activity causes changes to the magnitude and direction of the force from whole muscles &mdash; A modelling study",
-   journal = "Frontiers in Physiology (Integrative Physiology), article 298",
-   year    = "2014",
-   volume  = "5",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {H. Rahemi and N. Nigam and J. M. Wakeling},
+   title   = {Regionalizing muscle activity causes changes to the magnitude and direction of the force from whole muscles -- A modelling study},
+   journal = {Frontiers in Physiology (Integrative Physiology), article 298},
+   year    = {2014},
+   volume  = {5},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_90,
-   author  = "J. Reinhardt and A. Scacchi and J. M. Brader",
-   title   = "Microrheology close to an equilibrium phase transition",
-   journal = "J. Chem. Phys., article 144901",
-   year    = "2014",
-   volume  = "140",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Reinhardt and A. Scacchi and J. M. Brader},
+   title   = {Microrheology close to an equilibrium phase transition},
+   journal = {J. Chem. Phys., article 144901},
+   year    = {2014},
+   volume  = {140},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_91,
-   author  = "Y. Reinwald and K. Leonard and J. R. Henstock and J. P. Whiteley and J. M. Osborne and S. L. Waters and P. Levesque and A. J. El Haj",
-   title   = "Evaluation of the growth environment of a hydrostatic force bioreactor for preconditioning of tissue-engineered constructs",
-   journal = "Tissue engineering. Part C, Methods, article 24967717",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {Y. Reinwald and K. Leonard and J. R. Henstock and J. P. Whiteley and J. M. Osborne and S. L. Waters and P. Levesque and A. J. El Haj},
+   title   = {Evaluation of the growth environment of a hydrostatic force bioreactor for preconditioning of tissue-engineered constructs},
+   journal = {Tissue engineering. Part C, Methods, article 24967717},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_92,
-   author  = "T. Richter and T. Wick",
-   title   = "On time discretizations of fluid-structure interactions",
-   journal = "In: T. Carraro, M. Geiger, S. K&ouml;rkel, and R. Rannacher (eds), "Multiple Shooting and Time Domain Decomposition Methods", Contributions in Mathematical and Computational Science, Springer",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Richter and T. Wick},
+   title   = {On time discretizations of fluid-structure interactions},
+   journal = {In: T. Carraro, M. Geiger, S. K\"{o}rkel, and R. Rannacher (eds), ``Multiple Shooting and Time Domain Decomposition Methods'', Contributions in Mathematical and Computational Science, Springer},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_93,
-   author  = "D. Riedlbauer and M. Drexler and D. Drummer and P. Steinmann and J. Mergheim",
-   title   = "Modelling, simulation and experimental validation of heat transfer in selective laser melting of the polymeric material PA12",
-   journal = "Computational Materials Science",
-   year    = "2014",
-   volume  = "93",
-   pages   = "239--248",
-   url     = "",
-   doi     = ""
+   author  = {D. Riedlbauer and M. Drexler and D. Drummer and P. Steinmann and J. Mergheim},
+   title   = {Modelling, simulation and experimental validation of heat transfer in selective laser melting of the polymeric material PA12},
+   journal = {Computational Materials Science},
+   year    = {2014},
+   volume  = {93},
+   pages   = {239--248},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_94,
-   author  = "D. Riedlbauer and J. Mergheim and P. Steinmann",
-   title   = "Simulation of the temperature distribution in the selective beam melting process for polymer material",
-   journal = "AIP Conf. Proc. 1593, 708",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://scitation.aip.org/content/aip/proceeding/aipcp/1593?ver=pdfcov&page=2",
-   doi     = ""
+   author  = {D. Riedlbauer and J. Mergheim and P. Steinmann},
+   title   = {Simulation of the temperature distribution in the selective beam melting process for polymer material},
+   journal = {AIP Conf. Proc. 1593, 708},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://scitation.aip.org/content/aip/proceeding/aipcp/1593?ver=pdfcov&page=2},
+   doi     = {}
 }
 
 @article{2014_95,
-   author  = "D. Riedlbauer and J. Mergheim and P. Steinmann",
-   title   = "Thermomechanical Simulation of the Electron Beam Melting Process for TiAl6V4",
-   journal = "PAMM · Proc. Appl. Math. Mech., pp. 463 – 464",
-   year    = "2014",
-   volume  = "14",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410219/abstract",
-   doi     = ""
+   author  = {D. Riedlbauer and J. Mergheim and P. Steinmann},
+   title   = {Thermomechanical Simulation of the Electron Beam Melting Process for TiAl6V4},
+   journal = {PAMM: Proc. Appl. Math. Mech., pp. 463 -- 464},
+   year    = {2014},
+   volume  = {14},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410219/abstract},
+   doi     = {}
 }
 
 @article{2014_96,
-   author  = "D. Riedlbauer and P. Steinmann and J. Mergheim",
-   title   = "Thermomechanical finite element simulations of selective electron beam melting processes: performance considerations",
-   journal = "Computational Mechanics",
-   year    = "2014",
-   volume  = "54",
-   pages   = "109--122",
-   url     = "",
-   doi     = ""
+   author  = {D. Riedlbauer and P. Steinmann and J. Mergheim},
+   title   = {Thermomechanical finite element simulations of selective electron beam melting processes: performance considerations},
+   journal = {Computational Mechanics},
+   year    = {2014},
+   volume  = {54},
+   pages   = {109--122},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_97,
-   author  = "S. Riehl and P. Steinmann",
-   title   = "An integrated approach to shape optimization and mesh adaptivity based on material residual forces",
-   journal = "Computer Methods in Applied Mechanics and Engineering, pp. 640–663",
-   year    = "2014",
-   volume  = "278",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Riehl and P. Steinmann},
+   title   = {An integrated approach to shape optimization and mesh adaptivity based on material residual forces},
+   journal = {Computer Methods in Applied Mechanics and Engineering, pp. 640--663},
+   year    = {2014},
+   volume  = {278},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_98,
-   author  = "S. Rudraraju and A. van der Ven and K. Garikipati",
-   title   = "Three-dimensional isogeometric solutions to general boundary value problems of Toupin's gradient elasticity theory at finite strains",
-   journal = "Comp. Meth. App. Mech. Engr.",
-   year    = "2014",
-   volume  = "278",
-   pages   = "705--728",
-   url     = "",
-   doi     = ""
+   author  = {S. Rudraraju and A. van der Ven and K. Garikipati},
+   title   = {Three-dimensional isogeometric solutions to general boundary value problems of Toupin's gradient elasticity theory at finite strains},
+   journal = {Comp. Meth. App. Mech. Engr.},
+   year    = {2014},
+   volume  = {278},
+   pages   = {705--728},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_99,
-   author  = "A. Sabouni and P. Pouliot and A. Shmuel",
-   title   = "BRAIN initiative: Fast and parallel solver for real-time monitoring of the eddy current in the brain for TMS applications",
-   journal = "Proceedings of the Engineering in Medicine and Biology Society (EMBC), 2014 36th Annual International Conference of the IEEE",
-   year    = "2014",
-   volume  = "",
-   pages   = "6250--6253",
-   url     = "",
-   doi     = ""
+   author  = {A. Sabouni and P. Pouliot and A. Shmuel},
+   title   = {BRAIN initiative: Fast and parallel solver for real-time monitoring of the eddy current in the brain for TMS applications},
+   journal = {Proceedings of the Engineering in Medicine and Biology Society (EMBC), 2014 36th Annual International Conference of the IEEE},
+   year    = {2014},
+   volume  = {},
+   pages   = {6250--6253},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_100,
-   author  = "A. Schmidt",
-   title   = "Direct Metods for PDE-Constrained Optimization Using Derivative-Extended POD Reduced-Order Models ",
-   year    = "2014",
-   school  = "University of Heidelberg",
-   url     = "http://archiv.ub.uni-heidelberg.de/volltextserver/17780/"
+   author  = {A. Schmidt},
+   title   = {Direct Metods for PDE-Constrained Optimization Using Derivative-Extended POD Reduced-Order Models },
+   year    = {2014},
+   school  = {University of Heidelberg},
+   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/17780/}
 }
 
 @article{2014_101,
-   author  = "D. Sch&ouml;tzau and C. Schwab and T. Wihler and M. Wirz",
-   title   = "Exponential Convergence of hp-DGFEM for Elliptic Problems in Polyhedral Domains",
-   journal = "Spectral and High Order Methods for Partial Differential Equations - ICOSAHOM 2012. Lecture Notes in Computational Science and Engineering Vol. 95, pp 57-73 ",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
+   title   = {Exponential Convergence of hp-DGFEM for Elliptic Problems in Polyhedral Domains},
+   journal = {Spectral and High Order Methods for Partial Differential Equations - ICOSAHOM 2012. Lecture Notes in Computational Science and Engineering Vol. 95, pp 57-73 },
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_102,
-   author  = "S. Schoenawa and R. Hartmann",
-   title   = "Discontinuous Galerkin discretization of the Reynolds-averaged Navier-Stokes equations with the shear-stress transport model",
-   journal = "Journal of Computational Physics",
-   year    = "2014",
-   volume  = "262",
-   pages   = "194--216",
-   url     = "",
-   doi     = ""
+   author  = {S. Schoenawa and R. Hartmann},
+   title   = {Discontinuous Galerkin discretization of the Reynolds-averaged Navier-Stokes equations with the shear-stress transport model},
+   journal = {Journal of Computational Physics},
+   year    = {2014},
+   volume  = {262},
+   pages   = {194--216},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_103,
-   author  = "J. Sheldon and S. Miller and J. Pitt",
-   title   = "Methodology for Comparing Coupling Algorithms for Fluid-Structure Interaction Problems",
-   journal = "World Journal of Mathematics",
-   year    = "2014",
-   volume  = "4",
-   pages   = "54--70",
-   url     = "",
-   doi     = ""
+   author  = {J. Sheldon and S. Miller and J. Pitt},
+   title   = {Methodology for Comparing Coupling Algorithms for Fluid-Structure Interaction Problems},
+   journal = {World Journal of Mathematics},
+   year    = {2014},
+   volume  = {4},
+   pages   = {54--70},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_104,
-   author  = "J. R. D. Soiné",
-   title   = "Reconstruction and Simulation of Cellular Traction Forces",
-   year    = "2014",
-   school  = "University of Heidelberg",
-   url     = ""
+   author  = {J. R. D. Soin\'{e}},
+   title   = {Reconstruction and Simulation of Cellular Traction Forces},
+   year    = {2014},
+   school  = {University of Heidelberg},
+   url     = {}
 }
 
 @article{2014_105,
-   author  = "J. Stapf and C. Garbe",
-   title   = "A learning-based approach for highly accurate measurements of turbulent fluid flows",
-   journal = "Experiments in Fluids, article 1799",
-   year    = "2014",
-   volume  = "55",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Stapf and C. Garbe},
+   title   = {A learning-based approach for highly accurate measurements of turbulent fluid flows},
+   journal = {Experiments in Fluids, article 1799},
+   year    = {2014},
+   volume  = {55},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_106,
-   author  = "J. Stapf and C. Garbe",
-   title   = "A variational optical flow approach using learned motion models for the determination of fluid flows",
-   journal = "Proceedings, 17th International Symposium on Applications of Laser Techniques to Fluid Mechanics, Lisbon, Portugual",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Stapf and C. Garbe},
+   title   = {A variational optical flow approach using learned motion models for the determination of fluid flows},
+   journal = {Proceedings, 17th International Symposium on Applications of Laser Techniques to Fluid Mechanics, Lisbon, Portugual},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_107,
-   author  = "M. Stoll",
-   title   = "One-shot solution of a time-dependent time-periodic PDE-constrained optimization problem",
-   journal = "IMA Journal of Numerical Analysis, Volume 34, Issue 4",
-   year    = "2014",
-   volume  = "",
-   pages   = "1554--1577",
-   url     = "http://imajna.oxfordjournals.org/content/34/4/1554",
-   doi     = ""
+   author  = {M. Stoll},
+   title   = {One-shot solution of a time-dependent time-periodic PDE-constrained optimization problem},
+   journal = {IMA Journal of Numerical Analysis, Volume 34, Issue 4},
+   year    = {2014},
+   volume  = {},
+   pages   = {1554--1577},
+   url     = {http://imajna.oxfordjournals.org/content/34/4/1554},
+   doi     = {}
 }
 
 @article{2014_108,
-   author  = "S. Tirupathi and J. S. Hesthaven and Y. Liang and M. Parmentier",
-   title   = "Multilevel and Local Timestepping Discontinuous Galerkin Methods for Magma Dynamics",
-   journal = "Infoscience, article 197347",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Tirupathi and J. S. Hesthaven and Y. Liang and M. Parmentier},
+   title   = {Multilevel and Local Timestepping Discontinuous Galerkin Methods for Magma Dynamics},
+   journal = {Infoscience, article 197347},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_109,
-   author  = "M. Vavalis and G. Sarailidis",
-   title   = "Implementing hybrid PDE solvers",
-   journal = "Preprint",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Vavalis and G. Sarailidis},
+   title   = {Implementing hybrid PDE solvers},
+   journal = {Preprint},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_110,
-   author  = "A. Vidal-Ferrandiza and R. Fayeza and D. Ginestarb and G. Verdúa",
-   title   = "Solution of the Lambda modes problem of a nuclear power reactor using an h–p finite element method",
-   journal = "Annals of Nuclear Energy, pp. 338–349",
-   year    = "2014",
-   volume  = "72",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0306454914002473",
-   doi     = ""
+   author  = {A. Vidal-Ferrandiza and R. Fayeza and D. Ginestarb and G. Verdúa},
+   title   = {Solution of the Lambda modes problem of a nuclear power reactor using an h--p finite element method},
+   journal = {Annals of Nuclear Energy, pp. 338--349},
+   year    = {2014},
+   volume  = {72},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0306454914002473},
+   doi     = {}
 }
 
 @article{2014_111,
-   author  = "F. Vogel and J.-P. V. Pelteret and S. Kaessmair and P. Steinmann",
-   title   = "Magnetic force and torque on particles subject to a magnetic field",
-   journal = "European Journal of Mechanics A/Solids, Volume 48",
-   year    = "2014",
-   volume  = "",
-   pages   = "23--37",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0997753814000618",
-   doi     = "10.1016/j.euromechsol.2014.03.007"
+   author  = {F. Vogel and J.-P. V. Pelteret and S. Kaessmair and P. Steinmann},
+   title   = {Magnetic force and torque on particles subject to a magnetic field},
+   journal = {European Journal of Mechanics A/Solids, Volume 48},
+   year    = {2014},
+   volume  = {},
+   pages   = {23--37},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0997753814000618},
+   doi     = {10.1016/j.euromechsol.2014.03.007}
 }
 
 @article{2014_112,
-   author  = "J. Vuong and B. Simeon",
-   title   = "On finite element method–flux corrected transport stabilization for advection–diffusion problems in a partial differential–algebraic framework",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2014",
-   volume  = "262",
-   pages   = "115--126",
-   url     = "",
-   doi     = ""
+   author  = {J. Vuong and B. Simeon},
+   title   = {On finite element method--flux corrected transport stabilization for advection--diffusion problems in a partial differential--algebraic framework},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2014},
+   volume  = {262},
+   pages   = {115--126},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_113,
-   author  = "B. Walter and P. Saxena and J.-P. V. Pelteret and J. Kaschta and D. Schubert and P. Steinmann",
-   title   = "On The Preparation, Characterisation, Modelling And Simulation Of Magneto-Sensitive Elastomers",
-   journal = "Proceedings of the Second Seminar on the Mechanics of Multifunctional Materials, 12, 103-106",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Walter and P. Saxena and J.-P. V. Pelteret and J. Kaschta and D. Schubert and P. Steinmann},
+   title   = {On The Preparation, Characterisation, Modelling And Simulation Of Magneto-Sensitive Elastomers},
+   journal = {Proceedings of the Second Seminar on the Mechanics of Multifunctional Materials, 12, 103-106},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2014_114,
-   author  = "F. Wang",
-   title   = "Regularizing Inverse Problems",
-   year    = "2014",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {F. Wang},
+   title   = {Regularizing Inverse Problems},
+   year    = {2014},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @phdthesis{2014_115,
-   author  = "K. Wang",
-   title   = "Parallel Markov Chain Monte Carlo Methods for Large Scale Inverse Problems",
-   year    = "2014",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {K. Wang},
+   title   = {Parallel Markov Chain Monte Carlo Methods for Large Scale Inverse Problems},
+   year    = {2014},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @phdthesis{2014_116,
-   author  = "C. Weiler",
-   title   = "Optimum Experimental Design for the Identification of Gaussian Disorder Mobility Parameters in Charge Transport Models of Organic Semiconductors",
-   year    = "2014",
-   school  = "University of Heidelberg, Germany",
-   url     = ""
+   author  = {C. Weiler},
+   title   = {Optimum Experimental Design for the Identification of Gaussian Disorder Mobility Parameters in Charge Transport Models of Organic Semiconductors},
+   year    = {2014},
+   school  = {University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2014_117,
-   author  = "J. Weinbub and K. Rupp and S. Selberherr",
-   title   = "Highly flexible and reusable finite element simulations with ViennaX",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2014",
-   volume  = "270",
-   pages   = "484--495",
-   url     = "",
-   doi     = ""
+   author  = {J. Weinbub and K. Rupp and S. Selberherr},
+   title   = {Highly flexible and reusable finite element simulations with ViennaX},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2014},
+   volume  = {270},
+   pages   = {484--495},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_118,
-   author  = "J. Weinbub and K. Rupp and S. Selberherr",
-   title   = "ViennaX: a parallel plugin execution framework for scientific computing",
-   journal = "Engineering with Computers, Vol  30 (4), pp 651-668",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "http://link.springer.com/article/10.1007/s00366-013-0314-1",
-   doi     = ""
+   author  = {J. Weinbub and K. Rupp and S. Selberherr},
+   title   = {ViennaX: a parallel plugin execution framework for scientific computing},
+   journal = {Engineering with Computers, Vol  30 (4), pp 651-668},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {http://link.springer.com/article/10.1007/s00366-013-0314-1},
+   doi     = {}
 }
 
 @article{2014_119,
-   author  = "M. F. Wheeler and T. Wick and W. Wollner",
-   title   = "An Augmented-Lagrangian Method for the Phase-Field Approach for Pressurized Fractures",
-   journal = "Comput. Methods Appl. Mech. Engrg.",
-   year    = "2014",
-   volume  = "271",
-   pages   = "69--85",
-   url     = "",
-   doi     = ""
+   author  = {M. F. Wheeler and T. Wick and W. Wollner},
+   title   = {An Augmented-Lagrangian Method for the Phase-Field Approach for Pressurized Fractures},
+   journal = {Comput. Methods Appl. Mech. Engrg.},
+   year    = {2014},
+   volume  = {271},
+   pages   = {69--85},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_120,
-   author  = "T. Wick",
-   title   = "Modeling, Discretization, Optimization, and Simulation of Fluid-Structure Interaction",
-   journal = "Lecture notes (177 pages), IWR Heidelberg",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Modeling, Discretization, Optimization, and Simulation of Fluid-Structure Interaction},
+   journal = {Lecture notes (177 pages), IWR Heidelberg},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_121,
-   author  = "T. Wick and G. Singh and M. F. Wheeler",
-   title   = "Pressurized-Fracture propagation using a phase-field approach coupled to a reservoir simulator",
-   journal = "SPE 168597-MS, SPE HFTC Proc.",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick and G. Singh and M. F. Wheeler},
+   title   = {Pressurized-Fracture propagation using a phase-field approach coupled to a reservoir simulator},
+   journal = {SPE 168597-MS, SPE HFTC Proc.},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_122,
-   author  = "T. Wick and W. Wollner",
-   title   = "On the differentiability of fluid-structure interaction problems with respect to the problem data",
-   journal = "RICAM report 2014-16",
-   year    = "2014",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick and W. Wollner},
+   title   = {On the differentiability of fluid-structure interaction problems with respect to the problem data},
+   journal = {RICAM report 2014-16},
+   year    = {2014},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_123,
-   author  = "J. Willems",
-   title   = "Robust Multilevel Methods for General Symmetric Positive Definite Operators",
-   journal = "SIAM J. Numer. Anal., no. 1, 103-124",
-   year    = "2014",
-   volume  = "52",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Willems},
+   title   = {Robust Multilevel Methods for General Symmetric Positive Definite Operators},
+   journal = {SIAM J. Numer. Anal., no. 1, 103-124},
+   year    = {2014},
+   volume  = {52},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_124,
-   author  = "J. Wilmers and B. Lenhof",
-   title   = "Comparison of Different FE-approaches for Modelling of Short Fibre Composites",
-   journal = "Technische Mechanik",
-   year    = "2014",
-   volume  = "34",
-   pages   = "90--103",
-   url     = "",
-   doi     = ""
+   author  = {J. Wilmers and B. Lenhof},
+   title   = {Comparison of Different FE-approaches for Modelling of Short Fibre Composites},
+   journal = {Technische Mechanik},
+   year    = {2014},
+   volume  = {34},
+   pages   = {90--103},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_125,
-   author  = "J. Worthen and G. Stadler and N. Petra and M. Gurnis and O. Ghattas",
-   title   = "Towards adjoint-based inversion for rheological parameters in nonlinear viscous mantle flow",
-   journal = "Physics of the Earth and Planetary Interiors",
-   year    = "2014",
-   volume  = "234",
-   pages   = "23--34",
-   url     = "",
-   doi     = ""
+   author  = {J. Worthen and G. Stadler and N. Petra and M. Gurnis and O. Ghattas},
+   title   = {Towards adjoint-based inversion for rheological parameters in nonlinear viscous mantle flow},
+   journal = {Physics of the Earth and Planetary Interiors},
+   year    = {2014},
+   volume  = {234},
+   pages   = {23--34},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_126,
-   author  = "S. Yoon and J. T. Chung and Y. T. Kang",
-   title   = "The particle hydrodynamic effect on the mass transfer in a buoyant CO<sub>2</sub>-bubble through the experimental and computational studies",
-   journal = "International Journal of Heat and Mass Transfer",
-   year    = "2014",
-   volume  = "73",
-   pages   = "399--409",
-   url     = "",
-   doi     = ""
+   author  = {S. Yoon and J. T. Chung and Y. T. Kang},
+   title   = {The particle hydrodynamic effect on the mass transfer in a buoyant CO$_{2}$-bubble through the experimental and computational studies},
+   journal = {International Journal of Heat and Mass Transfer},
+   year    = {2014},
+   volume  = {73},
+   pages   = {399--409},
+   url     = {},
+   doi     = {}
 }
 
 @article{2014_127,
-   author  = "J. Zarestky and W. Bangerth",
-   title   = "Teaching HPC: Lessons from a flipped classroom, project-based course on finite element methods",
-   journal = "EduHPC '14, Proceedings of the Workshop on Education for High-Performance Computing",
-   year    = "2014",
-   volume  = "",
-   pages   = "34--41",
-   url     = "http://dl.acm.org/citation.cfm?id=2690860&dl=ACM&coll=DL&CFID=594739437&CFTOKEN=14279369",
-   doi     = ""
+   author  = {J. Zarestky and W. Bangerth},
+   title   = {Teaching HPC: Lessons from a flipped classroom, project-based course on finite element methods},
+   journal = {EduHPC '14, Proceedings of the Workshop on Education for High-Performance Computing},
+   year    = {2014},
+   volume  = {},
+   pages   = {34--41},
+   url     = {http://dl.acm.org/citation.cfm?id=2690860&dl=ACM&coll=DL&CFID=594739437&CFTOKEN=14279369},
+   doi     = {}
 }
 
 @phdthesis{2014_128,
-   author  = "Y. Zhang",
-   title   = "SP<sub>N</sub> Model Error and Iterative Solution Techniques",
-   year    = "2014",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {Y. Zhang},
+   title   = {SP$_{\textnormal{N}}$ Model Error and Iterative Solution Techniques},
+   year    = {2014},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -1,1619 +1,1619 @@
 % Encoding: ISO-8859-1
 
 @phdthesis{2015_0,
-   author  = "F. S. Alrashed",
-   title   = "Parallel multiphase Navier-Stokes solver",
-   year    = "2015",
-   school  = "Texas A&M University",
-   url     = "http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf"
+   author  = {F. S. Alrashed},
+   title   = {Parallel multiphase Navier-Stokes solver},
+   year    = {2015},
+   school  = {Texas A \& M University},
+   url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf}
 }
 
 @article{2015_1,
-   author  = "J. H. Adler and T. J. Atherton and D. B. Emerson and S. P. MacLachlan",
-   title   = "An energy-minimization finite-element approach for the Frank-Oseen Model of nematic liquid crystals",
-   journal = "SIAM J. Numer. Anal., Vol. 53",
-   year    = "2015",
-   volume  = "",
-   pages   = "2226--2254",
-   url     = "http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf",
-   doi     = ""
+   author  = {J. H. Adler and T. J. Atherton and D. B. Emerson and S. P. MacLachlan},
+   title   = {An energy-minimization finite-element approach for the Frank-Oseen Model of nematic liquid crystals},
+   journal = {SIAM J. Numer. Anal., Vol. 53},
+   year    = {2015},
+   volume  = {},
+   pages   = {2226--2254},
+   url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf},
+   doi     = {}
 }
 
 @article{2015_2,
-   author  = "J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan",
-   title   = "Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects",
-   journal = "SIAM Journal on Scientific Computing, 37(5), pp. S157-S176",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan},
+   title   = {Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects},
+   journal = {SIAM Journal on Scientific Computing, 37(5), pp. S157-S176},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_3,
-   author  = "F. Alvarez and S. Flores",
-   title   = "Existence And Approximation Results For Variational Problems Under Uniform Constraints On The Gradient By Power Penalty",
-   journal = "SIAM J. Math. Anal.",
-   year    = "2015",
-   volume  = "47",
-   pages   = "3466--3487",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/140988619",
-   doi     = "10.1137/140988619"
+   author  = {F. Alvarez and S. Flores},
+   title   = {Existence And Approximation Results For Variational Problems Under Uniform Constraints On The Gradient By Power Penalty},
+   journal = {SIAM J. Math. Anal.},
+   year    = {2015},
+   volume  = {47},
+   pages   = {3466--3487},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/140988619},
+   doi     = {10.1137/140988619}
 }
 
 @article{2015_4,
-   author  = "F. Alvarez and S. Flores",
-   title   = "Solving variational problems with uniform gradient bounds by p-Laplacian approximation",
-   journal = "CMM Technical Report No, 2015001, Departemento de Ingenieria, Universidad de Chile",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {F. Alvarez and S. Flores},
+   title   = {Solving variational problems with uniform gradient bounds by p-Laplacian approximation},
+   journal = {CMM Technical Report No, 2015001, Departemento de Ingenieria, Universidad de Chile},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_5,
-   author  = "H. Antil and R. H. Nochetto and P. Sodr&#xe9;",
-   title   = "Optimal control of a free boundary problem with surface tension effects: A priori error analysis",
-   journal = "SIAM Journal on Numerical Analysis, 53(5)",
-   year    = "2015",
-   volume  = "",
-   pages   = "2279--2306",
-   url     = "",
-   doi     = ""
+   author  = {H. Antil and R. H. Nochetto and P. Sodr\'{e}},
+   title   = {Optimal control of a free boundary problem with surface tension effects: A priori error analysis},
+   journal = {SIAM Journal on Numerical Analysis, 53(5)},
+   year    = {2015},
+   volume  = {},
+   pages   = {2279--2306},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_6,
-   author  = "D. Arndt and H. Dallmann and G. Lube",
-   title   = "Local projection FEM stabilization for the time-dependent incompressible Navier-Stokes problems",
-   journal = "Numerical Methods for Partial Differential Equations, Vol. 31, Issue 4",
-   year    = "2015",
-   volume  = "",
-   pages   = "1224--1250",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/num.21944/full",
-   doi     = ""
+   author  = {D. Arndt and H. Dallmann and G. Lube},
+   title   = {Local projection FEM stabilization for the time-dependent incompressible Navier-Stokes problems},
+   journal = {Numerical Methods for Partial Differential Equations, Vol. 31, Issue 4},
+   year    = {2015},
+   volume  = {},
+   pages   = {1224--1250},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/num.21944/full},
+   doi     = {}
 }
 
 @article{2015_7,
-   author  = "J. Austermann and D. Pollard and J.X. Mitrovica and R. Moucha and A. M. Forte and R. M. DeConto and D. B. Rowley and M. E. Raymo",
-   title   = "The impact of dynamic topography change on Antarctic Ice Sheet stability in the Pliocene",
-   journal = "Geology",
-   year    = "2015",
-   volume  = "43",
-   pages   = "927--930",
-   url     = "",
-   doi     = "10.1130/G36988.1."
+   author  = {J. Austermann and D. Pollard and J.X. Mitrovica and R. Moucha and A. M. Forte and R. M. DeConto and D. B. Rowley and M. E. Raymo},
+   title   = {The impact of dynamic topography change on Antarctic Ice Sheet stability in the Pliocene},
+   journal = {Geology},
+   year    = {2015},
+   volume  = {43},
+   pages   = {927--930},
+   url     = {},
+   doi     = {10.1130/G36988.1.}
 }
 
 @article{2015_8,
-   author  = "C. Baltzell and E. M. Parmentier and Y. Liang and S. Tirupathi",
-   title   = "A high-order numerical study of reactive dissolution in an upwelling heterogeneous mantle: 2. Effect of shear deformation",
-   journal = "Geochemistry, Geophysics, Geosystems, Vol. 16(11)",
-   year    = "2015",
-   volume  = "",
-   pages   = "3855--3869",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/2015GC006038/full",
-   doi     = ""
+   author  = {C. Baltzell and E. M. Parmentier and Y. Liang and S. Tirupathi},
+   title   = {A high-order numerical study of reactive dissolution in an upwelling heterogeneous mantle: 2. Effect of shear deformation},
+   journal = {Geochemistry, Geophysics, Geosystems, Vol. 16(11)},
+   year    = {2015},
+   volume  = {},
+   pages   = {3855--3869},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2015GC006038/full},
+   doi     = {}
 }
 
 @article{2015_9,
-   author  = "W. Bangerth",
-   title   = "Simulating Complex Flows in the Earth Mantle",
-   journal = "The 18th International Conference on Finite Elements in Flow Problems, Taiwan",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.fef2015.tw/Files/E%20Abstracts/J-007.pdf",
-   doi     = ""
+   author  = {W. Bangerth},
+   title   = {Simulating Complex Flows in the Earth Mantle},
+   journal = {The 18th International Conference on Finite Elements in Flow Problems, Taiwan},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.fef2015.tw/Files/E%20Abstracts/J-007.pdf},
+   doi     = {}
 }
 
 @article{2015_10,
-   author  = "W. Bangerth",
-   title   = "Finite Element Methods at Realistic Complexities",
-   journal = "Pan American Congress on Computational Mechanics–PANACM ",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://congress.cimne.com/PANACM2015/admin/files/fileabstract/a429.pdf",
-   doi     = ""
+   author  = {W. Bangerth},
+   title   = {Finite Element Methods at Realistic Complexities},
+   journal = {Pan American Congress on Computational Mechanics--PANACM },
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://congress.cimne.com/PANACM2015/admin/files/fileabstract/a429.pdf},
+   doi     = {}
 }
 
 @article{2015_11,
-   author  = "W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young",
-   title   = "The <abbr>deal.II</abbr> Library, Version 8.2",
-   journal = "Archive of Numerical Software",
-   year    = "2015",
-   volume  = "3",
-   pages   = "",
-   url     = "",
-   doi     = "10.11588/ans.2015.100.18031"
+   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
+   title   = {The \texttt{deal.II} Library, Version 8.2},
+   journal = {Archive of Numerical Software},
+   year    = {2015},
+   volume  = {3},
+   pages   = {},
+   url     = {},
+   doi     = {10.11588/ans.2015.100.18031}
 }
 
 @mastersthesis{2015_12,
-   author  = "M. Bardelloni",
-   title   = "High performance programming paradigms applied to computational fluid dynamic simulations",
-   year    = "2015",
-   school  = "SISSA",
-   url     = "http://urania.sissa.it/xmlui/handle/1963/35161"
+   author  = {M. Bardelloni},
+   title   = {High performance programming paradigms applied to computational fluid dynamic simulations},
+   year    = {2015},
+   school  = {SISSA},
+   url     = {http://urania.sissa.it/xmlui/handle/1963/35161}
 }
 
 @article{2015_13,
-   author  = "S. Bartels and A. Bonito and R. H. Nochetto",
-   title   = "Bilayer Plates: Model Reduction, &Gamma;-Convergent Finite Element Approximation and Discrete Gradient Flow",
-   journal = "Communications on Pure and Applied Mathematics",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1002/cpa.21626"
+   author  = {S. Bartels and A. Bonito and R. H. Nochetto},
+   title   = {Bilayer Plates: Model Reduction, $\Gamma$-Convergent Finite Element Approximation and Discrete Gradient Flow},
+   journal = {Communications on Pure and Applied Mathematics},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1002/cpa.21626}
 }
 
 @article{2015_14,
-   author  = "S. Bartels and R. H. Nochetto and A. J. Salgado",
-   title   = "A total variation diminishing interpolation operator and applications",
-   journal = "Math. Comp., Vol 84, 2569-2587",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.ams.org/journals/mcom/2015-84-296/S0025-5718-2015-02942-1/home.html",
-   doi     = ""
+   author  = {S. Bartels and R. H. Nochetto and A. J. Salgado},
+   title   = {A total variation diminishing interpolation operator and applications},
+   journal = {Math. Comp., Vol 84, 2569-2587},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.ams.org/journals/mcom/2015-84-296/S0025-5718-2015-02942-1/home.html},
+   doi     = {}
 }
 
 @article{2015_15,
-   author  = "M. Bause and U. K&ouml;cher",
-   title   = "Variational time discretization for mixed finite element approximations of nonstationary diffusion problems",
-   journal = "J. Comput. Appl. Math., pp. 208–224",
-   year    = "2015",
-   volume  = "289",
-   pages   = "",
-   url     = "https://dx.doi.org/10.1016/j.cam.2015.02.015",
-   doi     = ""
+   author  = {M. Bause and U. K\"{o}cher},
+   title   = {Variational time discretization for mixed finite element approximations of nonstationary diffusion problems},
+   journal = {J. Comput. Appl. Math., pp. 208--224},
+   year    = {2015},
+   volume  = {289},
+   pages   = {},
+   url     = {https://dx.doi.org/10.1016/j.cam.2015.02.015},
+   doi     = {}
 }
 
 @mastersthesis{2015_16,
-   author  = "B. Bercovici",
-   title   = "Experimental and numerical validation of ion extractor grids",
-   year    = "2015",
-   school  = "University of Illinois at Urbana-Champaign",
-   url     = "http://hdl.handle.net/2142/72822"
+   author  = {B. Bercovici},
+   title   = {Experimental and numerical validation of ion extractor grids},
+   year    = {2015},
+   school  = {University of Illinois at Urbana-Champaign},
+   url     = {http://hdl.handle.net/2142/72822}
 }
 
 @article{2015_17,
-   author  = "D. Biermann and H. Blum and J. Frohne and I. Iovkov and A. Rademacher and K. Rosin",
-   title   = "Simulation of MQL Deep Hole Drilling for Predicting Thermally Induced Workpiece Deformations",
-   journal = "Procedia CIRP",
-   year    = "2015",
-   volume  = "31",
-   pages   = "148--153",
-   url     = "",
-   doi     = ""
+   author  = {D. Biermann and H. Blum and J. Frohne and I. Iovkov and A. Rademacher and K. Rosin},
+   title   = {Simulation of MQL Deep Hole Drilling for Predicting Thermally Induced Workpiece Deformations},
+   journal = {Procedia CIRP},
+   year    = {2015},
+   volume  = {31},
+   pages   = {148--153},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_18,
-   author  = "F. Binder and F. Sch&ouml;pfer and T. Schuster",
-   title   = "Defect localization in fibre-reinforced composites by computing external volume forces from surface sensor measurements",
-   journal = "Inverse Problems ",
-   year    = "2015",
-   volume  = "31",
-   pages   = "",
-   url     = "http://iopscience.iop.org/0266-5611/31/2/025006/pdf/0266-5611_31_2_025006.pdf",
-   doi     = ""
+   author  = {F. Binder and F. Sch\"{o}pfer and T. Schuster},
+   title   = {Defect localization in fibre-reinforced composites by computing external volume forces from surface sensor measurements},
+   journal = {Inverse Problems },
+   year    = {2015},
+   volume  = {31},
+   pages   = {},
+   url     = {http://iopscience.iop.org/0266-5611/31/2/025006/pdf/0266-5611_31_2_025006.pdf},
+   doi     = {}
 }
 
 @article{2015_19,
-   author  = "A. Bonito and D. Devaud",
-   title   = "Adaptive Finite Element Methods for the Stokes Problems with Discontinuous Viscosity",
-   journal = "Math. Comp.",
-   year    = "2015",
-   volume  = "84",
-   pages   = "2137--2162",
-   url     = "http://www.ams.org/journals/mcom/2015-84-295/S0025-5718-2015-02935-4/home.html",
-   doi     = ""
+   author  = {A. Bonito and D. Devaud},
+   title   = {Adaptive Finite Element Methods for the Stokes Problems with Discontinuous Viscosity},
+   journal = {Math. Comp.},
+   year    = {2015},
+   volume  = {84},
+   pages   = {2137--2162},
+   url     = {http://www.ams.org/journals/mcom/2015-84-295/S0025-5718-2015-02935-4/home.html},
+   doi     = {}
 }
 
 @article{2015_20,
-   author  = "A. Bonito and J.-L. Guermond and S. Lee",
-   title   = "Modified Pressure-Correction Projection Methods: Open Boundary and Variable Time Stepping, Numerical Mathematics and Advanced Applications",
-   journal = "Proceedings of the ENUMATH 2013 Conference, Lecture Notes in Computational Science and Engineering",
-   year    = "2015",
-   volume  = "103",
-   pages   = "623--631",
-   url     = "",
-   doi     = ""
+   author  = {A. Bonito and J.-L. Guermond and S. Lee},
+   title   = {Modified Pressure-Correction Projection Methods: Open Boundary and Variable Time Stepping, Numerical Mathematics and Advanced Applications},
+   journal = {Proceedings of the ENUMATH 2013 Conference, Lecture Notes in Computational Science and Engineering},
+   year    = {2015},
+   volume  = {103},
+   pages   = {623--631},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_21,
-   author  = "A. Bonito and J. E. Pasciak",
-   title   = "Numerical Approximation of Fractional Powers of Elliptic Operators",
-   journal = "Math. Comp., Vol. 84",
-   year    = "2015",
-   volume  = "",
-   pages   = "2083--2110",
-   url     = "http://www.ams.org/journals/mcom/2015-84-295/S0025-5718-2015-02937-8/home.html",
-   doi     = ""
+   author  = {A. Bonito and J. E. Pasciak},
+   title   = {Numerical Approximation of Fractional Powers of Elliptic Operators},
+   journal = {Math. Comp., Vol. 84},
+   year    = {2015},
+   volume  = {},
+   pages   = {2083--2110},
+   url     = {http://www.ams.org/journals/mcom/2015-84-295/S0025-5718-2015-02937-8/home.html},
+   doi     = {}
 }
 
 @article{2015_22,
-   author  = "J. Bosch and M. Stoll",
-   title   = "Preconditioning for vector-valued Cahn-Hilliard equations",
-   journal = "SIAM J. Sci. COMPUT., Vol. 37, No. 5. pp. S216-S243",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://pubman.mpdl.mpg.de/pubman/item/escidoc:2125565/component/escidoc:2225345/2125565_bosch.pdf",
-   doi     = ""
+   author  = {J. Bosch and M. Stoll},
+   title   = {Preconditioning for vector-valued Cahn-Hilliard equations},
+   journal = {SIAM J. Sci. COMPUT., Vol. 37, No. 5. pp. S216-S243},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://pubman.mpdl.mpg.de/pubman/item/escidoc:2125565/component/escidoc:2225345/2125565_bosch.pdf},
+   doi     = {}
 }
 
 @article{2015_23,
-   author  = "M. B&uuml;rg and M. Nazarov",
-   title   = "Goal-Oriented adaptive finite element methods for elliptic problems revisited",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2015",
-   volume  = "287",
-   pages   = "125--147",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0377042715001843",
-   doi     = ""
+   author  = {M. B\"{u}rg and M. Nazarov},
+   title   = {Goal-Oriented adaptive finite element methods for elliptic problems revisited},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2015},
+   volume  = {287},
+   pages   = {125--147},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0377042715001843},
+   doi     = {}
 }
 
 @article{2015_24,
-   author  = "M. B&uuml;rg and A. Schr&ouml;der",
-   title   = "A posteriori error control of hp-finite elements for variational inequalities of the first and second kind",
-   journal = "Computers &amp; Maathematics with Applications, Vol. 70(12)",
-   year    = "2015",
-   volume  = "",
-   pages   = "2783--2802",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0898122115004101",
-   doi     = ""
+   author  = {M. B\"{u}rg and A. Schr\"{o}der},
+   title   = {A posteriori error control of hp-finite elements for variational inequalities of the first and second kind},
+   journal = {Computers \& Maathematics with Applications, Vol. 70(12)},
+   year    = {2015},
+   volume  = {},
+   pages   = {2783--2802},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0898122115004101},
+   doi     = {}
 }
 
 @article{2015_25,
-   author  = "T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikelic´",
-   title   = "Effective interface conditions for the forced infiltration of a viscous fluid into a porous medium using homogenization",
-   journal = "Comput. Methods Appl. Mech. Engrg., Volume 292",
-   year    = "2015",
-   volume  = "",
-   pages   = "195--220",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782514004204",
-   doi     = ""
+   author  = {T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikelic´},
+   title   = {Effective interface conditions for the forced infiltration of a viscous fluid into a porous medium using homogenization},
+   journal = {Comput. Methods Appl. Mech. Engrg., Volume 292},
+   year    = {2015},
+   volume  = {},
+   pages   = {195--220},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782514004204},
+   doi     = {}
 }
 
 @article{2015_26,
-   author  = "T. Carraro and S. Wetterauer",
-   title   = "On the implementation of the eXtended Finite Element Method (XFEM) for interface problems",
-   journal = "arXiv:1507.04238",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org.ezproxy.library.tamu.edu/pdf/1507.04238v1.pdf",
-   doi     = ""
+   author  = {T. Carraro and S. Wetterauer},
+   title   = {On the implementation of the eXtended Finite Element Method (XFEM) for interface problems},
+   journal = {arXiv:1507.04238},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org.ezproxy.library.tamu.edu/pdf/1507.04238v1.pdf},
+   doi     = {}
 }
 
 @article{2015_27,
-   author  = "N. Cavallini and O. Weeger and M.S. Pauletti and M. Martinelli and P. Antonio",
-   title   = "Effective Integration of Sophisticated Operators in Isogeometric Analysis with igatools",
-   journal = "Isogeometric Analysis and Applications, Vol. 107",
-   year    = "2015",
-   volume  = "",
-   pages   = "209--230",
-   url     = "http://link.springer.com/chapter/10.1007/978-3-319-23315-4_9",
-   doi     = ""
+   author  = {N. Cavallini and O. Weeger and M.S. Pauletti and M. Martinelli and P. Antonio},
+   title   = {Effective Integration of Sophisticated Operators in Isogeometric Analysis with igatools},
+   journal = {Isogeometric Analysis and Applications, Vol. 107},
+   year    = {2015},
+   volume  = {},
+   pages   = {209--230},
+   url     = {http://link.springer.com/chapter/10.1007/978-3-319-23315-4_9},
+   doi     = {}
 }
 
 @article{2015_28,
-   author  = "J. N. Chadwick and D. S. Bindel",
-   title   = "An Efficient Solver for Sparse Linear Systems Based on Rank-Structured Cholesky Factorization",
-   journal = "arXiv:1507.05593",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1507.05593",
-   doi     = ""
+   author  = {J. N. Chadwick and D. S. Bindel},
+   title   = {An Efficient Solver for Sparse Linear Systems Based on Rank-Structured Cholesky Factorization},
+   journal = {arXiv:1507.05593},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1507.05593},
+   doi     = {}
 }
 
 @article{2015_29,
-   author  = "P. Chandrashekar and M. Zenk",
-   title   = "Well-balanced nodal discontinuous Galerkin method for Euler equations with gravity",
-   journal = "arXiv:1511.08739",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1511.08739",
-   doi     = ""
+   author  = {P. Chandrashekar and M. Zenk},
+   title   = {Well-balanced nodal discontinuous Galerkin method for Euler equations with gravity},
+   journal = {arXiv:1511.08739},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1511.08739},
+   doi     = {}
 }
 
 @article{2015_30,
-   author  = "J. Choo and R. I. Borja",
-   title   = "Stabilized mixed finite elements for deformable porous media with double porosity",
-   journal = "Computer Methods in Applied Mechanics and Engineering, Vol. 293",
-   year    = "2015",
-   volume  = "",
-   pages   = "131--154",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782515001334",
-   doi     = ""
+   author  = {J. Choo and R. I. Borja},
+   title   = {Stabilized mixed finite elements for deformable porous media with double porosity},
+   journal = {Computer Methods in Applied Mechanics and Engineering, Vol. 293},
+   year    = {2015},
+   volume  = {},
+   pages   = {131--154},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782515001334},
+   doi     = {}
 }
 
 @article{2015_31,
-   author  = "B. Crestel and R. D. Russell and S. J. Ruuth",
-   title   = "Moving mesh methods on parametric surfaces",
-   journal = "Procedia Engineering, Vol. 124",
-   year    = "2015",
-   volume  = "",
-   pages   = "148--160",
-   url     = "http://www.sciencedirect.com/science/article/pii/S1877705815032300",
-   doi     = ""
+   author  = {B. Crestel and R. D. Russell and S. J. Ruuth},
+   title   = {Moving mesh methods on parametric surfaces},
+   journal = {Procedia Engineering, Vol. 124},
+   year    = {2015},
+   volume  = {},
+   pages   = {148--160},
+   url     = {http://www.sciencedirect.com/science/article/pii/S1877705815032300},
+   doi     = {}
 }
 
 @article{2015_32,
-   author  = "M. A. Dahlem and B. Schmidt and I. Bojak and S. Boie and F. Kneer and N. Hadjikhani and J. Kurths",
-   title   = "Cortical hot spots and labyrinths: Why cortical neuromodulation for episodic migraine with aura should be personalized",
-   journal = "Front Comput Neurosci.",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4350394/",
-   doi     = ""
+   author  = {M. A. Dahlem and B. Schmidt and I. Bojak and S. Boie and F. Kneer and N. Hadjikhani and J. Kurths},
+   title   = {Cortical hot spots and labyrinths: Why cortical neuromodulation for episodic migraine with aura should be personalized},
+   journal = {Front Comput Neurosci.},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4350394/},
+   doi     = {}
 }
 
 @article{2015_33,
-   author  = "W. Dahmen and S. M&uuml;ller and M. Rom and S. Schweikert and M. Selzer and J. von Wolfersdorf",
-   title   = "Numerical boundary layer investigations of transpiration-cooled turbulent channel flow",
-   journal = "International Journal of Heat and Mass Transfer, pp. 90–100",
-   year    = "2015",
-   volume  = "86",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0017931015002483",
-   doi     = ""
+   author  = {W. Dahmen and S. M\"{u}ller and M. Rom and S. Schweikert and M. Selzer and J. von Wolfersdorf},
+   title   = {Numerical boundary layer investigations of transpiration-cooled turbulent channel flow},
+   journal = {International Journal of Heat and Mass Transfer, pp. 90--100},
+   year    = {2015},
+   volume  = {86},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0017931015002483},
+   doi     = {}
 }
 
 @article{2015_34,
-   author  = "T. Dahmen and M. Roland and T. Tjardes and B. Bouillon and P. Slusallek and S. Diebels",
-   title   = "An automated workflow for the biomechanical simulation of a tibia with implant using computed tomography and the finite element method",
-   journal = "Computers &amp; Mathematics with Applications, Vol. 70, Issue 5",
-   year    = "2015",
-   volume  = "",
-   pages   = "903--916",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0898122115002953",
-   doi     = ""
+   author  = {T. Dahmen and M. Roland and T. Tjardes and B. Bouillon and P. Slusallek and S. Diebels},
+   title   = {An automated workflow for the biomechanical simulation of a tibia with implant using computed tomography and the finite element method},
+   journal = {Computers \& Mathematics with Applications, Vol. 70, Issue 5},
+   year    = {2015},
+   volume  = {},
+   pages   = {903--916},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0898122115002953},
+   doi     = {}
 }
 
 @phdthesis{2015_35,
-   author  = "H. Dallmann",
-   title   = "Finite element methods with local projection stabilization for thermally coupled incompressible flow",
-   year    = "2015",
-   school  = "University of G&ouml;ttingen, Germany",
-   url     = ""
+   author  = {H. Dallmann},
+   title   = {Finite element methods with local projection stabilization for thermally coupled incompressible flow},
+   year    = {2015},
+   school  = {University of G\"{o}ttingen, Germany},
+   url     = {}
 }
 
 @phdthesis{2015_36,
-   author  = "J. Dannberg",
-   title   = "Dynamics of mantle plumes: Linking scales and coupling physics",
-   year    = "2015",
-   school  = "Potsdam University, Germany",
-   url     = "https://publishup.uni-potsdam.de/opus4-ubp/frontdoor/index/index/docId/9102"
+   author  = {J. Dannberg},
+   title   = {Dynamics of mantle plumes: Linking scales and coupling physics},
+   year    = {2015},
+   school  = {Potsdam University, Germany},
+   url     = {https://publishup.uni-potsdam.de/opus4-ubp/frontdoor/index/index/docId/9102}
 }
 
 @mastersthesis{2015_37,
-   author  = "J. Davidsson",
-   title   = "Orbital-free Density-Functional Theory in a Finite Element Basis",
-   year    = "2015",
-   school  = "Department of Physics, Chemistry and Biology Linkopings universitet, SE-581 83 Linkoping, Sweden",
-   url     = "http://www.diva-portal.org/smash/get/diva2:864857/FULLTEXT01.pdf"
+   author  = {J. Davidsson},
+   title   = {Orbital-free Density-Functional Theory in a Finite Element Basis},
+   year    = {2015},
+   school  = {Department of Physics, Chemistry and Biology Linkopings universitet, SE-581 83 Linkoping, Sweden},
+   url     = {http://www.diva-portal.org/smash/get/diva2:864857/FULLTEXT01.pdf}
 }
 
 @article{2015_38,
-   author  = "G. Deolmi and W. Dahmen and S. M&uuml;ller",
-   title   = "Effective boundary conditions for compressible flows over rough boundaries",
-   journal = "Math. Models Methods Appl. Sci. 25, 1257",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.worldscientific.com/doi/abs/10.1142/S0218202515500323",
-   doi     = ""
+   author  = {G. Deolmi and W. Dahmen and S. M\"{u}ller},
+   title   = {Effective boundary conditions for compressible flows over rough boundaries},
+   journal = {Math. Models Methods Appl. Sci. 25, 1257},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.worldscientific.com/doi/abs/10.1142/S0218202515500323},
+   doi     = {}
 }
 
 @article{2015_39,
-   author  = "W. D&ouml;rfler and S. Findeisen",
-   title   = "Numerical optimization of a waveguide transition using finite element beam propagation",
-   journal = "International Journal of Numerical Modelling: Electronic Networks, Devices and Fields, Vol. 28, Issue 2",
-   year    = "2015",
-   volume  = "",
-   pages   = "201--212",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/jnm.1997/abstract?userIsAuthenticated=false&deniedAccessCustomisedMessage=",
-   doi     = ""
+   author  = {W. D\"{o}rfler and S. Findeisen},
+   title   = {Numerical optimization of a waveguide transition using finite element beam propagation},
+   journal = {International Journal of Numerical Modelling: Electronic Networks, Devices and Fields, Vol. 28, Issue 2},
+   year    = {2015},
+   volume  = {},
+   pages   = {201--212},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/jnm.1997/abstract?userIsAuthenticated=false&deniedAccessCustomisedMessage=},
+   doi     = {}
 }
 
 @article{2015_40,
-   author  = "A. Dorostkar and M. Neytcheva and B.  Lund",
-   title   = "Numerical and computational aspects of some block-preconditioners for saddle point systems",
-   journal = "Parallel Computing, Vol. 49",
-   year    = "2015",
-   volume  = "",
-   pages   = "164--178",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0167819115000897",
-   doi     = ""
+   author  = {A. Dorostkar and M. Neytcheva and B.  Lund},
+   title   = {Numerical and computational aspects of some block-preconditioners for saddle point systems},
+   journal = {Parallel Computing, Vol. 49},
+   year    = {2015},
+   volume  = {},
+   pages   = {164--178},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0167819115000897},
+   doi     = {}
 }
 
 @article{2015_41,
-   author  = "K. Drzycimski and L. Arnold",
-   title   = "Smoke and fire simulations with adaptive FEM",
-   journal = "Proceedings of the 27th International Conference on Parallel Computational Fluid Dynamics (Parallel CFD2015)",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.researchgate.net/publication/282611203_Smoke_and_Fire_Simulations_with_Adaptive_FEM",
-   doi     = ""
+   author  = {K. Drzycimski and L. Arnold},
+   title   = {Smoke and fire simulations with adaptive FEM},
+   journal = {Proceedings of the 27th International Conference on Parallel Computational Fluid Dynamics (Parallel CFD2015)},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.researchgate.net/publication/282611203_Smoke_and_Fire_Simulations_with_Adaptive_FEM},
+   doi     = {}
 }
 
 @article{2015_42,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Finite Element Approximation of Wave Propa- gation in Composite Material with Asymptotic Homogenization",
-   journal = "In proceedings of: the ASME Turbo Expo 2014: Turbine Technical Conference and Exposition, Vol. 7A, No. GT2014-26314, pp. V07AT28A009/1-10, June 16-20, Düsseldorf, Germany",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Finite Element Approximation of Wave Propa- gation in Composite Material with Asymptotic Homogenization},
+   journal = {In proceedings of: the ASME Turbo Expo 2014: Turbine Technical Conference and Exposition, Vol. 7A, No. GT2014-26314, pp. V07AT28A009/1-10, June 16-20, D\"{u}sseldorf, Germany},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_43,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Finite Element Model-based Structural Health Monitoring (SHM) Systems for Composite Material under Fluid-Structure Interaction (FSI) Effect",
-   journal = "In proceedings of: the 7 th European Workshop on Structural Health Monitoring, July 08–11, Nantes, France. In: The e-Journal of Nondestructive Testing (NDT), NDT.net issue, ISSN: 1435-4934, HAL Id: hal-01021185, Vol. 20, Issue 2 (Feb 2015), pp. 1380–1387",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Finite Element Model-based Structural Health Monitoring (SHM) Systems for Composite Material under Fluid-Structure Interaction (FSI) Effect},
+   journal = {In proceedings of: the 7 th European Workshop on Structural Health Monitoring, July 08--11, Nantes, France. In: The e-Journal of Nondestructive Testing (NDT), NDT.net issue, ISSN: 1435-4934, HAL Id: hal-01021185, Vol. 20, Issue 2 (Feb 2015), pp. 1380--1387},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_44,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Adaptive Finite Elements Simulation Methods and Applications for Monolithic Fluid-Structure Interaction (FSI) Problem",
-   journal = "In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1B, No. FEDSM2014-21379, pp. V01BT12A003/1–10, August 3–7, Chicago, USA",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Adaptive Finite Elements Simulation Methods and Applications for Monolithic Fluid-Structure Interaction (FSI) Problem},
+   journal = {In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1B, No. FEDSM2014-21379, pp. V01BT12A003/1--10, August 3--7, Chicago, USA},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_45,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Adaptive multigrid methods for extended fluid-structure interaction (EXFSI) problem &mdash; part 1: Mathematical modelling",
-   journal = "In proceedings of: the ASME 2015 International Mechanical Engineering Congress &amp; Expo, IMECE2015, Houston, TX",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Adaptive multigrid methods for extended fluid-structure interaction (EXFSI) problem -- part 1: Mathematical modelling},
+   journal = {In proceedings of: the ASME 2015 International Mechanical Engineering Congress \& Expo, IMECE2015, Houston, TX},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_46,
-   author  = "Y. El-Kurdi and W. J. Gross and M. M. Dehnavi and D. Giannacopoulos",
-   title   = "Parallel finite element technique using Gaussian belief propagation",
-   journal = "Computer Physics Communications, April ",
-   year    = "2015",
-   volume  = "193",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {Y. El-Kurdi and W. J. Gross and M. M. Dehnavi and D. Giannacopoulos},
+   title   = {Parallel finite element technique using Gaussian belief propagation},
+   journal = {Computer Physics Communications, April },
+   year    = {2015},
+   volume  = {193},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2015_47,
-   author  = "D. B. Emerson",
-   title   = "Advanced discretizations and multigrid methods for liquid crystal configurations",
-   year    = "2015",
-   school  = "Tufts University",
-   url     = "http://webhosting.math.tufts.edu/dbemerson/PHD_thesis.pdf"
+   author  = {D. B. Emerson},
+   title   = {Advanced discretizations and multigrid methods for liquid crystal configurations},
+   year    = {2015},
+   school  = {Tufts University},
+   url     = {http://webhosting.math.tufts.edu/dbemerson/PHD_thesis.pdf}
 }
 
 @article{2015_48,
-   author  = "A. Evgrafov",
-   title   = "On Chebyshev's method for topology optimization of Stokes flows",
-   journal = "Structural and Multidisciplinary Optimization, Vol. 51(4)",
-   year    = "2015",
-   volume  = "",
-   pages   = "801--811",
-   url     = "http://link.springer.com/article/10.1007/s00158-014-1176-x",
-   doi     = ""
+   author  = {A. Evgrafov},
+   title   = {On Chebyshev's method for topology optimization of Stokes flows},
+   journal = {Structural and Multidisciplinary Optimization, Vol. 51(4)},
+   year    = {2015},
+   volume  = {},
+   pages   = {801--811},
+   url     = {http://link.springer.com/article/10.1007/s00158-014-1176-x},
+   doi     = {}
 }
 
 @article{2015_49,
-   author  = "L. Fan and P. Monk",
-   title   = "Time dependent scattering from a grating",
-   journal = "Journal of Comput. Phys., Vol. 302, pp 97-113",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999115005677",
-   doi     = ""
+   author  = {L. Fan and P. Monk},
+   title   = {Time dependent scattering from a grating},
+   journal = {Journal of Comput. Phys., Vol. 302, pp 97-113},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999115005677},
+   doi     = {}
 }
 
 @mastersthesis{2015_50,
-   author  = "S. Farouq",
-   title   = "Performance comparisons of preconditioned iterative methods for problems arising in PDE-constrained optimization",
-   year    = "2015",
-   school  = "Uppsala University",
-   url     = "http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A815563&dswid=5325"
+   author  = {S. Farouq},
+   title   = {Performance comparisons of preconditioned iterative methods for problems arising in PDE-constrained optimization},
+   year    = {2015},
+   school  = {Uppsala University},
+   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A815563&dswid=5325}
 }
 
 @mastersthesis{2015_51,
-   author  = "N. Fehn",
-   title   = "A Discontinuous Galerkin Approach for the Unsteady Incompressible Navier&ndash;Stokes Equations",
-   year    = "2015",
-   school  = "Technische Universit&auml;t M&uuml;nchen",
-   url     = ""
+   author  = {N. Fehn},
+   title   = {A Discontinuous Galerkin Approach for the Unsteady Incompressible Navier--Stokes Equations},
+   year    = {2015},
+   school  = {Technische Universit\"{a}t M\"{u}nchen},
+   url     = {}
 }
 
 @article{2015_52,
-   author  = "L. A. Ferguson and M. Muddamallappa and J. R. Walton",
-   title   = "Numerical simulation of mode-III fracture incorporating interfacial mechanics",
-   journal = "International Journal of Fracture, issue 1",
-   year    = "2015",
-   volume  = "192",
-   pages   = "47--56",
-   url     = "http://link.springer.com/article/10.1007/s10704-014-9984-y",
-   doi     = ""
+   author  = {L. A. Ferguson and M. Muddamallappa and J. R. Walton},
+   title   = {Numerical simulation of mode-III fracture incorporating interfacial mechanics},
+   journal = {International Journal of Fracture, issue 1},
+   year    = {2015},
+   volume  = {192},
+   pages   = {47--56},
+   url     = {http://link.springer.com/article/10.1007/s10704-014-9984-y},
+   doi     = {}
 }
 
 @article{2015_53,
-   author  = "J. Fischer",
-   title   = "A Posteriori Modeling Error Estimates for the Assumption of Perfect Incompressibility in the Navier--Stokes Equation.",
-   journal = "SIAM Journal on Numerical Analysis, 53(5)",
-   year    = "2015",
-   volume  = "",
-   pages   = "2178--2205",
-   url     = "",
-   doi     = ""
+   author  = {J. Fischer},
+   title   = {A Posteriori Modeling Error Estimates for the Assumption of Perfect Incompressibility in the Navier--Stokes Equation.},
+   journal = {SIAM Journal on Numerical Analysis, 53(5)},
+   year    = {2015},
+   volume  = {},
+   pages   = {2178--2205},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_54,
-   author  = "E. Friedmann",
-   title   = "PDE/ODE modeling and simulation to determine the role of diffusion in long-term and -range cellular signaling",
-   journal = "BMC Biophysics, 8:10",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1186/s13628-015-0024-8"
+   author  = {E. Friedmann},
+   title   = {PDE/ODE modeling and simulation to determine the role of diffusion in long-term and -range cellular signaling},
+   journal = {BMC Biophysics, 8:10},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1186/s13628-015-0024-8}
 }
 
 @article{2015_55,
-   author  = "A. Frisani and Y. A. Hassan",
-   title   = "On the Immersed Boundary Method: Finite Element Versus Finite Volume Approach",
-   journal = "Computers &amp; Fluids",
-   year    = "2015",
-   volume  = "121",
-   pages   = "51--67",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045793015002765",
-   doi     = ""
+   author  = {A. Frisani and Y. A. Hassan},
+   title   = {On the Immersed Boundary Method: Finite Element Versus Finite Volume Approach},
+   journal = {Computers \& Fluids},
+   year    = {2015},
+   volume  = {121},
+   pages   = {51--67},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045793015002765},
+   doi     = {}
 }
 
 @phdthesis{2015_56,
-   author  = "R. R. Fu",
-   title   = "Magnetic fields in the early solar system",
-   year    = "2015",
-   school  = "Massachusetts Institute of Technology",
-   url     = "http://hdl.handle.net/1721.1/101348"
+   author  = {R. R. Fu},
+   title   = {Magnetic fields in the early solar system},
+   year    = {2015},
+   school  = {Massachusetts Institute of Technology},
+   url     = {http://hdl.handle.net/1721.1/101348}
 }
 
 @phdthesis{2015_57,
-   author  = "E. Furst",
-   title   = "Parallel Preconditioners for Finite Element Computations",
-   year    = "2015",
-   school  = "Honors thesis, Saint John's University",
-   url     = "http://digitalcommons.csbsju.edu/cgi/viewcontent.cgi?article=1065&context=honors_theses"
+   author  = {E. Furst},
+   title   = {Parallel Preconditioners for Finite Element Computations},
+   year    = {2015},
+   school  = {Honors thesis, Saint John's University},
+   url     = {http://digitalcommons.csbsju.edu/cgi/viewcontent.cgi?article=1065&context=honors_theses}
 }
 
 @phdthesis{2015_58,
-   author  = "D. Gerecht",
-   title   = "Adaptive Finite Element Simulation of Coupled PDE/ODE Systems Modeling Intercellular Signaling",
-   year    = "2015",
-   school  = "University of Heidelberg, Germany",
-   url     = ""
+   author  = {D. Gerecht},
+   title   = {Adaptive Finite Element Simulation of Coupled PDE/ODE Systems Modeling Intercellular Signaling},
+   year    = {2015},
+   school  = {University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2015_59,
-   author  = "A. Giavaras and E. Boateng",
-   title   = "Transient filling modelling at meso-level for RTM process using a single phase LSM",
-   journal = "International Journal of Material Forming, Vol. 8(2)",
-   year    = "2015",
-   volume  = "",
-   pages   = "197--210",
-   url     = "http://link.springer.com/article/10.1007/s12289-013-1160-9",
-   doi     = ""
+   author  = {A. Giavaras and E. Boateng},
+   title   = {Transient filling modelling at meso-level for RTM process using a single phase LSM},
+   journal = {International Journal of Material Forming, Vol. 8(2)},
+   year    = {2015},
+   volume  = {},
+   pages   = {197--210},
+   url     = {http://link.springer.com/article/10.1007/s12289-013-1160-9},
+   doi     = {}
 }
 
 @article{2015_60,
-   author  = "N. Giuliani and A. Mola and L. Heltai and L. Fomaggia",
-   title   = "FEM SUPG stabilisation of mixed isoparametric BEMs: application to linearised free surface flows",
-   journal = "Engineering Analysis with Boundary Elements, Vol. 59",
-   year    = "2015",
-   volume  = "",
-   pages   = "8--22",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0955799715001058",
-   doi     = ""
+   author  = {N. Giuliani and A. Mola and L. Heltai and L. Fomaggia},
+   title   = {FEM SUPG stabilisation of mixed isoparametric BEMs: application to linearised free surface flows},
+   journal = {Engineering Analysis with Boundary Elements, Vol. 59},
+   year    = {2015},
+   volume  = {},
+   pages   = {8--22},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0955799715001058},
+   doi     = {}
 }
 
 @article{2015_61,
-   author  = "F. Goldschmidt",
-   title   = "Modeling and simulation of adhesive bounded joints with a gradient in the mechanical properties",
-   journal = "PhD dissertation, University of des Saarlandes",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://scidok.sulb.uni-saarland.de/volltexte/2015/6197/",
-   doi     = ""
+   author  = {F. Goldschmidt},
+   title   = {Modeling and simulation of adhesive bounded joints with a gradient in the mechanical properties},
+   journal = {PhD dissertation, University of des Saarlandes},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://scidok.sulb.uni-saarland.de/volltexte/2015/6197/},
+   doi     = {}
 }
 
 @article{2015_62,
-   author  = "F. Goldschmidt and S. Diebels",
-   title   = "Modelling and numerical investigations of the mechanical behavior of polyurethane under the influence of moisture",
-   journal = "Archive of Applied Mechanics, Vol. 85, Issue 8",
-   year    = "2015",
-   volume  = "",
-   pages   = "1035--1042",
-   url     = "http://link.springer.com/article/10.1007/s00419-014-0943-x",
-   doi     = ""
+   author  = {F. Goldschmidt and S. Diebels},
+   title   = {Modelling and numerical investigations of the mechanical behavior of polyurethane under the influence of moisture},
+   journal = {Archive of Applied Mechanics, Vol. 85, Issue 8},
+   year    = {2015},
+   volume  = {},
+   pages   = {1035--1042},
+   url     = {http://link.springer.com/article/10.1007/s00419-014-0943-x},
+   doi     = {}
 }
 
 @article{2015_63,
-   author  = "F. Goldschmidt and S. Diebels",
-   title   = "Modeling the moisture and temperature dependent material behavior of adhesive bonds ",
-   journal = "Proc. Appl. Math. Mech. Vol. 15, issue 1, pp: 295-296",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410157/abstract",
-   doi     = ""
+   author  = {F. Goldschmidt and S. Diebels},
+   title   = {Modeling the moisture and temperature dependent material behavior of adhesive bonds },
+   journal = {Proc. Appl. Math. Mech. Vol. 15, issue 1, pp: 295-296},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410157/abstract},
+   doi     = {}
 }
 
 @phdthesis{2015_64,
-   author  = "J. Gong",
-   title   = "Formation of Physical Sedimentary Structure in the Presence of Microbial Communities",
-   year    = "2015",
-   school  = "Texas A&M University",
-   url     = ""
+   author  = {J. Gong},
+   title   = {Formation of Physical Sedimentary Structure in the Presence of Microbial Communities},
+   year    = {2015},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2015_65,
-   author  = "A. V. Grayver and T. V. Kolev",
-   title   = "Large-scale 3D geoelectromagnetic modeling using parallel adaptive high-order finite element method",
-   journal = "Geophysics, No. 6",
-   year    = "2015",
-   volume  = "80",
-   pages   = "277--291",
-   url     = "http://library.seg.org/doi/abs/10.1190/geo2015-0013.1",
-   doi     = ""
+   author  = {A. V. Grayver and T. V. Kolev},
+   title   = {Large-scale 3D geoelectromagnetic modeling using parallel adaptive high-order finite element method},
+   journal = {Geophysics, No. 6},
+   year    = {2015},
+   volume  = {80},
+   pages   = {277--291},
+   url     = {http://library.seg.org/doi/abs/10.1190/geo2015-0013.1},
+   doi     = {}
 }
 
 @article{2015_66,
-   author  = "A. V. Grayver",
-   title   = "Parallel 3D magnetotelluric inversion using adaptive finite-element method. Part I: theory and synthetic study",
-   journal = "Geophysical Journal International",
-   year    = "2015",
-   volume  = "202",
-   pages   = "584--603",
-   url     = "",
-   doi     = "10.1093/gji/ggv165"
+   author  = {A. V. Grayver},
+   title   = {Parallel 3D magnetotelluric inversion using adaptive finite-element method. Part I: theory and synthetic study},
+   journal = {Geophysical Journal International},
+   year    = {2015},
+   volume  = {202},
+   pages   = {584--603},
+   url     = {},
+   doi     = {10.1093/gji/ggv165}
 }
 
 @article{2015_67,
-   author  = "B. J. Grieshaber and A. T. McBride and B. D. Reddy and B D",
-   title   = "Uniformly convergent interior penalty methods using multilinear approximations for problems in elasticity",
-   journal = "SIAM Journal on Numerical Analysis",
-   year    = "2015",
-   volume  = "53",
-   pages   = "2255--2278",
-   url     = "",
-   doi     = ""
+   author  = {B. J. Grieshaber and A. T. McBride and B. D. Reddy and B D},
+   title   = {Uniformly convergent interior penalty methods using multilinear approximations for problems in elasticity},
+   journal = {SIAM Journal on Numerical Analysis},
+   year    = {2015},
+   volume  = {53},
+   pages   = {2255--2278},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_68,
-   author  = "S. H&auml;rting and A. Marciniak-Czochra and I. Takagi",
-   title   = "Stable patterns with jump discontinuity in systems with Turing instability and hysteresis",
-   journal = "arXiv:1506.00881",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1506.00881",
-   doi     = ""
+   author  = {S. H\"{a}rting and A. Marciniak-Czochra and I. Takagi},
+   title   = {Stable patterns with jump discontinuity in systems with Turing instability and hysteresis},
+   journal = {arXiv:1506.00881},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1506.00881},
+   doi     = {}
 }
 
 @article{2015_69,
-   author  = "R. Hartmann and T. Leicht",
-   title   = "Generalized adjoint consistent treatment of wall boundary conditions for compressible flows",
-   journal = "Journal of Computational Physics",
-   year    = "2015",
-   volume  = "300",
-   pages   = "754--778",
-   url     = "http://ganymed.iwr.uni-heidelberg.de/~hartmann/",
-   doi     = ""
+   author  = {R. Hartmann and T. Leicht},
+   title   = {Generalized adjoint consistent treatment of wall boundary conditions for compressible flows},
+   journal = {Journal of Computational Physics},
+   year    = {2015},
+   volume  = {300},
+   pages   = {754--778},
+   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/},
+   doi     = {}
 }
 
 @article{2015_70,
-   author  = "R. Hartmann and T. Leicht",
-   title   = "High-order unstructured grid generation and Discontinuous Galerkin discretization applied to a 3D high-lift configuration",
-   journal = "Proceedings of the 53rd AIAA Aerospace Sciences Meeting (SciTech 2015), AIAA 2015-0819, Kissimmee, Florida",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://ganymed.iwr.uni-heidelberg.de/~hartmann/",
-   doi     = ""
+   author  = {R. Hartmann and T. Leicht},
+   title   = {High-order unstructured grid generation and Discontinuous Galerkin discretization applied to a 3D high-lift configuration},
+   journal = {Proceedings of the 53rd AIAA Aerospace Sciences Meeting (SciTech 2015), AIAA 2015-0819, Kissimmee, Florida},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/},
+   doi     = {}
 }
 
 @phdthesis{2015_71,
-   author  = "D. Heilmann",
-   title   = "Magneto-statics in multi-material media",
-   year    = "2015",
-   school  = "Bachelor thesis, Friedrich-Alexander-Universität Erlangen-Nürnberg",
-   url     = ""
+   author  = {D. Heilmann},
+   title   = {Magneto-statics in multi-material media},
+   year    = {2015},
+   school  = {Bachelor thesis, Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   url     = {}
 }
 
 @article{2015_72,
-   author  = "T. Heister and M. F. Wheeler and T. Wick",
-   title   = "A primal-dual active set method and predictor-corrector mesh adaptivity for computing fracture propagation using a phase-field approach",
-   journal = "CMAME, Vol. 290, 15 June 2015, Pages 466-495, ISSN 0045-7825",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://dx.doi.org/10.1016/j.cma.2015.03.009",
-   doi     = ""
+   author  = {T. Heister and M. F. Wheeler and T. Wick},
+   title   = {A primal-dual active set method and predictor-corrector mesh adaptivity for computing fracture propagation using a phase-field approach},
+   journal = {CMAME, Vol. 290, 15 June 2015, Pages 466-495, ISSN 0045-7825},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://dx.doi.org/10.1016/j.cma.2015.03.009},
+   doi     = {}
 }
 
 @article{2015_73,
-   author  = "H. Holmgren and G. Kreiss",
-   title   = "Towards Accurate Modeling of Moving Contact Lines",
-   journal = "arXiv:1510.06639",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org.ezproxy.library.tamu.edu/abs/1510.06639",
-   doi     = ""
+   author  = {H. Holmgren and G. Kreiss},
+   title   = {Towards Accurate Modeling of Moving Contact Lines},
+   journal = {arXiv:1510.06639},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org.ezproxy.library.tamu.edu/abs/1510.06639},
+   doi     = {}
 }
 
 @article{2015_74,
-   author  = "A. P. Homyk",
-   title   = "Scalable Methods for Deterministic Integration of Quantum Emitters in Photonic Crystal Cavities",
-   journal = "PhD dissertation, California Institute of Technology, Pasadena",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://thesis.library.caltech.edu/8970/",
-   doi     = ""
+   author  = {A. P. Homyk},
+   title   = {Scalable Methods for Deterministic Integration of Quantum Emitters in Photonic Crystal Cavities},
+   journal = {PhD dissertation, California Institute of Technology, Pasadena},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://thesis.library.caltech.edu/8970/},
+   doi     = {}
 }
 
 @phdthesis{2015_75,
-   author  = "D. Janka",
-   title   = "Sequential quadratic programming with indefinite Hessian approximations for nonlinear optimum experimental design for parameter estimation in differential–algebraic equations",
-   year    = "2015",
-   school  = "University of Heidelberg, Germany",
-   url     = ""
+   author  = {D. Janka},
+   title   = {Sequential quadratic programming with indefinite Hessian approximations for nonlinear optimum experimental design for parameter estimation in differential--algebraic equations},
+   year    = {2015},
+   school  = {University of Heidelberg, Germany},
+   url     = {}
 }
 
 @article{2015_76,
-   author  = "G. Jean-Baptiste and G. Lofstead and R. A. Oldfield",
-   title   = "Delta: Data reduction for integrated application workflows",
-   journal = "Sandia Technical Report SAND2015-5029",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://prod.sandia.gov/techlib/access-control.cgi/2015/155029.pdf",
-   doi     = ""
+   author  = {G. Jean-Baptiste and G. Lofstead and R. A. Oldfield},
+   title   = {Delta: Data reduction for integrated application workflows},
+   journal = {Sandia Technical Report SAND2015-5029},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://prod.sandia.gov/techlib/access-control.cgi/2015/155029.pdf},
+   doi     = {}
 }
 
 @article{2015_77,
-   author  = "G. Kanschat and Y. Mao",
-   title   = "Multigrid methods for Hdiv-conforming discontinuous Galerkin methods for the Stokes equations",
-   journal = "J. Numer. Math no. 1",
-   year    = "2015",
-   volume  = "23",
-   pages   = "51--66",
-   url     = "http://arxiv.org/abs/1501.06021",
-   doi     = ""
+   author  = {G. Kanschat and Y. Mao},
+   title   = {Multigrid methods for Hdiv-conforming discontinuous Galerkin methods for the Stokes equations},
+   journal = {J. Numer. Math no. 1},
+   year    = {2015},
+   volume  = {23},
+   pages   = {51--66},
+   url     = {http://arxiv.org/abs/1501.06021},
+   doi     = {}
 }
 
 @article{2015_78,
-   author  = "A. Karrech and C. Schrank and K. Regenauer-Lieb",
-   title   = "A parallel computing tool for large-scale simulation of massive fluid injection in thermo-poro-mechanical systems",
-   journal = "Philosophical Magazine, Vol. 95, Issue 28-30",
-   year    = "2015",
-   volume  = "",
-   pages   = "3078--3102",
-   url     = "http://www.tandfonline.com/doi/abs/10.1080/14786435.2015.1067373",
-   doi     = ""
+   author  = {A. Karrech and C. Schrank and K. Regenauer-Lieb},
+   title   = {A parallel computing tool for large-scale simulation of massive fluid injection in thermo-poro-mechanical systems},
+   journal = {Philosophical Magazine, Vol. 95, Issue 28-30},
+   year    = {2015},
+   volume  = {},
+   pages   = {3078--3102},
+   url     = {http://www.tandfonline.com/doi/abs/10.1080/14786435.2015.1067373},
+   doi     = {}
 }
 
 @article{2015_79,
-   author  = "S. Kim and H. Zhang",
-   title   = "Optimized Schwarz Method with Complete Radiation Transmission Conditions for the Helmholtz Equation in Waveguides",
-   journal = "SIAM J. Numer. Anal., Vol. 53",
-   year    = "2015",
-   volume  = "",
-   pages   = "1537--1558",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/140980491",
-   doi     = ""
+   author  = {S. Kim and H. Zhang},
+   title   = {Optimized Schwarz Method with Complete Radiation Transmission Conditions for the Helmholtz Equation in Waveguides},
+   journal = {SIAM J. Numer. Anal., Vol. 53},
+   year    = {2015},
+   volume  = {},
+   pages   = {1537--1558},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/140980491},
+   doi     = {}
 }
 
 @article{2015_80,
-   author  = "R. Kircheis",
-   title   = "Structure Exploiting Parameter Estimation and Optimum Experimental Design Methods and Applications in Microbial Enhanced Oil Recovery",
-   journal = "PhD dissertation, University of Heidelberg",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://archiv.ub.uni-heidelberg.de/volltextserver/18762/",
-   doi     = ""
+   author  = {R. Kircheis},
+   title   = {Structure Exploiting Parameter Estimation and Optimum Experimental Design Methods and Applications in Microbial Enhanced Oil Recovery},
+   journal = {PhD dissertation, University of Heidelberg},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/18762/},
+   doi     = {}
 }
 
 @article{2015_81,
-   author  = "M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking",
-   title   = "An assessment of the phase field formulation for crack growth",
-   journal = "Computer Methods in Applied Mechanics and Engineering, Vol. 294",
-   year    = "2015",
-   volume  = "",
-   pages   = "313--330",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782515002017",
-   doi     = ""
+   author  = {M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking},
+   title   = {An assessment of the phase field formulation for crack growth},
+   journal = {Computer Methods in Applied Mechanics and Engineering, Vol. 294},
+   year    = {2015},
+   volume  = {},
+   pages   = {313--330},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782515002017},
+   doi     = {}
 }
 
 @phdthesis{2015_82,
-   author  = "U. K&ouml;cher",
-   title   = "Variational Space-Time Methods for the Elastic Wave Equation and the Diffusion Equation",
-   year    = "2015",
-   school  = "Department of Mechanical Engineering of the Helmut-Schmidt-University, University of the German Federal Armed Forces Hamburg",
-   url     = "http://nbn-resolving.de/urn:nbn:de:gbv:705-opus-31129"
+   author  = {U. K\"{o}cher},
+   title   = {Variational Space-Time Methods for the Elastic Wave Equation and the Diffusion Equation},
+   year    = {2015},
+   school  = {Department of Mechanical Engineering of the Helmut-Schmidt-University, University of the German Federal Armed Forces Hamburg},
+   url     = {http://nbn-resolving.de/urn:nbn:de:gbv:705-opus-31129}
 }
 
 @article{2015_83,
-   author  = "R. Kriemann and S. Le Borne",
-   title   = "H-FAINV: hierarchically factored approximate inverse preconditioners",
-   journal = "Computing and Visualization in Science, 17(3)",
-   year    = "2015",
-   volume  = "",
-   pages   = "135--150",
-   url     = "http://link.springer.com/article/10.1007/s00791-015-0254-y#page-1",
-   doi     = "10.1007/s00791-015-0254-y"
+   author  = {R. Kriemann and S. Le Borne},
+   title   = {H-FAINV: hierarchically factored approximate inverse preconditioners},
+   journal = {Computing and Visualization in Science, 17(3)},
+   year    = {2015},
+   volume  = {},
+   pages   = {135--150},
+   url     = {http://link.springer.com/article/10.1007/s00791-015-0254-y#page-1},
+   doi     = {10.1007/s00791-015-0254-y}
 }
 
 @article{2015_84,
-   author  = "P. A. Kuberry",
-   title   = "An Optimization-Based Approach to Decoupling Fluid-Structure Interaction",
-   journal = "PhD dissertation, Clemson University",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://tigerprints.clemson.edu/all_dissertations/1487/",
-   doi     = ""
+   author  = {P. A. Kuberry},
+   title   = {An Optimization-Based Approach to Decoupling Fluid-Structure Interaction},
+   journal = {PhD dissertation, Clemson University},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://tigerprints.clemson.edu/all_dissertations/1487/},
+   doi     = {}
 }
 
 @article{2015_85,
-   author  = "K. Kunisch and A. Rund",
-   title   = "Time optimal control of the monodomain model in cardiac electrophysiology",
-   journal = "IMA Journal of Applied Mathematics",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short",
-   doi     = ""
+   author  = {K. Kunisch and A. Rund},
+   title   = {Time optimal control of the monodomain model in cardiac electrophysiology},
+   journal = {IMA Journal of Applied Mathematics},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short},
+   doi     = {}
 }
 
 @article{2015_86,
-   author  = "P. Kus",
-   title   = "Convergence and stability of higher-order finite element solution of reaction-diffusion equation with Turing instability",
-   journal = "Conference Applications of Mathematics 2015, Institute of Mathematics CAS, Prague",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://am2015.math.cas.cz/proceedings/contributions/kus.pdf",
-   doi     = ""
+   author  = {P. Kus},
+   title   = {Convergence and stability of higher-order finite element solution of reaction-diffusion equation with Turing instability},
+   journal = {Conference Applications of Mathematics 2015, Institute of Mathematics CAS, Prague},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://am2015.math.cas.cz/proceedings/contributions/kus.pdf},
+   doi     = {}
 }
 
 @article{2015_87,
-   author  = "S. C. Kramer and J. Hagemann",
-   title   = "SciPAL: Expression templates and composition closure objects for high performance computational physics with CUDA and OpenMP",
-   journal = "ACM Transactions on Parallel Computing, 1(2), p. 15",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short",
-   doi     = ""
+   author  = {S. C. Kramer and J. Hagemann},
+   title   = {SciPAL: Expression templates and composition closure objects for high performance computational physics with CUDA and OpenMP},
+   journal = {ACM Transactions on Parallel Computing, 1(2), p. 15},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short},
+   doi     = {}
 }
 
 @article{2015_88,
-   author  = "S. Lee and M. F. Wheeler and T. Wick",
-   title   = "3D Fluid Filled Fracture Propagation in Porous Media using Phase Field and Adaptive Finite Elements",
-   journal = "Submitted",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Lee and M. F. Wheeler and T. Wick},
+   title   = {3D Fluid Filled Fracture Propagation in Porous Media using Phase Field and Adaptive Finite Elements},
+   journal = {Submitted},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2015_89,
-   author  = "A. Lemenager",
-   title   = "Numerical modelling of the Sydney Basin using temperature dependent thermal conductivity measurements",
-   year    = "2015",
-   school  = "Macquarie University",
-   url     = ""
+   author  = {A. Lemenager},
+   title   = {Numerical modelling of the Sydney Basin using temperature dependent thermal conductivity measurements},
+   year    = {2015},
+   school  = {Macquarie University},
+   url     = {}
 }
 
 @article{2015_90,
-   author  = "D. Li and R. Hartmann",
-   title   = "Adjoint-based airfoil optimization with discretization error control",
-   journal = "International Journal on Numerical Methods Fluids",
-   year    = "2015",
-   volume  = "77",
-   pages   = "1--17",
-   url     = "",
-   doi     = ""
+   author  = {D. Li and R. Hartmann},
+   title   = {Adjoint-based airfoil optimization with discretization error control},
+   journal = {International Journal on Numerical Methods Fluids},
+   year    = {2015},
+   volume  = {77},
+   pages   = {1--17},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_91,
-   author  = "J. Liu and M. Do-Quang and G. Amberg",
-   title   = "Thermohydrodynamics of boiling in binary compressible fluids",
-   journal = "Physical Review E 92, 043017",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://journals.aps.org/pre/abstract/10.1103/PhysRevE.92.043017",
-   doi     = ""
+   author  = {J. Liu and M. Do-Quang and G. Amberg},
+   title   = {Thermohydrodynamics of boiling in binary compressible fluids},
+   journal = {Physical Review E 92, 043017},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://journals.aps.org/pre/abstract/10.1103/PhysRevE.92.043017},
+   doi     = {}
 }
 
 @phdthesis{2015_92,
-   author  = "K. Ljungkvist",
-   title   = "Techniques for finite element methods on modern processors",
-   year    = "2015",
-   school  = "IT licentiate thesis, University of Uppsala, Sweden",
-   url     = ""
+   author  = {K. Ljungkvist},
+   title   = {Techniques for finite element methods on modern processors},
+   year    = {2015},
+   school  = {IT licentiate thesis, University of Uppsala, Sweden},
+   url     = {}
 }
 
 @phdthesis{2015_93,
-   author  = "A. A. Londero",
-   title   = "A Cut-Cell Implementation of the Finite Element Method in deal.ii",
-   year    = "2015",
-   school  = "Uppsala University, Aug",
-   url     = "http://www.diva-portal.org/smash/get/diva2:858026/FULLTEXT01.pdf"
+   author  = {A. A. Londero},
+   title   = {A Cut-Cell Implementation of the Finite Element Method in deal.ii},
+   year    = {2015},
+   school  = {Uppsala University, Aug},
+   url     = {http://www.diva-portal.org/smash/get/diva2:858026/FULLTEXT01.pdf}
 }
 
 @article{2015_94,
-   author  = "A. Madzvamuse and A. H. Chung and C. Venkataraman",
-   title   = "Stability analysis and simulations of coupled bulk-surface reaction–diffusion systems",
-   journal = "Proc. R. Soc. A. Vol. 471. No. 2175. The Royal Society",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Madzvamuse and A. H. Chung and C. Venkataraman},
+   title   = {Stability analysis and simulations of coupled bulk-surface reaction--diffusion systems},
+   journal = {Proc. R. Soc. A. Vol. 471. No. 2175. The Royal Society},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2015_95,
-   author  = "M. Maier",
-   title   = "Duality-based adaptivity of model and discretization in multiscale finite-element methods",
-   year    = "2015",
-   school  = "Doctoral thesis, Heidelberg University, Germany",
-   url     = ""
+   author  = {M. Maier},
+   title   = {Duality-based adaptivity of model and discretization in multiscale finite-element methods},
+   year    = {2015},
+   school  = {Doctoral thesis, Heidelberg University, Germany},
+   url     = {}
 }
 
 @article{2015_96,
-   author  = "S. M. Mallikarjunaiah and J. R. Walton",
-   title   = "On the direct numerical simulation of plane-strain fracture in a class of strain-limiting anisotropic elastic bodies",
-   journal = "International Journal of Fracture, Vol. 192(2)",
-   year    = "2015",
-   volume  = "",
-   pages   = "217--232",
-   url     = "http://link.springer.com/article/10.1007/s10704-015-0006-5",
-   doi     = ""
+   author  = {S. M. Mallikarjunaiah and J. R. Walton},
+   title   = {On the direct numerical simulation of plane-strain fracture in a class of strain-limiting anisotropic elastic bodies},
+   journal = {International Journal of Fracture, Vol. 192(2)},
+   year    = {2015},
+   volume  = {},
+   pages   = {217--232},
+   url     = {http://link.springer.com/article/10.1007/s10704-015-0006-5},
+   doi     = {}
 }
 
 @article{2015_97,
-   author  = "A. McBride and A. Javili and P. Steinmann and B. D. Reddy",
-   title   = "A finite element implementation of surface elasticity at finite strains in deal.II",
-   journal = "arXiv 1506.01361",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1506.01361",
-   doi     = ""
+   author  = {A. McBride and A. Javili and P. Steinmann and B. D. Reddy},
+   title   = {A finite element implementation of surface elasticity at finite strains in deal.II},
+   journal = {arXiv 1506.01361},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1506.01361},
+   doi     = {}
 }
 
 @article{2015_98,
-   author  = "C. E. Michoski and D. Meyerson and T. Isaac and F. Waelbroeck",
-   title   = "Discontinuous Galerkin methods for plasma physics in the scrape-off layer of tokamaks",
-   journal = "Journal of Computational Physics, Vol. 274",
-   year    = "2015",
-   volume  = "",
-   pages   = "898--919",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999114004768",
-   doi     = ""
+   author  = {C. E. Michoski and D. Meyerson and T. Isaac and F. Waelbroeck},
+   title   = {Discontinuous Galerkin methods for plasma physics in the scrape-off layer of tokamaks},
+   journal = {Journal of Computational Physics, Vol. 274},
+   year    = {2015},
+   volume  = {},
+   pages   = {898--919},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999114004768},
+   doi     = {}
 }
 
 @article{2015_99,
-   author  = "A. Mikelic and M. F. Wheeler and T. Wick",
-   title   = "A quasistatic phase field approach to fluid filled  fractures",
-   journal = "ICES preprint 13-22, 2013. Accepted for publication in Nonlinearity",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Mikelic and M. F. Wheeler and T. Wick},
+   title   = {A quasistatic phase field approach to fluid filled  fractures},
+   journal = {ICES preprint 13-22, 2013. Accepted for publication in Nonlinearity},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_100,
-   author  = "A. Mikelic and M. F. Wheeler and T. Wick",
-   title   = "A phase-field method for propagating fluid-filled fractures coupled to a surrounding porous medium",
-   journal = "Multiscale Model. Simul., issue 1, pp. 367–398",
-   year    = "2015",
-   volume  = "13",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/140967118",
-   doi     = ""
+   author  = {A. Mikelic and M. F. Wheeler and T. Wick},
+   title   = {A phase-field method for propagating fluid-filled fractures coupled to a surrounding porous medium},
+   journal = {Multiscale Model. Simul., issue 1, pp. 367--398},
+   year    = {2015},
+   volume  = {13},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/140967118},
+   doi     = {}
 }
 
 @article{2015_101,
-   author  = "A. Mikelic and M. F. Wheeler and T. Wick",
-   title   = "Phase-field modeling of fluid-driven fractures in a poroelastic medium",
-   journal = "Computational Geoscience, Volume 19, issue 6",
-   year    = "2015",
-   volume  = "",
-   pages   = "1171--1195",
-   url     = "http://link.springer.com/article/10.1007%2Fs10596-015-9532-5",
-   doi     = ""
+   author  = {A. Mikelic and M. F. Wheeler and T. Wick},
+   title   = {Phase-field modeling of fluid-driven fractures in a poroelastic medium},
+   journal = {Computational Geoscience, Volume 19, issue 6},
+   year    = {2015},
+   volume  = {},
+   pages   = {1171--1195},
+   url     = {http://link.springer.com/article/10.1007%2Fs10596-015-9532-5},
+   doi     = {}
 }
 
 @mastersthesis{2015_102,
-   author  = "P. Mital",
-   title   = "The Enriched Galerkin Method for Linear Elasticity and Phase Field Fracture Propagation",
-   year    = "2015",
-   school  = "UT Austin",
-   url     = "http://hdl.handle.net/2152/34222"
+   author  = {P. Mital},
+   title   = {The Enriched Galerkin Method for Linear Elasticity and Phase Field Fracture Propagation},
+   year    = {2015},
+   school  = {UT Austin},
+   url     = {http://hdl.handle.net/2152/34222}
 }
 
 @article{2015_103,
-   author  = "M. S. Muddamallappa",
-   title   = "On Two Theories for Brittle Fracture: Modeling and Direct Numerical Simulations",
-   journal = "PhD dissertation, Texas A&amp;M University.",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://oaktrust.library.tamu.edu/handle/1969.1/156484",
-   doi     = ""
+   author  = {M. S. Muddamallappa},
+   title   = {On Two Theories for Brittle Fracture: Modeling and Direct Numerical Simulations},
+   journal = {PhD dissertation, Texas A \& M University.},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://oaktrust.library.tamu.edu/handle/1969.1/156484},
+   doi     = {}
 }
 
 @article{2015_104,
-   author  = "I. Neitzel and T. Wick and W. Wollner",
-   title   = "An optimal control problem governed by a regularized phase field fraction propagation model",
-   journal = "IGDK 1754 Preprint No. IGDK-2015-12",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://preprint.math.uni-hamburg.de/public/papers/hbam/hbam2015-18.pdf",
-   doi     = ""
+   author  = {I. Neitzel and T. Wick and W. Wollner},
+   title   = {An optimal control problem governed by a regularized phase field fraction propagation model},
+   journal = {IGDK 1754 Preprint No. IGDK-2015-12},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://preprint.math.uni-hamburg.de/public/papers/hbam/hbam2015-18.pdf},
+   doi     = {}
 }
 
 @article{2015_105,
-   author  = "R. H. Nochetto and E. Otárola and A. J. Salgado",
-   title   = "A PDE Approach to Numerical Fractional Diffusion",
-   journal = "arXiv:1508.04382",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1508.04382",
-   doi     = ""
+   author  = {R. H. Nochetto and E. Ot\'{a}rola and A. J. Salgado},
+   title   = {A PDE Approach to Numerical Fractional Diffusion},
+   journal = {arXiv:1508.04382},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1508.04382},
+   doi     = {}
 }
 
 @article{2015_106,
-   author  = "R. H. Nochetto and E. Otárola and A. J. Salgado",
-   title   = "A PDE Approach to Fractional Diffusion in General Domains: A Priori Error Analysis",
-   journal = "Foundations of Computational Mathematics, Vol 15(3)",
-   year    = "2015",
-   volume  = "",
-   pages   = "733--791",
-   url     = "http://link.springer.com/article/10.1007/s10208-014-9208-x",
-   doi     = ""
+   author  = {R. H. Nochetto and E. Ot\'{a}rola and A. J. Salgado},
+   title   = {A PDE Approach to Fractional Diffusion in General Domains: A Priori Error Analysis},
+   journal = {Foundations of Computational Mathematics, Vol 15(3)},
+   year    = {2015},
+   volume  = {},
+   pages   = {733--791},
+   url     = {http://link.springer.com/article/10.1007/s10208-014-9208-x},
+   doi     = {}
 }
 
 @article{2015_107,
-   author  = "L. H. Odsaeter and T. Kvamsdal and M. F. Wheeler",
-   title   = "A postprocessing technique to produce locally conservative flux",
-   journal = "28th Nordic Seminar on Computational Mechanics. CENS, Institute of Cybernetics at Tallinn University of Technology",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://folk.ntnu.no/odsater/nscm_abstract.pdf",
-   doi     = ""
+   author  = {L. H. Odsaeter and T. Kvamsdal and M. F. Wheeler},
+   title   = {A postprocessing technique to produce locally conservative flux},
+   journal = {28th Nordic Seminar on Computational Mechanics. CENS, Institute of Cybernetics at Tallinn University of Technology},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://folk.ntnu.no/odsater/nscm_abstract.pdf},
+   doi     = {}
 }
 
 @article{2015_108,
-   author  = "M. A. Olshanskii and T. Heister and L. G. Rebholz and K. J. Galvin",
-   title   = "Natural vorticity boundary conditions on solid walls",
-   journal = "CMAME, Vol. 297",
-   year    = "2015",
-   volume  = "",
-   pages   = "18--37",
-   url     = "http://dx.doi.org/10.1016/j.cma.2015.08.011",
-   doi     = ""
+   author  = {M. A. Olshanskii and T. Heister and L. G. Rebholz and K. J. Galvin},
+   title   = {Natural vorticity boundary conditions on solid walls},
+   journal = {CMAME, Vol. 297},
+   year    = {2015},
+   volume  = {},
+   pages   = {18--37},
+   url     = {http://dx.doi.org/10.1016/j.cma.2015.08.011},
+   doi     = {}
 }
 
 @article{2015_109,
-   author  = "N. C. Papanicolaou and A. C. Aristotelous",
-   title   = "High-order discontinuous Galerkin methods for coupled thermoconvective flows under gravity modulation ",
-   journal = "AIP Conference Proceedings 1684, 090010",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://scitation.aip.org/content/aip/proceeding/aipcp/10.1063/1.4934335",
-   doi     = "10.1063/1.4934335"
+   author  = {N. C. Papanicolaou and A. C. Aristotelous},
+   title   = {High-order discontinuous Galerkin methods for coupled thermoconvective flows under gravity modulation },
+   journal = {AIP Conference Proceedings 1684, 090010},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://scitation.aip.org/content/aip/proceeding/aipcp/10.1063/1.4934335},
+   doi     = {10.1063/1.4934335}
 }
 
 @article{2015_110,
-   author  = "M. S. Pauletti and M. Martinelli and N. Cavallini and P. Antolin",
-   title   = "Igatools: An Isogeometric Analysis Library ",
-   journal = "SIAM J. Sci. Comput., issue 4, pp. 465–496",
-   year    = "2015",
-   volume  = "37",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/140955252",
-   doi     = "10.1137/140955252"
+   author  = {M. S. Pauletti and M. Martinelli and N. Cavallini and P. Antolin},
+   title   = {Igatools: An Isogeometric Analysis Library },
+   journal = {SIAM J. Sci. Comput., issue 4, pp. 465--496},
+   year    = {2015},
+   volume  = {37},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/140955252},
+   doi     = {10.1137/140955252}
 }
 
 @phdthesis{2015_111,
-   author  = "G. Peyre",
-   title   = "Methode EF et hyperreduction de modele: vers des calculs massifs a l'echelle micro",
-   year    = "2015",
-   school  = "Ecole Nationale Superieure des Mines de Paris",
-   url     = "https://hal.archives-ouvertes.fr/tel-01247931/"
+   author  = {G. Peyre},
+   title   = {Methode EF et hyperreduction de modele: vers des calculs massifs a l'echelle micro},
+   year    = {2015},
+   school  = {Ecole Nationale Superieure des Mines de Paris},
+   url     = {https://hal.archives-ouvertes.fr/tel-01247931/}
 }
 
 @article{2015_112,
-   author  = "E. G. Phillips and H. C. Elman",
-   title   = "A stochastic approach to uncertainty in the equations of MHD kinematics",
-   journal = "J. of Comput. Phys., Vol. 284, pp. 334–350",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999114008092",
-   doi     = ""
+   author  = {E. G. Phillips and H. C. Elman},
+   title   = {A stochastic approach to uncertainty in the equations of MHD kinematics},
+   journal = {J. of Comput. Phys., Vol. 284, pp. 334--350},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999114008092},
+   doi     = {}
 }
 
 @article{2015_113,
-   author  = "H. Rahemi and N. Nigam and J. M. Wakeling",
-   title   = "The effect of intramuscular fat on skeletal muscle mechanics: implications for the elderly and obese",
-   journal = "DOI: 10.1098/rsif.2015.0365., Interface, Jul",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://rsif.royalsocietypublishing.org/content/12/109/20150365?cpetoc",
-   doi     = ""
+   author  = {H. Rahemi and N. Nigam and J. M. Wakeling},
+   title   = {The effect of intramuscular fat on skeletal muscle mechanics: implications for the elderly and obese},
+   journal = {DOI: 10.1098/rsif.2015.0365., Interface, Jul},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://rsif.royalsocietypublishing.org/content/12/109/20150365?cpetoc},
+   doi     = {}
 }
 
 @article{2015_114,
-   author  = "S. M. Renda and R. Hartmann and C. De Bartolo and M. Wallraff",
-   title   = "A high-order discontinuous Galerkin method for all-speed flows",
-   journal = "International Journal for Numerical Methods in Fluids, issue 4, pp. 224–247",
-   year    = "2015",
-   volume  = "77",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/fld.3987/abstract",
-   doi     = ""
+   author  = {S. M. Renda and R. Hartmann and C. De Bartolo and M. Wallraff},
+   title   = {A high-order discontinuous Galerkin method for all-speed flows},
+   journal = {International Journal for Numerical Methods in Fluids, issue 4, pp. 224--247},
+   year    = {2015},
+   volume  = {77},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.3987/abstract},
+   doi     = {}
 }
 
 @article{2015_115,
-   author  = "T. Richter and T. Wick",
-   title   = "Variational localization of the dual weighted residual estimator",
-   journal = "Journal for Computational and Applied Mathematics, Volume 279, Issue C",
-   year    = "2015",
-   volume  = "",
-   pages   = "192--208",
-   url     = "http://dl.acm.org/citation.cfm?id=2802959",
-   doi     = ""
+   author  = {T. Richter and T. Wick},
+   title   = {Variational localization of the dual weighted residual estimator},
+   journal = {Journal for Computational and Applied Mathematics, Volume 279, Issue C},
+   year    = {2015},
+   volume  = {},
+   pages   = {192--208},
+   url     = {http://dl.acm.org/citation.cfm?id=2802959},
+   doi     = {}
 }
 
 @article{2015_116,
-   author  = "D. Riedlbauer and P. Steinmann and J. Mergheim",
-   title   = "Thermomechanical simulation of the selective laser melting process for PA12 including volumetric shrinkage",
-   journal = "ROCEEDINGS OF PPS-30: The 30th International Conference of the Polymer Processing Society–Conference Papers, Vol. 1664, No. 1",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://scitation.aip.org/content/aip/proceeding/aipcp/10.1063/1.4918512",
-   doi     = ""
+   author  = {D. Riedlbauer and P. Steinmann and J. Mergheim},
+   title   = {Thermomechanical simulation of the selective laser melting process for PA12 including volumetric shrinkage},
+   journal = {ROCEEDINGS OF PPS-30: The 30th International Conference of the Polymer Processing Society--Conference Papers, Vol. 1664, No. 1},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://scitation.aip.org/content/aip/proceeding/aipcp/10.1063/1.4918512},
+   doi     = {}
 }
 
 @article{2015_117,
-   author  = "S. Riehl and P. Steinmann",
-   title   = "A staggered approach to shape and topology optimization using the traction method and an evolutionary-type advancing front algorithm",
-   journal = "Computer Methods in Applied Mechanics and Engineering, pp. 1–30",
-   year    = "2015",
-   volume  = "287",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0377042715001934",
-   doi     = ""
+   author  = {S. Riehl and P. Steinmann},
+   title   = {A staggered approach to shape and topology optimization using the traction method and an evolutionary-type advancing front algorithm},
+   journal = {Computer Methods in Applied Mechanics and Engineering, pp. 1--30},
+   year    = {2015},
+   volume  = {287},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0377042715001934},
+   doi     = {}
 }
 
 @article{2015_118,
-   author  = "M.  Roland and T. Tjardes and T. Dahmen and R. Otchwemah and P. Slusallek and B. Bouillon and S. Diebels",
-   title   = "An algorithmic strategy for the simulation of bone healing directly on computed tomography data",
-   journal = "Proceedings in Applied Mathematics and Mechanics, Vol. 15(1)",
-   year    = "2015",
-   volume  = "",
-   pages   = "105--106",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/pamm.201510043/abstract",
-   doi     = ""
+   author  = {M.  Roland and T. Tjardes and T. Dahmen and R. Otchwemah and P. Slusallek and B. Bouillon and S. Diebels},
+   title   = {An algorithmic strategy for the simulation of bone healing directly on computed tomography data},
+   journal = {Proceedings in Applied Mathematics and Mechanics, Vol. 15(1)},
+   year    = {2015},
+   volume  = {},
+   pages   = {105--106},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201510043/abstract},
+   doi     = {}
 }
 
 @article{2015_119,
-   author  = "S. Roya and L. Heltai and F. Costanzo",
-   title   = "Benchmarking the immersed finite element method for fluid–structure interaction problems",
-   journal = "Computers &amp; Mathematics with Applications, issue 10, pp. 1167–1188",
-   year    = "2015",
-   volume  = "69",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0898122115001078",
-   doi     = ""
+   author  = {S. Roya and L. Heltai and F. Costanzo},
+   title   = {Benchmarking the immersed finite element method for fluid--structure interaction problems},
+   journal = {Computers \& Mathematics with Applications, issue 10, pp. 1167--1188},
+   year    = {2015},
+   volume  = {69},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0898122115001078},
+   doi     = {}
 }
 
 @article{2015_120,
-   author  = "A. J. Salgado",
-   title   = "Convergence Analysis of Fractional Time-Stepping Techniques for Incompressible Fluids with Microstructure",
-   journal = "Journal of Scientific Computing, Volume 64, Issue 1",
-   year    = "2015",
-   volume  = "",
-   pages   = "216--233",
-   url     = "http://link.springer.com/article/10.1007%2Fs10915-014-9926-x",
-   doi     = ""
+   author  = {A. J. Salgado},
+   title   = {Convergence Analysis of Fractional Time-Stepping Techniques for Incompressible Fluids with Microstructure},
+   journal = {Journal of Scientific Computing, Volume 64, Issue 1},
+   year    = {2015},
+   volume  = {},
+   pages   = {216--233},
+   url     = {http://link.springer.com/article/10.1007%2Fs10915-014-9926-x},
+   doi     = {}
 }
 
 @article{2015_121,
-   author  = "A. Sartori and N. Giuliani and M. Bardelloni and L. Heltai",
-   title   = "deal2lkit: A toolkit library for high performance programming in deal.II",
-   journal = "Print, SISSA, Italy",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "https://urania.sissa.it/xmlui/bitstream/handle/1963/35006/paper_deal2lkit.pdf?sequence=1&isAllowed=y",
-   doi     = ""
+   author  = {A. Sartori and N. Giuliani and M. Bardelloni and L. Heltai},
+   title   = {deal2lkit: A toolkit library for high performance programming in deal.II},
+   journal = {Print, SISSA, Italy},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {https://urania.sissa.it/xmlui/bitstream/handle/1963/35006/paper_deal2lkit.pdf?sequence=1&isAllowed=y},
+   doi     = {}
 }
 
 @article{2015_122,
-   author  = "P. Saxenaa and J.-P. Pelteret and P. Steinmann",
-   title   = "Modelling of iron-filled magneto-active polymers with a dispersed chain-like microstructure",
-   journal = "European Journal of Mechanics - A/Solids, pp. 132–151",
-   year    = "2015",
-   volume  = "50",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0997753814001508",
-   doi     = ""
+   author  = {P. Saxenaa and J.-P. Pelteret and P. Steinmann},
+   title   = {Modelling of iron-filled magneto-active polymers with a dispersed chain-like microstructure},
+   journal = {European Journal of Mechanics - A/Solids, pp. 132--151},
+   year    = {2015},
+   volume  = {50},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0997753814001508},
+   doi     = {}
 }
 
 @article{2015_123,
-   author  = "T. Scheffer and F. Goldschmidt and S. Diebels",
-   title   = "Implementation of the strongly pronounced non-linear viscoelasticity of an incompressible filled rubber",
-   journal = "Technische Mechanik, Vol. 35(2)",
-   year    = "2015",
-   volume  = "",
-   pages   = "118--132",
-   url     = "http://www.uni-magdeburg.de/ifme/zeitschrift_tm/2015_Heft2/04_Scheffer.pdf",
-   doi     = ""
+   author  = {T. Scheffer and F. Goldschmidt and S. Diebels},
+   title   = {Implementation of the strongly pronounced non-linear viscoelasticity of an incompressible filled rubber},
+   journal = {Technische Mechanik, Vol. 35(2)},
+   year    = {2015},
+   volume  = {},
+   pages   = {118--132},
+   url     = {http://www.uni-magdeburg.de/ifme/zeitschrift_tm/2015_Heft2/04_Scheffer.pdf},
+   doi     = {}
 }
 
 @article{2015_124,
-   author  = "S. Schmitt and P. Gumbsch and K. Schulz",
-   title   = "Internal stresses in a homogenized representation of dislocation microstructures",
-   journal = "Journal of the Mechanics and Physics of Solids, Vol. 84",
-   year    = "2015",
-   volume  = "",
-   pages   = "528--544",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0022509615300946",
-   doi     = ""
+   author  = {S. Schmitt and P. Gumbsch and K. Schulz},
+   title   = {Internal stresses in a homogenized representation of dislocation microstructures},
+   journal = {Journal of the Mechanics and Physics of Solids, Vol. 84},
+   year    = {2015},
+   volume  = {},
+   pages   = {528--544},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0022509615300946},
+   doi     = {}
 }
 
 @phdthesis{2015_125,
-   author  = "S. Schoenawa",
-   title   = "Higher-order discontinuous Galerkin discretizations of two-equation models of turbulence",
-   year    = "2015",
-   school  = "TU Braunschweig, Germany",
-   url     = ""
+   author  = {S. Schoenawa},
+   title   = {Higher-order discontinuous Galerkin discretizations of two-equation models of turbulence},
+   year    = {2015},
+   school  = {TU Braunschweig, Germany},
+   url     = {}
 }
 
 @article{2015_126,
-   author  = "A. E. Shyer and T. R. Huycke and C. Lee and L. Mahadevan and C. J. Tabin",
-   title   = "Bending Gradients: How the Intestinal Stem Cell Gets Its Home",
-   journal = "Cell, issue 3",
-   year    = "2015",
-   volume  = "161",
-   pages   = "569--580",
-   url     = "http://dx.doi.org/10.1016/j.cell.2015.03.041",
-   doi     = ""
+   author  = {A. E. Shyer and T. R. Huycke and C. Lee and L. Mahadevan and C. J. Tabin},
+   title   = {Bending Gradients: How the Intestinal Stem Cell Gets Its Home},
+   journal = {Cell, issue 3},
+   year    = {2015},
+   volume  = {161},
+   pages   = {569--580},
+   url     = {http://dx.doi.org/10.1016/j.cell.2015.03.041},
+   doi     = {}
 }
 
 @article{2015_127,
-   author  = "J. Stapf",
-   title   = "Novel learning-based techniques for dense fluid motion measurements",
-   journal = "PhD dissertation, Ruperto-Carola University of Heidelberg, Germany",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://archiv.ub.uni-heidelberg.de/volltextserver/18116/",
-   doi     = ""
+   author  = {J. Stapf},
+   title   = {Novel learning-based techniques for dense fluid motion measurements},
+   journal = {PhD dissertation, Ruperto-Carola University of Heidelberg, Germany},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/18116/},
+   doi     = {}
 }
 
 @article{2015_128,
-   author  = "M. Stevens and C. Downs and D. Emerson and J. Adler and S. MacIachlan and T. E. Vandervelde",
-   title   = "Predicting V<sub>OC</sub> at ultra-high solar concentration using computational numerical analysis",
-   journal = "Proceedings of the 31st European Photovoltaic Solar Energy Conference (EUPVSC). Hamburg, Germany, Sept. 14–18",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.semanticscholar.org/paper/Predicting-V-Oc-at-Ultra-high-Solar-Concentration-Stevens-Downs/b1fa511a5ec06f75f6223c57cbc9c53823d9c4fc/pdf",
-   doi     = ""
+   author  = {M. Stevens and C. Downs and D. Emerson and J. Adler and S. MacIachlan and T. E. Vandervelde},
+   title   = {Predicting V$_{\textnormal{OC}}$ at ultra-high solar concentration using computational numerical analysis},
+   journal = {Proceedings of the 31st European Photovoltaic Solar Energy Conference (EUPVSC). Hamburg, Germany, Sept. 14--18},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.semanticscholar.org/paper/Predicting-V-Oc-at-Ultra-high-Solar-Concentration-Stevens-Downs/b1fa511a5ec06f75f6223c57cbc9c53823d9c4fc/pdf},
+   doi     = {}
 }
 
 @article{2015_129,
-   author  = "M. A. Stevens and C. Downs and D. Emerson and J. Adler and S. Maclachlan and T. E. Vandervelde",
-   title   = "Studying anomalous open-circuit voltage drop-out in concentrated photovoltaics using computational numerical analysis",
-   journal = "Proceedings of the 42nd Photovoltaic Specialist Conference (PVSC), 2015, . IEEE",
-   year    = "2015",
-   volume  = "",
-   pages   = "1--5",
-   url     = "",
-   doi     = ""
+   author  = {M. A. Stevens and C. Downs and D. Emerson and J. Adler and S. Maclachlan and T. E. Vandervelde},
+   title   = {Studying anomalous open-circuit voltage drop-out in concentrated photovoltaics using computational numerical analysis},
+   journal = {Proceedings of the 42nd Photovoltaic Specialist Conference (PVSC), 2015, . IEEE},
+   year    = {2015},
+   volume  = {},
+   pages   = {1--5},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_130,
-   author  = "M. Stoll and T. Breiten",
-   title   = "A low-rank in time approach to PDE-constrained optimization",
-   journal = "SIAM J. Sci Comput., Vol 37, No.1, pp. B1-B29",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/130926365",
-   doi     = ""
+   author  = {M. Stoll and T. Breiten},
+   title   = {A low-rank in time approach to PDE-constrained optimization},
+   journal = {SIAM J. Sci Comput., Vol 37, No.1, pp. B1-B29},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/130926365},
+   doi     = {}
 }
 
 @mastersthesis{2015_131,
-   author  = "M. Tezzele",
-   title   = "Isogeometric analysis in HPC: object oriented design and open source massively parallel implementation",
-   year    = "2015",
-   school  = "University of Milan",
-   url     = ""
+   author  = {M. Tezzele},
+   title   = {Isogeometric analysis in HPC: object oriented design and open source massively parallel implementation},
+   year    = {2015},
+   school  = {University of Milan},
+   url     = {}
 }
 
 @article{2015_132,
-   author  = "K. Thurley and D. Gerecht and E. Friedmann and T. H&ouml;fer",
-   title   = "Three-Dimensional Gradients of Cytokine Signaling between T Cells",
-   journal = "PLOS Computational Biology, article e1004206",
-   year    = "2015",
-   volume  = "11",
-   pages   = "",
-   url     = "http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1004206",
-   doi     = "10.1371/journal.pcbi.1004206"
+   author  = {K. Thurley and D. Gerecht and E. Friedmann and T. H\"{o}fer},
+   title   = {Three-Dimensional Gradients of Cytokine Signaling between T Cells},
+   journal = {PLOS Computational Biology, article e1004206},
+   year    = {2015},
+   volume  = {11},
+   pages   = {},
+   url     = {http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1004206},
+   doi     = {10.1371/journal.pcbi.1004206}
 }
 
 @article{2015_133,
-   author  = "S. Tirupathi and J. S. Hesthaven and Y. Liang",
-   title   = "Modeling 3D Magma Dynamics Using a Discontinuous Galerkin Method",
-   journal = "Communications in Computational Physics, num. 01, pp 230-246",
-   year    = "2015",
-   volume  = "18",
-   pages   = "",
-   url     = "http://infoscience.epfl.ch/record/197481",
-   doi     = ""
+   author  = {S. Tirupathi and J. S. Hesthaven and Y. Liang},
+   title   = {Modeling 3D Magma Dynamics Using a Discontinuous Galerkin Method},
+   journal = {Communications in Computational Physics, num. 01, pp 230-246},
+   year    = {2015},
+   volume  = {18},
+   pages   = {},
+   url     = {http://infoscience.epfl.ch/record/197481},
+   doi     = {}
 }
 
 @article{2015_134,
-   author  = "S. Tirupathi and J. S. Hesthaven and Y. Liang and M. Parmentier",
-   title   = "Multilevel and local time-stepping discontinuous Galerkin methods for magma dynamics",
-   journal = "Computational Geosciences, Vol. 19, Issue 4",
-   year    = "2015",
-   volume  = "",
-   pages   = "965--978",
-   url     = "http://link.springer.com/article/10.1007/s10596-015-9514-7",
-   doi     = ""
+   author  = {S. Tirupathi and J. S. Hesthaven and Y. Liang and M. Parmentier},
+   title   = {Multilevel and local time-stepping discontinuous Galerkin methods for magma dynamics},
+   journal = {Computational Geosciences, Vol. 19, Issue 4},
+   year    = {2015},
+   volume  = {},
+   pages   = {965--978},
+   url     = {http://link.springer.com/article/10.1007/s10596-015-9514-7},
+   doi     = {}
 }
 
 @article{2015_135,
-   author  = "N. Tosi and C. Stein and L. Noack and C. Huttig and P. Maierova and H. Samuel and D. R. Davies and C. R. Wilson and S. C. Kramer and C. Thieulot and A. Glerum and M. Fraters and W. Spakman and A. Rozel and P. J. Tackley",
-   title   = "A community benchmark for viscoplastic thermal convection in a 2-D square box",
-   journal = "Geochemistry, Geophysics, Geosystems, Vol. 16, Issue 7",
-   year    = "2015",
-   volume  = "",
-   pages   = "2175--2196",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/2015GC005807/full",
-   doi     = ""
+   author  = {N. Tosi and C. Stein and L. Noack and C. Huttig and P. Maierova and H. Samuel and D. R. Davies and C. R. Wilson and S. C. Kramer and C. Thieulot and A. Glerum and M. Fraters and W. Spakman and A. Rozel and P. J. Tackley},
+   title   = {A community benchmark for viscoplastic thermal convection in a 2-D square box},
+   journal = {Geochemistry, Geophysics, Geosystems, Vol. 16, Issue 7},
+   year    = {2015},
+   volume  = {},
+   pages   = {2175--2196},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2015GC005807/full},
+   doi     = {}
 }
 
 @article{2015_136,
-   author  = "B. Turcksin and T. Heister and W. Bangerth",
-   title   = "Clone and graft: Testing scientific applications as they are built",
-   journal = "arXiv: 1508.07231",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1508.07231",
-   doi     = ""
+   author  = {B. Turcksin and T. Heister and W. Bangerth},
+   title   = {Clone and graft: Testing scientific applications as they are built},
+   journal = {arXiv: 1508.07231},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1508.07231},
+   doi     = {}
 }
 
 @article{2015_137,
-   author  = "F. P. Vanegas and J. Galvis and J. M. Mantilla",
-   title   = "Some numerical studies of oscillating chemical reactions using discontinuous finite elements",
-   journal = "Revista de la Facultad de Ciencias, Universidad Nacional de Colombia, issue 2",
-   year    = "2015",
-   volume  = "3",
-   pages   = "81--93",
-   url     = "http://www.revistas.unal.edu.co/index.php/rfc/article/viewFile/50864/51158",
-   doi     = ""
+   author  = {F. P. Vanegas and J. Galvis and J. M. Mantilla},
+   title   = {Some numerical studies of oscillating chemical reactions using discontinuous finite elements},
+   journal = {Revista de la Facultad de Ciencias, Universidad Nacional de Colombia, issue 2},
+   year    = {2015},
+   volume  = {3},
+   pages   = {81--93},
+   url     = {http://www.revistas.unal.edu.co/index.php/rfc/article/viewFile/50864/51158},
+   doi     = {}
 }
 
 @article{2015_138,
-   author  = "A. Vidal-Ferrandiz and R. Fayez and D. Ginestar and G. Verdu",
-   title   = "Moving meshes to solve the time-dependent neutron diffusion equation in hexagonal geometry",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2015",
-   volume  = "291",
-   pages   = "197--208",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0377042715001934",
-   doi     = ""
+   author  = {A. Vidal-Ferrandiz and R. Fayez and D. Ginestar and G. Verdu},
+   title   = {Moving meshes to solve the time-dependent neutron diffusion equation in hexagonal geometry},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2015},
+   volume  = {291},
+   pages   = {197--208},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0377042715001934},
+   doi     = {}
 }
 
 @article{2015_139,
-   author  = "G. Vienne and X. Chen and Y. S. Teh and Y. J. Ng and N. O. Chia and C. P. Ooi",
-   title   = "Novel layout of a bi-metallic nanoring for magnetic field pulse generation from light",
-   journal = "New J. Phys., article 013049",
-   year    = "2015",
-   volume  = "17",
-   pages   = "",
-   url     = "http://iopscience.iop.org/1367-2630/17/1/013049",
-   doi     = ""
+   author  = {G. Vienne and X. Chen and Y. S. Teh and Y. J. Ng and N. O. Chia and C. P. Ooi},
+   title   = {Novel layout of a bi-metallic nanoring for magnetic field pulse generation from light},
+   journal = {New J. Phys., article 013049},
+   year    = {2015},
+   volume  = {17},
+   pages   = {},
+   url     = {http://iopscience.iop.org/1367-2630/17/1/013049},
+   doi     = {}
 }
 
 @article{2015_140,
-   author  = "B. Wacker",
-   title   = "Stabilisierte Lagrange Finite-Elemente im Elektromagnetismus und in der inkompressiblen Magnetohydrodynamik",
-   journal = "PhD dissertation, University of Goettingen",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "https://ediss.uni-goettingen.de/bitstream/handle/11858/00-1735-0000-0023-9675-E/Dissertation_Wacker_2015_10_26_Final.pdf?sequence=1",
-   doi     = ""
+   author  = {B. Wacker},
+   title   = {Stabilisierte Lagrange Finite-Elemente im Elektromagnetismus und in der inkompressiblen Magnetohydrodynamik},
+   journal = {PhD dissertation, University of Goettingen},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {https://ediss.uni-goettingen.de/bitstream/handle/11858/00-1735-0000-0023-9675-E/Dissertation_Wacker_2015_10_26_Final.pdf?sequence=1},
+   doi     = {}
 }
 
 @phdthesis{2015_141,
-   author  = "M. Wallraff",
-   title   = "An investigation of multigrid algorithms for a higher order Discontinuous Galerkin RANS solver",
-   year    = "2015",
-   school  = "TU Braunschweig, Germany",
-   url     = ""
+   author  = {M. Wallraff},
+   title   = {An investigation of multigrid algorithms for a higher order Discontinuous Galerkin RANS solver},
+   year    = {2015},
+   school  = {TU Braunschweig, Germany},
+   url     = {}
 }
 
 @article{2015_142,
-   author  = "M. Wallraff and R. Hartmann and T. Leicht",
-   title   = "Multigrid solver algorithms for DG methods and applications to aerodynamic flows",
-   journal = "In N. Kroll and C. Hirsch and F. Bassi and C. Johnston and K. Hillewaert, editors, IDIHOM - Industrialization of High-Order Methods - A Top Down Approach, Vol. 128 of Notes on Numerical Fluid Mechanics and Multidisciplinary Design, pages 153-178, Springer",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Wallraff and R. Hartmann and T. Leicht},
+   title   = {Multigrid solver algorithms for DG methods and applications to aerodynamic flows},
+   journal = {In N. Kroll and C. Hirsch and F. Bassi and C. Johnston and K. Hillewaert, editors, IDIHOM - Industrialization of High-Order Methods - A Top Down Approach, Vol. 128 of Notes on Numerical Fluid Mechanics and Multidisciplinary Design, pages 153-178, Springer},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_143,
-   author  = "D. Wells",
-   title   = "Stabilization of POD-ROMs",
-   journal = "PhD dissertation, Virginia Tech",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "https://vtechworks.lib.vt.edu/handle/10919/52960",
-   doi     = ""
+   author  = {D. Wells},
+   title   = {Stabilization of POD-ROMs},
+   journal = {PhD dissertation, Virginia Tech},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {https://vtechworks.lib.vt.edu/handle/10919/52960},
+   doi     = {}
 }
 
 @article{2015_144,
-   author  = "D. Wells and Z. Wang and X. Xie and T. Iliescu",
-   title   = "Regularized Reduced Order Models",
-   journal = "arXiv:1506.07555",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Wells and Z. Wang and X. Xie and T. Iliescu},
+   title   = {Regularized Reduced Order Models},
+   journal = {arXiv:1506.07555},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_145,
-   author  = "H. Wernsing and C. B&uuml;skens.",
-   title   = "Parameter identification for finite element based models in dry machining applications",
-   journal = "Procedia CIRP, 31",
-   year    = "2015",
-   volume  = "",
-   pages   = "328--333",
-   url     = "",
-   doi     = ""
+   author  = {H. Wernsing and C. B\"{u}skens.},
+   title   = {Parameter identification for finite element based models in dry machining applications},
+   journal = {Procedia CIRP, 31},
+   year    = {2015},
+   volume  = {},
+   pages   = {328--333},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_146,
-   author  = "T. Wick and S. Lee and M. F. Wheeler",
-   title   = "3D Phase-Field for Pressurized Fracture Propagation in Heterogeneous Media",
-   journal = "VI International Conference on Computational Methods for Coupled Problems in Science and Engineering 2015 Proceedings",
-   year    = "2015",
-   volume  = "",
-   pages   = "605--613",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick and S. Lee and M. F. Wheeler},
+   title   = {3D Phase-Field for Pressurized Fracture Propagation in Heterogeneous Media},
+   journal = {VI International Conference on Computational Methods for Coupled Problems in Science and Engineering 2015 Proceedings},
+   year    = {2015},
+   volume  = {},
+   pages   = {605--613},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_147,
-   author  = "T. Wick and G. Singh and M. F. Wheeler",
-   title   = "Fluid-Filled Fracture Propagation using a Phase-Field Approach and Coupling to a Reservoir Simulator",
-   journal = "Reservoir Simulator, SPE Journal",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "https://people.ricam.oeaw.ac.at/t.wick/publikationen_engl.html",
-   doi     = "10.2118/168597-PA"
+   author  = {T. Wick and G. Singh and M. F. Wheeler},
+   title   = {Fluid-Filled Fracture Propagation using a Phase-Field Approach and Coupling to a Reservoir Simulator},
+   journal = {Reservoir Simulator, SPE Journal},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {https://people.ricam.oeaw.ac.at/t.wick/publikationen_engl.html},
+   doi     = {10.2118/168597-PA}
 }
 
 @article{2015_148,
-   author  = "D. Wick and T. Wick and H. R. Hellmig and H.-J. Christ",
-   title   = "Numerical simulations of crack propagation in screws with phase-field modeling",
-   journal = "Computational Materials Science",
-   year    = "2015",
-   volume  = "109",
-   pages   = "367--379",
-   url     = "",
-   doi     = ""
+   author  = {D. Wick and T. Wick and H. R. Hellmig and H.-J. Christ},
+   title   = {Numerical simulations of crack propagation in screws with phase-field modeling},
+   journal = {Computational Materials Science},
+   year    = {2015},
+   volume  = {109},
+   pages   = {367--379},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_149,
-   author  = "J. Wilmers and S. Bargmann",
-   title   = "A continuum mechanical model for the description of solvent induced swelling in polymeric glasses: Thermomechanics coupled with diffusion",
-   journal = "European Journal of Mechanics - A/Solids, Vol. 53",
-   year    = "2015",
-   volume  = "",
-   pages   = "10--18",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0997753815000224",
-   doi     = ""
+   author  = {J. Wilmers and S. Bargmann},
+   title   = {A continuum mechanical model for the description of solvent induced swelling in polymeric glasses: Thermomechanics coupled with diffusion},
+   journal = {European Journal of Mechanics - A/Solids, Vol. 53},
+   year    = {2015},
+   volume  = {},
+   pages   = {10--18},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0997753815000224},
+   doi     = {}
 }
 
 @mastersthesis{2015_150,
-   author  = "I. van Zelst",
-   title   = "Mantle dynamics on Venus: insights from numerical modelling",
-   year    = "2015",
-   school  = "University of Utrecht, The Netherlands",
-   url     = "http://dspace.library.uu.nl/bitstream/handle/1874/316227/Iris_van_Zelst_final_master_thesis.pdf"
+   author  = {I. van Zelst},
+   title   = {Mantle dynamics on Venus: insights from numerical modelling},
+   year    = {2015},
+   school  = {University of Utrecht, The Netherlands},
+   url     = {http://dspace.library.uu.nl/bitstream/handle/1874/316227/Iris_van_Zelst_final_master_thesis.pdf}
 }
 
 @article{2015_151,
-   author  = "A. Zareei and M.-R. Alam",
-   title   = "Cloaking in shallow-water waves via nonlinear medium transformation",
-   journal = "Journal of Fluid Mechanics",
-   year    = "2015",
-   volume  = "778",
-   pages   = "273--287",
-   url     = "http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=9886676&fileId=S002211201500350X",
-   doi     = ""
+   author  = {A. Zareei and M.-R. Alam},
+   title   = {Cloaking in shallow-water waves via nonlinear medium transformation},
+   journal = {Journal of Fluid Mechanics},
+   year    = {2015},
+   volume  = {778},
+   pages   = {273--287},
+   url     = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=9886676&fileId=S002211201500350X},
+   doi     = {}
 }
 
 @article{2015_152,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "Non-oscillatory Reweighted Least Square Finite Element Method for SN Transport",
-   journal = "Transactions of American Nuclear Society, Vol. 113, No. 1, pp 688-691",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {Non-oscillatory Reweighted Least Square Finite Element Method for SN Transport},
+   journal = {Transactions of American Nuclear Society, Vol. 113, No. 1, pp 688-691},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2015_153,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "Non-oscillatory Reweighted Least Square Finite Element for Solving PN Transport",
-   journal = "Transactions of American Nuclear Society, Vol. 113, No. 1, pp 692-695",
-   year    = "2015",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {Non-oscillatory Reweighted Least Square Finite Element for Solving PN Transport},
+   journal = {Transactions of American Nuclear Society, Vol. 113, No. 1, pp 692-695},
+   year    = {2015},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1,2308 +1,1434 @@
 % Encoding: ISO-8859-1
 
 @article{2016_0,
-   author  = "J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan",
-   title   = "A Deflation Technique for Detecting Multiple Liquid Crystal Equilibrium States",
-   journal = "arXiv:1601.07383",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://arxiv.org/abs/1601.07383",
-   doi     = ""
+   author  = {J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan},
+   title   = {A Deflation Technique for Detecting Multiple Liquid Crystal Equilibrium States},
+   journal = {arXiv:1601.07383},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://arxiv.org/abs/1601.07383},
+   doi     = {}
 }
 
 @article{2016_1,
-   author  = "J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel",
-   title   = "Constrained Optimization for Liquid Crystal Equilibria",
-   journal = "SIAM J. Sci. Comput., (1), B50-B76",
-   year    = "2016",
-   volume  = "38",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/141001846",
-   doi     = ""
+   author  = {J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel},
+   title   = {Constrained Optimization for Liquid Crystal Equilibria},
+   journal = {SIAM J. Sci. Comput., (1), B50-B76},
+   year    = {2016},
+   volume  = {38},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/141001846},
+   doi     = {}
 }
 
 @article{2016_2,
-   author  = "J. C. Araujo-Cabarcas and C. Engstr&ouml;m",
-   title   = "On spurious solutions in finite element approximations of resonances in open systems",
-   journal = "ICES REPORT 16-18, and arxiv:1606.09635",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1606.09635",
-   doi     = ""
+   author  = {J. C. Araujo-Cabarcas and C. Engstr\"{o}m},
+   title   = {On spurious solutions in finite element approximations of resonances in open systems},
+   journal = {ICES REPORT 16-18, and arxiv:1606.09635},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1606.09635},
+   doi     = {}
 }
 
 @article{2016_3,
-   author  = "T. Arbogast and M. A. Hesse and and A. L. Taicher",
-   title   = "Mixed methods for two-phase Darcy-Stokes mixtures of partially melted materials with regions of zero porosity",
-   journal = "ICES REPORT 16-18",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.ices.utexas.edu/media/reports/2016/1618.pdf",
-   doi     = ""
+   author  = {T. Arbogast and M. A. Hesse and and A. L. Taicher},
+   title   = {Mixed methods for two-phase Darcy-Stokes mixtures of partially melted materials with regions of zero porosity},
+   journal = {ICES REPORT 16-18},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.ices.utexas.edu/media/reports/2016/1618.pdf},
+   doi     = {}
 }
 
 @article{2016_4,
-   author  = "T. Arbogast and A. L. Taicher",
-   title   = "A Linear Degenerate Elliptic Equation Arising from Two-Phase Mixtures",
-   journal = "SIAM J. Numer. Anal., issue 5",
-   year    = "2016",
-   volume  = "54",
-   pages   = "3105--3122",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/16M1067846",
-   doi     = ""
+   author  = {T. Arbogast and A. L. Taicher},
+   title   = {A Linear Degenerate Elliptic Equation Arising from Two-Phase Mixtures},
+   journal = {SIAM J. Numer. Anal., issue 5},
+   year    = {2016},
+   volume  = {54},
+   pages   = {3105--3122},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1067846},
+   doi     = {}
 }
 
 @phdthesis{2016_5,
-   author  = "D. Arndt",
-   title   = "Stabilized Finite Element Methods for Coupled Incompressible Flow",
-   year    = "2016",
-   school  = "Georg-August-Universit&auml;t G&ouml;ttingen, Germany",
-   url     = ""
+   author  = {D. Arndt},
+   title   = {Stabilized Finite Element Methods for Coupled Incompressible Flow},
+   year    = {2016},
+   school  = {Georg-August-Universit\"{a}t G\"{o}ttingen, Germany},
+   url     = {}
 }
 
 @article{2016_6,
-   author  = "O. Axelsson and S. Farouq and M. Neytcheva",
-   title   = "Comparison of preconditioned Krylov subspace iteration methods for PDE-constrained optimization problems. Poisson and convection-diffusion control",
-   journal = "Numerical Algorithm, issue 3",
-   year    = "2016",
-   volume  = "73",
-   pages   = "631--663",
-   url     = "https://link.springer.com/article/10.1007/s11075-016-0111-1",
-   doi     = ""
+   author  = {O. Axelsson and S. Farouq and M. Neytcheva},
+   title   = {Comparison of preconditioned Krylov subspace iteration methods for PDE-constrained optimization problems. Poisson and convection-diffusion control},
+   journal = {Numerical Algorithm, issue 3},
+   year    = {2016},
+   volume  = {73},
+   pages   = {631--663},
+   url     = {https://link.springer.com/article/10.1007/s11075-016-0111-1},
+   doi     = {}
 }
 
 @mastersthesis{2016_7,
-   author  = "C. A. Balen",
-   title   = "A Multi-Component Mass Transport Model for Polymer Electrolyte Fuel Cells",
-   year    = "2016",
-   school  = "University of Alberta, Australia",
-   url     = "http://www.esdlab.mece.ualberta.ca/pdfs/Balen_Chad_A_201607_MSc.pdf"
+   author  = {C. A. Balen},
+   title   = {A Multi-Component Mass Transport Model for Polymer Electrolyte Fuel Cells},
+   year    = {2016},
+   school  = {University of Alberta, Australia},
+   url     = {http://www.esdlab.mece.ualberta.ca/pdfs/Balen_Chad_A_201607_MSc.pdf}
 }
 
 @article{2016_8,
-   author  = "J. Ballani and D. Kressner and M. Peters",
-   title   = "Multilevel tensor approximation of PDEs with random data",
-   journal = "ArXiv: 1606.05505",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1606.05505",
-   doi     = ""
+   author  = {J. Ballani and D. Kressner and M. Peters},
+   title   = {Multilevel tensor approximation of PDEs with random data},
+   journal = {ArXiv: 1606.05505},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1606.05505},
+   doi     = {}
 }
 
 @article{2016_9,
-   author  = "J. Ballani and D. Kressner",
-   title   = "Reduced basis methods: from low-rank matrices to low-rank tensors",
-   journal = "SIAM Journal on Scientific Computing Vol. 38, No. 4, pp. A2045-A2067",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/15M1042784",
-   doi     = ""
+   author  = {J. Ballani and D. Kressner},
+   title   = {Reduced basis methods: from low-rank matrices to low-rank tensors},
+   journal = {SIAM Journal on Scientific Computing Vol. 38, No. 4, pp. A2045-A2067},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1042784},
+   doi     = {}
 }
 
 @article{2016_10,
-   author  = "W. Bangerth and D. Davydov and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and B. Turcksin and D. Wells",
-   title   = "The <abbr>deal.II</abbr> Library, Version 8.4",
-   journal = "Journal of Numerical Mathematics",
-   year    = "2016",
-   volume  = "24",
-   pages   = "135--141",
-   url     = "",
-   doi     = "10.1515/jnma-2016-1045"
+   author  = {W. Bangerth and D. Davydov and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and B. Turcksin and D. Wells},
+   title   = {The \texttt{deal.II} Library, Version 8.4},
+   journal = {Journal of Numerical Mathematics},
+   year    = {2016},
+   volume  = {24},
+   pages   = {135--141},
+   url     = {},
+   doi     = {10.1515/jnma-2016-1045}
 }
 
 @article{2016_11,
-   author  = "W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and B. Turcksin",
-   title   = "The <abbr>deal.II</abbr> Library, Version 8.3",
-   journal = "Archive of Numerical Software",
-   year    = "2016",
-   volume  = "4",
-   pages   = "1--11",
-   url     = "",
-   doi     = "10.11588/ans.2016.100.23122"
+   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and B. Turcksin},
+   title   = {The \texttt{deal.II} Library, Version 8.3},
+   journal = {Archive of Numerical Software},
+   year    = {2016},
+   volume  = {4},
+   pages   = {1--11},
+   url     = {},
+   doi     = {10.11588/ans.2016.100.23122}
 }
 
 @article{2016_12,
-   author  = "A. Barker and T. Rees and M. Stoll",
-   title   = "A fast solver for an H<sup>1</sup> regularized PDE-constrained optimization problem",
-   journal = "Communications in Computational Physics, issue 1",
-   year    = "2016",
-   volume  = "19",
-   pages   = "143--167",
-   url     = "https://www.cambridge.org/core/journals/communications-in-computational-physics/article/fast-solver-for-an-h1-regularized-pdeconstrained-optimization-problem/8109B45FF4F96F568D3383EA8835A7E7",
-   doi     = ""
+   author  = {A. Barker and T. Rees and M. Stoll},
+   title   = {A fast solver for an H$^{1}$ regularized PDE-constrained optimization problem},
+   journal = {Communications in Computational Physics, issue 1},
+   year    = {2016},
+   volume  = {19},
+   pages   = {143--167},
+   url     = {https://www.cambridge.org/core/journals/communications-in-computational-physics/article/fast-solver-for-an-h1-regularized-pdeconstrained-optimization-problem/8109B45FF4F96F568D3383EA8835A7E7},
+   doi     = {}
 }
 
 @article{2016_13,
-   author  = "M. Bause and U. Köcher",
-   title   = "Iterative coupling of variational space-time methods for Biot's system of poroelasticity",
-   journal = "Numer. Math. Adv. Appl. ENUMATH",
-   year    = "2016",
-   volume  = "2015",
-   pages   = "143--151",
-   url     = "https://link.springer.com/chapter/10.1007%2F978-3-319-39929-4_15",
-   doi     = ""
+   author  = {M. Bause and U. K\"{o}cher},
+   title   = {Iterative coupling of variational space-time methods for Biot's system of poroelasticity},
+   journal = {Numer. Math. Adv. Appl. ENUMATH},
+   year    = {2016},
+   volume  = {2015},
+   pages   = {143--151},
+   url     = {https://link.springer.com/chapter/10.1007%2F978-3-319-39929-4_15},
+   doi     = {}
 }
 
 @phdthesis{2016_14,
-   author  = "C. Beez",
-   title   = "Funktionsinterpolation: Alternativen zu EIM/DEIM",
-   year    = "2016",
-   school  = "Project thesis, Friedrich-Alexander-Universit&auml;t Erlangen-N&uuml;rnberg",
-   url     = ""
+   author  = {C. Beez},
+   title   = {Funktionsinterpolation: Alternativen zu EIM/DEIM},
+   year    = {2016},
+   school  = {Project thesis, Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   url     = {}
 }
 
 @mastersthesis{2016_15,
-   author  = "C. A. H. Blom",
-   title   = "State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls",
-   year    = "2016",
-   school  = "Utrecht University, The Netherlands",
-   url     = ""
+   author  = {C. A. H. Blom},
+   title   = {State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls},
+   year    = {2016},
+   school  = {Utrecht University, The Netherlands},
+   url     = {}
 }
 
 @article{2016_16,
-   author  = "A. Bonito and A. Demlow",
-   title   = "Convergence and optimality of higher-order adaptive finite element methods for eigenvalue clusters",
-   journal = "SIAM J. Numer. Anal., issue 4, pp. 2379–2388",
-   year    = "2016",
-   volume  = "54",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/15M1036877.",
-   doi     = ""
+   author  = {A. Bonito and A. Demlow},
+   title   = {Convergence and optimality of higher-order adaptive finite element methods for eigenvalue clusters},
+   journal = {SIAM J. Numer. Anal., issue 4, pp. 2379--2388},
+   year    = {2016},
+   volume  = {54},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1036877.},
+   doi     = {}
 }
 
 @article{2016_17,
-   author  = "A. Bonito and J.-L. Guermond and S. Lee",
-   title   = "Numerical Simulations of Bouncing Jets",
-   journal = "Internat. J. Numer. Methods Fluids, Vol. 80, No. 1",
-   year    = "2016",
-   volume  = "",
-   pages   = "53--75",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/fld.4071/full",
-   doi     = ""
+   author  = {A. Bonito and J.-L. Guermond and S. Lee},
+   title   = {Numerical Simulations of Bouncing Jets},
+   journal = {Internat. J. Numer. Methods Fluids, Vol. 80, No. 1},
+   year    = {2016},
+   volume  = {},
+   pages   = {53--75},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.4071/full},
+   doi     = {}
 }
 
 @article{2016_18,
-   author  = "J. Bosch",
-   title   = "Fast Iterative Solvers for Cahn–Hilliard Problems",
-   journal = "PhD dissertation, Otto von Guericke University Magdeburg, Germany",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://pubman.mpdl.mpg.de/pubman/item/escidoc:2306051/component/escidoc:2400003/Dissertation_Bosch.pdf",
-   doi     = ""
+   author  = {J. Bosch},
+   title   = {Fast Iterative Solvers for Cahn--Hilliard Problems},
+   journal = {PhD dissertation, Otto von Guericke University Magdeburg, Germany},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://pubman.mpdl.mpg.de/pubman/item/escidoc:2306051/component/escidoc:2400003/Dissertation_Bosch.pdf},
+   doi     = {}
 }
 
 @article{2016_19,
-   author  = "C. A. Brand",
-   title   = "Forces and Flow of Contractile Networks",
-   journal = "PhD dissertation, University of Heidelberg, Germany",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://archiv.ub.uni-heidelberg.de/volltextserver/20233/",
-   doi     = ""
+   author  = {C. A. Brand},
+   title   = {Forces and Flow of Contractile Networks},
+   journal = {PhD dissertation, University of Heidelberg, Germany},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20233/},
+   doi     = {}
 }
 
 @article{2016_20,
-   author  = "B. Brands and J. Mergheim and P. Steinmann",
-   title   = "Reduced-order modelling for linear heat conduction with parametrised moving heat sources",
-   journal = "GAMM-Mitteilungen",
-   year    = "2016",
-   volume  = "39",
-   pages   = "170--188",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/gamm.201610011/full",
-   doi     = "10.1002/gamm.201610011"
+   author  = {B. Brands and J. Mergheim and P. Steinmann},
+   title   = {Reduced-order modelling for linear heat conduction with parametrised moving heat sources},
+   journal = {GAMM-Mitteilungen},
+   year    = {2016},
+   volume  = {39},
+   pages   = {170--188},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/gamm.201610011/full},
+   doi     = {10.1002/gamm.201610011}
 }
 
 @article{2016_21,
-   author  = "S.C. Brenner and M. Oh and S. Pollock and K. Porwal and M. Schedensack and N. S. Sharma",
-   title   = "A C<sup>0</sup> Interior Penalty Method for Elliptic Distributed Optimal Control Problems in Three Dimensions with Pointwise State Constraints",
-   journal = "Topics in Numerical Partial Differential Equations and Scientific Computing",
-   year    = "2016",
-   volume  = "160",
-   pages   = "1--22",
-   url     = "https://link.springer.com/chapter/10.1007/978-1-4939-6399-7_1",
-   doi     = ""
+   author  = {S.C. Brenner and M. Oh and S. Pollock and K. Porwal and M. Schedensack and N. S. Sharma},
+   title   = {A C$^{0}$ Interior Penalty Method for Elliptic Distributed Optimal Control Problems in Three Dimensions with Pointwise State Constraints},
+   journal = {Topics in Numerical Partial Differential Equations and Scientific Computing},
+   year    = {2016},
+   volume  = {160},
+   pages   = {1--22},
+   url     = {https://link.springer.com/chapter/10.1007/978-1-4939-6399-7_1},
+   doi     = {}
 }
 
 @article{2016_22,
-   author  = "G. Bucci and Y. M. Chiang and W. C. Carter",
-   title   = "Formulation of the coupled electrochemical-mechanical boundary value problem, with applications to transport of multiple charged species",
-   journal = "Acta Materialia Vol. 104",
-   year    = "2016",
-   volume  = "",
-   pages   = "33--51",
-   url     = "http://www.sciencedirect.com/science/article/pii/S1359645415300811",
-   doi     = ""
+   author  = {G. Bucci and Y. M. Chiang and W. C. Carter},
+   title   = {Formulation of the coupled electrochemical-mechanical boundary value problem, with applications to transport of multiple charged species},
+   journal = {Acta Materialia Vol. 104},
+   year    = {2016},
+   volume  = {},
+   pages   = {33--51},
+   url     = {http://www.sciencedirect.com/science/article/pii/S1359645415300811},
+   doi     = {}
 }
 
 @mastersthesis{2016_23,
-   author  = "L. Bystricky",
-   title   = "Using deal.ii to solve problems in computational fluid dynamics",
-   year    = "2016",
-   school  = "The Florida State University",
-   url     = "http://search.proquest.com/docview/1806862661/previewPDF/E6506DE2A6364AD3PQ/1?accountid=7082"
+   author  = {L. Bystricky},
+   title   = {Using deal.ii to solve problems in computational fluid dynamics},
+   year    = {2016},
+   school  = {The Florida State University},
+   url     = {http://search.proquest.com/docview/1806862661/previewPDF/E6506DE2A6364AD3PQ/1?accountid=7082}
 }
 
 @article{2016_24,
-   author  = "K. Bzowski and D. Bachniak and M. Pernach and M. Pietrzyk",
-   title   = "Sensitivity analysis of phase transformation model based on solution of diffusion equation",
-   journal = "Archives of Civil and Mechanical Engineering, Vol. 16",
-   year    = "2016",
-   volume  = "",
-   pages   = "186--192",
-   url     = "http://www.sciencedirect.com/science/article/pii/S164496651500093X",
-   doi     = ""
+   author  = {K. Bzowski and D. Bachniak and M. Pernach and M. Pietrzyk},
+   title   = {Sensitivity analysis of phase transformation model based on solution of diffusion equation},
+   journal = {Archives of Civil and Mechanical Engineering, Vol. 16},
+   year    = {2016},
+   volume  = {},
+   pages   = {186--192},
+   url     = {http://www.sciencedirect.com/science/article/pii/S164496651500093X},
+   doi     = {}
 }
 
 @article{2016_25,
-   author  = "A. Cangiani and E. H. Georgoulis and I. Kyza and S. Metcalfe",
-   title   = "Adaptivity and blow-up detection for nonlinear evolution problems",
-   journal = "SIAM J. Sci. Comput., issue 6, pp. A3833–A3856",
-   year    = "2016",
-   volume  = "38",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/16M106073X?journalCode=sjoce3",
-   doi     = ""
+   author  = {A. Cangiani and E. H. Georgoulis and I. Kyza and S. Metcalfe},
+   title   = {Adaptivity and blow-up detection for nonlinear evolution problems},
+   journal = {SIAM J. Sci. Comput., issue 6, pp. A3833--A3856},
+   year    = {2016},
+   volume  = {38},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/16M106073X?journalCode=sjoce3},
+   doi     = {}
 }
 
 @article{2016_26,
-   author  = "T. Carraro and E. Friedmann and D. Gerecht",
-   title   = "Coupling vs decoupling approaches for PDE/ODE systems modeling intercellular signaling",
-   journal = "Journal of Computational Physics",
-   year    = "2016",
-   volume  = "314",
-   pages   = "522--537",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999116001728",
-   doi     = ""
+   author  = {T. Carraro and E. Friedmann and D. Gerecht},
+   title   = {Coupling vs decoupling approaches for PDE/ODE systems modeling intercellular signaling},
+   journal = {Journal of Computational Physics},
+   year    = {2016},
+   volume  = {314},
+   pages   = {522--537},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116001728},
+   doi     = {}
 }
 
 @article{2016_27,
-   author  = "N. Castelletto and J. A. White and M. Ferronato",
-   title   = "Scalable algorithms for three-field mixed finite element coupled poromechanics",
-   journal = "Journal of Computational Physics",
-   year    = "2016",
-   volume  = "327",
-   pages   = "894--918",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999116304843",
-   doi     = ""
+   author  = {N. Castelletto and J. A. White and M. Ferronato},
+   title   = {Scalable algorithms for three-field mixed finite element coupled poromechanics},
+   journal = {Journal of Computational Physics},
+   year    = {2016},
+   volume  = {327},
+   pages   = {894--918},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116304843},
+   doi     = {}
 }
 
 @article{2016_28,
-   author  = "P. Chidyagwai and S. Ladenheim and and D. B. Szyld",
-   title   = "Constraint Preconditioning for the Coupled Stokes--Darcy System",
-   journal = "SIAM J. Sci. Comput., issue 2, A668–A690",
-   year    = "2016",
-   volume  = "38",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/15M1032156?journalCode=sjoce3",
-   doi     = ""
+   author  = {P. Chidyagwai and S. Ladenheim and and D. B. Szyld},
+   title   = {Constraint Preconditioning for the Coupled Stokes--Darcy System},
+   journal = {SIAM J. Sci. Comput., issue 2, A668--A690},
+   year    = {2016},
+   volume  = {38},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1032156?journalCode=sjoce3},
+   doi     = {}
 }
 
 @article{2016_29,
-   author  = "J. Choo and J. A. White and R. I. Borja",
-   title   = "Hydromechanical modeling of unsaturated flow in double porosity media",
-   journal = "ASCE International Journal of Geomechanics, issue 6",
-   year    = "2016",
-   volume  = "16",
-   pages   = "",
-   url     = "http://stanford.edu/~jinhyun/files/Choo_White_Borja_IJOG_2015.pdf",
-   doi     = ""
+   author  = {J. Choo and J. A. White and R. I. Borja},
+   title   = {Hydromechanical modeling of unsaturated flow in double porosity media},
+   journal = {ASCE International Journal of Geomechanics, issue 6},
+   year    = {2016},
+   volume  = {16},
+   pages   = {},
+   url     = {http://stanford.edu/~jinhyun/files/Choo_White_Borja_IJOG_2015.pdf},
+   doi     = {}
 }
 
 @article{2016_30,
-   author  = "M. Chugunova and B. Jadamba and C.-Y. Kao and C. Klymko and E. Thomas and B. Zhao",
-   title   = "Study of a Mixed Dispersal Population Dynamics Model",
-   journal = "Topics in Numerical Partial Differential Equations and Scientific Computing",
-   year    = "2016",
-   volume  = "160",
-   pages   = "51--77",
-   url     = "https://link.springer.com/chapter/10.1007/978-1-4939-6399-7_3",
-   doi     = ""
+   author  = {M. Chugunova and B. Jadamba and C.-Y. Kao and C. Klymko and E. Thomas and B. Zhao},
+   title   = {Study of a Mixed Dispersal Population Dynamics Model},
+   journal = {Topics in Numerical Partial Differential Equations and Scientific Computing},
+   year    = {2016},
+   volume  = {160},
+   pages   = {51--77},
+   url     = {https://link.springer.com/chapter/10.1007/978-1-4939-6399-7_3},
+   doi     = {}
 }
 
 @phdthesis{2016_31,
-   author  = "S. Cox",
-   title   = "Adaptive large-scale mantle convection simulations",
-   year    = "2016",
-   school  = "University of Leicester",
-   url     = ""
+   author  = {S. Cox},
+   title   = {Adaptive large-scale mantle convection simulations},
+   year    = {2016},
+   school  = {University of Leicester},
+   url     = {}
 }
 
 @article{2016_32,
-   author  = "H. Dallmann and D. Arndt and G. Lube",
-   title   = "Local projection stabilization for the Oseen problem",
-   journal = "IMA Journal of Numerical Analysis, issue 2",
-   year    = "2016",
-   volume  = "36",
-   pages   = "796--823",
-   url     = "",
-   doi     = ""
+   author  = {H. Dallmann and D. Arndt and G. Lube},
+   title   = {Local projection stabilization for the Oseen problem},
+   journal = {IMA Journal of Numerical Analysis, issue 2},
+   year    = {2016},
+   volume  = {36},
+   pages   = {796--823},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_33,
-   author  = "J. Dannberg and T. Heister",
-   title   = "Compressible Magma/Mantle Dynamics: 3d, Adaptive Simulations in ASPECT",
-   journal = "Geophysics Journal International",
-   year    = "2016",
-   volume  = "207",
-   pages   = "1343--1366",
-   url     = "http://dx.doi.org/10.1093/gji/ggw329",
-   doi     = ""
+   author  = {J. Dannberg and T. Heister},
+   title   = {Compressible Magma/Mantle Dynamics: 3d, Adaptive Simulations in ASPECT},
+   journal = {Geophysics Journal International},
+   year    = {2016},
+   volume  = {207},
+   pages   = {1343--1366},
+   url     = {http://dx.doi.org/10.1093/gji/ggw329},
+   doi     = {}
 }
 
 @article{2016_34,
-   author  = "D. Davydov and T. D. Young and P. Steinmann",
-   title   = "On the adaptive finite element analysis of the Kohn-Sham equations: Methods, algorithms, and implementation",
-   journal = "International Journal for Numerical Methods in Engineering, Vol. 106",
-   year    = "2016",
-   volume  = "",
-   pages   = "863--888",
-   url     = "http://dx.doi.org/10.1002/nme.5140",
-   doi     = ""
+   author  = {D. Davydov and T. D. Young and P. Steinmann},
+   title   = {On the adaptive finite element analysis of the Kohn-Sham equations: Methods, algorithms, and implementation},
+   journal = {International Journal for Numerical Methods in Engineering, Vol. 106},
+   year    = {2016},
+   volume  = {},
+   pages   = {863--888},
+   url     = {http://dx.doi.org/10.1002/nme.5140},
+   doi     = {}
 }
 
 @article{2016_35,
-   author  = "D. S. J. Dhillon and M. C. Milinkovitch and M. Zwicker",
-   title   = "Bifurcation Analysis of Reaction Diffusion Systems on Arbitrary Surfaces",
-   journal = "ArXiv:1605.01583",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1605.01583",
-   doi     = ""
+   author  = {D. S. J. Dhillon and M. C. Milinkovitch and M. Zwicker},
+   title   = {Bifurcation Analysis of Reaction Diffusion Systems on Arbitrary Surfaces},
+   journal = {ArXiv:1605.01583},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1605.01583},
+   doi     = {}
 }
 
 @article{2016_36,
-   author  = "B. S. M. Ebna Hai and M. Bause and P. A. Kuberry",
-   title   = "Finite Element Approximation of the eXtended Fluid-Structure Interaction (eXFSI) Problem",
-   journal = "In proceedings of: the ASME 2016 Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2016-7506, pp. V01AT11A001/1–12, July 10–14, Washington, DC, USA",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause and P. A. Kuberry},
+   title   = {Finite Element Approximation of the eXtended Fluid-Structure Interaction (eXFSI) Problem},
+   journal = {In proceedings of: the ASME 2016 Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2016-7506, pp. V01AT11A001/1--12, July 10--14, Washington, DC, USA},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_37,
-   author  = "L. Ellam and N. Zabaras and M. Girolami",
-   title   = "A Bayesian approach to multiscale inverse problems with on-the-fly scale determination",
-   journal = "Journal of Computational Physics",
-   year    = "2016",
-   volume  = "326",
-   pages   = "115--140",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999116303886",
-   doi     = ""
+   author  = {L. Ellam and N. Zabaras and M. Girolami},
+   title   = {A Bayesian approach to multiscale inverse problems with on-the-fly scale determination},
+   journal = {Journal of Computational Physics},
+   year    = {2016},
+   volume  = {326},
+   pages   = {115--140},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303886},
+   doi     = {}
 }
 
 @article{2016_38,
-   author  = "P. Exner and J. Brezina",
-   title   = "Partition of unity methods for approximation of point water sources in porous media",
-   journal = "Applied Mathematics and Computation",
-   year    = "2016",
-   volume  = "273",
-   pages   = "21--32",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0096300315012862",
-   doi     = ""
+   author  = {P. Exner and J. Brezina},
+   title   = {Partition of unity methods for approximation of point water sources in porous media},
+   journal = {Applied Mathematics and Computation},
+   year    = {2016},
+   volume  = {273},
+   pages   = {21--32},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0096300315012862},
+   doi     = {}
 }
 
 @article{2016_39,
-   author  = "F. Freddi and G. Royer-Carfagni",
-   title   = "Phase-field slip-line theory of plasticity",
-   journal = "Journal of the Mechanics and Physics of Solids",
-   year    = "2016",
-   volume  = "94",
-   pages   = "257--272",
-   url     = "",
-   doi     = "10.1016/j.jmps.2016.04.024"
+   author  = {F. Freddi and G. Royer-Carfagni},
+   title   = {Phase-field slip-line theory of plasticity},
+   journal = {Journal of the Mechanics and Physics of Solids},
+   year    = {2016},
+   volume  = {94},
+   pages   = {257--272},
+   url     = {},
+   doi     = {10.1016/j.jmps.2016.04.024}
 }
 
 @article{2016_40,
-   author  = "F. Freddi and E. Sacco",
-   title   = "A damage model for a finite thickness composite interface accounting for in-plane deformation",
-   journal = "Engineering Fraction Mechanics",
-   year    = "2016",
-   volume  = "163",
-   pages   = "396--415",
-   url     = "http://dx.doi.org/10.1016/j.engfracmech.2016.06.001",
-   doi     = ""
+   author  = {F. Freddi and E. Sacco},
+   title   = {A damage model for a finite thickness composite interface accounting for in-plane deformation},
+   journal = {Engineering Fraction Mechanics},
+   year    = {2016},
+   volume  = {163},
+   pages   = {396--415},
+   url     = {http://dx.doi.org/10.1016/j.engfracmech.2016.06.001},
+   doi     = {}
 }
 
 @article{2016_41,
-   author  = "F. Freddi and E. Sacco",
-   title   = "An interphase model for the analysis of the masonry-FRP bond",
-   journal = "Composite Structures, Volume 138",
-   year    = "2016",
-   volume  = "",
-   pages   = "322--334",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0263822315010442",
-   doi     = ""
+   author  = {F. Freddi and E. Sacco},
+   title   = {An interphase model for the analysis of the masonry-FRP bond},
+   journal = {Composite Structures, Volume 138},
+   year    = {2016},
+   volume  = {},
+   pages   = {322--334},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0263822315010442},
+   doi     = {}
 }
 
 @article{2016_42,
-   author  = "S. Frei",
-   title   = "Eulerian finite element methods for interface problems and fluid-structure interactions",
-   journal = "PhD dissertation, University of Heidelberg, Heidelberg, Germany",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/21590",
-   doi     = ""
+   author  = {S. Frei},
+   title   = {Eulerian finite element methods for interface problems and fluid-structure interactions},
+   journal = {PhD dissertation, University of Heidelberg, Heidelberg, Germany},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/21590},
+   doi     = {}
 }
 
 @article{2016_43,
-   author  = "S. Frei and T. Richter and T. Wick",
-   title   = "Long-term simulation of large deformation, mechano-chemical fluid-structure interactions in ALE and fully Eulerian coordinates",
-   journal = "Journal of Computational Physics",
-   year    = "2016",
-   volume  = "321",
-   pages   = "874--891",
-   url     = "",
-   doi     = ""
+   author  = {S. Frei and T. Richter and T. Wick},
+   title   = {Long-term simulation of large deformation, mechano-chemical fluid-structure interactions in ALE and fully Eulerian coordinates},
+   journal = {Journal of Computational Physics},
+   year    = {2016},
+   volume  = {321},
+   pages   = {874--891},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_44,
-   author  = "J. Frohne and T. Heister and W. Bangerth",
-   title   = "Efficient numerical methods for the large-scale, parallel solution of elastoplastic contact problems",
-   journal = "International Journal for Numerical Methods in Engineering",
-   year    = "2016",
-   volume  = "105",
-   pages   = "416--439",
-   url     = "",
-   doi     = ""
+   author  = {J. Frohne and T. Heister and W. Bangerth},
+   title   = {Efficient numerical methods for the large-scale, parallel solution of elastoplastic contact problems},
+   journal = {International Journal for Numerical Methods in Engineering},
+   year    = {2016},
+   volume  = {105},
+   pages   = {416--439},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_45,
-   author  = "G. Fu and Y. Jin and and W. Qiu",
-   title   = "Parameter-free superconvergent H(div)-conforming HDG methods for the Brinkman equations",
-   journal = "ArXiv:1607.07662",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1607.07662",
-   doi     = ""
+   author  = {G. Fu and Y. Jin and and W. Qiu},
+   title   = {Parameter-free superconvergent H(div)-conforming HDG methods for the Brinkman equations},
+   journal = {ArXiv:1607.07662},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1607.07662},
+   doi     = {}
 }
 
 @article{2016_46,
-   author  = "J. P. Gallego-Valencia and C. Klingenberg and P. Chandrashekar",
-   title   = "On limiting for higher order discontinuous Galerkin method for 2D Euler equations",
-   journal = "Bulletin of the Brazilian Mathematical Society, New Series, issue 1",
-   year    = "2016",
-   volume  = "47",
-   pages   = "335--345",
-   url     = "https://link.springer.com/article/10.1007/s00574-016-0142-1",
-   doi     = ""
+   author  = {J. P. Gallego-Valencia and C. Klingenberg and P. Chandrashekar},
+   title   = {On limiting for higher order discontinuous Galerkin method for 2D Euler equations},
+   journal = {Bulletin of the Brazilian Mathematical Society, New Series, issue 1},
+   year    = {2016},
+   volume  = {47},
+   pages   = {335--345},
+   url     = {https://link.springer.com/article/10.1007/s00574-016-0142-1},
+   doi     = {}
 }
 
 @article{2016_47,
-   author  = "R. Gassm&ouml;ller and J. Dannberg and E. Bredow and B. Steinberger and T. H. Torsvik",
-   title   = "Major influence of plume-ridge interaction, lithosphere thickness variations, and global mantle flow on hotspot volcanism - The example of Tristan",
-   journal = "Geochem. Geophys. Geosyst., 1454-1479",
-   year    = "2016",
-   volume  = "17",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/2015GC006177/full",
-   doi     = ""
+   author  = {R. Gassm\"{o}ller and J. Dannberg and E. Bredow and B. Steinberger and T. H. Torsvik},
+   title   = {Major influence of plume-ridge interaction, lithosphere thickness variations, and global mantle flow on hotspot volcanism - The example of Tristan},
+   journal = {Geochem. Geophys. Geosyst., 1454-1479},
+   year    = {2016},
+   volume  = {17},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2015GC006177/full},
+   doi     = {}
 }
 
 @article{2016_48,
-   author  = "S. S. Ghorashi and T. Lahmer and A. S. Bagherzadeh and G. Zi and T. Rabczuk",
-   title   = "A stochastic computational method based on goal-oriented error estimation for heterogeneous geological materials",
-   journal = "Engineering Geology, in Press",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0013795216302289",
-   doi     = ""
+   author  = {S. S. Ghorashi and T. Lahmer and A. S. Bagherzadeh and G. Zi and T. Rabczuk},
+   title   = {A stochastic computational method based on goal-oriented error estimation for heterogeneous geological materials},
+   journal = {Engineering Geology, in Press},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0013795216302289},
+   doi     = {}
 }
 
 @article{2016_49,
-   author  = "S. S. Ghorashi",
-   title   = "Goal-Oriented Adaptive Modeling of 3d Elastoplasticity Problems",
-   journal = "PhD dissertation, Bauhaus-Universitat Weimar, Weimar, Germany",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. S. Ghorashi},
+   title   = {Goal-Oriented Adaptive Modeling of 3d Elastoplasticity Problems},
+   journal = {PhD dissertation, Bauhaus-Universitat Weimar, Weimar, Germany},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_50,
-   author  = "M. C. Giestas and J. P. Milhazes and A. M. Joyce and H. L. Pina",
-   title   = "CFD modeling of a small case solar pond",
-   journal = "Proceedings of the EuroSun 2016 conference, Palma de Mallorca, Spain, 11-14 October 2016; International Solar Energy Society",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. C. Giestas and J. P. Milhazes and A. M. Joyce and H. L. Pina},
+   title   = {CFD modeling of a small case solar pond},
+   journal = {Proceedings of the EuroSun 2016 conference, Palma de Mallorca, Spain, 11-14 October 2016; International Solar Energy Society},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_51,
-   author  = "J.-L. Guermond and Bojan and L. Saavedra and Y. Yang",
-   title   = "Invariant domains preserving ALE approximation of hyperbolic systems with continuous finite elements",
-   journal = "ArXiv: 1603.01184",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1603.01184",
-   doi     = ""
+   author  = {J.-L. Guermond and Bojan and L. Saavedra and Y. Yang},
+   title   = {Invariant domains preserving ALE approximation of hyperbolic systems with continuous finite elements},
+   journal = {ArXiv: 1603.01184},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1603.01184},
+   doi     = {}
 }
 
 @article{2016_52,
-   author  = "D. K. Gupta and M. Langelaar and F. van Keulen",
-   title   = "Combined mesh and penalization adaptivity based topology optimization",
-   journal = "Proceedings of the 57th AIAA/ASCE/AHS/ASC Structures, Structural Dynamics, and Materials Conference, AIAA SciTech",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://dx.doi.org/10.2514/6.2016-0943",
-   doi     = ""
+   author  = {D. K. Gupta and M. Langelaar and F. van Keulen},
+   title   = {Combined mesh and penalization adaptivity based topology optimization},
+   journal = {Proceedings of the 57th AIAA/ASCE/AHS/ASC Structures, Structural Dynamics, and Materials Conference, AIAA SciTech},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://dx.doi.org/10.2514/6.2016-0943},
+   doi     = {}
 }
 
 @mastersthesis{2016_53,
-   author  = "T. Hamann",
-   title   = "A linear finite element model of the biceps brachii skeletal muscle",
-   year    = "2016",
-   school  = "Friedrich-Alexander-Universität Erlangen-Nürnberg",
-   url     = ""
+   author  = {T. Hamann},
+   title   = {A linear finite element model of the biceps brachii skeletal muscle},
+   year    = {2016},
+   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   url     = {}
 }
 
 @phdthesis{2016_54,
-   author  = "M. Harmon",
-   title   = "Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells",
-   year    = "2016",
-   school  = "University of Texas at Austin",
-   url     = ""
+   author  = {M. Harmon},
+   title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
+   year    = {2016},
+   school  = {University of Texas at Austin},
+   url     = {}
 }
 
 @article{2016_55,
-   author  = "M. Harmon and I. M. Gamba and K. Ren",
-   title   = "Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells",
-   journal = "Journal of Computational Physics",
-   year    = "2016",
-   volume  = "327",
-   pages   = "140--167",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999116303825",
-   doi     = ""
+   author  = {M. Harmon and I. M. Gamba and K. Ren},
+   title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
+   journal = {Journal of Computational Physics},
+   year    = {2016},
+   volume  = {327},
+   pages   = {140--167},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303825},
+   doi     = {}
 }
 
 @article{2016_56,
-   author  = "R. Hartmann and T. Leicht",
-   title   = "Generation of unstructured curvilinear grids and high-order Discontinuous Galerkin discretization applied to a 3D high-lift configuration",
-   journal = "International Journal on Numerical Methods Fluids",
-   year    = "2016",
-   volume  = "82",
-   pages   = "316--333",
-   url     = "http://ganymed.iwr.uni-heidelberg.de/~hartmann/",
-   doi     = ""
+   author  = {R. Hartmann and T. Leicht},
+   title   = {Generation of unstructured curvilinear grids and high-order Discontinuous Galerkin discretization applied to a 3D high-lift configuration},
+   journal = {International Journal on Numerical Methods Fluids},
+   year    = {2016},
+   volume  = {82},
+   pages   = {316--333},
+   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/},
+   doi     = {}
 }
 
 @article{2016_57,
-   author  = "S. H&auml;rting",
-   title   = "Reaction-diffusion-ODE systems: de-novo formation of irregular patterns and model reduction",
-   journal = "PhD Dissertation, University of Heidelberg, Germany",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://archiv.ub.uni-heidelberg.de/volltextserver/20550/",
-   doi     = ""
+   author  = {S. H\"{a}rting},
+   title   = {Reaction-diffusion-ODE systems: de-novo formation of irregular patterns and model reduction},
+   journal = {PhD Dissertation, University of Heidelberg, Germany},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20550/},
+   doi     = {}
 }
 
 @article{2016_58,
-   author  = "M. Herz and P. Knabner",
-   title   = "Including van der Waals Forces in Diffusion-Convection Equations - Modeling, Analysis, and Numerical Simulations",
-   journal = "ArXiv:1608.08431",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1608.08431",
-   doi     = ""
+   author  = {M. Herz and P. Knabner},
+   title   = {Including van der Waals Forces in Diffusion-Convection Equations - Modeling, Analysis, and Numerical Simulations},
+   journal = {ArXiv:1608.08431},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1608.08431},
+   doi     = {}
 }
 
 @article{2016_59,
-   author  = "M. Homolya and D. A. Ham",
-   title   = "A parallel edge orientation algorithm for quadrilateral meshes",
-   journal = "SIAM Journal on Scientific Computing, pp. S48-S61",
-   year    = "2016",
-   volume  = "38",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Homolya and D. A. Ham},
+   title   = {A parallel edge orientation algorithm for quadrilateral meshes},
+   journal = {SIAM Journal on Scientific Computing, pp. S48-S61},
+   year    = {2016},
+   volume  = {38},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_60,
-   author  = "T. Jiang and S. Rudraraju and A. Roy and A. Van der Ven and K. Garikipati and M. L. Falk",
-   title   = "Multi-physics simulations of lithiation-induced stress in Li<sub>1+x</sub>Ti<sub>2</sub>O<sub>4</sub> electrode particles",
-   journal = "ArXiv: 1609.08713",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1609.08713",
-   doi     = ""
+   author  = {T. Jiang and S. Rudraraju and A. Roy and A. Van der Ven and K. Garikipati and M. L. Falk},
+   title   = {Multi-physics simulations of lithiation-induced stress in Li$_{1+x}$Ti$_{2}$O$_{4}$ electrode particles},
+   journal = {ArXiv: 1609.08713},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1609.08713},
+   doi     = {}
 }
 
 @mastersthesis{2016_61,
-   author  = "D. Jodlbauer",
-   title   = "Robust Preconditioners for Fluid-Structure-Interaction Problems",
-   year    = "2016",
-   school  = "Johannes Kepler University Linz, Austria",
-   url     = ""
+   author  = {D. Jodlbauer},
+   title   = {Robust Preconditioners for Fluid-Structure-Interaction Problems},
+   year    = {2016},
+   school  = {Johannes Kepler University Linz, Austria},
+   url     = {}
 }
 
 @mastersthesis{2016_62,
-   author  = "R. Kahler",
-   title   = "On Identification of Nonlinear Parameters in PDEs",
-   year    = "2016",
-   school  = "Rochester Institute of Technology",
-   url     = "http://scholarworks.rit.edu/theses/9018/"
+   author  = {R. Kahler},
+   title   = {On Identification of Nonlinear Parameters in PDEs},
+   year    = {2016},
+   school  = {Rochester Institute of Technology},
+   url     = {http://scholarworks.rit.edu/theses/9018/}
 }
 
 @article{2016_63,
-   author  = "A. Kalichmanow",
-   title   = "Vergleich der k-space Methode und der Hybridisierbaren Diskontinuierlichen Galerkin Methode für die akustische Wellengleichung",
-   journal = "Term Paper, Technical University of Munich",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Kalichmanow},
+   title   = {Vergleich der k-space Methode und der Hybridisierbaren Diskontinuierlichen Galerkin Methode f\"{u}r die akustische Wellengleichung},
+   journal = {Term Paper, Technical University of Munich},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_64,
-   author  = "G. Kanschat and Y. Mao",
-   title   = "Multiplicative overlapping Schwarz smoothers for H<sup>div</sup>-conforming discontinuous Galerkin methods for the Stokes problem",
-   journal = "Domain Decomposition Methods in Science and Engineering XXII; Dickopf, Th., Gander, M.J., Halpern, L., Krause, R., Pavarino, L.F. (Eds.)",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {G. Kanschat and Y. Mao},
+   title   = {Multiplicative overlapping Schwarz smoothers for H$^{\textnormal{div}}$-conforming discontinuous Galerkin methods for the Stokes problem},
+   journal = {Domain Decomposition Methods in Science and Engineering XXII; Dickopf, Th., Gander, M.J., Halpern, L., Krause, R., Pavarino, L.F. (Eds.)},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_65,
-   author  = "A. Karangelis",
-   title   = "Analysis and Massively Parallel Implementation of the 2-Lagrange Multiplier Methods and Optimized Schwarz Methods",
-   journal = "PhD dissertation, Heriot-Watt University, Edinburgh, UK",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.macs.hw.ac.uk/~sl398/thesis-karangelis.pdf",
-   doi     = ""
+   author  = {A. Karangelis},
+   title   = {Analysis and Massively Parallel Implementation of the 2-Lagrange Multiplier Methods and Optimized Schwarz Methods},
+   journal = {PhD dissertation, Heriot-Watt University, Edinburgh, UK},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.macs.hw.ac.uk/~sl398/thesis-karangelis.pdf},
+   doi     = {}
 }
 
 @article{2016_66,
-   author  = "P. Karban and I. Dolezel",
-   title   = "Modeling of fast transients on transmission line using higher-order adaptive methods",
-   journal = "2016 ELEKTRO",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=7512133",
-   doi     = ""
+   author  = {P. Karban and I. Dolezel},
+   title   = {Modeling of fast transients on transmission line using higher-order adaptive methods},
+   journal = {2016 ELEKTRO},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=7512133},
+   doi     = {}
 }
 
 @article{2016_67,
-   author  = "S. Kim and H. Zhang",
-   title   = "Optimized double sweep Schwarz method by complete radiation boundary conditions",
-   journal = "Computers &amp; Mathematics with Applications, issue 6",
-   year    = "2016",
-   volume  = "72",
-   pages   = "1573--1589",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0898122116304266",
-   doi     = ""
+   author  = {S. Kim and H. Zhang},
+   title   = {Optimized double sweep Schwarz method by complete radiation boundary conditions},
+   journal = {Computers \& Mathematics with Applications, issue 6},
+   year    = {2016},
+   volume  = {72},
+   pages   = {1573--1589},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0898122116304266},
+   doi     = {}
 }
 
 @article{2016_68,
-   author  = "M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking",
-   title   = "Modeling Crack Growth during Li Extraction in Storage Particles Using a Fracture Phase Field Approach",
-   journal = "Journal of The Electrochemical Society, Vol. 63(2), 102-118",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://jes.ecsdl.org/content/163/2/A102.short",
-   doi     = ""
+   author  = {M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking},
+   title   = {Modeling Crack Growth during Li Extraction in Storage Particles Using a Fracture Phase Field Approach},
+   journal = {Journal of The Electrochemical Society, Vol. 63(2), 102-118},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://jes.ecsdl.org/content/163/2/A102.short},
+   doi     = {}
 }
 
 @article{2016_69,
-   author  = "P.H.A. Konzen and E. Sauter and F.S. Azevedo and P. Zingano",
-   title   = "Numerical simulations with the finite element method for the Burgers’ equation on the real line",
-   journal = "arXiv:1605.01109",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1605.01109",
-   doi     = ""
+   author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo and P. Zingano},
+   title   = {Numerical simulations with the finite element method for the Burgers' equation on the real line},
+   journal = {arXiv:1605.01109},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1605.01109},
+   doi     = {}
 }
 
 @article{2016_70,
-   author  = "P.H.A. Konzen and E. Sauter and F.S. Azevedo",
-   title   = "Green Function Formulation and Finite Element Discretization for Solving the Heat Radiative Transfer in a Slab",
-   journal = "Journal of Computational and Theoretical Transport, no. 5",
-   year    = "2016",
-   volume  = "45",
-   pages   = "368--385",
-   url     = "http://www.tandfonline.com/doi/pdf/10.1080/23324309.2016.1179647?needAccess=true",
-   doi     = ""
+   author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo},
+   title   = {Green Function Formulation and Finite Element Discretization for Solving the Heat Radiative Transfer in a Slab},
+   journal = {Journal of Computational and Theoretical Transport, no. 5},
+   year    = {2016},
+   volume  = {45},
+   pages   = {368--385},
+   url     = {http://www.tandfonline.com/doi/pdf/10.1080/23324309.2016.1179647?needAccess=true},
+   doi     = {}
 }
 
 @article{2016_71,
-   author  = "S. C. Kramer and J. Hagemann  and L. Kunneke and and J. Lebert",
-   title   = "Parallel Statistical Multiresolution Estimation for Image Reconstruction",
-   journal = "SIAM J. Sci. Comput., issue 5, C533–C559",
-   year    = "2016",
-   volume  = "38",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/15M1020332",
-   doi     = ""
+   author  = {S. C. Kramer and J. Hagemann  and L. Kunneke and and J. Lebert},
+   title   = {Parallel Statistical Multiresolution Estimation for Image Reconstruction},
+   journal = {SIAM J. Sci. Comput., issue 5, C533--C559},
+   year    = {2016},
+   volume  = {38},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1020332},
+   doi     = {}
+}
+
+@article{2016_72,
+   author  = {M. Kronbichler and A. Diagne and H. Holmgren},
+   title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
+   journal = {The International Journal of High Performance Computing Applications, in press},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://hpc.sagepub.com/content/early/2016/10/05/1094342016671790},
+   doi     = {10.1177/1094342016671790}
 }
 
 @article{2016_73,
-   author  = "M. Kronbichler and S. Schoeder and C. M&uuml;ller and W. A. Wall",
-   title   = "Comparison of implicit and explicit hybridizable discontinuous Galerkin methods for the acoustic wave equation",
-   journal = "International Journal for Numerical Methods in Engineering, Vol 106",
-   year    = "2016",
-   volume  = "",
-   pages   = "712--739",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/nme.5137/full",
-   doi     = "10.1002/nme.5137"
+   author  = {M. Kronbichler and S. Schoeder and C. M\"{u}ller and W. A. Wall},
+   title   = {Comparison of implicit and explicit hybridizable discontinuous Galerkin methods for the acoustic wave equation},
+   journal = {International Journal for Numerical Methods in Engineering, Vol 106},
+   year    = {2016},
+   volume  = {},
+   pages   = {712--739},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5137/full},
+   doi     = {10.1002/nme.5137}
 }
 
 @article{2016_74,
-   author  = "M. Kronbichler and W. A. Wall",
-   title   = "A performance comparison of continuous and discontinuous Galerkin methods with fast multigrid solvers",
-   journal = "arxiv.org:1611.03029",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Kronbichler and W. A. Wall},
+   title   = {A performance comparison of continuous and discontinuous Galerkin methods with fast multigrid solvers},
+   journal = {arxiv.org:1611.03029},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @mastersthesis{2016_75,
-   author  = "M. Kufner",
-   title   = "Entwurf und Implementierung eines Perfectly Matched Layer für die lineare Akustik",
-   year    = "2016",
-   school  = "Technical University of Munich",
-   url     = ""
+   author  = {M. Kufner},
+   title   = {Entwurf und Implementierung eines Perfectly Matched Layer f\"{u}r die lineare Akustik},
+   year    = {2016},
+   school  = {Technical University of Munich},
+   url     = {}
 }
 
 @article{2016_76,
-   author  = "K. Kunisch and K. Pieper and A. Rund",
-   title   = "Time optimal control for a reaction diffusion system arising in cardiac electrophysiology - a monolithic approach",
-   journal = "ESAIM:M2AN, Vol. 50",
-   year    = "2016",
-   volume  = "",
-   pages   = "381--414",
-   url     = "http://www.esaim-m2an.org/articles/m2an/abs/2016/02/m2an141121/m2an141121.html",
-   doi     = ""
+   author  = {K. Kunisch and K. Pieper and A. Rund},
+   title   = {Time optimal control for a reaction diffusion system arising in cardiac electrophysiology - a monolithic approach},
+   journal = {ESAIM:M2AN, Vol. 50},
+   year    = {2016},
+   volume  = {},
+   pages   = {381--414},
+   url     = {http://www.esaim-m2an.org/articles/m2an/abs/2016/02/m2an141121/m2an141121.html},
+   doi     = {}
 }
 
 @article{2016_77,
-   author  = "S. Lee and Y.-J. Lee and M. F. Wheeler",
-   title   = "A Locally Conservative Enriched Galerkin Approximation and Efficient Solver for the Parabolic Problems",
-   journal = "SIAM Journal on Scientific Computing, Issue 3, pp. A1404-A1429",
-   year    = "2016",
-   volume  = "38",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/15M1041109",
-   doi     = ""
+   author  = {S. Lee and Y.-J. Lee and M. F. Wheeler},
+   title   = {A Locally Conservative Enriched Galerkin Approximation and Efficient Solver for the Parabolic Problems},
+   journal = {SIAM Journal on Scientific Computing, Issue 3, pp. A1404-A1429},
+   year    = {2016},
+   volume  = {38},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1041109},
+   doi     = {}
 }
 
 @article{2016_78,
-   author  = "S. Lee and M. Mikelic and M. F. Wheeler and T. Wick",
-   title   = "Phase-field modeling of proppant-filled fractures in a poroelastic medium",
-   journal = "Comp. Meth. Appl. Mech. Engrg.",
-   year    = "2016",
-   volume  = "312",
-   pages   = "509--451",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782516300305",
-   doi     = "10.1016/j.cma.2016.02.008"
+   author  = {S. Lee and M. Mikelic and M. F. Wheeler and T. Wick},
+   title   = {Phase-field modeling of proppant-filled fractures in a poroelastic medium},
+   journal = {Comp. Meth. Appl. Mech. Engrg.},
+   year    = {2016},
+   volume  = {312},
+   pages   = {509--451},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516300305},
+   doi     = {10.1016/j.cma.2016.02.008}
 }
 
 @article{2016_79,
-   author  = "S. Lee and J. E. Reber and N. W. Hayman and M. F. Wheeler",
-   title   = "Investigation of wing crack formation with a combined phase-field and experimental approach",
-   journal = "Geophysical Research Letters",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/2016GL069979/full",
-   doi     = "10.1002/2016GL069979"
+   author  = {S. Lee and J. E. Reber and N. W. Hayman and M. F. Wheeler},
+   title   = {Investigation of wing crack formation with a combined phase-field and experimental approach},
+   journal = {Geophysical Research Letters},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2016GL069979/full},
+   doi     = {10.1002/2016GL069979}
 }
 
 @article{2016_80,
-   author  = "S. Lee and M. F. Wheeler and T. Wick",
-   title   = "Pressure and fluid-driven fracture propagation in porous media using an adaptive finite element phase field model",
-   journal = "Comp. Meth. Appl. Mech. Engrg.",
-   year    = "2016",
-   volume  = "305",
-   pages   = "111--132",
-   url     = "http://dx.doi.org/10.1016/j.cma.2016.02.037",
-   doi     = "10.1016/j.cma.2016.02.037"
+   author  = {S. Lee and M. F. Wheeler and T. Wick},
+   title   = {Pressure and fluid-driven fracture propagation in porous media using an adaptive finite element phase field model},
+   journal = {Comp. Meth. Appl. Mech. Engrg.},
+   year    = {2016},
+   volume  = {305},
+   pages   = {111--132},
+   url     = {http://dx.doi.org/10.1016/j.cma.2016.02.037},
+   doi     = {10.1016/j.cma.2016.02.037}
 }
 
 @mastersthesis{2016_81,
-   author  = "S. Legat",
-   title   = "Advancement of a semi-explicit discontinuous Galerkin approach for simulation of turbulent incompressible flow",
-   year    = "2016",
-   school  = "Technical University of Munich",
-   url     = ""
+   author  = {S. Legat},
+   title   = {Advancement of a semi-explicit discontinuous Galerkin approach for simulation of turbulent incompressible flow},
+   year    = {2016},
+   school  = {Technical University of Munich},
+   url     = {}
 }
 
 @article{2016_82,
-   author  = "D. Li and R. Hartmann",
-   title   = "Adjoint-based error estimation and mesh refinement in an adjoint-based airfoil shape optimization of a transonic benchmark problem",
-   journal = "New Results in Numerical and Experimental Fluid Mechanics X: Contributions to the 19th STAB/DGLR Symposium Munich, Germany, 2014, Notes on Numerical Fluid Mechanics and Multidisciplinary Design, Springer. ",
-   year    = "2016",
-   volume  = "",
-   pages   = "537--546",
-   url     = "",
-   doi     = ""
+   author  = {D. Li and R. Hartmann},
+   title   = {Adjoint-based error estimation and mesh refinement in an adjoint-based airfoil shape optimization of a transonic benchmark problem},
+   journal = {New Results in Numerical and Experimental Fluid Mechanics X: Contributions to the 19th STAB/DGLR Symposium Munich, Germany, 2014, Notes on Numerical Fluid Mechanics and Multidisciplinary Design, Springer. },
+   year    = {2016},
+   volume  = {},
+   pages   = {537--546},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_83,
-   author  = "J. Liu and G. Amberg and and M. Do-Quang",
-   title   = "Diffuse interface method for a compressible binary fluid",
-   journal = "Physical Rev. E, 013121",
-   year    = "2016",
-   volume  = "93",
-   pages   = "",
-   url     = "https://journals.aps.org/pre/abstract/10.1103/PhysRevE.93.013121",
-   doi     = ""
+   author  = {J. Liu and G. Amberg and and M. Do-Quang},
+   title   = {Diffuse interface method for a compressible binary fluid},
+   journal = {Physical Rev. E, 013121},
+   year    = {2016},
+   volume  = {93},
+   pages   = {},
+   url     = {https://journals.aps.org/pre/abstract/10.1103/PhysRevE.93.013121},
+   doi     = {}
 }
 
 @article{2016_84,
-   author  = "A. Madzvamuse and A. H. W. Chung",
-   title   = "The bulk-surface finite element method for reaction–diffusion systems on stationary volumes",
-   journal = "Finite Elements in Analysis and Design",
-   year    = "2016",
-   volume  = "108",
-   pages   = "9--21",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0168874X15001377",
-   doi     = ""
+   author  = {A. Madzvamuse and A. H. W. Chung},
+   title   = {The bulk-surface finite element method for reaction--diffusion systems on stationary volumes},
+   journal = {Finite Elements in Analysis and Design},
+   year    = {2016},
+   volume  = {108},
+   pages   = {9--21},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0168874X15001377},
+   doi     = {}
 }
 
 @article{2016_85,
-   author  = "M. Maier and R. Rannacher",
-   title   = "A duality-based optimization approach for model adaptivity in heterogeneous multiscale problems",
-   journal = "ArXiv:1611.09437",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1611.09437",
-   doi     = ""
+   author  = {M. Maier and R. Rannacher},
+   title   = {A duality-based optimization approach for model adaptivity in heterogeneous multiscale problems},
+   journal = {ArXiv:1611.09437},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1611.09437},
+   doi     = {}
 }
 
 @article{2016_86,
-   author  = "M. Maier and R. Rannacher",
-   title   = "Duality-based adaptivity in finite element discretization of heterogeneous multiscale problems",
-   journal = "Journal of Numerical Mathematics, Issue 3",
-   year    = "2016",
-   volume  = "24",
-   pages   = "167--188",
-   url     = "https://www.degruyter.com/view/j/jnma.2016.24.issue-3/jnma-2014-0074/jnma-2014-0074.xml",
-   doi     = ""
+   author  = {M. Maier and R. Rannacher},
+   title   = {Duality-based adaptivity in finite element discretization of heterogeneous multiscale problems},
+   journal = {Journal of Numerical Mathematics, Issue 3},
+   year    = {2016},
+   volume  = {24},
+   pages   = {167--188},
+   url     = {https://www.degruyter.com/view/j/jnma.2016.24.issue-3/jnma-2014-0074/jnma-2014-0074.xml},
+   doi     = {}
 }
 
 @article{2016_87,
-   author  = "Ž. Marojević and E. G&ouml;kl&uuml; and C. L&auml;mmerzahl",
-   title   = "ATUS-PRO: A FEM-based solver for the time-dependent and stationary Gross-Pitaevskii equation",
-   journal = "Computer Physics Communications",
-   year    = "2016",
-   volume  = "202",
-   pages   = "216--232",
-   url     = "",
-   doi     = ""
+   author  = {\v{Z}. Marojevi\'{c}' and E. G\"{o}kl\"{u} and C. L\"{a}mmerzahl},
+   title   = {ATUS-PRO: A FEM-based solver for the time-dependent and stationary Gross-Pitaevskii equation},
+   journal = {Computer Physics Communications},
+   year    = {2016},
+   volume  = {202},
+   pages   = {216--232},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_88,
-   author  = "R. Milk and S. Rave and F. Schindler",
-   title   = "pyMOR - Generic Algorithms and Interfaces for Model Order Reduction",
-   journal = "SIAM J. Sci. Comput., issue 5, pp. S194-S216",
-   year    = "2016",
-   volume  = "38",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/15M1026614",
-   doi     = ""
+   author  = {R. Milk and S. Rave and F. Schindler},
+   title   = {pyMOR - Generic Algorithms and Interfaces for Model Order Reduction},
+   journal = {SIAM J. Sci. Comput., issue 5, pp. S194-S216},
+   year    = {2016},
+   volume  = {38},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1026614},
+   doi     = {}
 }
 
 @article{2016_89,
-   author  = "P. Mital and T. Wick and M. F. Wheeler and G. Pencheva",
-   title   = "Discontinuous and enriched Galerkin methods for phase-field fracture propagation in elasticity",
-   journal = "In: Numerical Mathematics and Advanced Applications, Proceedings of the ENUMATH 2015 conference, Springer",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {P. Mital and T. Wick and M. F. Wheeler and G. Pencheva},
+   title   = {Discontinuous and enriched Galerkin methods for phase-field fracture propagation in elasticity},
+   journal = {In: Numerical Mathematics and Advanced Applications, Proceedings of the ENUMATH 2015 conference, Springer},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_90,
-   author  = "H. Mößinger and F. Förster-Zügel and H. F. Schlaak",
-   title   = "Simulation of the Transient Electromechanical Behaviour of Dielectric Elastomer Transducers",
-   journal = "Proc. SPIE 9798, Electroactive Polymer Actuators and Devices (EAPAD), April 15",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.onepetro.org/conference-paper/ISOPE-I-16-438",
-   doi     = "10.1117/12.2219133"
+   author  = {H. M\"{o}{\ss}inger and F. F\"{o}rster-Z\"{u}gel and H. F. Schlaak},
+   title   = {Simulation of the Transient Electromechanical Behaviour of Dielectric Elastomer Transducers},
+   journal = {Proc. SPIE 9798, Electroactive Polymer Actuators and Devices (EAPAD), April 15},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.onepetro.org/conference-paper/ISOPE-I-16-438},
+   doi     = {10.1117/12.2219133}
 }
 
 @article{2016_91,
-   author  = "A. Mola and L. Heltai and A. D. Simone",
-   title   = "Ship Sinkage and Trim Predictions Based on a CAD Interfaced Fully Nonlinear Potential Model",
-   journal = "Proceedings of the Twenty-sixth International Ocean and Polar Engineering Conference Rhodes, Greece, June 26-July 1",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.onepetro.org/conference-paper/ISOPE-I-16-438",
-   doi     = ""
+   author  = {A. Mola and L. Heltai and A. D. Simone},
+   title   = {Ship Sinkage and Trim Predictions Based on a CAD Interfaced Fully Nonlinear Potential Model},
+   journal = {Proceedings of the Twenty-sixth International Ocean and Polar Engineering Conference Rhodes, Greece, June 26-July 1},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.onepetro.org/conference-paper/ISOPE-I-16-438},
+   doi     = {}
 }
 
 @article{2016_92,
-   author  = "M. Monavari and S. Sandfeld and M. Zaiser",
-   title   = "Continuum Representation of Systems of Dislocation Lines: A General Method for Deriving Closed-Form Evolution Equations",
-   journal = "Journal of the Mechanics and Physics of Solids",
-   year    = "2016",
-   volume  = "95",
-   pages   = "575--601",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0022509615301903",
-   doi     = ""
+   author  = {M. Monavari and S. Sandfeld and M. Zaiser},
+   title   = {Continuum Representation of Systems of Dislocation Lines: A General Method for Deriving Closed-Form Evolution Equations},
+   journal = {Journal of the Mechanics and Physics of Solids},
+   year    = {2016},
+   volume  = {95},
+   pages   = {575--601},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0022509615301903},
+   doi     = {}
 }
 
 @article{2016_93,
-   author  = "R. F. M. Moawad",
-   title   = "Approximation of The Neutron Diffusion Equation on Hexagonal Geometries Using a h-p Finite Element Method",
-   journal = "PhD dissertation, La Universitat Politècnica de València, Spain",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://riunet.upv.es/handle/10251/65353",
-   doi     = ""
+   author  = {R. F. M. Moawad},
+   title   = {Approximation of The Neutron Diffusion Equation on Hexagonal Geometries Using a h-p Finite Element Method},
+   journal = {PhD dissertation, La Universitat Polit\`{e}cnica de Val\`{e}ncia, Spain},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://riunet.upv.es/handle/10251/65353},
+   doi     = {}
 }
 
 @article{2016_94,
-   author  = "J. J. Munoz-Criollo and P. J. Cleall and S. W. Rees",
-   title   = "Factors influencing collection performance of near surface interseasonal ground energy collection and storage systems",
-   journal = "Geomechanics for Energy and the Environment",
-   year    = "2016",
-   volume  = "6",
-   pages   = "45--57",
-   url     = "http://www.sciencedirect.com/science/article/pii/S235238081630020X",
-   doi     = ""
+   author  = {J. J. Munoz-Criollo and P. J. Cleall and S. W. Rees},
+   title   = {Factors influencing collection performance of near surface interseasonal ground energy collection and storage systems},
+   journal = {Geomechanics for Energy and the Environment},
+   year    = {2016},
+   volume  = {6},
+   pages   = {45--57},
+   url     = {http://www.sciencedirect.com/science/article/pii/S235238081630020X},
+   doi     = {}
 }
 
 @article{2016_95,
-   author  = "L. Murphy and C. Venkataraman and A. Madzvamuse",
-   title   = "A computational approach for mode isolation for reaction-diffusion systems on arbitrary geometries",
-   journal = "arXiv:1604.05653",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1604.05653",
-   doi     = ""
+   author  = {L. Murphy and C. Venkataraman and A. Madzvamuse},
+   title   = {A computational approach for mode isolation for reaction-diffusion systems on arbitrary geometries},
+   journal = {arXiv:1604.05653},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1604.05653},
+   doi     = {}
 }
 
 @mastersthesis{2016_96,
-   author  = "R. K. Narayanan",
-   title   = "Parallel particle-in-cell performance optimization: a case study of electrospray simulation",
-   year    = "2016",
-   school  = "The Pennsylvania State University, University Park",
-   url     = "https://etda.libraries.psu.edu/files/final_submissions/11560"
+   author  = {R. K. Narayanan},
+   title   = {Parallel particle-in-cell performance optimization: a case study of electrospray simulation},
+   year    = {2016},
+   school  = {The Pennsylvania State University, University Park},
+   url     = {https://etda.libraries.psu.edu/files/final_submissions/11560}
 }
 
 @article{2016_97,
-   author  = "R. H. Nochetto and A. J. Salgado and I. Thomas",
-   title   = "A diffuse interface model for two-phase ferrofluid flows",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2016",
-   volume  = "309",
-   pages   = "497--531",
-   url     = "",
-   doi     = ""
+   author  = {R. H. Nochetto and A. J. Salgado and I. Thomas},
+   title   = {A diffuse interface model for two-phase ferrofluid flows},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2016},
+   volume  = {309},
+   pages   = {497--531},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_98,
-   author  = "R. H. Nochetto and A. J. Salgado and I. Tomas",
-   title   = "The equations of ferrohydrodynamics: modeling and numerical methods",
-   journal = "Mathematical Models and Methods in Applied Sciences, No. 13",
-   year    = "2016",
-   volume  = "26",
-   pages   = "2393--2449",
-   url     = "http://www.worldscientific.com/doi/abs/10.1142/S0218202516500573?journalCode=m3as",
-   doi     = ""
+   author  = {R. H. Nochetto and A. J. Salgado and I. Tomas},
+   title   = {The equations of ferrohydrodynamics: modeling and numerical methods},
+   journal = {Mathematical Models and Methods in Applied Sciences, No. 13},
+   year    = {2016},
+   volume  = {26},
+   pages   = {2393--2449},
+   url     = {http://www.worldscientific.com/doi/abs/10.1142/S0218202516500573?journalCode=m3as},
+   doi     = {}
 }
 
 @article{2016_99,
-   author  = "P. Oswald and G. Poy and A. Dequidt",
-   title   = "Lehmann rotation of twisted bipolar cholesteric droplets: role of Leslie, Akopyan and Zel’dovich thermomechanical coupling terms of nematodynamics",
-   journal = "Liquid Crystal",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.tandfonline.com/doi/abs/10.1080/02678292.2016.1255363",
-   doi     = "10.1080/02678292.2016.1255363"
+   author  = {P. Oswald and G. Poy and A. Dequidt},
+   title   = {Lehmann rotation of twisted bipolar cholesteric droplets: role of Leslie, Akopyan and Zel'dovich thermomechanical coupling terms of nematodynamics},
+   journal = {Liquid Crystal},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.tandfonline.com/doi/abs/10.1080/02678292.2016.1255363},
+   doi     = {10.1080/02678292.2016.1255363}
 }
 
 @article{2016_100,
-   author  = "E. W. Owen and C. H. W. Barnes",
-   title   = "Ground-State Electronic Structure of Quasi-One-Dimensional Wires in Semiconductor Heterostructures",
-   journal = "Phys. Rev. Applied, pp. 054007/1-12",
-   year    = "2016",
-   volume  = "6",
-   pages   = "",
-   url     = "http://link.aps.org/doi/10.1103/PhysRevApplied.6.054007",
-   doi     = "10.1103/PhysRevApplied.6.054007"
+   author  = {E. W. Owen and C. H. W. Barnes},
+   title   = {Ground-State Electronic Structure of Quasi-One-Dimensional Wires in Semiconductor Heterostructures},
+   journal = {Phys. Rev. Applied, pp. 054007/1-12},
+   year    = {2016},
+   volume  = {6},
+   pages   = {},
+   url     = {http://link.aps.org/doi/10.1103/PhysRevApplied.6.054007},
+   doi     = {10.1103/PhysRevApplied.6.054007}
 }
 
 @article{2016_101,
-   author  = "J.-P. Pelteret and D. Davydov and A. McBride and D. K. Vu and P. Steinmann",
-   title   = "Computational electro-elasticity and magneto-elasticity for quasi-incompressible media immersed in free space",
-   journal = "International Journal for Numerical Methods in Engineering, issue 11",
-   year    = "2016",
-   volume  = "108",
-   pages   = "1307--1342",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/nme.5254/full",
-   doi     = ""
+   author  = {J.-P. Pelteret and D. Davydov and A. McBride and D. K. Vu and P. Steinmann},
+   title   = {Computational electro-elasticity and magneto-elasticity for quasi-incompressible media immersed in free space},
+   journal = {International Journal for Numerical Methods in Engineering, issue 11},
+   year    = {2016},
+   volume  = {108},
+   pages   = {1307--1342},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5254/full},
+   doi     = {}
 }
 
 @article{2016_102,
-   author  = "M. Porcelli and V. Simoncini and M. Stoll",
-   title   = "Preconditioning PDE-constrained optimization with L1-sparsity and control constraints",
-   journal = "ArXiv:1611.07201",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1611.07201",
-   doi     = ""
+   author  = {M. Porcelli and V. Simoncini and M. Stoll},
+   title   = {Preconditioning PDE-constrained optimization with L1-sparsity and control constraints},
+   journal = {ArXiv:1611.07201},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1611.07201},
+   doi     = {}
 }
 
 @article{2016_103,
-   author  = "A. Potschka",
-   title   = "Backward step control for Hilbert space problems",
-   journal = "ArXiv:1608.01863",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/pdf/1608.01863",
-   doi     = ""
+   author  = {A. Potschka},
+   title   = {Backward step control for Hilbert space problems},
+   journal = {ArXiv:1608.01863},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/pdf/1608.01863},
+   doi     = {}
 }
 
 @phdthesis{2016_104,
-   author  = "M. Quezada de Luna",
-   title   = "High-order and maximum principle preserving (MPP) techniques for solving conservation laws with applications on multiphase flow",
-   year    = "2016",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {M. Quezada de Luna},
+   title   = {High-order and maximum principle preserving (MPP) techniques for solving conservation laws with applications on multiphase flow},
+   year    = {2016},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @mastersthesis{2016_105,
-   author  = "J. R. Roberge",
-   title   = "Computational Design of Ceramic Bone Scaffolds Fabricated Via Direct Ink Writing",
-   year    = "2016",
-   school  = "University of Connecticut, Connecticut",
-   url     = "http://digitalcommons.uconn.edu/gs_theses/989/"
+   author  = {J. R. Roberge},
+   title   = {Computational Design of Ceramic Bone Scaffolds Fabricated Via Direct Ink Writing},
+   year    = {2016},
+   school  = {University of Connecticut, Connecticut},
+   url     = {http://digitalcommons.uconn.edu/gs_theses/989/}
 }
 
 @article{2016_106,
-   author  = "I. R. Rose",
-   title   = "True polar wander on convecting planets",
-   journal = "PhD dissertation, University of Califonia, Berkeley",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://search.proquest.com/docview/1873864258?pq-origsite=gscholar",
-   doi     = ""
+   author  = {I. R. Rose},
+   title   = {True polar wander on convecting planets},
+   journal = {PhD dissertation, University of Califonia, Berkeley},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://search.proquest.com/docview/1873864258?pq-origsite=gscholar},
+   doi     = {}
 }
 
 @article{2016_107,
-   author  = "S. Lee and A. Salgado",
-   title   = "Stability analysis of pressure correction schemes for the Navier-Stokes equations with traction boundary conditions",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2016",
-   volume  = "309",
-   pages   = "307--324",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782516304923",
-   doi     = ""
+   author  = {S. Lee and A. Salgado},
+   title   = {Stability analysis of pressure correction schemes for the Navier-Stokes equations with traction boundary conditions},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2016},
+   volume  = {309},
+   pages   = {307--324},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516304923},
+   doi     = {}
 }
 
 @article{2016_108,
-   author  = "A. Samii and C. Michoski and C. Dawson",
-   title   = "A parallel and adaptive hybridized discontinuous Galerkin method for anisotropic nonhomogeneous diffusion",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2016",
-   volume  = "304",
-   pages   = "118--139",
-   url     = "",
-   doi     = "10.1016/j.cma.2016.02.009"
+   author  = {A. Samii and C. Michoski and C. Dawson},
+   title   = {A parallel and adaptive hybridized discontinuous Galerkin method for anisotropic nonhomogeneous diffusion},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2016},
+   volume  = {304},
+   pages   = {118--139},
+   url     = {},
+   doi     = {10.1016/j.cma.2016.02.009}
 }
 
 @article{2016_109,
-   author  = "T. Schl&ouml;gl and S. Leyendecker",
-   title   = "Dynamic Simulation of Dielectric Elastomer Actuated Multibody Systems",
-   journal = "Proceedings of the ASME 2016 Conference on Smart Materials, Adaptive Structures and Intelligent Systems SMASIS2016, September 28-30",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://proceedings.asmedigitalcollection.asme.org/proceeding.aspx?articleid=2589204",
-   doi     = ""
+   author  = {T. Schl\"{o}gl and S. Leyendecker},
+   title   = {Dynamic Simulation of Dielectric Elastomer Actuated Multibody Systems},
+   journal = {Proceedings of the ASME 2016 Conference on Smart Materials, Adaptive Structures and Intelligent Systems SMASIS2016, September 28-30},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://proceedings.asmedigitalcollection.asme.org/proceeding.aspx?articleid=2589204},
+   doi     = {}
 }
 
 @article{2016_110,
-   author  = "T. Schl&ouml;gl and S. Leyendecker",
-   title   = "Electrostatic–viscoelastic finite element model of dielectric actuators",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2016",
-   volume  = "299",
-   pages   = "421--439",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782515003461",
-   doi     = ""
+   author  = {T. Schl\"{o}gl and S. Leyendecker},
+   title   = {Electrostatic--viscoelastic finite element model of dielectric actuators},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2016},
+   volume  = {299},
+   pages   = {421--439},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782515003461},
+   doi     = {}
 }
 
 @phdthesis{2016_111,
-   author  = "J. Sheldon",
-   title   = "A hybridizable discontinuous Galerkin method for modeling fluid-structure interaction.",
-   year    = "2016",
-   school  = "The Pennsylvania State University",
-   url     = ""
+   author  = {J. Sheldon},
+   title   = {A hybridizable discontinuous Galerkin method for modeling fluid-structure interaction.},
+   year    = {2016},
+   school  = {The Pennsylvania State University},
+   url     = {}
 }
 
 @article{2016_112,
-   author  = "J. P. Sheldon and S. T. Miller and J. S. Pitt",
-   title   = "A hybridizable discontinuous Galerkin method for modeling fluid–structure interaction",
-   journal = "Journal of Computational Physics, pp. 91–114",
-   year    = "2016",
-   volume  = "326",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999116303941",
-   doi     = ""
+   author  = {J. P. Sheldon and S. T. Miller and J. S. Pitt},
+   title   = {A hybridizable discontinuous Galerkin method for modeling fluid--structure interaction},
+   journal = {Journal of Computational Physics, pp. 91--114},
+   year    = {2016},
+   volume  = {326},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303941},
+   doi     = {}
 }
 
 @article{2016_113,
-   author  = "J. R. D. Soine and N. Hersch and G. Drssen and N. Hampe and B. Hoffmann and R. Merkel and U. S. Schwarz",
-   title   = "Measuring cellular traction forces on non-planar substrates",
-   journal = "DOI: 10.1098/rsfs.2016.0024",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://rsfs.royalsocietypublishing.org/content/6/5/20160024",
-   doi     = ""
+   author  = {J. R. D. Soine and N. Hersch and G. Drssen and N. Hampe and B. Hoffmann and R. Merkel and U. S. Schwarz},
+   title   = {Measuring cellular traction forces on non-planar substrates},
+   journal = {},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://rsfs.royalsocietypublishing.org/content/6/5/20160024},
+   doi     = {10.1098/rsfs.2016.0024}
 }
 
 @article{2016_114,
-   author  = "S. Sticko and G. Kreiss",
-   title   = "Higher Order Cut Elements for the Wave Equation",
-   journal = "arXiv:1608.0310",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1608.03107",
-   doi     = ""
+   author  = {S. Sticko and G. Kreiss},
+   title   = {Higher Order Cut Elements for the Wave Equation},
+   journal = {arXiv:1608.0310},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1608.03107},
+   doi     = {}
 }
 
 @article{2016_115,
-   author  = "M. Stoll and J. Pearson and P. K. Maini",
-   title   = "Fast solvers for optimal control problems from pattern formation",
-   journal = "Journal of Computational Physics, Volume 304",
-   year    = "2016",
-   volume  = "",
-   pages   = "27--45",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999115006683",
-   doi     = ""
+   author  = {M. Stoll and J. Pearson and P. K. Maini},
+   title   = {Fast solvers for optimal control problems from pattern formation},
+   journal = {Journal of Computational Physics, Volume 304},
+   year    = {2016},
+   volume  = {},
+   pages   = {27--45},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999115006683},
+   doi     = {}
 }
 
 @article{2016_117,
-   author  = "B. Turcksin and M. Kronbichler and W. Bangerth",
-   title   = "WorkStream &mdash; a design pattern for multicore-enabled finite element computations",
-   journal = "ACM Transactions on Mathematical Software, pp. 2/1-29",
-   year    = "2016",
-   volume  = "43",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Turcksin and M. Kronbichler and W. Bangerth},
+   title   = {WorkStream -- a design pattern for multicore-enabled finite element computations},
+   journal = {ACM Transactions on Mathematical Software, pp. 2/1-29},
+   year    = {2016},
+   volume  = {43},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_118,
-   author  = "M. Veske and A. Kyritsakis and F. Djurabekova and R. Aare and K. Eimre and V. Zadin",
-   title   = "Atomistic modeling of metal surfaces under high electric fields: Direct coupling of electric fields to the atomistic simulations",
-   journal = "29th International Vacuum Nanoelectronics Conference (IVNC), Vancouver, Canada",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://ieeexplore.ieee.org/document/7551501/",
-   doi     = ""
+   author  = {M. Veske and A. Kyritsakis and F. Djurabekova and R. Aare and K. Eimre and V. Zadin},
+   title   = {Atomistic modeling of metal surfaces under high electric fields: Direct coupling of electric fields to the atomistic simulations},
+   journal = {29th International Vacuum Nanoelectronics Conference (IVNC), Vancouver, Canada},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://ieeexplore.ieee.org/document/7551501/},
+   doi     = {}
 }
 
 @article{2016_119,
-   author  = "A. Vidal-Ferrandiz and S. Gonzalez-Pintor and D. Ginestart and G. Verdu and M. Asadzadeh and C. Demaziere",
-   title   = "Use of discontinuity factors in high-order finite element methods",
-   journal = "Annals of Nuclear Energy, Part 2",
-   year    = "2016",
-   volume  = "87",
-   pages   = "728--738",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0306454915003357",
-   doi     = ""
+   author  = {A. Vidal-Ferrandiz and S. Gonzalez-Pintor and D. Ginestart and G. Verdu and M. Asadzadeh and C. Demaziere},
+   title   = {Use of discontinuity factors in high-order finite element methods},
+   journal = {Annals of Nuclear Energy, Part 2},
+   year    = {2016},
+   volume  = {87},
+   pages   = {728--738},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0306454915003357},
+   doi     = {}
 }
 
 @article{2016_120,
-   author  = "A. Voll and J. Stollenwerk and P. Loosen",
-   title   = "Computing specific intensity distributions for laser material processing by solving an inverse heat conduction problem",
-   journal = "Proc. SPIE 9741, High-Power Laser Materials Processing: Lasers, Beam Delivery, Diagnostics, and Applications V, 974105, March",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=2505859",
-   doi     = ""
+   author  = {A. Voll and J. Stollenwerk and P. Loosen},
+   title   = {Computing specific intensity distributions for laser material processing by solving an inverse heat conduction problem},
+   journal = {Proc. SPIE 9741, High-Power Laser Materials Processing: Lasers, Beam Delivery, Diagnostics, and Applications V, 974105, March},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=2505859},
+   doi     = {}
 }
 
 @article{2016_121,
-   author  = "B. Wacker and D. Arndt and G. Lube",
-   title   = "Nodal-based Finite Element Methods with Local Projection Stabilization for Linearized Incompressible Magnetohydrodynamics",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2016",
-   volume  = "302",
-   pages   = "170--192",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782516000062",
-   doi     = ""
+   author  = {B. Wacker and D. Arndt and G. Lube},
+   title   = {Nodal-based Finite Element Methods with Local Projection Stabilization for Linearized Incompressible Magnetohydrodynamics},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2016},
+   volume  = {302},
+   pages   = {170--192},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516000062},
+   doi     = {}
 }
 
 @article{2016_122,
-   author  = "T. Wick",
-   title   = "Coupling fluid-structure interaction with phase-field fracture: modeling and a numerical example",
-   journal = "In: Numerical Mathematics and Advanced Applications, Proceedings of the ENUMATH 2015 conference, Springer",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Coupling fluid-structure interaction with phase-field fracture: modeling and a numerical example},
+   journal = {In: Numerical Mathematics and Advanced Applications, Proceedings of the ENUMATH 2015 conference, Springer},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_123,
-   author  = "T. Wick",
-   title   = "Coupling fluid-structure interaction with phase-field fracture",
-   journal = "Journal of Computational Physics",
-   year    = "2016",
-   volume  = "327",
-   pages   = "67--96",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Coupling fluid-structure interaction with phase-field fracture},
+   journal = {Journal of Computational Physics},
+   year    = {2016},
+   volume  = {327},
+   pages   = {67--96},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_124,
-   author  = "T. Wick",
-   title   = "Goal functional evaluations for phase-field fracture using PU-based DWR mesh adaptivity",
-   journal = "Computational Mechanics",
-   year    = "2016",
-   volume  = "57",
-   pages   = "1017--1035",
-   url     = "http://dx.doi.org/10.1007/s00466-016-1275-1",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Goal functional evaluations for phase-field fracture using PU-based DWR mesh adaptivity},
+   journal = {Computational Mechanics},
+   year    = {2016},
+   volume  = {57},
+   pages   = {1017--1035},
+   url     = {http://dx.doi.org/10.1007/s00466-016-1275-1},
+   doi     = {}
 }
 
 @article{2016_125,
-   author  = "J. A. White and N. Castelletto and H. A. Tchelepi",
-   title   = "Block-partitioned solvers for coupled poromechanics: A unified framework",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2016",
-   volume  = "303",
-   pages   = "55--74",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782516000104",
-   doi     = ""
+   author  = {J. A. White and N. Castelletto and H. A. Tchelepi},
+   title   = {Block-partitioned solvers for coupled poromechanics: A unified framework},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2016},
+   volume  = {303},
+   pages   = {55--74},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516000104},
+   doi     = {}
 }
 
 @phdthesis{2016_126,
-   author  = "Y. Yang",
-   title   = "Continuous finite element approximation of hyperbolic systems",
-   year    = "2016",
-   school  = "Texas A&amp;M University",
-   url     = "https://oaktrust.library.tamu.edu/handle/1969.1/157976"
+   author  = {Y. Yang},
+   title   = {Continuous finite element approximation of hyperbolic systems},
+   year    = {2016},
+   school  = {Texas A \& M University},
+   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/157976}
 }
 
 @article{2016_127,
-   author  = "T. D. Young and R. Vargas and J.Garza",
-   title   = "A Hartree–Fock study of the confined helium atom: Local and global basis set approaches",
-   journal = "Physics Letters A, Vol. 380",
-   year    = "2016",
-   volume  = "",
-   pages   = "712--717",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0375960115009998",
-   doi     = ""
+   author  = {T. D. Young and R. Vargas and J.Garza},
+   title   = {A Hartree--Fock study of the confined helium atom: Local and global basis set approaches},
+   journal = {Physics Letters A, Vol. 380},
+   year    = {2016},
+   volume  = {},
+   pages   = {712--717},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0375960115009998},
+   doi     = {}
 }
 
 @article{2016_128,
-   author  = "S. Zhang and C. O'Neill",
-   title   = "The early geodynamic evolution of Mars-type planets",
-   journal = "Icarus, Vol. 265, pp. 187–208",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0019103515004856",
-   doi     = ""
+   author  = {S. Zhang and C. O'Neill},
+   title   = {The early geodynamic evolution of Mars-type planets},
+   journal = {Icarus, Vol. 265, pp. 187--208},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0019103515004856},
+   doi     = {}
 }
 
 @article{2016_129,
-   author  = "S. Zhang and J. A. Norato and A. L. Gain and N. Lyu",
-   title   = "A geometry projection method for the topology optimization of plate structures",
-   journal = "Structural and  Multidisciplinary Optimization, issue 5, pp. 1173–1190",
-   year    = "2016",
-   volume  = "54",
-   pages   = "",
-   url     = "https://link.springer.com/article/10.1007/s00158-016-1466-6",
-   doi     = ""
+   author  = {S. Zhang and J. A. Norato and A. L. Gain and N. Lyu},
+   title   = {A geometry projection method for the topology optimization of plate structures},
+   journal = {Structural and  Multidisciplinary Optimization, issue 5, pp. 1173--1190},
+   year    = {2016},
+   volume  = {54},
+   pages   = {},
+   url     = {https://link.springer.com/article/10.1007/s00158-016-1466-6},
+   doi     = {}
+}
+
+@phdthesis{2016_130,
+   author  = {W. Zheng},
+   title   = {Least-Squares and Other Residual Based Techniques for Radiation Transport Calculations},
+   year    = {2016},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2016_131,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "Moment closures based on minimizing the residual of the PN angular expansion in radiation transport",
-   journal = "J. Comput. Phys.",
-   year    = "2016",
-   volume  = "314",
-   pages   = "682--699",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999116001820",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {Moment closures based on minimizing the residual of the PN angular expansion in radiation transport},
+   journal = {J. Comput. Phys.},
+   year    = {2016},
+   volume  = {314},
+   pages   = {682--699},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116001820},
+   doi     = {}
 }
 
 @article{2016_132,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "Effectively Non-oscillatory Regularized L1 Finite Elements for Particle Transport Simulations",
-   journal = "J. Comput. Phys., submitted",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {Effectively Non-oscillatory Regularized L1 Finite Elements for Particle Transport Simulations},
+   journal = {J. Comput. Phys., submitted},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_133,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "Asymptotic preserving least square PN methods of transport equation",
-   journal = "Proceedings of PHYSOR 2016, Sun Valley, Idaho, May 1-5",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {Asymptotic preserving least square PN methods of transport equation},
+   journal = {Proceedings of PHYSOR 2016, Sun Valley, Idaho, May 1-5},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_134,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "Accurate Least-Squares PN Scaling based on Problem Optical Thickness for solving Neutron Transport Problems",
-   journal = "arxiv.org:1609.06699",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {Accurate Least-Squares PN Scaling based on Problem Optical Thickness for solving Neutron Transport Problems},
+   journal = {arxiv.org:1609.06699},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2016_135,
-   author  = "W. Zheng and R. G. McClarren and J. E. Morel",
-   title   = "An Accurate Globally Conservative Subdomain Discontinuous Least-squares Scheme for Solving Neutron Transport Problems",
-   journal = "arxiv.org:1612.01982",
-   year    = "2016",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
-}
-
-@Misc{Arndt2016a,
-  author       = {Arndt, D and Lucero, P and Witte, J and Kanschat, PEG},
-  title        = {{A Parallel Multigrid Matrix-Free Solver using Schwarz Smoothers}},
-  howpublished = {PDE Software Frameworks 2016},
-  year         = {2016},
-  owner        = {Jean-Paul Pelteret},
-  timestamp    = {2018.11.20},
-  url          = {http://www.mathsim.eu/~darndt/files/PDESoft2016Arndt.pdf},
-}
-
-@Article{Assier,
-  author    = {Assier, RC and Poon, C and Peake, N},
-  title     = {{Spectral study of the Laplace--Beltrami operator arising in the problem of acoustic wave scattering by a quarter-plane}},
-  journal   = {The Quarterly Journal of Mechanics and Applied Mathematics},
-  year      = {2016},
-  volume    = {69},
-  number    = {3},
-  pages     = {281--317},
-  month     = {aug},
-  doi       = {10.1093/qjmam/hbw008},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Oxford University Press ({OUP})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Bonitoa,
-  author    = {Andrea Bonito and Joseph E. Pasciak},
-  title     = {{Numerical approximation of fractional powers of regularly accretive operators}},
-  journal   = {{IMA} Journal of Numerical Analysis},
-  year      = {2016},
-  volume    = {37},
-  number    = {3},
-  pages     = {1245--1273},
-  month     = {aug},
-  note      = {Possible duplicate},
-  doi       = {10.1093/imanum/drw042},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Oxford University Press ({OUP})},
-  timestamp = {2018.11.20},
-}
-
-@Manual{chen2016manchester,
-  title     = {{The Manchester Thermal Analyzer}},
-  author    = {Chen, Yi-Chung and Ladenheim, Scott and Mihajlovi{\'{c}}, Milan and Pavlidis, Vasilis},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://pdfs.semanticscholar.org/853e/b3362f9d2670680f21dc7ed280e745fa6a9f.pdf},
-}
-
-@Article{Cockburn,
-  author    = {Bernardo Cockburn and Alan Demlow},
-  title     = {{Hybridizable discontinuous Galerkin and mixed finite element methods for elliptic problems on surfaces}},
-  journal   = {Mathematics of Computation},
-  year      = {2016},
-  volume    = {85},
-  number    = {302},
-  pages     = {2609--2638},
-  month     = {mar},
-  doi       = {10.1090/mcom/3093},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {American Mathematical Society ({AMS})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Cruz,
-  author    = {Luis M. De La Cruz and Eduardo Ramos},
-  title     = {General Template Units for the Finite Volume Method in Box-Shaped Domains},
-  journal   = {{ACM} Transactions on Mathematical Software},
-  year      = {2016},
-  volume    = {43},
-  number    = {1},
-  pages     = {1--32},
-  month     = {aug},
-  doi       = {10.1145/2835175},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Association for Computing Machinery ({ACM})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Dalcin,
-  author    = {L. Dalcin and N. Collier and P. Vignal and A.M.A. C{\^{o}}rtes and V.M. Calo},
-  title     = {{PetIGA: A framework for high-performance isogeometric analysis}},
-  journal   = {Computer Methods in Applied Mechanics and Engineering},
-  year      = {2016},
-  volume    = {308},
-  pages     = {151--181},
-  month     = {aug},
-  doi       = {10.1016/j.cma.2016.05.011},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-}
-
-@Article{Dillen2016,
-  author    = {Jonathan Dillen and Zhenping He and Chung-Yuen Hui and Anand Jagota},
-  title     = {Geometry of defects at shape-complementary soft interfaces},
-  journal   = {Extreme Mechanics Letters},
-  year      = {2016},
-  volume    = {9},
-  pages     = {74--83},
-  month     = {dec},
-  doi       = {10.1016/j.eml.2016.05.006},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-  url       = {https://core.ac.uk/download/pdf/82226290.pdf},
-}
-
-@Article{Ervin,
-  author    = {V.J. Ervin and Hyesuk Lee and A.J. Salgado},
-  title     = {{Generalized Newtonian fluid flow through a porous medium}},
-  journal   = {Journal of Mathematical Analysis and Applications},
-  year      = {2016},
-  volume    = {433},
-  number    = {1},
-  pages     = {603--621},
-  month     = {jan},
-  doi       = {10.1016/j.jmaa.2015.07.054},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-  url       = {https://www.sciencedirect.com/science/article/pii/S0022247X15007003},
-}
-
-@Article{gersbacher2016implementation,
-  author        = {Christoph Gersbacher},
-  title         = {Implementation of $hp$-adaptive discontinuous finite element methods in Dune-Fem},
-  journal       = {CoRR},
-  year          = {2016},
-  volume        = {abs/1604.07242},
-  archiveprefix = {arXiv},
-  eprint        = {1604.07242},
-  owner         = {Jean-Paul Pelteret},
-  timestamp     = {2018.11.20},
-  url           = {http://arxiv.org/abs/1604.07242},
-}
-
-@PhdThesis{Guittet2016,
-  author    = {Guittet, A},
-  title     = {{Simulation of incompressible viscous flows on distributed Octree grids}},
-  school    = {University of California},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://search.proquest.com/openview/a7b27aaca7f352c4cd8446610eeb79f0/1?pq-origsite=gscholar&cbl=18750&diss=y},
-}
-
-@Book{John2016,
-  title     = {Finite Element Methods for Incompressible Flow Problems},
-  publisher = {Springer International Publishing},
-  year      = {2016},
-  author    = {Volker John},
-  doi       = {10.1007/978-3-319-45750-5},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://link.springer.com/content/pdf/10.1007/978-3-319-45750-5.pdf},
-}
-
-@Book{Klinsmann2016,
-  title     = {The Effects of Internal Stress and Lithium Transport on Fracture in Storage Materials in Lithium-Ion Batteries},
-  publisher = {KIT Scientific Publishing},
-  year      = {2016},
-  author    = {Klinsmann, Markus},
-  volume    = {54},
-  series    = {Schriftenreihe des Instituts fuer Angewandte Materialien, Karlsruher Institut f\"{u}r Technologie},
-  isbn      = {9783731504559},
-  ean       = {9783731504559},
-  owner     = {Jean-Paul Pelteret},
-  pagetotal = {246},
-  timestamp = {2018.11.20},
-  url       = {https://books.google.com/books?hl=en&lr=&id=DaPBCwAAQBAJ&oi=fnd&pg=PA1&ots=OQG-TEOrRd&sig=Rpv8vp1yic72js-9bWMDR3l2lPY},
-}
-
-@Article{Klinsmanna,
-  author    = {Markus Klinsmann and Daniele Rosato and Marc Kamlah and Robert M. McMeeking},
-  title     = {{Modeling crack growth during Li insertion in storage particles using a fracture phase field approach}},
-  journal   = {Journal of the Mechanics and Physics of Solids},
-  year      = {2016},
-  volume    = {92},
-  pages     = {313--344},
-  month     = {jul},
-  doi       = {10.1016/j.jmps.2016.04.004},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-}
-
-@MastersThesis{Kottapalli,
-  author    = {Shravan Kottapalli},
-  title     = {{Numerical Prediction of Flow Induced Vibrations in Nuclear Reactors through Pressure Fluctuation Modeling}},
-  school    = {Delft University of Technology},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://repository.tudelft.nl/islandora/object/uuid:f2c3e758-6c90-4877-8c89-cea243be882c/datastream/OBJ/www.cfd-online.com/Wiki/Reynolds_stress _model_(RSM).pdf},
-}
-
-@Article{Kuberry,
-  author    = {Paul Kuberry and Hyesuk Lee},
-  title     = {{Convergence of a fluid--structure interaction problem decoupled by a Neumann control over a single time step}},
-  journal   = {Journal of Mathematical Analysis and Applications},
-  year      = {2016},
-  volume    = {437},
-  number    = {1},
-  pages     = {645--667},
-  month     = {may},
-  doi       = {10.1016/j.jmaa.2016.01.022},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-  url       = {https://www.sciencedirect.com/science/article/pii/S0022247X16000470},
-}
-
-@InProceedings{Lahnert,
-  author    = {Michael Lahnert and Carsten Burstedde and Christian Holm and Miriam Mehl and Georg Rempfer and Florian Weik},
-  title     = {Towards Lattice--Boltzmann On Dynamically Adaptive Grids -- Minimally-invasive Grid Exchange In Espresso},
-  booktitle = {Proceedings of the {VII} European Congress on Computational Methods in Applied Sciences and Engineering},
-  year      = {2016},
-  doi       = {10.7712/100016.1982.4659},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://pdfs.semanticscholar.org/8fc8/2d82beb2997c127248b85ceec8c21bdecfca.pdf},
-}
-
-@InCollection{LeBorne2016,
-  author    = {{Le Borne}, Sabine},
-  title     = {Hierarchical Preconditioners for High-Order {FEM}},
-  booktitle = {Lecture Notes in Computational Science and Engineering},
-  publisher = {Springer International Publishing},
-  year      = {2016},
-  pages     = {559--566},
-  doi       = {10.1007/978-3-319-18827-0_57},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://link.springer.com/10.1007/978-3-319-18827-0_57},
-}
-
-@TechReport{Lee2016b,
-  author      = {Lee, S and Mikelic, A and Wheeler, MF and Wick, T},
-  title       = {Phase-field modeling of proppant-filled fractures in a poroelastic medium},
-  institution = {The Institute for Computational Engineering and Sciences},
-  year        = {2016},
-  number      = {ICES REPORT 16-03},
-  address     = {The University of Texas at Austin},
-  note        = {Possible duplicate of article "Phase-field modeling of proppant..."},
-  owner       = {Jean-Paul Pelteret},
-  timestamp   = {2018.11.20},
-  url         = {https://www.ices.utexas.edu/media/reports/2016/1603.pdf},
-}
-
-@Article{Lemenager,
-  author    = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang},
-  title     = {{Numerical Modelling of the Sydney Basin Using Temperature Dependent Thermal Conductivity Measurements}},
-  journal   = {{ASEG} Extended Abstracts},
-  year      = {2016},
-  volume    = {1},
-  pages     = {1--7},
-  doi       = {10.1071/aseg2016ab238},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {{CSIRO} Publishing},
-  timestamp = {2018.11.20},
-  url       = {http://www.publish.csiro.au/EX/ASEG2016ab238},
-}
-
-@Article{Madzvamuse,
-  author    = {A. Madzvamuse and A. H. Chung},
-  title     = {{Analysis and Simulations of Coupled Bulk-surface Reaction-Diffusion Systems on Exponentially Evolving Volumes}},
-  journal   = {Mathematical Modelling of Natural Phenomena},
-  year      = {2016},
-  volume    = {11},
-  number    = {5},
-  pages     = {4--32},
-  doi       = {10.1051/mmnp/201611502},
-  editor    = {A. Morozov and M. Ptashnyk and V. Volpert},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {{EDP} Sciences},
-  timestamp = {2018.11.20},
-}
-
-@Article{Mandal,
-  author    = {Subhamoy Mandal and Xose Luis Dean-Ben and Daniel Razansky},
-  title     = {Visual Quality Enhancement in Optoacoustic Tomography Using Active Contour Segmentation Priors},
-  journal   = {{IEEE} Transactions on Medical Imaging},
-  year      = {2016},
-  volume    = {35},
-  number    = {10},
-  pages     = {2209--2217},
-  month     = {oct},
-  doi       = {10.1109/tmi.2016.2553156},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})},
-  timestamp = {2018.11.20},
-}
-
-@InProceedings{mihankhah2016environment,
-  author    = {Ehsan Mihankhah and Danwei Wang},
-  title     = {Environment characterization using Laplace eigenvalues},
-  booktitle = {2016 14th International Conference on Control, Automation, Robotics and Vision (ICARCV)},
-  year      = {2016},
-  pages     = {1--6},
-  month     = {nov},
-  publisher = {{IEEE}},
-  doi       = {10.1109/icarcv.2016.7838769},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@Article{Mirzadeh,
-  author    = {Mohammad Mirzadeh and Arthur Guittet and Carsten Burstedde and Frederic Gibou},
-  title     = {{Parallel level-set methods on adaptive tree-based grids}},
-  journal   = {Journal of Computational Physics},
-  year      = {2016},
-  volume    = {322},
-  pages     = {345--364},
-  month     = {oct},
-  doi       = {10.1016/j.jcp.2016.06.017},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-}
-
-@Article{Mitchell,
-  author    = {Lawrence Mitchell and Eike Hermann M�ller},
-  title     = {{High level implementation of geometric multigrid solvers for finite element problems: Applications in atmospheric modelling}},
-  journal   = {Journal of Computational Physics},
-  year      = {2016},
-  volume    = {327},
-  pages     = {1--18},
-  month     = {dec},
-  doi       = {10.1016/j.jcp.2016.09.037},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-}
-
-@Article{Mitchell2016,
-  author    = {Florian Rathgeber and David A. Ham and Lawrence Mitchell and Michael Lange and Fabio Luporini and Andrew T. T. Mcrae and Gheorghe-Teodor Bercea and Graham R. Markall and Paul H. J. Kelly},
-  title     = {{Firedrake: automating the finite element method by composing abstractions}},
-  journal   = {{ACM} Transactions on Mathematical Software},
-  year      = {2016},
-  volume    = {43},
-  number    = {3},
-  pages     = {1--27},
-  month     = {dec},
-  doi       = {10.1145/2998441},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Association for Computing Machinery ({ACM})},
-  timestamp = {2018.11.20},
-  url       = {http://www.doc.ic.ac.uk/~lmitche1/08-06-PASC-firedrake.pdf},
-}
-
-@Misc{Mohebujjaman2016,
-  author    = {Muhammad Mohebujjaman},
-  title     = {Solution of incompressible viscous time-dependent Navier-Stokes equations using projection method},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/project/Solution-of-incompressible-viscous-time-dependent-Navier-Stokes-equations-using-projection-method/attachment/57ad503e08aef1b475aef153/AS:394116325232643@1470976062899/download/project+_write.pdf?context=ProjectUpdatesLog},
-}
-
-@MastersThesis{Rahman2016,
-  author    = {Rahman, Mohammad Arifur},
-  title     = {An a posteriori error estimator for the C$^{0}$ Interior Penalty Approximations of Fourth Order Elliptic Boundary Value Problem on Quadrilateral Meshes},
-  school    = {The University of Texas at El Paso},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://search.proquest.com/openview/a1ba7b7eb39434a7aa45eb9e604a8e22/1?pq-origsite=gscholar&cbl=18750&diss=y},
-}
-
-@InProceedings{Riedlbauer,
-  author    = {Riedlbauer, D and Steinmann, P and Mergheim, J},
-  title     = {{Simulation of temperature distribution and mechanical material behaviour in selective beam melting processes}},
-  booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://www.eccomas2016.org/proceedings/pdf/4477.pdf},
-}
-
-@InProceedings{rodriguez2016new,
-  author    = {Rodr\'{i}guez-Gonz\'{a}lez, Juan and Montesi, Laurent},
-  title     = {A new finite element code for the study of strain-localization under strike-slip faults},
-  booktitle = {American Geophysical Union Fall Meeting Abstracts},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://agu.confex.com/agu/fm16/meetingapp.cgi/Paper/183591},
-}
-
-@PhdThesis{Roszmann2016,
-  author    = {Roszmann, Jordan Douglas},
-  title     = {Simulation and growth of cadmium zinc telluride from small seeds by the travelling heater method},
-  school    = {University of Victoria},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://dspace.library.uvic.ca/handle/1828/7347},
-}
-
-@Article{Salinger_2016,
-  author    = {Andrew G. Salinger and Roscoe A. Bartlett and Andrew M. Bradley and Qiushi Chen and Irina P. Demeshko and Xujiao Gao and Glen A. Hansen and Alejandro Mota and Richard P. Muller and Erik Nielsen and Jakob T. Ostien and Roger P. Pawlowski and Mauro Perego and Eric T. Phipps and WaiChing Sun and Irina K. Tezaur},
-  title     = {{Albany: Using component-based design to develop a flexible, generic multiphysics analysis code}},
-  journal   = {International Journal for Multiscale Computational Engineering},
-  year      = {2016},
-  volume    = {14},
-  number    = {4},
-  pages     = {415--438},
-  doi       = {10.1615/intjmultcompeng.2016017040},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Begell House},
-  timestamp = {2018.11.20},
-}
-
-@InProceedings{Salmoiraghi2016,
-  author    = {Salmoiraghi, F and Ballarin, F and Corsi, G and Mola, A and Tezzele, M},
-  title     = {Advances in geometrical parametrization and reduced order models and methods for computational fluid dynamics problems in applied sciences and engineering},
-  booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://preprints.sissa.it/xmlui/handle/1963/35179},
-}
-
-@TechReport{Sasidharan2016,
-  author      = {Sasidharan, Aparna and Snir, Marc},
-  title       = {MiniAMR -- A miniapp for Adaptive Mesh Refinement},
-  institution = {University of Illinois at Urbana-Champaign},
-  year        = {2016},
-  owner       = {Jean-Paul Pelteret},
-  timestamp   = {2018.11.20},
-  url         = {https://www.ideals.illinois.edu/handle/2142/91046},
-}
-
-@InProceedings{Schaller_2016,
-  author    = {Matthieu Schaller and Pedro Gonnet and Aidan B. G. Chalk and Peter W. Draper},
-  title     = {{SWIFT: Using Task-Based Parallelism, Fully Asynchronous Communication, and Graph Partition-Based Domain Decomposition for Strong Scaling on more than 100,000 Cores}},
-  booktitle = {Proceedings of the Platform for Advanced Scientific Computing Conference},
-  year      = {2016},
-  publisher = {{ACM} Press},
-  doi       = {10.1145/2929908.2929916},
-  journal   = {dl.acm.org},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@PhdThesis{Scheffer2016,
-  author    = {Scheffer, Tobias},
-  title     = {Charakterisierung des nichtlinear-viskoelastischen Materialverhaltens gef{\"{u}}llter Elastomere},
-  school    = {Universit\"{a}t des Saarlandes},
-  year      = {2016},
-  doi       = {10.22028/D291-23130},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/23186},
-}
-
-@MastersThesis{siehrnewton,
-  author    = {Siehr, Philipp},
-  title     = {{Das Newton-Verfahren zur Berechnung variationeller Eigenwertprobleme}},
-  school    = {Universit\"{a}t Heidelberg},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@InProceedings{Stegmann_2016,
-  author       = {P. G. Stegmann and P. Yang},
-  title        = {{Development of a Discontinuous Galerkin Time Domain Solver on a staggered grid for pan-spectral single scattering analysis}},
-  booktitle    = {Light, Energy and the Environment},
-  year         = {2016},
-  organization = {Optical Society of America},
-  publisher    = {{OSA}},
-  doi          = {10.1364/fts.2016.jw4a.29},
-  owner        = {Jean-Paul Pelteret},
-  timestamp    = {2018.11.20},
-}
-
-@PhdThesis{Stegmann2016,
-  author    = {Stegmann, Patrick G\"{u}nther},
-  title     = {Light Scattering by Non-Spherical Particles},
-  school    = {Technische Universit\"{a}t Darmstadt},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://tuprints.ulb.tu-darmstadt.de/5257/},
-}
-
-@PhdThesis{Tsoeu2016,
-  author    = {T{\v{s}}oeu, Mohohlo Samuel},
-  title     = {Electrical Impedance Tomography/Spectroscopy (EITS): a Code Division Multiplexed (CDM) approaches},
-  school    = {University of Cape Town},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://open.uct.ac.za/handle/11427/22866},
-}
-
-@Article{Turner_2016,
-  author    = {John A. Turner and Kevin Clarno and Matt Sieger and Roscoe Bartlett and Benjamin Collins and Roger Pawlowski and Rodney Schmidt and Randall Summers},
-  title     = {{The Virtual Environment for Reactor Applications (VERA): Design and architecture}},
-  journal   = {Journal of Computational Physics},
-  year      = {2016},
-  volume    = {326},
-  pages     = {544--568},
-  month     = {dec},
-  doi       = {10.1016/j.jcp.2016.09.003},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-}
-
-@PhdThesis{White2016,
-  author    = {White, Raymon},
-  title     = {{Parallel block preconditioning of the incompressible Navier-Stokes equations with weakly imposed boundary conditions}},
-  school    = {University of Manchester},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://search.proquest.com/openview/283931f019e73788c05df3ebafe35abc/1?pq-origsite=gscholar&cbl=2026366&diss=y},
-}
-
-@TechReport{Wilbrandt,
-  author      = {Wilbrandt, U and Bartsch, C and Ahmed, N and Alia, N and Anker, F},
-  title       = {ParMooN -- a modernized program package based on mapped finite elements},
-  institution = {Weierstra{\ss}-Institut f\"{u}r Angewandte Analysis und Stochastik},
-  year        = {2016},
-  owner       = {Jean-Paul Pelteret},
-  timestamp   = {2018.11.20},
-  url         = {http://www.wias-berlin.de/preprint/2316/wias_preprints_2316_20161220.pdf},
-}
-
-@InProceedings{Xu_2016,
-  author    = {Li-Yang Xu and Shuai Ye and Yong-Quan Feng and Hao Li and Xin-Hai Xu and Xiao-Guang Ren},
-  title     = {High Order Accurate Curved-element Implementation in {OpenFOAM} for Discontinuous Galerkin Method},
-  booktitle = {Advanced Science and Technology Letters},
-  year      = {2016},
-  volume    = {142},
-  month     = {dec},
-  publisher = {Science {\&} Engineering Research Support {soCiety}},
-  doi       = {10.14257/astl.2016.142.08},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://www.researchgate.net/profile/Hao_Li192/publication/312344754_High_Order_Accurate_Curved-element_Implementation_in_OpenFOAM_for_Discontinuous_Galerkin_Method/links/590d26134585159781831faa/High-Order-Accurate-Curved-element-Implementation-in-OpenFOAM-for-Discontinuous-Galerkin-Method.pdf},
-}
-
-@Article{Zander_2016,
-  author    = {Nils Zander and Tino Bog and Mohamed Elhaddad and Felix Frischmann and Stefan Kollmannsberger and Ernst Rank},
-  title     = {{The multi-level hp-method for three-dimensional problems: Dynamically changing high-order mesh refinement with arbitrary hanging nodes}},
-  journal   = {Computer Methods in Applied Mechanics and Engineering},
-  year      = {2016},
-  volume    = {310},
-  pages     = {252--277},
-  month     = {oct},
-  doi       = {10.1016/j.cma.2016.07.007},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-}
-
-@MastersThesis{Huang2016,
-  author    = {Tzu-Hsuan Huang},
-  title     = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
-  school    = {National Taiwan University},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://hdl.handle.net/11296/2hzk7d},
-}
-
-@Article{Yoon2016,
-  author    = {Yoon, Sungho and Kang, Yong Tae},
-  title     = {{Mass Transfer Enhancement by a Single Emulsion Droplet}},
-  journal   = {International Journal of Air-Conditioning and Refrigeration},
-  year      = {2016},
-  volume    = {24},
-  number    = {01},
-  pages     = {1650003},
-  month     = {mar},
-  doi       = {10.1142/S2010132516500036},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://www.worldscientific.com/doi/abs/10.1142/S2010132516500036},
-}
-
-@Article{McRae2016,
-  author    = {McRae, A. T. T. and Bercea, G.-T. and Mitchell, L. and Ham, D. A. and Cotter, C. J.},
-  title     = {Automated Generation and Symbolic Manipulation of Tensor Product Finite Elements},
-  journal   = {{SIAM} Journal on Scientific Computing},
-  year      = {2016},
-  volume    = {38},
-  number    = {5},
-  pages     = {S25--S47},
-  month     = {jan},
-  doi       = {10.1137/15m1021167},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Maurer2016,
-  author    = {Maurer, Daniel and Wieners, Christian},
-  title     = {A scalable parallel factorization of finite element matrices with distributed Schur complements},
-  journal   = {Numerical Linear Algebra with Applications},
-  year      = {2016},
-  volume    = {23},
-  number    = {5},
-  pages     = {848--864},
-  month     = {jun},
-  doi       = {10.1002/nla.2057},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Wiley},
-  timestamp = {2018.11.20},
-}
-
-@InProceedings{Lofstead2016,
-  author    = {Lofstead, Jay and Jean-Baptiste, Gregory and Oldfield, Ron},
-  title     = {Delta: Data Reduction for Integrated Application Workflows and Data Storage},
-  booktitle = {ISC High Performance 2016: High Performance Computing},
-  year      = {2016},
-  editor    = {Taufer, M. and Mohr, B. and Kunkel, J.},
-  volume    = {9945},
-  series    = {Lecture Notes in Computer Science},
-  pages     = {142--152},
-  publisher = {Springer International Publishing},
-  doi       = {10.1007/978-3-319-46079-6_11},
-  isbn      = {978-3-319-46079-6},
-  journal   = {Springer},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@Article{Leibner2016,
-  author        = {Leibner, Tobias and Milk, Ren{\'{e}} and Schindler, Felix},
-  title         = {{Extending DUNE: The dune-xt modules}},
-  journal       = {arxiv.org},
-  year          = {2016},
-  month         = {feb},
-  archiveprefix = {arXiv},
-  arxivid       = {1602.08991},
-  eprint        = {1602.08991},
-  owner         = {Jean-Paul Pelteret},
-  timestamp     = {2018.11.20},
-  url           = {http://arxiv.org/abs/1602.08991},
-}
-
-@Article{Jiang2016,
-  author    = {Jiang, Tonghu and Rudraraju, Shiva and Roy, Anindya and {Van der Ven}, Anton and Garikipati, Krishna and Falk, Michael L.},
-  title     = {Multiphysics Simulations of Lithiation-Induced Stress in Li$_{1+x}$Ti$_{2}$O$_{4}$ Electrode Particles},
-  journal   = {The Journal of Physical Chemistry C},
-  year      = {2016},
-  volume    = {120},
-  number    = {49},
-  pages     = {27871--27881},
-  month     = {dec},
-  issn      = {1932-7447},
-  note      = {TODO: Update existing entry that only has arxiv data},
-  doi       = {10.1021/acs.jpcc.6b09775},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {American Chemical Society ({ACS})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Giuliani2016,
-  author        = {Giuliani, Andrew and Krivodonova, Lilia},
-  title         = {Edge coloring in unstructured CFD codes},
-  journal       = {arxiv.org},
-  year          = {2016},
-  month         = {jan},
-  archiveprefix = {arXiv},
-  arxivid       = {1601.07613},
-  date          = {2016-01-28},
-  eprint        = {http://arxiv.org/abs/1601.07613v2},
-  eprintclass   = {cs.DC},
-  eprinttype    = {arXiv},
-  file          = {:http\://arxiv.org/pdf/1601.07613v2:PDF},
-  keywords      = {cs.DC},
-  owner         = {Jean-Paul Pelteret},
-  timestamp     = {2018.11.20},
-  url           = {http://arxiv.org/abs/1601.07613},
-}
-
-@Article{Gholami2016,
-  author    = {Gholami, Amir and Malhotra, Dhairya and Sundar, Hari and Biros, George},
-  title     = {{FFT}, {FMM}, or Multigrid? A comparative Study of State-Of-the-Art Poisson Solvers for Uniform and Nonuniform Grids in the Unit Cube},
-  journal   = {SIAM Journal on Scientific Computing},
-  year      = {2016},
-  volume    = {38},
-  number    = {3},
-  pages     = {C280--C306},
-  month     = {jan},
-  issn      = {1064-8275},
-  doi       = {10.1137/15m1010798},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Feng2016,
-  author    = {Feng, Xinzeng and Hui, Chung-Yuen},
-  title     = {{Force sensing using 3D displacement measurements in linear elastic bodies}},
-  journal   = {Computational Mechanics},
-  year      = {2016},
-  volume    = {58},
-  number    = {1},
-  pages     = {91--105},
-  month     = {apr},
-  issn      = {0178-7675},
-  doi       = {10.1007/s00466-016-1283-1},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Springer Nature},
-  timestamp = {2018.11.20},
-}
-
-@Article{Choo2016,
-  author    = {Choo, Jinhyun and White, Joshua A. and Borja, Ronaldo I.},
-  title     = {{Hydromechanical Modeling of Unsaturated Flow in Double Porosity Media}},
-  journal   = {International Journal of Geomechanics},
-  year      = {2016},
-  volume    = {16},
-  number    = {6},
-  pages     = {D4016002},
-  month     = {dec},
-  issn      = {1532-3641},
-  note      = {TODO: Update existing entry that only has limited data},
-  doi       = {10.1061/(ASCE)GM.1943-5622.0000558},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {American Society of Civil Engineers ({ASCE})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Chidyagwai2016,
-  author    = {Chidyagwai, Prince and Ladenheim, Scott and Szyld, Daniel B.},
-  title     = {{Constraint Preconditioning for the Coupled Stokes--Darcy System}},
-  journal   = {{SIAM} Journal on Scientific Computing},
-  year      = {2016},
-  volume    = {38},
-  number    = {2},
-  pages     = {A668--A690},
-  month     = {jan},
-  issn      = {1064-8275},
-  note      = {TODO: Update existing entry that only has limited data},
-  doi       = {10.1137/15M1032156},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Burstedde2016,
-  author    = {Burstedde, Carsten and Holke, Johannes},
-  title     = {{A Tetrahedral Space-Filling Curve for Nonconforming Adaptive Meshes}},
-  journal   = {{SIAM} Journal on Scientific Computing},
-  year      = {2016},
-  volume    = {38},
-  number    = {5},
-  pages     = {C471--C503},
-  month     = {jan},
-  issn      = {1064-8275},
-  doi       = {10.1137/15M1040049},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Bauman2016,
-  author    = {Bauman, Paul T. and Stogner, Roy H.},
-  title     = {{GRINS: A Multiphysics Framework Based on the libMesh Finite Element Library}},
-  journal   = {{SIAM} Journal on Scientific Computing},
-  year      = {2016},
-  volume    = {38},
-  number    = {5},
-  pages     = {S78--S100},
-  month     = {jan},
-  issn      = {1064-8275},
-  doi       = {10.1137/15M1026110},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Zhenga,
-  author        = {Zheng, Weixiong and McClarren, Ryan G.},
-  title         = {{Effective Non-oscillatory Regularized L Finite Elements for Particle Transport Simulations}},
-  journal       = {arxiv.org},
-  year          = {2016},
-  month         = {dec},
-  note          = {TODO: Update existing entry that only has limited data},
-  archiveprefix = {arXiv},
-  arxivid       = {1612.05581},
-  date          = {2016-12-16},
-  eprint        = {1612.05581},
-  eprintclass   = {physics.comp-ph},
-  eprinttype    = {arXiv},
-  file          = {:http\://arxiv.org/pdf/1612.05581v1:PDF},
-  keywords      = {physics.comp-ph},
-  owner         = {Jean-Paul Pelteret},
-  timestamp     = {2018.11.20},
-  url           = {https://arxiv.org/abs/1612.05581},
-}
-
-@MastersThesis{Maroudas2016,
-  author    = {Maroudas, Emmanouil},
-  title     = {{Support of PDEs for multidomain problems in a solving environment}},
-  school    = {University of Thessaly},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {http://ir.lib.uth.gr/bitstream/handle/11615/46361/14595.pdf?sequence=1},
-}
-
-@InProceedings{Droba2106,
-  author    = {Droba, Justin},
-  title     = {{Tangle-Free Finite Element Mesh Motion for Ablation Problems}},
-  booktitle = {46th {AIAA} Thermophysics Conference},
-  year      = {2016},
-  address   = {Reston, Virginia},
-  month     = {jun},
-  publisher = {American Institute of Aeronautics and Astronautics},
-  doi       = {10.2514/6.2016-3386},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@InCollection{John_2016,
-  author    = {John, Volker},
-  title     = {{The Time-Dependent Navier--Stokes Equations: Laminar Flows}},
-  booktitle = {Finite Element Methods for Incompressible Flow Problems},
-  publisher = {Springer International Publishing},
-  year      = {2016},
-  volume    = {51},
-  series    = {Springer Series in Computational Mathematics},
-  pages     = {355--445},
-  doi       = {10.1007/978-3-319-45750-5_7},
-  journal   = {Springer},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@TechReport{Heltai,
-  author      = {Heltai, L and Rotundo, N},
-  title       = {Error estimates in weighted Sobolev norms for finite element immersed interface methods},
-  institution = {Weierstra{\ss}-Institut f\"{u}r Angewandte Analysis und Stochastik},
-  year        = {2016},
-  owner       = {Jean-Paul Pelteret},
-  timestamp   = {2018.11.20},
-  url         = {http://www.wias-berlin.de/preprint/2323/wias_preprints_2323.pdf},
-}
-
-@Article{2016_72,
-  author    = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
-  title     = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
-  journal   = {The International Journal of High Performance Computing Applications},
-  year      = {2016},
-  volume    = {32},
-  number    = {2},
-  pages     = {266--287},
-  month     = {oct},
-  doi       = {10.1177/1094342016671790},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {{SAGE} Publications},
-  timestamp = {2018.11.20},
-  url       = {https://mediatum.ub.tum.de/1272587},
-}
-
-@PhdThesis{2016_130,
-  author    = {W. Zheng},
-  title     = {Least-Squares and Other Residual Based Techniques for Radiation Transport Calculations},
-  school    = {Texas A \& M University},
-  year      = {2016},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-  url       = {https://oaktrust.library.tamu.edu/handle/1969.1/159075},
-}
-
-@Article{Peterson,
-  author        = {John W. Peterson and Roy H. Stogner},
-  title         = {{A C$^{1}$-continuous finite element formulation for solving the Jeffery-Hamel boundary value problem}},
-  journal       = {arxiv.org},
-  year          = {2016},
-  month         = {dec},
-  archiveprefix = {arXiv},
-  arxivid       = {1612.06312},
-  date          = {2016-12-19},
-  eprint        = {1612.06312},
-  eprintclass   = {math.NA},
-  eprinttype    = {arXiv},
-  keywords      = {math.NA, 34B15},
-  owner         = {Jean-Paul Pelteret},
-  timestamp     = {2018.11.20},
-  url           = {http://arxiv.org/abs/1612.06312},
+   author  = {W. Zheng and R. G. McClarren and J. E. Morel},
+   title   = {An Accurate Globally Conservative Subdomain Discontinuous Least-squares Scheme for Solving Neutron Transport Problems},
+   journal = {arxiv.org:1612.01982},
+   year    = {2016},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1,1074 +1,1085 @@
 % Encoding: ISO-8859-1
 
 @mastersthesis{2017_116,
-   author  = "A. Ström",
-   title   = "Preconditioned iterative methods for PDE-constrained optimization problems with pointwise state constraints",
-   year    = "2017",
-   school  = "Uppsala University, Sweden",
-   url     = "http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A1081649&dswid=292"
+   author  = {A. Str\"{o}m},
+   title   = {Preconditioned iterative methods for PDE-constrained optimization problems with pointwise state constraints},
+   year    = {2017},
+   school  = {Uppsala University, Sweden},
+   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A1081649&dswid=292}
 }
 
 @article{2017_0,
-   author  = "J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan",
-   title   = "Combining Deflation and Nested Iteration for Computing Multiple Solutions of Nonlinear Variational Problems",
-   journal = "SIAM J. Sci. Comput., issue 1, B29-B52",
-   year    = "2017",
-   volume  = "39",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/16M1058728",
-   doi     = ""
+   author  = {J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan},
+   title   = {Combining Deflation and Nested Iteration for Computing Multiple Solutions of Nonlinear Variational Problems},
+   journal = {SIAM J. Sci. Comput., issue 1, B29-B52},
+   year    = {2017},
+   volume  = {39},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1058728},
+   doi     = {}
 }
 
 @article{2017_1,
-   author  = "R. Agelek and M. Anderson and W. Bangerth and W. L. Barth",
-   title   = "On orienting edges of unstructured two- and three-dimensional meshes",
-   journal = "ACM Transactions on Mathematical Software, article 5",
-   year    = "2017",
-   volume  = "44",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {R. Agelek and M. Anderson and W. Bangerth and W. L. Barth},
+   title   = {On orienting edges of unstructured two- and three-dimensional meshes},
+   journal = {ACM Transactions on Mathematical Software, article 5},
+   year    = {2017},
+   volume  = {44},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_2,
-   author  = "T. Almani and S. Lee and M. F. Wheeler and T. Wick",
-   title   = "Multirate coupling for flow and geomechanics applied to hydraulic fracturing using an adaptive phase-field technique",
-   journal = "SPE RSC 182610-MS, Feb. 2017, Montgomery, Texas, USA",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Almani and S. Lee and M. F. Wheeler and T. Wick},
+   title   = {Multirate coupling for flow and geomechanics applied to hydraulic fracturing using an adaptive phase-field technique},
+   journal = {SPE RSC 182610-MS, Feb. 2017, Montgomery, Texas, USA},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_3,
-   author  = "J. C. Araujo-Cabarcas and C. Engstr&ouml;m",
-   title   = "On spurious solutions in finite element approximations of resonances in open systems",
-   journal = "Computers and Mathematics with Applications",
-   year    = "2017",
-   volume  = "74",
-   pages   = "2385--2402",
-   url     = "",
-   doi     = ""
+   author  = {J. C. Araujo-Cabarcas and C. Engstr\"{o}m},
+   title   = {On spurious solutions in finite element approximations of resonances in open systems},
+   journal = {Computers and Mathematics with Applications},
+   year    = {2017},
+   volume  = {74},
+   pages   = {2385--2402},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_4,
-   author  = "T. Arbogast and M. A. Hesse and and A. L. Taicher",
-   title   = "Mixed Methods for Two-Phase Darcy--Stokes Mixtures of Partially Melted Materials with Regions of Zero Porosity",
-   journal = "SIAM Journal on Scientific Computing, issue 2, pp. B375-B402",
-   year    = "2017",
-   volume  = "39",
-   pages   = "",
-   url     = "http://epubs.siam.org/doi/abs/10.1137/16M1091095",
-   doi     = ""
+   author  = {T. Arbogast and M. A. Hesse and and A. L. Taicher},
+   title   = {Mixed Methods for Two-Phase Darcy--Stokes Mixtures of Partially Melted Materials with Regions of Zero Porosity},
+   journal = {SIAM Journal on Scientific Computing, issue 2, pp. B375-B402},
+   year    = {2017},
+   volume  = {39},
+   pages   = {},
+   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1091095},
+   doi     = {}
 }
 
 @article{2017_5,
-   author  = "D. Arndt and W. Bangerth and D. Davydov and T. Heister and L. Heltai and M. Kronbichler and M. Maier and B. Turcksin and D. Wells",
-   title   = "The <abbr>deal.II</abbr> Library, Version 8.5",
-   journal = "Journal of Numerical Mathematics",
-   year    = "2017",
-   volume  = "25",
-   pages   = "137--146",
-   url     = "",
-   doi     = "10.1515/jnma-2017-0058"
+   author  = {D. Arndt and W. Bangerth and D. Davydov and T. Heister and L. Heltai and M. Kronbichler and M. Maier and B. Turcksin and D. Wells},
+   title   = {The \texttt{deal.II} Library, Version 8.5},
+   journal = {Journal of Numerical Mathematics},
+   year    = {2017},
+   volume  = {25},
+   pages   = {137--146},
+   url     = {},
+   doi     = {10.1515/jnma-2017-0058}
 }
 
 @article{2017_6,
-   author  = "J. Austermann and J. X. Mitrovica and P. Huybers and A. Rovere",
-   title   = "Detection of a dynamic topography signal in last interglacial sea-level records",
-   journal = "Science Advances 3.7: e1700457",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1126/sciadv.1700457"
+   author  = {J. Austermann and J. X. Mitrovica and P. Huybers and A. Rovere},
+   title   = {Detection of a dynamic topography signal in last interglacial sea-level records},
+   journal = {Science Advances 3.7: e1700457},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1126/sciadv.1700457}
 }
 
 @article{2017_7,
-   author  = "O. Axelsson and S. Farouq and M. Neytcheva",
-   title   = "A preconditioner for optimal control problems, constrained by Stokes equation with a time-harmonic control",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2017",
-   volume  = "310",
-   pages   = "5--18",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0377042716302631",
-   doi     = ""
+   author  = {O. Axelsson and S. Farouq and M. Neytcheva},
+   title   = {A preconditioner for optimal control problems, constrained by Stokes equation with a time-harmonic control},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2017},
+   volume  = {310},
+   pages   = {5--18},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302631},
+   doi     = {}
 }
 
 @article{2017_8,
-   author  = "H. Badnava and E. Etemadi and M. A. Msekh",
-   title   = "A Phase Field Model for Rate-Dependent Ductile Fracture",
-   journal = "Metals, article 180",
-   year    = "2017",
-   volume  = "7",
-   pages   = "",
-   url     = "http://www.mdpi.com/2075-4701/7/5/180/htm",
-   doi     = ""
+   author  = {H. Badnava and E. Etemadi and M. A. Msekh},
+   title   = {A Phase Field Model for Rate-Dependent Ductile Fracture},
+   journal = {Metals, article 180},
+   year    = {2017},
+   volume  = {7},
+   pages   = {},
+   url     = {http://www.mdpi.com/2075-4701/7/5/180/htm},
+   doi     = {}
 }
 
 @article{2017_9,
-   author  = "H. Badnava and M. A. Msekh and E. Etemadi and T. Rabczuk",
-   title   = "An h-adaptive thermo-mechanical phase field model for fracture",
-   journal = "Finite Elements in Analysis and Design",
-   year    = "2017",
-   volume  = "138",
-   pages   = "31--47",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0168874X17303347?",
-   doi     = ""
+   author  = {H. Badnava and M. A. Msekh and E. Etemadi and T. Rabczuk},
+   title   = {An h-adaptive thermo-mechanical phase field model for fracture},
+   journal = {Finite Elements in Analysis and Design},
+   year    = {2017},
+   volume  = {138},
+   pages   = {31--47},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0168874X17303347?},
+   doi     = {}
 }
 
 @article{2017_10,
-   author  = "A. Basak and V. I. Levitas",
-   title   = "Interfacial stresses within boundary between martensitic variants: Analytical and numerical finite strain solutions for three phase field models",
-   journal = "Acta Materialia",
-   year    = "2017",
-   volume  = "139",
-   pages   = "174--187",
-   url     = "",
-   doi     = ""
+   author  = {A. Basak and V. I. Levitas},
+   title   = {Interfacial stresses within boundary between martensitic variants: Analytical and numerical finite strain solutions for three phase field models},
+   journal = {Acta Materialia},
+   year    = {2017},
+   volume  = {139},
+   pages   = {174--187},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_11,
-   author  = "M. Bause and F. A. Radu and U. Köcher",
-   title   = "Space-time finite element approximation of the Biot poroelasticity system with iterative coupling",
-   journal = "Comput. Meth. Appl. Mech. Engrg.",
-   year    = "2017",
-   volume  = "320",
-   pages   = "745--768",
-   url     = "https://www.sciencedirect.com/science/article/pii/S0045782516316164?via%3Dihub",
-   doi     = ""
+   author  = {M. Bause and F. A. Radu and U. K\"{o}cher},
+   title   = {Space-time finite element approximation of the Biot poroelasticity system with iterative coupling},
+   journal = {Comput. Meth. Appl. Mech. Engrg.},
+   year    = {2017},
+   volume  = {320},
+   pages   = {745--768},
+   url     = {https://www.sciencedirect.com/science/article/pii/S0045782516316164?via%3Dihub},
+   doi     = {}
 }
 
 @article{2017_12,
-   author  = "M. Bause and F. Radu and U. K&ouml;cher",
-   title   = "Error analysis for discretizations of parabolic problems using continuous finite elements in time and mixed finite elements in space",
-   journal = "Numerische Mathematik",
-   year    = "2017",
-   volume  = "137",
-   pages   = "773--818",
-   url     = "https://link.springer.com/article/10.1007%2Fs00211-017-0894-6",
-   doi     = "10.1007/s00211-017-0894-6"
+   author  = {M. Bause and F. Radu and U. K\"{o}cher},
+   title   = {Error analysis for discretizations of parabolic problems using continuous finite elements in time and mixed finite elements in space},
+   journal = {Numerische Mathematik},
+   year    = {2017},
+   volume  = {137},
+   pages   = {773--818},
+   url     = {https://link.springer.com/article/10.1007%2Fs00211-017-0894-6},
+   doi     = {10.1007/s00211-017-0894-6}
 }
 
 @article{2017_13,
-   author  = "L. C. Berselli and D. Wells and X. Xie and T. Iliescu",
-   title   = "Spatial filtering for reduced order modeling",
-   journal = "arXiv.org preprint 1707.04133",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1707.04133",
-   doi     = ""
+   author  = {L. C. Berselli and D. Wells and X. Xie and T. Iliescu},
+   title   = {Spatial filtering for reduced order modeling},
+   journal = {arXiv.org preprint 1707.04133},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1707.04133},
+   doi     = {}
 }
 
 @article{2017_14,
-   author  = "D. Biermann and H. Blum and I. Iovkov and A. Rademacher and K. Rosin and F.-T. Suttmeier",
-   title   = "Modelling, Simulation and Compensation of Thermomechanically Induced Deviations in Deep-Hole Drilling with Minimum Quantity Lubrication",
-   journal = "In: Biermann D., Hollmann F. (eds): Thermal Effects in Complex Machining Processes. Lecture Notes in Production Engineering. Springer",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://doi.org/10.1007/978-3-319-57120-1_10",
-   doi     = ""
+   author  = {D. Biermann and H. Blum and I. Iovkov and A. Rademacher and K. Rosin and F.-T. Suttmeier},
+   title   = {Modelling, Simulation and Compensation of Thermomechanically Induced Deviations in Deep-Hole Drilling with Minimum Quantity Lubrication},
+   journal = {In: Biermann D., Hollmann F. (eds): Thermal Effects in Complex Machining Processes. Lecture Notes in Production Engineering. Springer},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://doi.org/10.1007/978-3-319-57120-1_10},
+   doi     = {}
 }
 
 @article{2017_15,
-   author  = "E. Bonetti and C. Cavaterra and F. Freddi and M. Grasselli and R. Natalini",
-   title   = "A nonlinear model for marble sulphation including surface rugosity: theoretical and numerical results",
-   journal = "arXiv:1710.01225",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {E. Bonetti and C. Cavaterra and F. Freddi and M. Grasselli and R. Natalini},
+   title   = {A nonlinear model for marble sulphation including surface rugosity: theoretical and numerical results},
+   journal = {arXiv:1710.01225},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_16,
-   author  = "E. Bonetti and F. Freddi and A. Segatti",
-   title   = "An existence result for a model of complete damage in elastic materials with reversible evolution",
-   journal = "Continuum Mechanics and Thermodynamics, issue 1",
-   year    = "2017",
-   volume  = "29",
-   pages   = "31--50",
-   url     = "https://link.springer.com/article/10.1007/s00161-016-0520-3",
-   doi     = ""
+   author  = {E. Bonetti and F. Freddi and A. Segatti},
+   title   = {An existence result for a model of complete damage in elastic materials with reversible evolution},
+   journal = {Continuum Mechanics and Thermodynamics, issue 1},
+   year    = {2017},
+   volume  = {29},
+   pages   = {31--50},
+   url     = {https://link.springer.com/article/10.1007/s00161-016-0520-3},
+   doi     = {}
 }
 
 @mastersthesis{2017_17,
-   author  = "P. Br&auml;uer",
-   title   = "Reduced-Order modeling for transient thermoelasticity with moving sources using global-local bases",
-   year    = "2017",
-   school  = "Friedrich-Alexander-Universit&auml;t Erlangen-N&uuml;rnberg",
-   url     = ""
+   author  = {P. Br\"{a}uer},
+   title   = {Reduced-Order modeling for transient thermoelasticity with moving sources using global-local bases},
+   year    = {2017},
+   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   url     = {}
 }
 
 @article{2017_18,
-   author  = "E. Bredow and B. Steinberger and R. Gassm&ouml;ller and J. Dannberg",
-   title   = "How plume-ridge interaction shapes the crustal thickness pattern of the R&eacute;union hotspot track",
-   journal = "Geochem. Geophys. Geosyst.",
-   year    = "2017",
-   volume  = "18",
-   pages   = "",
-   url     = "",
-   doi     = "10.1002/2017GC006875"
+   author  = {E. Bredow and B. Steinberger and R. Gassm\"{o}ller and J. Dannberg},
+   title   = {How plume-ridge interaction shapes the crustal thickness pattern of the R\'{e}union hotspot track},
+   journal = {Geochem. Geophys. Geosyst.},
+   year    = {2017},
+   volume  = {18},
+   pages   = {},
+   url     = {},
+   doi     = {10.1002/2017GC006875}
 }
 
 @article{2017_19,
-   author  = "S. Brisard",
-   title   = "Reconstructing displacements from the solution to the periodic Lippmann–Schwinger equation discretized on a uniform grid",
-   journal = "International Journal for Numerical Methods in Engineering, issue 4",
-   year    = "2017",
-   volume  = "109",
-   pages   = "459--486",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/nme.5263/full",
-   doi     = ""
+   author  = {S. Brisard},
+   title   = {Reconstructing displacements from the solution to the periodic Lippmann--Schwinger equation discretized on a uniform grid},
+   journal = {International Journal for Numerical Methods in Engineering, issue 4},
+   year    = {2017},
+   volume  = {109},
+   pages   = {459--486},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5263/full},
+   doi     = {}
 }
 
 @article{2017_20,
-   author  = "G. Bucci and T. Swamy and Y.-M. Chiang and W. C. Carter",
-   title   = "Modeling of internal mechanical failure of all-solid-state batteries during electrochemical cycling, and implications for battery design",
-   journal = "Journals of Materials Chemistry A",
-   year    = "2017",
-   volume  = "5",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {G. Bucci and T. Swamy and Y.-M. Chiang and W. C. Carter},
+   title   = {Modeling of internal mechanical failure of all-solid-state batteries during electrochemical cycling, and implications for battery design},
+   journal = {Journals of Materials Chemistry A},
+   year    = {2017},
+   volume  = {5},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_21,
-   author  = "T. Cajuhi and L. Sanavia and L. DeLorenzis",
-   title   = "Phase-ﬁeld modeling of fracture in variably saturated porous media",
-   journal = "Computational Mechanics, in print",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://doi.org/10.1007/s00466-017-1459-3",
-   doi     = ""
+   author  = {T. Cajuhi and L. Sanavia and L. DeLorenzis},
+   title   = {Phase-field modeling of fracture in variably saturated porous media},
+   journal = {Computational Mechanics, in print},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://doi.org/10.1007/s00466-017-1459-3},
+   doi     = {}
 }
 
 @article{2017_22,
-   author  = "T. Carraro and C. Goll",
-   title   = "A Goal-Oriented Error Estimator for a Class of Homogenization Problems",
-   journal = "Journal of Scientific Computing, issue 3",
-   year    = "2017",
-   volume  = "71",
-   pages   = "1169--1196",
-   url     = "https://link.springer.com/article/10.1007/s10915-016-0338-y",
-   doi     = ""
+   author  = {T. Carraro and C. Goll},
+   title   = {A Goal-Oriented Error Estimator for a Class of Homogenization Problems},
+   journal = {Journal of Scientific Computing, issue 3},
+   year    = {2017},
+   volume  = {71},
+   pages   = {1169--1196},
+   url     = {https://link.springer.com/article/10.1007/s10915-016-0338-y},
+   doi     = {}
 }
 
 @article{2017_23,
-   author  = "A. Carreño and A. Vidal-Ferrandiz and D. Ginestar and G. Verdú",
-   title   = "Multilevel method to compute the lambda modes of the neutron diffusion equation",
-   journal = "Applied Mathematics and Nonlinear Sciences",
-   year    = "2017",
-   volume  = "2",
-   pages   = "225--236",
-   url     = "",
-   doi     = ""
+   author  = {A. Carre\~{n}o and A. Vidal-Ferrandiz and D. Ginestar and G. Verdú},
+   title   = {Multilevel method to compute the lambda modes of the neutron diffusion equation},
+   journal = {Applied Mathematics and Nonlinear Sciences},
+   year    = {2017},
+   volume  = {2},
+   pages   = {225--236},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_24,
-   author  = "S. Charnyi and T. Heister and M. A. Olshanskii and L. G. Rebholz",
-   title   = "On conservation laws of Navier-Stokes Galerkin discretizations",
-   journal = "Journal of Computational Physics",
-   year    = "2017",
-   volume  = "337",
-   pages   = "289--308",
-   url     = "http://www.sciencedirect.com/science/article/pii/S002199911730133X",
-   doi     = ""
+   author  = {S. Charnyi and T. Heister and M. A. Olshanskii and L. G. Rebholz},
+   title   = {On conservation laws of Navier-Stokes Galerkin discretizations},
+   journal = {Journal of Computational Physics},
+   year    = {2017},
+   volume  = {337},
+   pages   = {289--308},
+   url     = {http://www.sciencedirect.com/science/article/pii/S002199911730133X},
+   doi     = {}
 }
 
 @phdthesis{2017_25,
-   author  = "H.-C. Chu",
-   title   = "Application of the fictitious domain method to flow problems with complex geometries",
-   year    = "2017",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {H.-C. Chu},
+   title   = {Application of the fictitious domain method to flow problems with complex geometries},
+   year    = {2017},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2017_26,
-   author  = "J. Choo and W. C. Sun",
-   title   = "Coupled phase-field and plasticity modeling of geological materials: From brittle fracture to ductile flow",
-   journal = "Computer Methods in Applied Mechanics and Engineering, in press, doi: 10.1016/j.cma.2017.10.009",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Choo and W. C. Sun},
+   title   = {Coupled phase-field and plasticity modeling of geological materials: From brittle fracture to ductile flow},
+   journal = {Computer Methods in Applied Mechanics and Engineering, in press, doi: 10.1016/j.cma.2017.10.009},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_27,
-   author  = "J. Dannberg and Z. Eilon and U. Faul and R. Gassm&ouml;ller and P. Moulik and R. Myhill",
-   title   = "The importance of grain size to mantle dynamics and seismological observations",
-   journal = "Geochem. Geophys. Geosyst., 18",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1002/2017GC006944"
+   author  = {J. Dannberg and Z. Eilon and U. Faul and R. Gassm\"{o}ller and P. Moulik and R. Myhill},
+   title   = {The importance of grain size to mantle dynamics and seismological observations},
+   journal = {Geochem. Geophys. Geosyst., 18},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1002/2017GC006944}
 }
 
 @mastersthesis{2017_28,
-   author  = "K. David",
-   title   = "Multi-patch Discontinuous Galerkin Isogeometric Analysis for Porous Media Flow",
-   year    = "2017",
-   school  = "Delft University of Technology, Delft, Netherlands ",
-   url     = "http://repository.tudelft.nl/islandora/object/uuid:85dfa311-2926-4390-a91b-876141e607e0/datastream/OBJ/view"
+   author  = {K. David},
+   title   = {Multi-patch Discontinuous Galerkin Isogeometric Analysis for Porous Media Flow},
+   year    = {2017},
+   school  = {Delft University of Technology, Delft, Netherlands },
+   url     = {http://repository.tudelft.nl/islandora/object/uuid:85dfa311-2926-4390-a91b-876141e607e0/datastream/OBJ/view}
 }
 
 @article{2017_29,
-   author  = "D. Davydov and T. Gerasimov and J.-P. Pelteret and P. Steinmann",
-   title   = "Convergence study of the h-adaptive PUM and the hp-adaptive FEM applied to eigenvalue problems in quantum mechanics",
-   journal = "Advanced Modeling and Simulation in Engineering Sciences",
-   year    = "2017",
-   volume  = "4",
-   pages   = "2213--7467",
-   url     = "",
-   doi     = "10.1186/s40323-017-0093-0"
+   author  = {D. Davydov and T. Gerasimov and J.-P. Pelteret and P. Steinmann},
+   title   = {Convergence study of the h-adaptive PUM and the hp-adaptive FEM applied to eigenvalue problems in quantum mechanics},
+   journal = {Advanced Modeling and Simulation in Engineering Sciences},
+   year    = {2017},
+   volume  = {4},
+   pages   = {2213--7467},
+   url     = {},
+   doi     = {10.1186/s40323-017-0093-0}
 }
 
 @article{2017_30,
-   author  = "G. Deolmi and W. Dahmen and S. Muller",
-   title   = "Effective Boundary Conditions: A General Strategy and Application to Compressible Flows Over Rough Boundaries",
-   journal = "Communications in Computational Physics, issue 2",
-   year    = "2017",
-   volume  = "21",
-   pages   = "358--400",
-   url     = "https://www.cambridge.org/core/journals/communications-in-computational-physics/article/div-classtitleeffective-boundary-conditions-a-general-strategy-and-application-to-compressible-flows-over-rough-boundariesdiv/7ABD9971121A46E7F96077F4BE2F026F",
-   doi     = ""
+   author  = {G. Deolmi and W. Dahmen and S. Muller},
+   title   = {Effective Boundary Conditions: A General Strategy and Application to Compressible Flows Over Rough Boundaries},
+   journal = {Communications in Computational Physics, issue 2},
+   year    = {2017},
+   volume  = {21},
+   pages   = {358--400},
+   url     = {https://www.cambridge.org/core/journals/communications-in-computational-physics/article/div-classtitleeffective-boundary-conditions-a-general-strategy-and-application-to-compressible-flows-over-rough-boundariesdiv/7ABD9971121A46E7F96077F4BE2F026F},
+   doi     = {}
 }
 
 @phdthesis{2017_31,
-   author  = "A. M. De Villiers",
-   title   = "A patient-specific FSI model for vascular access in haemodialysis",
-   year    = "2017",
-   school  = "University of Cape Town",
-   url     = "http://hdl.handle.net/11427/24441"
+   author  = {A. M. De Villiers},
+   title   = {A patient-specific FSI model for vascular access in haemodialysis},
+   year    = {2017},
+   school  = {University of Cape Town},
+   url     = {http://hdl.handle.net/11427/24441}
 }
 
 @article{2017_32,
-   author  = "A. M. De Villiers and A. T. McBride and B. D. Reddy and T. Franz and B. S. Spottiswoode",
-   title   = "A validated patient-specific FSI model for vascular access in haemodialysis",
-   journal = "Biomechanics and Modeling in Mechanobiology, accepted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://doi.org/10.1007/s10237-017-0973-8",
-   doi     = ""
+   author  = {A. M. De Villiers and A. T. McBride and B. D. Reddy and T. Franz and B. S. Spottiswoode},
+   title   = {A validated patient-specific FSI model for vascular access in haemodialysis},
+   journal = {Biomechanics and Modeling in Mechanobiology, accepted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://doi.org/10.1007/s10237-017-0973-8},
+   doi     = {}
 }
 
 @article{2017_33,
-   author  = "S. DeWitt and L. S. Solomon and A. R. Natarajan and V. Araulio-Peters and S. Rudrajaru and L. K. Aegesen and B. Puchala and E. A. Marquis and A. van der Ven and K. Thornton and J. E. Allison",
-   title   = "Misfit-driven β′′′ precipitate composition and morphology in Mg-Nd alloys",
-   journal = "Acta Materialia",
-   year    = "2017",
-   volume  = "136",
-   pages   = "378--389",
-   url     = "http://www.sciencedirect.com/science/article/pii/S1359645417305281",
-   doi     = ""
+   author  = {S. DeWitt and L. S. Solomon and A. R. Natarajan and V. Araulio-Peters and S. Rudrajaru and L. K. Aegesen and B. Puchala and E. A. Marquis and A. van der Ven and K. Thornton and J. E. Allison},
+   title   = {Misfit-driven {\ss}''' precipitate composition and morphology in Mg-Nd alloys},
+   journal = {Acta Materialia},
+   year    = {2017},
+   volume  = {136},
+   pages   = {378--389},
+   url     = {http://www.sciencedirect.com/science/article/pii/S1359645417305281},
+   doi     = {}
 }
 
 @article{2017_34,
-   author  = "M. Diehl",
-   title   = "Review and outlook: Mechanical, thermodynamic, and kinetic continuum modeling of metallic materials at the grain scale",
-   journal = "MRS Communications",
-   year    = "2017",
-   volume  = "7",
-   pages   = "735--746",
-   url     = "",
-   doi     = "10.1557/mrc.2017.98"
+   author  = {M. Diehl},
+   title   = {Review and outlook: Mechanical, thermodynamic, and kinetic continuum modeling of metallic materials at the grain scale},
+   journal = {MRS Communications},
+   year    = {2017},
+   volume  = {7},
+   pages   = {735--746},
+   url     = {},
+   doi     = {10.1557/mrc.2017.98}
 }
 
 @phdthesis{2017_35,
-   author  = "T. Dockhorn",
-   title   = "Turbulence modeling for large eddy simulation of incompressible flows using high-order discontinuous Galerkin methods",
-   year    = "2017",
-   school  = "Bachelor's Thesis, Technical University of Munich",
-   url     = ""
+   author  = {T. Dockhorn},
+   title   = {Turbulence modeling for large eddy simulation of incompressible flows using high-order discontinuous Galerkin methods},
+   year    = {2017},
+   school  = {Bachelor's Thesis, Technical University of Munich},
+   url     = {}
 }
 
 @phdthesis{2017_36,
-   author  = "B. S. M. Ebna Hai",
-   title   = "Finite Element Approximation of Ultrasonic Wave Propagation under Fluid-Structure Interaction for Structural Health Monitoring Systems",
-   year    = "2017",
-   school  = "Helmut Schmidt University-University of the Federal Armed Forces Hambur, Germany",
-   url     = ""
+   author  = {B. S. M. Ebna Hai},
+   title   = {Finite Element Approximation of Ultrasonic Wave Propagation under Fluid-Structure Interaction for Structural Health Monitoring Systems},
+   year    = {2017},
+   school  = {Helmut Schmidt University-University of the Federal Armed Forces Hambur, Germany},
+   url     = {}
 }
 
 @article{2017_37,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Mathematical Modelling and Numerical Simulation of the On-line Structural Health Monitoring System",
-   journal = "In proceedings of: the 11 th International Workshop on Structural Health Monitoring, Structural Health Monitoring 2017, Sept 12–14, Stanford University, CA, USA. In: F-K. Chang and F. Kopsaftopoulos (Ed.), “Structural Health Monitoring 2017: Real-Time Material State Awareness and Data-Driven Safety Assurance.”",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Mathematical Modelling and Numerical Simulation of the On-line Structural Health Monitoring System},
+   journal = {In proceedings of: the 11 th International Workshop on Structural Health Monitoring, Structural Health Monitoring 2017, Sept 12--14, Stanford University, CA, USA. In: F-K. Chang and F. Kopsaftopoulos (Ed.), ``Structural Health Monitoring 2017: Real-Time Material State Awareness and Data-Driven Safety Assurance.''},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_38,
-   author  = "B. S. M. Ebna Hai and M. Bause",
-   title   = "Finite Element Approximation of Fluid-Structure Interaction (FSI) Problem with Coupled Wave Propagation",
-   journal = "In proceedings of: the 88 th GAMM Annual Meeting of the International Association of Applied Mathematics and Mechanics, March 6–10, Weimar, Germany. In: PAMM - Proceedings in Applied Mathematics and Mechanics",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. S. M. Ebna Hai and M. Bause},
+   title   = {Finite Element Approximation of Fluid-Structure Interaction (FSI) Problem with Coupled Wave Propagation},
+   journal = {In proceedings of: the 88 th GAMM Annual Meeting of the International Association of Applied Mathematics and Mechanics, March 6--10, Weimar, Germany. In: PAMM - Proceedings in Applied Mathematics and Mechanics},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_39,
-   author  = "B. Endtmayer and T. Wick",
-   title   = "A Partition-of-Unity Dual-Weighted Residual Approach for Multi-Objective Goal Functional Error Estimation Applied to Elliptic Problems",
-   journal = "Computational Methods in Applied Mathematics, accepted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Endtmayer and T. Wick},
+   title   = {A Partition-of-Unity Dual-Weighted Residual Approach for Multi-Objective Goal Functional Error Estimation Applied to Elliptic Problems},
+   journal = {Computational Methods in Applied Mathematics, accepted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_40,
-   author  = "V. J. Ervin and H. Lee and J. Ruiz-Ramirez",
-   title   = "Nonlinear Darcy fluid flow with deposition",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2017",
-   volume  = "309",
-   pages   = "79--94",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0377042716302977",
-   doi     = ""
+   author  = {V. J. Ervin and H. Lee and J. Ruiz-Ramirez},
+   title   = {Nonlinear Darcy fluid flow with deposition},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2017},
+   volume  = {309},
+   pages   = {79--94},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302977},
+   doi     = {}
 }
 
 @article{2017_41,
-   author  = "N. Fehn and W. A. Wall and M. Kronbichler",
-   title   = "On the stability of projection methods for the incompressible Navier-Stokes equations based on high-order discontinuous Galerkin discretizations",
-   journal = "Journal of Computational Physics",
-   year    = "2017",
-   volume  = "351",
-   pages   = "392--421",
-   url     = "",
-   doi     = ""
+   author  = {N. Fehn and W. A. Wall and M. Kronbichler},
+   title   = {On the stability of projection methods for the incompressible Navier-Stokes equations based on high-order discontinuous Galerkin discretizations},
+   journal = {Journal of Computational Physics},
+   year    = {2017},
+   volume  = {351},
+   pages   = {392--421},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_42,
-   author  = "D. M. Fernandez Becerra and A. Akbarzadeh-Sharbaf and D. Giannacopoulos",
-   title   = "Solving Finite-Element Time-Domain Problems with GaBP",
-   journal = "IEEE Transactions on Magnetics PP(99):1-1",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. M. Fernandez Becerra and A. Akbarzadeh-Sharbaf and D. Giannacopoulos},
+   title   = {Solving Finite-Element Time-Domain Problems with GaBP},
+   journal = {IEEE Transactions on Magnetics PP(99):1-1},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_43,
-   author  = "F. Freddi and F. Iurlano",
-   title   = "Numerical insight of a variational smeared approach to cohesive fracture",
-   journal = "Journal of the Mechanics and Physics of Solids",
-   year    = "2017",
-   volume  = "98",
-   pages   = "156--171",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0022509616304860",
-   doi     = ""
+   author  = {F. Freddi and F. Iurlano},
+   title   = {Numerical insight of a variational smeared approach to cohesive fracture},
+   journal = {Journal of the Mechanics and Physics of Solids},
+   year    = {2017},
+   volume  = {98},
+   pages   = {156--171},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0022509616304860},
+   doi     = {}
 }
 
 @phdthesis{2017_44,
-   author  = "A. Fuchs",
-   title   = "Hermite-artige Basisfunktionen f&uuml;r diskontinuierliche Galerkin-Verfahren hoher Ordnung",
-   year    = "2017",
-   school  = "Bachelor's Thesis, Technical University of Munich",
-   url     = ""
+   author  = {A. Fuchs},
+   title   = {Hermite-artige Basisfunktionen f\"{u}r diskontinuierliche Galerkin-Verfahren hoher Ordnung},
+   year    = {2017},
+   school  = {Bachelor's Thesis, Technical University of Munich},
+   url     = {}
 }
 
 @phdthesis{2017_45,
-   author  = "J. P. Gallego-Valencia",
-   title   = "On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamic model",
-   year    = "2017",
-   school  = "University of W&uuml;rzburg, Germany",
-   url     = "https://link.springer.com/article/10.1007/s00574-016-0142-1"
+   author  = {J. P. Gallego-Valencia},
+   title   = {On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamic model},
+   year    = {2017},
+   school  = {University of W\"{u}rzburg, Germany},
+   url     = {https://link.springer.com/article/10.1007/s00574-016-0142-1}
 }
 
 @article{2017_46,
-   author  = "R. Gassm&ouml;ller and E. Heien and E. G. Puckett and W. Bangerth",
-   title   = "Flexible and scalable particle-in-cell methods for massively parallel computations",
-   journal = "Submitted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1612.03369",
-   doi     = ""
+   author  = {R. Gassm\"{o}ller and E. Heien and E. G. Puckett and W. Bangerth},
+   title   = {Flexible and scalable particle-in-cell methods for massively parallel computations},
+   journal = {Submitted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1612.03369},
+   doi     = {}
 }
 
 @article{2017_47,
-   author  = "K. Garikipati",
-   title   = "Perspectives on the mathematics of biological patterning and morphogenesis",
-   journal = "Journal of the Mechanics and Physics of Solids",
-   year    = "2017",
-   volume  = "99",
-   pages   = "192--210",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0022509616306111",
-   doi     = ""
+   author  = {K. Garikipati},
+   title   = {Perspectives on the mathematics of biological patterning and morphogenesis},
+   journal = {Journal of the Mechanics and Physics of Solids},
+   year    = {2017},
+   volume  = {99},
+   pages   = {192--210},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0022509616306111},
+   doi     = {}
 }
 
 @phdthesis{2017_48,
-   author  = "A. Ghesmati",
-   title   = "Residual and goal-oriented h- and hp-adaptive finite element; application for elliptic and saddle point problems",
-   year    = "2017",
-   school  = "Texas A&amp;M University",
-   url     = ""
+   author  = {A. Ghesmati},
+   title   = {Residual and goal-oriented h- and hp-adaptive finite element; application for elliptic and saddle point problems},
+   year    = {2017},
+   school  = {Texas A \& M University},
+   url     = {}
 }
 
 @article{2017_49,
-   author  = "S. S. Ghorashi and T. Rabczuk",
-   title   = "Goal-oriented error estimation and mesh adaptivity in 3d elastoplasticity problems",
-   journal = "International Journal of Fracture, issue 1",
-   year    = "2017",
-   volume  = "203",
-   pages   = "3--19",
-   url     = "https://link.springer.com/article/10.1007/s10704-016-0113-y",
-   doi     = ""
+   author  = {S. S. Ghorashi and T. Rabczuk},
+   title   = {Goal-oriented error estimation and mesh adaptivity in 3d elastoplasticity problems},
+   journal = {International Journal of Fracture, issue 1},
+   year    = {2017},
+   volume  = {203},
+   pages   = {3--19},
+   url     = {https://link.springer.com/article/10.1007/s10704-016-0113-y},
+   doi     = {}
 }
 
 @article{2017_50,
-   author  = "A. Glerum and C. Thieulot and M. Fraters and C. Blom and W. Spakman",
-   title   = "Implementing nonlinear viscoplasticity in ASPECT: benchmarking and applications to 3D subduction modeling",
-   journal = "Submitted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.solid-earth-discuss.net/se-2017-9/",
-   doi     = ""
+   author  = {A. Glerum and C. Thieulot and M. Fraters and C. Blom and W. Spakman},
+   title   = {Implementing nonlinear viscoplasticity in ASPECT: benchmarking and applications to 3D subduction modeling},
+   journal = {Submitted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.solid-earth-discuss.net/se-2017-9/},
+   doi     = {}
 }
 
 @mastersthesis{2017_51,
-   author  = "C. Goering",
-   title   = "Implicit-explicit Runge-Kutta methods for acoustics with the hybridizable discontinuous Galerkin method",
-   year    = "2017",
-   school  = "Technical University of Munich",
-   url     = ""
+   author  = {C. Goering},
+   title   = {Implicit-explicit Runge-Kutta methods for acoustics with the hybridizable discontinuous Galerkin method},
+   year    = {2017},
+   school  = {Technical University of Munich},
+   url     = {}
 }
 
 @article{2017_52,
-   author  = "C. Goering",
-   title   = "Slope limiters and shock capturing for acoustics with HDG discretization",
-   journal = "Term Paper, Technical University of Munich",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {C. Goering},
+   title   = {Slope limiters and shock capturing for acoustics with HDG discretization},
+   journal = {Term Paper, Technical University of Munich},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_53,
-   author  = "J.-L. Guermond and M. Nazarov and B. Popov and I. Tomas",
-   title   = "Second-order invariant domain preserving approximation of the Euler equations using convex limiting",
-   journal = "arXiv:1710.004",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J.-L. Guermond and M. Nazarov and B. Popov and I. Tomas},
+   title   = {Second-order invariant domain preserving approximation of the Euler equations using convex limiting},
+   journal = {arXiv:1710.004},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_54,
-   author  = "D. R. Gulevich and V. P. Koshelets and F. V. Kusmartsev",
-   title   = "Generation of high-frequency chaotic signal with Josephson fluxons",
-   journal = "arXiv:1709.04052",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. R. Gulevich and V. P. Koshelets and F. V. Kusmartsev},
+   title   = {Generation of high-frequency chaotic signal with Josephson fluxons},
+   journal = {arXiv:1709.04052},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_55,
-   author  = "J.-L. Guermond and M. Quesada de Luna and T. Thompson",
-   title   = "An conservative anti-diffusion technique for the level set method",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2017",
-   volume  = "321",
-   pages   = "448--468",
-   url     = "http://www.sciencedirect.com/science/article/pii/S037704271730081X",
-   doi     = ""
+   author  = {J.-L. Guermond and M. Quesada de Luna and T. Thompson},
+   title   = {An conservative anti-diffusion technique for the level set method},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2017},
+   volume  = {321},
+   pages   = {448--468},
+   url     = {http://www.sciencedirect.com/science/article/pii/S037704271730081X},
+   doi     = {}
 }
 
 @article{2017_56,
-   author  = "D. K. Gupta and G. J. van der Veen and A. M. Aragon and M. Langelaar and F. van Keulen",
-   title   = "Bounds for decoupled design and analysis discretizations in topology optimization",
-   journal = "International Journal for Numerical Methods in Engineering, in press",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/nme.5455/full",
-   doi     = ""
+   author  = {D. K. Gupta and G. J. van der Veen and A. M. Aragon and M. Langelaar and F. van Keulen},
+   title   = {Bounds for decoupled design and analysis discretizations in topology optimization},
+   journal = {International Journal for Numerical Methods in Engineering, in press},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5455/full},
+   doi     = {}
 }
 
 @mastersthesis{2017_57,
-   author  = "S. Haider",
-   title   = "Numerical analysis and comparison of high performance incompressible Navier Stokes equations solvers based on the discontinuous Galerkin Method",
-   year    = "2017",
-   school  = "Technical University of Munich",
-   url     = ""
+   author  = {S. Haider},
+   title   = {Numerical analysis and comparison of high performance incompressible Navier Stokes equations solvers based on the discontinuous Galerkin Method},
+   year    = {2017},
+   school  = {Technical University of Munich},
+   url     = {}
 }
 
 @phdthesis{2017_58,
-   author  = "C. Hanowski",
-   title   = "Numerical Homogenisation of Magneto-Active Materials",
-   year    = "2017",
-   school  = "Project thesis, Friedrich-Alexander-Universit&auml;t Erlangen-N&uuml;rnberg",
-   url     = ""
+   author  = {C. Hanowski},
+   title   = {Numerical Homogenisation of Magneto-Active Materials},
+   year    = {2017},
+   school  = {Project thesis, Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   url     = {}
 }
 
 @article{2017_59,
-   author  = "Y. He and E. G. Puckett and M. I. Billen",
-   title   = "A Discontinuous Galerkin Method with a Bound Preserving Limiter for the Advection of non-Diffusive Fields in Solid Earth Geodynamics",
-   journal = "Physics of the Earth and Planetary Interiors",
-   year    = "2017",
-   volume  = "263",
-   pages   = "23--37",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0031920116300747",
-   doi     = ""
+   author  = {Y. He and E. G. Puckett and M. I. Billen},
+   title   = {A Discontinuous Galerkin Method with a Bound Preserving Limiter for the Advection of non-Diffusive Fields in Solid Earth Geodynamics},
+   journal = {Physics of the Earth and Planetary Interiors},
+   year    = {2017},
+   volume  = {263},
+   pages   = {23--37},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0031920116300747},
+   doi     = {}
 }
 
 @article{2017_60,
-   author  = "T. Heister and J. Dannberg and R. Gassm&ouml;ller and W. Bangerth",
-   title   = "High Accuracy Mantle Convection Simulation through Modern Numerical Methods. II: Realistic Models and Problems",
-   journal = "Geophysical Journal International, 210",
-   year    = "2017",
-   volume  = "",
-   pages   = "833--851",
-   url     = "https://doi.org/10.1093/gji/ggx195",
-   doi     = ""
+   author  = {T. Heister and J. Dannberg and R. Gassm\"{o}ller and W. Bangerth},
+   title   = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods. II: Realistic Models and Problems},
+   journal = {Geophysical Journal International, 210},
+   year    = {2017},
+   volume  = {},
+   pages   = {833--851},
+   url     = {https://doi.org/10.1093/gji/ggx195},
+   doi     = {}
 }
 
 @article{2017_61,
-   author  = "G. Jansen and R. Sohrabi and S. A. Miller",
-   title   = "HULK – Simple and fast generation of structured hexahedral meshes for improved subsurface simulations",
-   journal = "Computers &amp; Geoscience",
-   year    = "2017",
-   volume  = "99",
-   pages   = "159--170",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0098300416307063",
-   doi     = ""
+   author  = {G. Jansen and R. Sohrabi and S. A. Miller},
+   title   = {HULK -- Simple and fast generation of structured hexahedral meshes for improved subsurface simulations},
+   journal = {Computers \& Geoscience},
+   year    = {2017},
+   volume  = {99},
+   pages   = {159--170},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0098300416307063},
+   doi     = {}
 }
 
 @article{2017_62,
-   author  = "D. Jodlbauer and T. Wick",
-   title   = "A monolithic FSI solver applied to the FSI 1,2,3 benchmarks",
-   journal = "In: Fluid-Structure Interaction: Modeling, Adaptive Discretization and Solvers, S. Frei and B. Holm and T. Richter and T. Wick and H. Yang (eds.), Walter de Gruyter",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Jodlbauer and T. Wick},
+   title   = {A monolithic FSI solver applied to the FSI 1,2,3 benchmarks},
+   journal = {In: Fluid-Structure Interaction: Modeling, Adaptive Discretization and Solvers, S. Frei and B. Holm and T. Richter and T. Wick and H. Yang (eds.), Walter de Gruyter},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_63,
-   author  = "G. Kanschat and R. Lazarov and Y. Mao",
-   title   = "Geometric Multigrid for Darcy and Brinkman models of flows in highly heterogeneous porous media: A numerical study",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2017",
-   volume  = "310",
-   pages   = "174--185",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0377042716302333",
-   doi     = ""
+   author  = {G. Kanschat and R. Lazarov and Y. Mao},
+   title   = {Geometric Multigrid for Darcy and Brinkman models of flows in highly heterogeneous porous media: A numerical study},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2017},
+   volume  = {310},
+   pages   = {174--185},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302333},
+   doi     = {}
 }
 
 @article{2017_64,
-   author  = "G. Kanschat and J. P. L. Lorca",
-   title   = "A Weakly Penalized Discontinuous Galerkin Method for Radiation in Dense, Scattering Media",
-   journal = "Computational Methods in Applied Mathematics, issue 4",
-   year    = "2017",
-   volume  = "16",
-   pages   = "563--577",
-   url     = "https://www.degruyter.com/view/j/cmam.2016.16.issue-4/cmam-2016-0023/cmam-2016-0023.xml",
-   doi     = ""
+   author  = {G. Kanschat and J. P. L. Lorca},
+   title   = {A Weakly Penalized Discontinuous Galerkin Method for Radiation in Dense, Scattering Media},
+   journal = {Computational Methods in Applied Mathematics, issue 4},
+   year    = {2017},
+   volume  = {16},
+   pages   = {563--577},
+   url     = {https://www.degruyter.com/view/j/cmam.2016.16.issue-4/cmam-2016-0023/cmam-2016-0023.xml},
+   doi     = {}
 }
 
 @article{2017_65,
-   author  = "A. Karrecha and F. Abbassi and H. Basarir and M. Attar",
-   title   = "Self-consistent fractal damage of natural geo-materials in finite strain",
-   journal = "Mechanics of Materials, pp. 107–120",
-   year    = "2017",
-   volume  = "104",
-   pages   = "",
-   url     = "https://www.degruyter.com/view/j/cmam.2016.16.issue-4/cmam-2016-0023/cmam-2016-0023.xml",
-   doi     = ""
+   author  = {A. Karrecha and F. Abbassi and H. Basarir and M. Attar},
+   title   = {Self-consistent fractal damage of natural geo-materials in finite strain},
+   journal = {Mechanics of Materials, pp. 107--120},
+   year    = {2017},
+   volume  = {104},
+   pages   = {},
+   url     = {https://www.degruyter.com/view/j/cmam.2016.16.issue-4/cmam-2016-0023/cmam-2016-0023.xml},
+   doi     = {}
 }
 
 @article{2017_66,
-   author  = "J. A. Kauffman and J. P. Sheldon and S. T. Miller",
-   title   = "Overset meshing coupled with hybridizable discontinuous Galerkin finite elements",
-   journal = "International Journal for Numerical Methods in Engineering",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/nme.5512/full",
-   doi     = ""
+   author  = {J. A. Kauffman and J. P. Sheldon and S. T. Miller},
+   title   = {Overset meshing coupled with hybridizable discontinuous Galerkin finite elements},
+   journal = {International Journal for Numerical Methods in Engineering},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5512/full},
+   doi     = {}
 }
 
 @article{2017_67,
-   author  = "B. Krank and N. Fehn and W. A. Wall and M. Kronbichler",
-   title   = "A high-order semi-explicit discontinuous Galerkin solver for 3D incompressible flow with application to DNS and LES of turbulent channel flow",
-   journal = "Journal of Computational Physics",
-   year    = "2017",
-   volume  = "348",
-   pages   = "634--659",
-   url     = "",
-   doi     = ""
+   author  = {B. Krank and N. Fehn and W. A. Wall and M. Kronbichler},
+   title   = {A high-order semi-explicit discontinuous Galerkin solver for 3D incompressible flow with application to DNS and LES of turbulent channel flow},
+   journal = {Journal of Computational Physics},
+   year    = {2017},
+   volume  = {348},
+   pages   = {634--659},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_68,
-   author  = "B. Krank and M. Kronbichler and W. A. Wall",
-   title   = "A multiscale approach to hybrid RANS/LES wall modeling",
-   journal = "arxiv.org:/1705.08813",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Krank and M. Kronbichler and W. A. Wall},
+   title   = {A multiscale approach to hybrid RANS/LES wall modeling},
+   journal = {arxiv.org:/1705.08813},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_69,
-   author  = "B. Krank and M. Kronbichler and W. A. Wall",
-   title   = "Direct numerical simulation of flow over periodic hills up to Re<sub>H</sub>=10,595",
-   journal = "Submitted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Krank and M. Kronbichler and W. A. Wall},
+   title   = {Direct numerical simulation of flow over periodic hills up to Re$_{\textnormal{H}}$=10,595},
+   journal = {Submitted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_70,
-   author  = "B. Krank and M. Kronbichler and W. A. Wall",
-   title   = "Wall modeling via function enrichment: extension to detached-eddy simulation",
-   journal = "arxiv.org:1712.08469",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Krank and M. Kronbichler and W. A. Wall},
+   title   = {Wall modeling via function enrichment: extension to detached-eddy simulation},
+   journal = {arxiv.org:1712.08469},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_71,
-   author  = "M. Kronbichler and K. Kormann",
-   title   = "Fast matrix-free evaluation of discontinuous Galerkin finite element operators",
-   journal = "arxiv.org:1711.03590",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Kronbichler and K. Kormann},
+   title   = {Fast matrix-free evaluation of discontinuous Galerkin finite element operators},
+   journal = {arxiv.org:1711.03590},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_72,
-   author  = "M. Kronbichler and K. Kormann and I. Pasichnyk and M. Allalen",
-   title   = "Fast matrix-free discontinuous Galerkin kernels on modern computer architectures",
-   journal = "ISC High Performance 2017, LNCS 10266",
-   year    = "2017",
-   volume  = "",
-   pages   = "237--255",
-   url     = "https://dx.doi.org/10.1007/978-3-319-58667-0_13",
-   doi     = ""
+   author  = {M. Kronbichler and K. Kormann and I. Pasichnyk and M. Allalen},
+   title   = {Fast matrix-free discontinuous Galerkin kernels on modern computer architectures},
+   journal = {ISC High Performance 2017, LNCS 10266},
+   year    = {2017},
+   volume  = {},
+   pages   = {237--255},
+   url     = {https://dx.doi.org/10.1007/978-3-319-58667-0_13},
+   doi     = {}
 }
 
 @article{2017_73,
-   author  = "M. Kronbichler and G. Kreiss",
-   title   = "A phase-field microscale enhancement for macro models of capillary-driven contact point dynamics",
-   journal = "The Journal for Computational Multiphase Flows",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "http://dx.doi.org/10.1177/1757482X17700148",
-   doi     = ""
+   author  = {M. Kronbichler and G. Kreiss},
+   title   = {A phase-field microscale enhancement for macro models of capillary-driven contact point dynamics},
+   journal = {The Journal for Computational Multiphase Flows},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {http://dx.doi.org/10.1177/1757482X17700148},
+   doi     = {}
 }
 
 @article{2017_74,
-   author  = "R.M. Kynch and P.D. Ledger",
-   title   = "Resolving the sign conflict problem for hp–hexahedral Nédélec elements with application to eddy current problems",
-   journal = "Computers &amp; Structures",
-   year    = "2017",
-   volume  = "181",
-   pages   = "41--54",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045794916303480",
-   doi     = ""
+   author  = {R.M. Kynch and P.D. Ledger},
+   title   = {Resolving the sign conflict problem for hp--hexahedral N\'{e}d\'{e}lec elements with application to eddy current problems},
+   journal = {Computers \& Structures},
+   year    = {2017},
+   volume  = {181},
+   pages   = {41--54},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045794916303480},
+   doi     = {}
 }
 
 @article{2017_75,
-   author  = "S. Lee and M. F. Wheeler",
-   title   = "Adaptive enriched Galerkin methods for miscible displacement problems with entropy residual stabilization",
-   journal = "Journal of Computational Physics",
-   year    = "2017",
-   volume  = "331",
-   pages   = "19--37",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999116305952",
-   doi     = ""
+   author  = {S. Lee and M. F. Wheeler},
+   title   = {Adaptive enriched Galerkin methods for miscible displacement problems with entropy residual stabilization},
+   journal = {Journal of Computational Physics},
+   year    = {2017},
+   volume  = {331},
+   pages   = {19--37},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116305952},
+   doi     = {}
+}
+
+@article{2017_76,
+   author  = {S. Lee and M. F. Wheeler and T. Wick},
+   title   = {Iterative coupling of flow, geomechanics and adaptive phase-field fracture including level-set crack width approaches},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2017},
+   volume  = {314},
+   pages   = {40--60},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_77,
-   author  = "S. Lee and M. F. Wheeler and T. Wick and S. Srinivasan",
-   title   = "Initialization of phase-field fracture propagation in porous media using probability maps of fracture networks",
-   journal = "Mechanics Research Communications, pp. 16–23",
-   year    = "2017",
-   volume  = "80",
-   pages   = "",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0093641316300106",
-   doi     = "10.1016/j.mechrescom.2016.04.002"
+   author  = {S. Lee and M. F. Wheeler and T. Wick and S. Srinivasan},
+   title   = {Initialization of phase-field fracture propagation in porous media using probability maps of fracture networks},
+   journal = {Mechanics Research Communications, pp. 16--23},
+   year    = {2017},
+   volume  = {80},
+   pages   = {},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0093641316300106},
+   doi     = {10.1016/j.mechrescom.2016.04.002}
 }
 
 @article{2017_78,
-   author  = "D. Li and M. Gurnis and G. Stadler",
-   title   = "Towards adjoint-based inversion of time-dependent mantle convection with nonlinear viscosity",
-   journal = "Geophysics Journal International",
-   year    = "2017",
-   volume  = "209",
-   pages   = "86--105",
-   url     = "",
-   doi     = ""
+   author  = {D. Li and M. Gurnis and G. Stadler},
+   title   = {Towards adjoint-based inversion of time-dependent mantle convection with nonlinear viscosity},
+   journal = {Geophysics Journal International},
+   year    = {2017},
+   volume  = {209},
+   pages   = {86--105},
+   url     = {},
+   doi     = {}
 }
 
 @phdthesis{2017_79,
-   author  = "S. Lin",
-   title   = "High Performance Techniques Applied in Partial Differential Equations Library",
-   year    = "2017",
-   school  = "Honors thesis, St. Johns University",
-   url     = ""
+   author  = {S. Lin},
+   title   = {High Performance Techniques Applied in Partial Differential Equations Library},
+   year    = {2017},
+   school  = {Honors thesis, St. Johns University},
+   url     = {}
 }
 
 @phdthesis{2017_80,
-   author  = "K. Ljungkvist",
-   title   = "Finite element computations on multicore and graphics processors",
-   year    = "2017",
-   school  = "University of Uppsala, Sweden",
-   url     = ""
+   author  = {K. Ljungkvist},
+   title   = {Finite element computations on multicore and graphics processors},
+   year    = {2017},
+   school  = {University of Uppsala, Sweden},
+   url     = {}
 }
 
 @article{2017_81,
-   author  = "M. Maier and D. Margetis and M. Luskin",
-   title   = "Dipole excitation of surface plasmon on a conducting sheet: finite element approximation and validation",
-   journal = "Journal of Computational Physics",
-   year    = "2017",
-   volume  = "339",
-   pages   = "126--146",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999117302012",
-   doi     = ""
+   author  = {M. Maier and D. Margetis and M. Luskin},
+   title   = {Dipole excitation of surface plasmon on a conducting sheet: finite element approximation and validation},
+   journal = {Journal of Computational Physics},
+   year    = {2017},
+   volume  = {339},
+   pages   = {126--146},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999117302012},
+   doi     = {}
 }
 
 @article{2017_82,
-   author  = "S. McGovern and S. Kollet and C. M. Bürger and R. L. Schwede and O. G. Podlaha",
-   title   = "Novel basin modelling concept for simulating deformation from mechanical compaction using level sets",
-   journal = "Computational Geosciences, accepted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://link.springer.com/article/10.1007%2Fs10596-017-9643-2",
-   doi     = ""
+   author  = {S. McGovern and S. Kollet and C. M. B\"{u}rger and R. L. Schwede and O. G. Podlaha},
+   title   = {Novel basin modelling concept for simulating deformation from mechanical compaction using level sets},
+   journal = {Computational Geosciences, accepted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://link.springer.com/article/10.1007%2Fs10596-017-9643-2},
+   doi     = {}
 }
 
 @mastersthesis{2017_83,
-   author  = "M. Mentler",
-   title   = "High performance implementation of one-field elasticity using the deal.II Finite Element library",
-   year    = "2017",
-   school  = "Friedrich-Alexander-Universit&auml;t Erlangen-N&uuml;rnberg",
-   url     = ""
+   author  = {M. Mentler},
+   title   = {High performance implementation of one-field elasticity using the deal.II Finite Element library},
+   year    = {2017},
+   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   url     = {}
 }
 
 @article{2017_84,
-   author  = "A. Mola and L. Heitai and and A. DeSimone",
-   title   = "Wet and Dry Transom Stern Treatment for Unsteady and Nonlinear Potential Flow Model for Naval Hydrodynamics Simulations",
-   journal = "Journal of Ship Research, no. 1",
-   year    = "2017",
-   volume  = "61",
-   pages   = "1--14",
-   url     = "http://texasamcolstattx.library.ingentaconnect.com/content/sname/jsr/2017/00000061/00000001/art00001",
-   doi     = ""
+   author  = {A. Mola and L. Heitai and and A. DeSimone},
+   title   = {Wet and Dry Transom Stern Treatment for Unsteady and Nonlinear Potential Flow Model for Naval Hydrodynamics Simulations},
+   journal = {Journal of Ship Research, no. 1},
+   year    = {2017},
+   volume  = {61},
+   pages   = {1--14},
+   url     = {http://texasamcolstattx.library.ingentaconnect.com/content/sname/jsr/2017/00000061/00000001/art00001},
+   doi     = {}
 }
 
 @article{2017_85,
-   author  = "S. H. Na and W.C. Sun",
-   title   = "Computational thermo-hydro-mechanics for multiphase freezing and thawing porous media in the finite deformation range",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2017",
-   volume  = "318",
-   pages   = "667--700",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782516311240",
-   doi     = ""
+   author  = {S. H. Na and W.C. Sun},
+   title   = {Computational thermo-hydro-mechanics for multiphase freezing and thawing porous media in the finite deformation range},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2017},
+   volume  = {318},
+   pages   = {667--700},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516311240},
+   doi     = {}
 }
 
 @article{2017_86,
-   author  = "I. Neitzel and T. Wick and W. Wollner",
-   title   = "An Optimal Control Problem Governed by a Regularized Phase-Field Fracture Propagation Model",
-   journal = "SIAM Journal on Control and Optimization, accepted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {I. Neitzel and T. Wick and W. Wollner},
+   title   = {An Optimal Control Problem Governed by a Regularized Phase-Field Fracture Propagation Model},
+   journal = {SIAM Journal on Control and Optimization, accepted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_87,
-   author  = "L. H. Odsæter and M. F. Wheeler and T. Kvamsdal and M. G. Larson",
-   title   = "Postprocessing of non-conservative flux for compatibility with transport in heterogeneous media",
-   journal = "Computer Methods in Applied Mechanics and Engineering",
-   year    = "2017",
-   volume  = "315",
-   pages   = "799--830",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0045782516303565",
-   doi     = ""
+   author  = {L. H. Ods\ae{}ter and M. F. Wheeler and T. Kvamsdal and M. G. Larson},
+   title   = {Postprocessing of non-conservative flux for compatibility with transport in heterogeneous media},
+   journal = {Computer Methods in Applied Mechanics and Engineering},
+   year    = {2017},
+   volume  = {315},
+   pages   = {799--830},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516303565},
+   doi     = {}
 }
 
 @article{2017_88,
-   author  = "G. Poy and F. Bunel and P. Oswald",
-   title   = "Role of anchoring energy on the texture of cholesteric droplets: Finite-element simulations and experiments",
-   journal = "Phs. Rev. E, article 012705",
-   year    = "2017",
-   volume  = "96",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {G. Poy and F. Bunel and P. Oswald},
+   title   = {Role of anchoring energy on the texture of cholesteric droplets: Finite-element simulations and experiments},
+   journal = {Phs. Rev. E, article 012705},
+   year    = {2017},
+   volume  = {96},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_89,
-   author  = "E. G. Puckett and D. L. Turcotte and L. H. Kellogg and Y. He and J. M. Robey and H. Lokavarapu",
-   title   = "New numerical approaches for modeling thermochemical convection in a compositionally stratified fluid",
-   journal = "Submitted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1703.02202",
-   doi     = ""
+   author  = {E. G. Puckett and D. L. Turcotte and L. H. Kellogg and Y. He and J. M. Robey and H. Lokavarapu},
+   title   = {New numerical approaches for modeling thermochemical convection in a compositionally stratified fluid},
+   journal = {Submitted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1703.02202},
+   doi     = {}
 }
 
 @phdthesis{2017_90,
-   author  = "T. O. Quinelato",
-   title   = "Mixed Hybrid Finite Element Methods in Elasticity and Poroelasticity",
-   year    = "2017",
-   school  = "Laboratório Nacional de Computação Científica, Brazil",
-   url     = ""
+   author  = {T. O. Quinelato},
+   title   = {Mixed Hybrid Finite Element Methods in Elasticity and Poroelasticity},
+   year    = {2017},
+   school  = {Laborat\'{o}rio Nacional de Computa\c{c}\~{a}o Cient\'{i}fica, Brazil},
+   url     = {}
 }
 
 @article{2017_91,
-   author  = "D. Riedlbauer and T. Scharowski and R. F. Singer and P. Steinmann and C. K&ouml;rner and J. Mergheim",
-   title   = "Macroscopic simulation and experimental measurement of melt pool characteristics in selective electron beam melting of Ti-6Al-4V",
-   journal = "The International Journal of Advanced Manufacturing Technology",
-   year    = "2017",
-   volume  = "88",
-   pages   = "1309--1317",
-   url     = "",
-   doi     = ""
+   author  = {D. Riedlbauer and T. Scharowski and R. F. Singer and P. Steinmann and C. K\"{o}rner and J. Mergheim},
+   title   = {Macroscopic simulation and experimental measurement of melt pool characteristics in selective electron beam melting of Ti-6Al-4V},
+   journal = {The International Journal of Advanced Manufacturing Technology},
+   year    = {2017},
+   volume  = {88},
+   pages   = {1309--1317},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_92,
-   author  = "S. Riehl and P. Steinmann",
-   title   = "On structural shape optimization using an embedding domain discretization technique",
-   journal = "International Journal for Numerical Methods in Engineering, issue 9",
-   year    = "2017",
-   volume  = "109",
-   pages   = "1315--1343",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/nme.5326/full",
-   doi     = ""
+   author  = {S. Riehl and P. Steinmann},
+   title   = {On structural shape optimization using an embedding domain discretization technique},
+   journal = {International Journal for Numerical Methods in Engineering, issue 9},
+   year    = {2017},
+   volume  = {109},
+   pages   = {1315--1343},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5326/full},
+   doi     = {}
 }
 
 @article{2017_93,
-   author  = "I. Rose and B. Buffett",
-   title   = "Scaling rates of true polar wander in convecting planets and moons",
-   journal = "Physics of the Earth and Planetary Interiors",
-   year    = "2017",
-   volume  = "273",
-   pages   = "1--10",
-   url     = "https://doi.org/10.1016/j.pepi.2017.10.003",
-   doi     = ""
+   author  = {I. Rose and B. Buffett},
+   title   = {Scaling rates of true polar wander in convecting planets and moons},
+   journal = {Physics of the Earth and Planetary Interiors},
+   year    = {2017},
+   volume  = {273},
+   pages   = {1--10},
+   url     = {https://doi.org/10.1016/j.pepi.2017.10.003},
+   doi     = {}
 }
 
 @article{2017_94,
-   author  = "I. Rose and B. Buffett and T. Heister",
-   title   = "Stability and accuracy of free surface time integration in viscous flows",
-   journal = "Physics of the Earth and Planetary Interiors",
-   year    = "2017",
-   volume  = "262",
-   pages   = "90--100",
-   url     = "http://dx.doi.org/10.1016/j.pepi.2016.11.007",
-   doi     = ""
+   author  = {I. Rose and B. Buffett and T. Heister},
+   title   = {Stability and accuracy of free surface time integration in viscous flows},
+   journal = {Physics of the Earth and Planetary Interiors},
+   year    = {2017},
+   volume  = {262},
+   pages   = {90--100},
+   url     = {http://dx.doi.org/10.1016/j.pepi.2016.11.007},
+   doi     = {}
 }
 
 @article{2017_95,
-   author  = "S. Schoeder and M. Kronbichler and W. A. Wall",
-   title   = "Photoacoustic Image Reconstruction: Material Detection and Acoustical Heterogeneities",
-   journal = "Inverse Problems, No. 5",
-   year    = "2017",
-   volume  = "33",
-   pages   = "",
-   url     = "http://iopscience.iop.org/article/10.1088/1361-6420/aa635b/meta",
-   doi     = ""
+   author  = {S. Schoeder and M. Kronbichler and W. A. Wall},
+   title   = {Photoacoustic Image Reconstruction: Material Detection and Acoustical Heterogeneities},
+   journal = {Inverse Problems, No. 5},
+   year    = {2017},
+   volume  = {33},
+   pages   = {},
+   url     = {http://iopscience.iop.org/article/10.1088/1361-6420/aa635b/meta},
+   doi     = {}
 }
 
 @article{2017_96,
-   author  = "G. Scovazzi and M. F. Wheeler and A. Mikelic and S. Lee",
-   title   = "Analytical and variational numerical methods for unstable miscible displacement flows in porous media",
-   journal = "Journal of Computational Physics",
-   year    = "2017",
-   volume  = "335",
-   pages   = "444--496",
-   url     = "http://www.sciencedirect.com/science/article/pii/S0021999117300311",
-   doi     = ""
+   author  = {G. Scovazzi and M. F. Wheeler and A. Mikelic and S. Lee},
+   title   = {Analytical and variational numerical methods for unstable miscible displacement flows in porous media},
+   journal = {Journal of Computational Physics},
+   year    = {2017},
+   volume  = {335},
+   pages   = {444--496},
+   url     = {http://www.sciencedirect.com/science/article/pii/S0021999117300311},
+   doi     = {}
 }
 
 @article{2017_97,
-   author  = "J. Seydel and T. Schuster",
-   title   = "Identifying the stored energy of a hyperelastic structure by using an attenuated Landweber method",
-   journal = "ArXiv:1704.06559",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1704.06559",
-   doi     = ""
+   author  = {J. Seydel and T. Schuster},
+   title   = {Identifying the stored energy of a hyperelastic structure by using an attenuated Landweber method},
+   journal = {ArXiv:1704.06559},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1704.06559},
+   doi     = {}
 }
 
 @article{2017_98,
-   author  = "K. Takeyama and T. R. Saitoh and J. Makino",
-   title   = "Variable inertia method: A novel numerical method for mantle convection simulation",
-   journal = "New Astronomy",
-   year    = "2017",
-   volume  = "50",
-   pages   = "82--103",
-   url     = "http://www.sciencedirect.com/science/article/pii/S138410761630046X",
-   doi     = ""
+   author  = {K. Takeyama and T. R. Saitoh and J. Makino},
+   title   = {Variable inertia method: A novel numerical method for mantle convection simulation},
+   journal = {New Astronomy},
+   year    = {2017},
+   volume  = {50},
+   pages   = {82--103},
+   url     = {http://www.sciencedirect.com/science/article/pii/S138410761630046X},
+   doi     = {}
 }
 
 @article{2017_99,
-   author  = "I. Toulopoulos and T. Wick",
-   title   = "Numerical methods for power-law diffusion problems",
-   journal = "SIAM Journal on Scientific Computing, accepted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {I. Toulopoulos and T. Wick},
+   title   = {Numerical methods for power-law diffusion problems},
+   journal = {SIAM Journal on Scientific Computing, accepted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_100,
-   author  = "S. N. Verner and K. Garikipati",
-   title   = "A computational study of the mechanisms of growth-driven folding patterns on shells, with application to the developing brain",
-   journal = "arXiv:1709.05546",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1709.05546",
-   doi     = ""
+   author  = {S. N. Verner and K. Garikipati},
+   title   = {A computational study of the mechanisms of growth-driven folding patterns on shells, with application to the developing brain},
+   journal = {arXiv:1709.05546},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1709.05546},
+   doi     = {}
 }
 
 @article{2017_101,
-   author  = "M. Veske and A. Kyritsakis and K. Eimre and V. Zadin and A. Aabloo and F. Djurabekova",
-   title   = "Dynamic coupling of a finite element solver to large-scale atomistic simulations",
-   journal = "arXiv:1706.09661",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Veske and A. Kyritsakis and K. Eimre and V. Zadin and A. Aabloo and F. Djurabekova},
+   title   = {Dynamic coupling of a finite element solver to large-scale atomistic simulations},
+   journal = {arXiv:1706.09661},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @Article{2017_102,
@@ -1085,160 +1096,102 @@
 }
 
 @article{2017_103,
-   author  = "Z. Wang and J. B. Siegel and K. Garikipati",
-   title   = "Intercalation driven porosity effects in coupled continuum models for the electrical, chemical, thermal and mechanical response of battery electrode materials",
-   journal = "Journal of The Electrochemical Society, pp. A2199-A2212",
-   year    = "2017",
-   volume  = "164",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {Z. Wang and J. B. Siegel and K. Garikipati},
+   title   = {Intercalation driven porosity effects in coupled continuum models for the electrical, chemical, thermal and mechanical response of battery electrode materials},
+   journal = {Journal of The Electrochemical Society, pp. A2199-A2212},
+   year    = {2017},
+   volume  = {164},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_104,
-   author  = "T. Wick",
-   title   = "Modified Newton methods for solving fully monolithic phase-field quasi-static brittle fracture propagation",
-   journal = "Comp. Meth. Appl. Mech. Engrg., accepted",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Modified Newton methods for solving fully monolithic phase-field quasi-static brittle fracture propagation},
+   journal = {Comp. Meth. Appl. Mech. Engrg., accepted},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_105,
-   author  = "T. Wick",
-   title   = "An error-oriented Newton/inexact augmented Lagrangian approach for fully monolithic phase-field fracture propagation",
-   journal = "SIAM J. Sci. Comput., pp. B589-B617",
-   year    = "2017",
-   volume  = "39",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {An error-oriented Newton/inexact augmented Lagrangian approach for fully monolithic phase-field fracture propagation},
+   journal = {SIAM J. Sci. Comput., pp. B589-B617},
+   year    = {2017},
+   volume  = {39},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_106,
-   author  = "T. Wick",
-   title   = "Coupling fluid-structure interaction with phase-field fracture: algorithmic details",
-   journal = "In: Fluid-Structure Interaction: Modeling, Adaptive Discretization and Solvers, S. Frei and B. Holm and T. Richter and T. Wick and H. Yang (eds.), Walter de Gruyter",
-   year    = "2017",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Coupling fluid-structure interaction with phase-field fracture: algorithmic details},
+   journal = {In: Fluid-Structure Interaction: Modeling, Adaptive Discretization and Solvers, S. Frei and B. Holm and T. Richter and T. Wick and H. Yang (eds.), Walter de Gruyter},
+   year    = {2017},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_107,
-   author  = "J. Wilmers and A. McBride and S. Bargmann",
-   title   = "Interface elasticity effects in polymer-filled nanoporous metals",
-   journal = "Journal of the Mechanics and Physics of Solids",
-   year    = "2017",
-   volume  = "99",
-   pages   = "163--177",
-   url     = "",
-   doi     = ""
+   author  = {J. Wilmers and A. McBride and S. Bargmann},
+   title   = {Interface elasticity effects in polymer-filled nanoporous metals},
+   journal = {Journal of the Mechanics and Physics of Solids},
+   year    = {2017},
+   volume  = {99},
+   pages   = {163--177},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_108,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "A Continuous-Discontinuous Hybrid Finite Element Method for S<sub>N</sub> Transport",
-   journal = "Transaction of American Nuclear Society",
-   year    = "2017",
-   volume  = "117",
-   pages   = "647--649",
-   url     = "",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {A Continuous-Discontinuous Hybrid Finite Element Method for S$_{\textnormal{N}}$ Transport},
+   journal = {Transaction of American Nuclear Society},
+   year    = {2017},
+   volume  = {117},
+   pages   = {647--649},
+   url     = {},
+   doi     = {}
 }
 
 @article{2017_109,
-   author  = "W. Zheng and R. G. McClarren",
-   title   = "Accurate least-squares P<sub>N</sub> scaling based on problem optical thickness for solving neutron transport problems",
-   journal = "Progress in Nuclear Energy",
-   year    = "2017",
-   volume  = "101",
-   pages   = "394--400",
-   url     = "https://www.sciencedirect.com/science/article/pii/S0149197017301403",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren},
+   title   = {Accurate least-squares P$_{\textnormal{N}}$ scaling based on problem optical thickness for solving neutron transport problems},
+   journal = {Progress in Nuclear Energy},
+   year    = {2017},
+   volume  = {101},
+   pages   = {394--400},
+   url     = {https://www.sciencedirect.com/science/article/pii/S0149197017301403},
+   doi     = {}
 }
 
 @article{2017_110,
-   author  = "W. Zheng and R. G. McClarren and J. E. Morel",
-   title   = "An Accurate Globally Conservative Subdomain Discontinuous Least-Squares Scheme for Solving Neutron Transport Problems",
-   journal = "Nuclear Science and Engineering",
-   year    = "2017",
-   volume  = "189",
-   pages   = "259--271",
-   url     = "https://www.tandfonline.com/doi/abs/10.1080/00295639.2017.1407592",
-   doi     = ""
+   author  = {W. Zheng and R. G. McClarren and J. E. Morel},
+   title   = {An Accurate Globally Conservative Subdomain Discontinuous Least-Squares Scheme for Solving Neutron Transport Problems},
+   journal = {Nuclear Science and Engineering},
+   year    = {2017},
+   volume  = {189},
+   pages   = {259--271},
+   url     = {https://www.tandfonline.com/doi/abs/10.1080/00295639.2017.1407592},
+   doi     = {}
 }
 
 @article{2017_111,
-   author  = "J. Zhou and A. Putz and M. Secanell",
-   title   = "A Mixed Wettability Pore Size Distribution Based Mathematical Model for Analyzing Two-Phase Flow in Porous Electrodes I. Mathematical Model",
-   journal = "Journal of The Electrochemical Society, issue 6, F530-F539",
-   year    = "2017",
-   volume  = "164",
-   pages   = "",
-   url     = "http://jes.ecsdl.org/content/164/6/F530.short",
-   doi     = ""
-}
-
-@Article{AlmeidaKonzen2017a,
-  author    = {Pedro Henrique de Almeida Konzen and F S Azevedo and E Sauter and P R A Zingano},
-  title     = {{Numerical Simulations with the Galerkin Least Squares Finite Element Method for the Burgers' Equation on the Real Line}},
-  journal   = {Trends in Applied and Computational Mathematics},
-  year      = {2017},
-  volume    = {18},
-  number    = {2},
-  pages     = {0287},
-  month     = {aug},
-  note      = {Possible duplicate},
-  doi       = {10.5540/tema.2017.018.02.0287},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Brazilian Society for Computational and Applied Mathematics ({SBMAC})},
-  timestamp = {2018.11.20},
-}
-
-@Article{Maier,
-  author    = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
-  title     = {Dipole excitation of surface plasmon on a conducting sheet: Finite element approximation and validation},
-  journal   = {Journal of Computational Physics},
-  year      = {2017},
-  volume    = {339},
-  pages     = {126--145},
-  month     = {jun},
-  note      = {Possible duplicate},
-  doi       = {10.1016/j.jcp.2017.03.014},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-}
-
-@InProceedings{kodanganallur2016parallel,
-  author    = {{Kodanganallur Narayanan}, Ramachandran},
-  title     = {{Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation}},
-  booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})},
-  year      = {2017},
-  month     = {may},
-  publisher = {{IEEE}},
-  doi       = {10.1109/ipdpsw.2017.160},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@Article{2017_76,
-  author    = {S. Lee and M. F. Wheeler and T. Wick},
-  title     = {Iterative coupling of flow, geomechanics and adaptive phase-field fracture including level-set crack width approaches},
-  journal   = {Journal of Computational and Applied Mathematics},
-  year      = {2017},
-  volume    = {314},
-  pages     = {40--60},
-  month     = {apr},
-  doi       = {10.1016/j.cam.2016.10.022},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Elsevier {BV}},
-  timestamp = {2018.11.20},
-  url       = {https://pdfs.semanticscholar.org/02aa/832e109562d3201aaab220f0b6e3a4ddddbb.pdf},
+   author  = {J. Zhou and A. Putz and M. Secanell},
+   title   = {A Mixed Wettability Pore Size Distribution Based Mathematical Model for Analyzing Two-Phase Flow in Porous Electrodes I. Mathematical Model},
+   journal = {Journal of The Electrochemical Society, issue 6, F530-F539},
+   year    = {2017},
+   volume  = {164},
+   pages   = {},
+   url     = {http://jes.ecsdl.org/content/164/6/F530.short},
+   doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1,586 +1,525 @@
 % Encoding: ISO-8859-1
 
 @article{2018_0,
-   author  = "G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells",
-   title   = "The <abbr>deal.II</abbr> Library, Version 9.0",
-   journal = "Journal of Numerical Mathematics, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
+   title   = {The \texttt{deal.II} Library, Version 9.0},
+   journal = {Journal of Numerical Mathematics, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_1,
-   author  = "J. C. Araujo-Cabarcas and C. Engstr&ouml;m and E. Jarlebring",
-   title   = "Efficient resonance computations for Helmholtz problems based on a Dirichlet-to-Neumann map",
-   journal = "Journal of Computational and Applied Mathematics",
-   year    = "2018",
-   volume  = "330",
-   pages   = "177--192",
-   url     = "",
-   doi     = ""
+   author  = {J. C. Araujo-Cabarcas and C. Engstr\"{o}m and E. Jarlebring},
+   title   = {Efficient resonance computations for Helmholtz problems based on a Dirichlet-to-Neumann map},
+   journal = {Journal of Computational and Applied Mathematics},
+   year    = {2018},
+   volume  = {330},
+   pages   = {177--192},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_2,
-   author  = "A. Basak and V. I. Levitas",
-   title   = "Phase field study of surface-induced melting and solidification from a nanovoid: Effect of dimensionless width of void surface and void size",
-   journal = "Applied Physics Letters, article 201602",
-   year    = "2018",
-   volume  = "112",
-   pages   = "",
-   url     = "https://doi.org/10.1063/1.5029911",
-   doi     = ""
+   author  = {A. Basak and V. I. Levitas},
+   title   = {Phase field study of surface-induced melting and solidification from a nanovoid: Effect of dimensionless width of void surface and void size},
+   journal = {Applied Physics Letters, article 201602},
+   year    = {2018},
+   volume  = {112},
+   pages   = {},
+   url     = {https://doi.org/10.1063/1.5029911},
+   doi     = {}
 }
 
 @article{2018_3,
-   author  = "M. Bause and U. Köcher and F. A. Radu and F. Schieweck",
-   title   = "Post-processed Galerkin approximation of improved order for wave equations",
-   journal = "Submitted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Bause and U. K\"{o}cher and F. A. Radu and F. Schieweck},
+   title   = {Post-processed Galerkin approximation of improved order for wave equations},
+   journal = {Submitted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_4,
-   author  = "A. Bonito and A. Demlow and J. Owen",
-   title   = "A Priori error estimates for finite element approximations to eigenvalues and eigenfunctions of the Laplace-Beltrami operator",
-   journal = "Submitted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {A. Bonito and A. Demlow and J. Owen},
+   title   = {A Priori error estimates for finite element approximations to eigenvalues and eigenfunctions of the Laplace-Beltrami operator},
+   journal = {Submitted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_5,
-   author  = "J. Both and U. Köcher",
-   title   = "Numerical investigation on the fixed-stress splitting scheme for Biot's equations: Optimality of the tuning parameter",
-   journal = "Numer. Math. Adv. Appl. ENUMATH 2017, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Both and U. K\"{o}cher},
+   title   = {Numerical investigation on the fixed-stress splitting scheme for Biot's equations: Optimality of the tuning parameter},
+   journal = {Numer. Math. Adv. Appl. ENUMATH 2017, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_6,
-   author  = "K. D. Brauss and A. J. Meir",
-   title   = "On a parallel, 3-dimensional, finite element solver for viscous, resistive, stationary magnetohydrodynamics equations: Velocity–current formulation",
-   journal = "Applied Numerical Mathematics, in press",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://doi.org/10.1016/j.apnum.2018.01.014",
-   doi     = ""
+   author  = {K. D. Brauss and A. J. Meir},
+   title   = {On a parallel, 3-dimensional, finite element solver for viscous, resistive, stationary magnetohydrodynamics equations: Velocity--current formulation},
+   journal = {Applied Numerical Mathematics, in press},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://doi.org/10.1016/j.apnum.2018.01.014},
+   doi     = {}
 }
 
 @article{2018_7,
-   author  = "E. Bredow and B. Steinberger",
-   title   = "Variable melt production rate of the Kerguelen hotspot due to long-term plume-ridge interaction",
-   journal = "Geophysical Research Letters, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/2017GL075822/full",
-   doi     = "10.1002/2017GL075822"
+   author  = {E. Bredow and B. Steinberger},
+   title   = {Variable melt production rate of the Kerguelen hotspot due to long-term plume-ridge interaction},
+   journal = {Geophysical Research Letters, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2017GL075822/full},
+   doi     = {10.1002/2017GL075822}
 }
 
 @article{2018_8,
-   author  = "J. Choo and W. C. Sun",
-   title   = "Cracking and damage from crystallization in pores: Coupled chemo-hydro-mechanics and phase-field modeling",
-   journal = "Computer Methods in Applied Mechanics and Engineering, pp. 347–379",
-   year    = "2018",
-   volume  = "335",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Choo and W. C. Sun},
+   title   = {Cracking and damage from crystallization in pores: Coupled chemo-hydro-mechanics and phase-field modeling},
+   journal = {Computer Methods in Applied Mechanics and Engineering, pp. 347--379},
+   year    = {2018},
+   volume  = {335},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_9,
-   author  = "J. Choo and S. Lee",
-   title   = "Enriched Galerkin ﬁnite elements for coupled poromechanics with local mass conservation",
-   journal = "Computer Methods in Applied Mechanics and Engineering, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {J. Choo and S. Lee},
+   title   = {Enriched Galerkin finite elements for coupled poromechanics with local mass conservation},
+   journal = {Computer Methods in Applied Mechanics and Engineering, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_10,
-   author  = "J. Chung and M. S. Fabien and M. G. Knepley and R. T. Mills",
-   title   = "Comparative study of finite element methods using the Time-Accuracy-Size (TAS) spectrum analysis",
-   journal = "arXiv:1802.07832",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1802.07832",
-   doi     = ""
+   author  = {J. Chung and M. S. Fabien and M. G. Knepley and R. T. Mills},
+   title   = {Comparative study of finite element methods using the Time-Accuracy-Size (TAS) spectrum analysis},
+   journal = {arXiv:1802.07832},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1802.07832},
+   doi     = {}
 }
 
 @article{2018_11,
-   author  = "D. Davydov and T. Heister and M. Kronbichler and P. Steinmann",
-   title   = "Matrix-free locally adaptive finite element solution of density-functional theory with nonorthogonal orbitals and multigrid preconditioning",
-   journal = "Physica Status Solidi B: Basic Solid State Physics",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1002/pssb.201800069"
+   author  = {D. Davydov and T. Heister and M. Kronbichler and P. Steinmann},
+   title   = {Matrix-free locally adaptive finite element solution of density-functional theory with nonorthogonal orbitals and multigrid preconditioning},
+   journal = {Physica Status Solidi B: Basic Solid State Physics},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1002/pssb.201800069}
 }
 
 @article{2018_12,
-   author  = "N. Demo and M. Tezzele and A. Mola and G. Rozza",
-   title   = "An efficient shape parametrisation by free-form deformation enhanced by active subspace for hull hydrodynamic ship design problems in open source environment",
-   journal = "arXiv:1801.06369",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {N. Demo and M. Tezzele and A. Mola and G. Rozza},
+   title   = {An efficient shape parametrisation by free-form deformation enhanced by active subspace for hull hydrodynamic ship design problems in open source environment},
+   journal = {arXiv:1801.06369},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_13,
-   author  = "G. Di Ilio and B. Dorschner and G. Bella and S. Succi and I. V. Karlin",
-   title   = "Simulation of turbulent ﬂows with the entropic multi-relaxation time lattice Boltzmann method on body-ﬁtted meshes",
-   journal = "Journal of Fluid Mechanics",
-   year    = "2018",
-   volume  = "849",
-   pages   = "35--56",
-   url     = "https://www.researchgate.net/publication/325069808_Simulation_of_turbulent_flows_with_the_entropic_multi-relaxation_time_lattice_Boltzmann_method_on_body-fitted_meshes",
-   doi     = "10.1017/jfm.2018.413"
+   author  = {G. Di Ilio and B. Dorschner and G. Bella and S. Succi and I. V. Karlin},
+   title   = {Simulation of turbulent flows with the entropic multi-relaxation time lattice Boltzmann method on body-fitted meshes},
+   journal = {Journal of Fluid Mechanics},
+   year    = {2018},
+   volume  = {849},
+   pages   = {35--56},
+   url     = {https://www.researchgate.net/publication/325069808_Simulation_of_turbulent_flows_with_the_entropic_multi-relaxation_time_lattice_Boltzmann_method_on_body-fitted_meshes},
+   doi     = {10.1017/jfm.2018.413}
 }
 
 @mastersthesis{2018_14,
-   author  = "N. Dommaraju",
-   title   = "Partition of unity finite element method with overlapping enrichment domains",
-   year    = "2018",
-   school  = "Friedrich-Alexander-Universität Erlangen-Nürnberg",
-   url     = ""
+   author  = {N. Dommaraju},
+   title   = {Partition of unity finite element method with overlapping enrichment domains},
+   year    = {2018},
+   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   url     = {}
 }
 
 @article{2018_15,
-   author  = "B. Endtmayer and U. Langer and T. Wick",
-   title   = "Multigoal-Oriented Error Estimates for Non-linear Problems",
-   journal = "arXiv:1804.01331",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {B. Endtmayer and U. Langer and T. Wick},
+   title   = {Multigoal-Oriented Error Estimates for Non-linear Problems},
+   journal = {arXiv:1804.01331},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_16,
-   author  = "L. Failer and T. Wick",
-   title   = "Adaptive Time-Step Control for Nonlinear Fluid-Structure Interaction",
-   journal = "Journal of Computational Physics",
-   year    = "2018",
-   volume  = "366",
-   pages   = "448--477",
-   url     = "https://www.sciencedirect.com/science/article/pii/S0021999118302377",
-   doi     = ""
+   author  = {L. Failer and T. Wick},
+   title   = {Adaptive Time-Step Control for Nonlinear Fluid-Structure Interaction},
+   journal = {Journal of Computational Physics},
+   year    = {2018},
+   volume  = {366},
+   pages   = {448--477},
+   url     = {https://www.sciencedirect.com/science/article/pii/S0021999118302377},
+   doi     = {}
 }
 
 @article{2018_17,
-   author  = "N. Fehn and W. A. Wall and M. Kronbichler",
-   title   = "A matrix-free high-order discontinuous Galerkin compressible Navier-Stokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows",
-   journal = "arXiv:1806.03095",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1802.01439",
-   doi     = ""
+   author  = {N. Fehn and W. A. Wall and M. Kronbichler},
+   title   = {A matrix-free high-order discontinuous Galerkin compressible Navier-Stokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
+   journal = {arXiv:1806.03095},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1802.01439},
+   doi     = {}
 }
 
 @article{2018_18,
-   author  = "N. Fehn and W. A. Wall and M. Kronbichler",
-   title   = "Efficiency of high-performance discontinuous Galerkin spectral element methods for under-resolved turbulent incompressible flows",
-   journal = "arXiv:1802.01439",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1802.01439",
-   doi     = ""
+   author  = {N. Fehn and W. A. Wall and M. Kronbichler},
+   title   = {Efficiency of high-performance discontinuous Galerkin spectral element methods for under-resolved turbulent incompressible flows},
+   journal = {arXiv:1802.01439},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1802.01439},
+   doi     = {}
 }
 
 @article{2018_19,
-   author  = "N. Fehn and W. A. Wall and M. Kronbichler",
-   title   = "Robust and efficient discontinuous Galerkin methods for under-resolved turbulent incompressible flows",
-   journal = "arXiv:1801.08103",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1801.08103",
-   doi     = ""
+   author  = {N. Fehn and W. A. Wall and M. Kronbichler},
+   title   = {Robust and efficient discontinuous Galerkin methods for under-resolved turbulent incompressible flows},
+   journal = {arXiv:1801.08103},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1801.08103},
+   doi     = {}
 }
 
 @article{2018_20,
-   author  = "Z. Ge and H. Holmgren and M. Kronbichler and L. Brandt and G. Kreiss",
-   title   = "Effective slip over partially filled microcavities and its possible failure",
-   journal = "Physical Review Fluids 3, 054201",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://journals.aps.org/prfluids/abstract/10.1103/PhysRevFluids.3.054201",
-   doi     = ""
+   author  = {Z. Ge and H. Holmgren and M. Kronbichler and L. Brandt and G. Kreiss},
+   title   = {Effective slip over partially filled microcavities and its possible failure},
+   journal = {Physical Review Fluids 3, 054201},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://journals.aps.org/prfluids/abstract/10.1103/PhysRevFluids.3.054201},
+   doi     = {}
 }
 
 @article{2018_21,
-   author  = "C. Goll and T. Wick and W. Wollner",
-   title   = "DOpElib: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving PDEs and Optimization Problems with PDEs",
-   journal = "Archive of Numerical Software",
-   year    = "2018",
-   volume  = "5",
-   pages   = "1--14",
-   url     = "",
-   doi     = ""
+   author  = {C. Goll and T. Wick and W. Wollner},
+   title   = {DOpElib: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving PDEs and Optimization Problems with PDEs},
+   journal = {Archive of Numerical Software},
+   year    = {2018},
+   volume  = {5},
+   pages   = {1--14},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_22,
-   author  = "X. Guo and H. Song and K. Wu and J. Killough",
-   title   = "Pressure characteristics and performance of multi-stage fractured horizontal well in shale gas reservoirs with coupled flow and geomechanics",
-   journal = "Journal of Petroleum Science and Engineering",
-   year    = "2018",
-   volume  = "163",
-   pages   = "1--15",
-   url     = "https://www.sciencedirect.com/science/article/pii/S0920410517309956?via%3Dihub",
-   doi     = ""
+   author  = {X. Guo and H. Song and K. Wu and J. Killough},
+   title   = {Pressure characteristics and performance of multi-stage fractured horizontal well in shale gas reservoirs with coupled flow and geomechanics},
+   journal = {Journal of Petroleum Science and Engineering},
+   year    = {2018},
+   volume  = {163},
+   pages   = {1--15},
+   url     = {https://www.sciencedirect.com/science/article/pii/S0920410517309956?via%3Dihub},
+   doi     = {}
 }
 
 @article{2018_23,
-   author  = "X. Guo and K. Wu and J. Killough",
-   title   = "Investigation of production-induced stress changes for infill-well stimulation in Eagle Ford Shale",
-   journal = "SPE Journal, article SPE-189974-PA",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.onepetro.org/journal-paper/SPE-189974-PA",
-   doi     = "10.2118/189974-PA"
+   author  = {X. Guo and K. Wu and J. Killough},
+   title   = {Investigation of production-induced stress changes for infill-well stimulation in Eagle Ford Shale},
+   journal = {SPE Journal, article SPE-189974-PA},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.onepetro.org/journal-paper/SPE-189974-PA},
+   doi     = {10.2118/189974-PA}
 }
 
 @article{2018_24,
-   author  = "L. Hov Odsæter and T. Kvamsdal and M. G Larson",
-   title   = "A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media",
-   journal = "arXiv:1803.03423",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {L. Hov Ods\ae{}ter and T. Kvamsdal and M. G Larson},
+   title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
+   journal = {arXiv:1803.03423},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_25,
-   author  = "D. Jodlbauer and U. Langer and T. Wick",
-   title   = "Parallel Block-Preconditioned Monolithic Solvers for Fluid-Structure-Interaction Problems",
-   journal = "arXiv:1801.05648",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Jodlbauer and U. Langer and T. Wick},
+   title   = {Parallel Block-Preconditioned Monolithic Solvers for Fluid-Structure-Interaction Problems},
+   journal = {arXiv:1801.05648},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_26,
-   author  = "U. Köcher",
-   title   = "Influence of the SIPG penalisation on the numerical properties of linear systems for elastic wave propagation",
-   journal = "Numer. Math. Adv. Appl. ENUMATH 2017, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {U. K\"{o}cher},
+   title   = {Influence of the SIPG penalisation on the numerical properties of linear systems for elastic wave propagation},
+   journal = {Numer. Math. Adv. Appl. ENUMATH 2017, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_27,
-   author  = "U. Köcher and M. Bause",
-   title   = "A mixed discontinuous-continuous Galerkin time discretisation for Biot's system",
-   journal = "Submitted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {U. K\"{o}cher and M. Bause},
+   title   = {A mixed discontinuous-continuous Galerkin time discretisation for Biot's system},
+   journal = {Submitted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_28,
-   author  = "B. Krank and M. Kronbichler and W. A. Wall",
-   title   = "Direct Numerical Simulation of Flow over Periodic Hills up to Re<sub>H</sub> = 10,595",
-   journal = "Flow, Turbulence, and Combustion",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://doi.org/10.1007/s10494-018-9941-3",
-   doi     = ""
+   author  = {B. Krank and M. Kronbichler and W. A. Wall},
+   title   = {Direct Numerical Simulation of Flow over Periodic Hills up to Re$_{\textnormal{H}}$ = 10,595},
+   journal = {Flow, Turbulence, and Combustion},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://doi.org/10.1007/s10494-018-9941-3},
+   doi     = {}
 }
 
 @article{2018_29,
-   author  = "B. Krank and M. Kronbichler and W. A. Wall",
-   title   = "Wall modeling via function enrichment within a high-order DG method for RANS simulations of incompressible flow",
-   journal = "International Journal for Numerical Methods in Fluids 86(1)",
-   year    = "2018",
-   volume  = "",
-   pages   = "107--129",
-   url     = "http://onlinelibrary.wiley.com/doi/10.1002/fld.4409",
-   doi     = ""
+   author  = {B. Krank and M. Kronbichler and W. A. Wall},
+   title   = {Wall modeling via function enrichment within a high-order DG method for RANS simulations of incompressible flow},
+   journal = {International Journal for Numerical Methods in Fluids 86(1)},
+   year    = {2018},
+   volume  = {},
+   pages   = {107--129},
+   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.4409},
+   doi     = {}
 }
 
 @article{2018_30,
-   author  = "M. Kronbichler and K. Kormann and W. A. Wall",
-   title   = "Fast matrix-free evaluation of hybridizable discontinuous Galerkin operators",
-   journal = "Numer. Math. Adv. Appl. ENUMATH 2017, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Kronbichler and K. Kormann and W. A. Wall},
+   title   = {Fast matrix-free evaluation of hybridizable discontinuous Galerkin operators},
+   journal = {Numer. Math. Adv. Appl. ENUMATH 2017, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_31,
-   author  = "M. Kronbichler and B. Krank and N. Fehn and S. Legat and W. A. Wall",
-   title   = "A new high-order discontinuous Galerkin solver for DNS and LES of turbulent incompressible flow",
-   journal = "New Results in Numerical and Experimental Fluid Mechanics XI",
-   year    = "2018",
-   volume  = "",
-   pages   = "467--477",
-   url     = "",
-   doi     = ""
+   author  = {M. Kronbichler and B. Krank and N. Fehn and S. Legat and W. A. Wall},
+   title   = {A new high-order discontinuous Galerkin solver for DNS and LES of turbulent incompressible flow},
+   journal = {New Results in Numerical and Experimental Fluid Mechanics XI},
+   year    = {2018},
+   volume  = {},
+   pages   = {467--477},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_32,
-   author  = "M. Maier and D. Margetis and M. Luskin",
-   title   = "Generation of surface plasmon-polaritons by edge effect",
-   journal = "Communications in Mathematical Sciences, Vol. 16",
-   year    = "2018",
-   volume  = "",
-   pages   = "77--97",
-   url     = "http://www.intlpress.com/site/pub/pages/journals/items/cms/content/vols/0016/0001/a004/",
-   doi     = ""
+   author  = {M. Maier and D. Margetis and M. Luskin},
+   title   = {Generation of surface plasmon-polaritons by edge effect},
+   journal = {Communications in Mathematical Sciences, Vol. 16},
+   year    = {2018},
+   volume  = {},
+   pages   = {77--97},
+   url     = {http://www.intlpress.com/site/pub/pages/journals/items/cms/content/vols/0016/0001/a004/},
+   doi     = {}
 }
 
 @article{2018_33,
-   author  = "M. Maier and R. Rannacher",
-   title   = "A duality-based optimization approach for model adaptivity in heterogeneous multiscale problems",
-   journal = "SIAM Multiscale Modeling and Simulation, Vol. 16",
-   year    = "2018",
-   volume  = "",
-   pages   = "412--428",
-   url     = "https://epubs.siam.org/doi/10.1137/16M1105670",
-   doi     = ""
+   author  = {M. Maier and R. Rannacher},
+   title   = {A duality-based optimization approach for model adaptivity in heterogeneous multiscale problems},
+   journal = {SIAM Multiscale Modeling and Simulation, Vol. 16},
+   year    = {2018},
+   volume  = {},
+   pages   = {412--428},
+   url     = {https://epubs.siam.org/doi/10.1137/16M1105670},
+   doi     = {}
 }
 
 @article{2018_34,
-   author  = "M. Maier and A. Nemilentsau and T. Low and M. Luskin",
-   title   = "Ultracompact amplitude modulator by coupling hyperbolic polaritons over a graphene-covered gap",
-   journal = "ACS Photonics, Vol. 5",
-   year    = "2018",
-   volume  = "",
-   pages   = "544--551",
-   url     = "https://journals.aps.org/prb/abstract/10.1103/PhysRevB.97.035307",
-   doi     = ""
+   author  = {M. Maier and A. Nemilentsau and T. Low and M. Luskin},
+   title   = {Ultracompact amplitude modulator by coupling hyperbolic polaritons over a graphene-covered gap},
+   journal = {ACS Photonics, Vol. 5},
+   year    = {2018},
+   volume  = {},
+   pages   = {544--551},
+   url     = {https://journals.aps.org/prb/abstract/10.1103/PhysRevB.97.035307},
+   doi     = {}
 }
 
 @article{2018_35,
-   author  = "J.-P. V. Pelteret and B. Walter and P. Steinmann",
-   title   = "Application of metaheuristic algorithms to the identification of nonlinear magneto-viscoelastic constitutive parameters",
-   journal = "Journal of Magnetism and Magnetic Materials, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1016/j.jmmm.2018.02.094"
+   author  = {J.-P. V. Pelteret and B. Walter and P. Steinmann},
+   title   = {Application of metaheuristic algorithms to the identification of nonlinear magneto-viscoelastic constitutive parameters},
+   journal = {Journal of Magnetism and Magnetic Materials, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1016/j.jmmm.2018.02.094}
 }
 
 @phdthesis{2018_36,
-   author  = "M. Sabawi",
-   title   = "Discontinuous Galerkin timestepping for nonlinear parabolic problems",
-   year    = "2018",
-   school  = "University of Leicester",
-   url     = ""
+   author  = {M. Sabawi},
+   title   = {Discontinuous Galerkin timestepping for nonlinear parabolic problems},
+   year    = {2018},
+   school  = {University of Leicester},
+   url     = {}
 }
 
 @article{2018_37,
-   author  = "A. Scacchi and J. M. Brader",
-   title   = "Local phase transitions in driven colloidal suspensions",
-   journal = "Molecular Physics",
-   year    = "2018",
-   volume  = "116",
-   pages   = "378--387",
-   url     = "https://doi.org/10.1080/00268976.2017.1393117",
-   doi     = "10.1080/00268976.2017.1393117"
+   author  = {A. Scacchi and J. M. Brader},
+   title   = {Local phase transitions in driven colloidal suspensions},
+   journal = {Molecular Physics},
+   year    = {2018},
+   volume  = {116},
+   pages   = {378--387},
+   url     = {https://doi.org/10.1080/00268976.2017.1393117},
+   doi     = {10.1080/00268976.2017.1393117}
 }
 
 @article{2018_38,
-   author  = "S. Schoeder and K. Kormann and W. A. Wall and M. Kronbichler",
-   title   = "Efficient Explicit Time Stepping of High Order Discontinuous Galerkin Schemes for Waves",
-   journal = "arXiv:1805.03981",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1805.03981",
-   doi     = ""
+   author  = {S. Schoeder and K. Kormann and W. A. Wall and M. Kronbichler},
+   title   = {Efficient Explicit Time Stepping of High Order Discontinuous Galerkin Schemes for Waves},
+   journal = {arXiv:1805.03981},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1805.03981},
+   doi     = {}
 }
 
 @article{2018_39,
-   author  = "S. Schoeder and M. Kronbichler and W. A. Wall",
-   title   = "Arbitrary High-Order Explicit Hybridizable Discontinuous Galerkin Methods for the Acoustic Wave Equation",
-   journal = "Journal of Scientific Computing, accepted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = "10.1007/s10915-018-0649-2"
+   author  = {S. Schoeder and M. Kronbichler and W. A. Wall},
+   title   = {Arbitrary High-Order Explicit Hybridizable Discontinuous Galerkin Methods for the Acoustic Wave Equation},
+   journal = {Journal of Scientific Computing, accepted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {10.1007/s10915-018-0649-2}
 }
 
 @article{2018_40,
-   author  = "S. Schoeder and S. Sticko and G. Kreiss and M. Kronbichler",
-   title   = "High Order Cut Discontinuous Galerkin Methods with Local Time Stepping for Acoustics",
-   journal = "Submitted",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {S. Schoeder and S. Sticko and G. Kreiss and M. Kronbichler},
+   title   = {High Order Cut Discontinuous Galerkin Methods with Local Time Stepping for Acoustics},
+   journal = {Submitted},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_41,
-   author  = "S. Sticko and G. Ludvigsson and G. Kreiss",
-   title   = "High Order Cut Finite Elements for the Elastic Wave Equation",
-   journal = "arXiv:1804.00332",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://arxiv.org/abs/1804.00332",
-   doi     = ""
+   author  = {S. Sticko and G. Ludvigsson and G. Kreiss},
+   title   = {High Order Cut Finite Elements for the Elastic Wave Equation},
+   journal = {arXiv:1804.00332},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://arxiv.org/abs/1804.00332},
+   doi     = {}
 }
 
 @article{2018_42,
-   author  = "M. Tezzele and F. Salmoiraghi and A. Mola and G. Rozza",
-   title   = "Dimension reduction in heterogeneous parametric spaces with application to naval engineering shape design problems",
-   journal = "arXiv:1709.03298",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {M. Tezzele and F. Salmoiraghi and A. Mola and G. Rozza},
+   title   = {Dimension reduction in heterogeneous parametric spaces with application to naval engineering shape design problems},
+   journal = {arXiv:1709.03298},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_43,
-   author  = "C. Van Duijn and A. Mikelic and M. Wheeler and T. Wick",
-   title   = "Thermoporoelasticity via homogenization I. Modeling and formal two-scale expansions",
-   journal = "Preprint",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {C. Van Duijn and A. Mikelic and M. Wheeler and T. Wick},
+   title   = {Thermoporoelasticity via homogenization I. Modeling and formal two-scale expansions},
+   journal = {Preprint},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_44,
-   author  = "D. Wells and J. W. Banks",
-   title   = "Using p-Refinement to Increase Boundary Derivative Convergence Rates.",
-   journal = "arXiv:1711.05922",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "",
-   doi     = ""
+   author  = {D. Wells and J. W. Banks},
+   title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates.},
+   journal = {arXiv:1711.05922},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {},
+   doi     = {}
 }
 
 @article{2018_45,
-   author  = "T. Wick",
-   title   = "Numerical Methods for Partial Differential Equations",
-   journal = "Lecture notes, Institute of Applied Mathematics, Leibniz Universität Hannover, Germany",
-   year    = "2018",
-   volume  = "",
-   pages   = "",
-   url     = "https://www.ifam.uni-hannover.de/1562.html",
-   doi     = ""
+   author  = {T. Wick},
+   title   = {Numerical Methods for Partial Differential Equations},
+   journal = {Lecture notes, Institute of Applied Mathematics, Leibniz Universit\"{a}t Hannover, Germany},
+   year    = {2018},
+   volume  = {},
+   pages   = {},
+   url     = {https://www.ifam.uni-hannover.de/1562.html},
+   doi     = {}
 }
 
 @article{2018_46,
-   author  = "N. Zhang and Z.-X. Li",
-   title   = "Formation of mantle “lone plumes” in the global downwelling zone — A case for subduction-controlled plume generation beneath the South China Sea",
-   journal = "Tectonophysics",
-   year    = "2018",
-   volume  = "723",
-   pages   = "1--13",
-   url     = "https://www.sciencedirect.com/science/article/pii/S0040195117305000",
-   doi     = "10.1016/j.tecto.2017.11.038"
+   author  = {N. Zhang and Z.-X. Li},
+   title   = {Formation of mantle ``lone plumes'' in the global downwelling zone -- A case for subduction-controlled plume generation beneath the South China Sea},
+   journal = {Tectonophysics},
+   year    = {2018},
+   volume  = {723},
+   pages   = {1--13},
+   url     = {https://www.sciencedirect.com/science/article/pii/S0040195117305000},
+   doi     = {10.1016/j.tecto.2017.11.038}
 }
 
 @article{2018_47,
-   author  = "J. J. Zhou and S. Shukla and A. Putz and M. Secanell",
-   title   = "Analysis of the role of the microporous layer in improving polymer electrolyte fuel cell performance",
-   journal = "Electrochimica Acta",
-   year    = "2018",
-   volume  = "268",
-   pages   = "366--382",
-   url     = "https://www.sciencedirect.com/science/article/pii/S0013468618304043?via%3Dihub",
-   doi     = "10.1016/j.electacta.2018.02.100"
-}
-
-@Article{Wei_er_2018,
-  author    = {Steffen Wei{\ss}er and Thomas Wick},
-  title     = {The Dual-Weighted Residual Estimator Realized on Polygonal Meshes},
-  journal   = {Computational Methods in Applied Mathematics},
-  year      = {2018},
-  volume    = {18},
-  number    = {4},
-  pages     = {753--776},
-  month     = {oct},
-  doi       = {10.1515/cmam-2017-0046},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Walter de Gruyter {GmbH}},
-  timestamp = {2018.11.20},
-  url       = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf},
-}
-
-@InProceedings{Deolmi2018,
-  author    = {Deolmi, G. and Dahmen, W. and M{\"{u}}ller, S. and Albers, M. and Meysonnat, P. S. and Schr{\"{o}}der, W.},
-  title     = {{Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface}},
-  booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
-  year      = {2018},
-  volume    = {236},
-  series    = {Springer Proceedings in Mathematics \& Statistics},
-  pages     = {473--485},
-  publisher = {Springer International Publishing},
-  doi       = {10.1007/978-3-319-91545-6_36},
-  journal   = {Springer},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@InProceedings{Chandrashekar2018,
-  author    = {Chandrashekar, Praveen and Gallego-Valencia, Juan Pablo and Klingenberg, Christian},
-  title     = {{A Runge--Kutta Discontinuous Galerkin Scheme for the Ideal Magnetohydrodynamical Model}},
-  booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
-  year      = {2018},
-  volume    = {236},
-  series    = {Springer Proceedings in Mathematics \& Statistics},
-  pages     = {335--344},
-  publisher = {Springer International Publishing},
-  doi       = {10.1007/978-3-319-91545-6_27},
-  journal   = {Springer},
-  owner     = {Jean-Paul Pelteret},
-  timestamp = {2018.11.20},
-}
-
-@Article{Potschka2018a,
-  author    = {Potschka, Andreas},
-  title     = {{Backward step control for Hilbert space problems}},
-  journal   = {Numerical Algorithms},
-  year      = {2018},
-  pages     = {1--30},
-  month     = {may},
-  issn      = {1017-1398},
-  note      = {TODO: Update existing entry that only has arxiv data},
-  doi       = {10.1007/s11075-018-0539-6},
-  owner     = {Jean-Paul Pelteret},
-  publisher = {Springer Nature},
-  timestamp = {2018.11.20},
+   author  = {J. J. Zhou and S. Shukla and A. Putz and M. Secanell},
+   title   = {Analysis of the role of the microporous layer in improving polymer electrolyte fuel cell performance},
+   journal = {Electrochimica Acta},
+   year    = {2018},
+   volume  = {268},
+   pages   = {366--382},
+   url     = {https://www.sciencedirect.com/science/article/pii/S0013468618304043?via%3Dihub},
+   doi     = {10.1016/j.electacta.2018.02.100}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
Changes Jabref entries to use brackets, guarding against runaway latex commands. Removes unicode and HTML from all entries.