### PR TITLE
Change encoding enforced by Jabref.

### DIFF
--- a/publications-1998.bib
+++ b/publications-1998.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @MastersThesis{1998_0,
   author    = {W. Bangerth},

--- a/publications-1999.bib
+++ b/publications-1999.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @Article{1999_0,
   author    = {W. Bangerth and G. Kanschat},

--- a/publications-2000.bib
+++ b/publications-2000.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @Article{2000_0,
   author    = {W. Bangerth},

--- a/publications-2001.bib
+++ b/publications-2001.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @Article{2001_0,
   author    = {A. Barinka and T. Barsch and P. Charton and A. Cohen and S. Dahlke and W. Dahmen and K. Urban},

--- a/publications-2002.bib
+++ b/publications-2002.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @phdthesis{2002_0,
    author  = {W. Bangerth},

--- a/publications-2003.bib
+++ b/publications-2003.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @phdthesis{2003_0,
    author  = {S. Achatz},

--- a/publications-2004.bib
+++ b/publications-2004.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2004_0,
    author  = {W. Bangerth and },

--- a/publications-2005.bib
+++ b/publications-2005.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2005_0,
    author  = {M. Anderson and W. Bangerth and G. Carey},

--- a/publications-2006.bib
+++ b/publications-2006.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @mastersthesis{2006_0,
    author  = {M. Allmaras},

--- a/publications-2007.bib
+++ b/publications-2007.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2007_0,
    author  = {N. Antonic and M. Vrdoljak},

--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2008_0,
    author  = {W. Bangerth},

--- a/publications-2009.bib
+++ b/publications-2009.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2009_0,
    author  = {S. G. Abaimov and A. Roy and J.P. Cusumano},

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2010_0,
    author  = {M. Alexe and A. Sandu},

--- a/publications-2011.bib
+++ b/publications-2011.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2011_0,
    author  = {I. Adeniran and M. J. McPate and H. J. Wichtel and J. C. Hancox and H. Zhang},

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @phdthesis{2012_0,
    author  = {I. Adeniran},

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @mastersthesis{2013_0,
    author  = {G. Alam},

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2014_0,
    author  = {S. G. Abaimov and J. P. Cusumano},

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -1175,7 +1175,7 @@
 }
 
 @article{2014_110,
-   author  = {A. Vidal-Ferrandiza and R. Fayeza and D. Ginestarb and G. Verdúa},
+   author  = {A. Vidal-Ferrandiz and R. Fayez and D. Ginestar and G. Verd\'{u}},
    title   = {Solution of the Lambda modes problem of a nuclear power reactor using an h--p finite element method},
    journal = {Annals of Nuclear Energy, pp. 338--349},
    year    = {2014},

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @phdthesis{2015_0,
    author  = {F. S. Alrashed},

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -267,7 +267,7 @@
 }
 
 @article{2015_25,
-   author  = {T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikelic´},
+   author  = {T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikeli\'{c}},
    title   = {Effective interface conditions for the forced infiltration of a viscous fluid into a porous medium using homogenization},
    journal = {Comput. Methods Appl. Mech. Engrg., Volume 292},
    year    = {2015},

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2016_0,
    author  = {J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan},

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -259,7 +259,7 @@
 }
 
 @article{2017_23,
-   author  = {A. Carre\~{n}o and A. Vidal-Ferrandiz and D. Ginestar and G. Verdú},
+   author  = {A. Carre\~{n}o and A. Vidal-Ferrandiz and D. Ginestar and G. Verd\'{u}},
    title   = {Multilevel method to compute the lambda modes of the neutron diffusion equation},
    journal = {Applied Mathematics and Nonlinear Sciences},
    year    = {2017},

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @mastersthesis{2017_116,
    author  = {A. Str\"{o}m},

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1,4 +1,4 @@
-% Encoding: ISO-8859-1
+% Encoding: US-ASCII
 
 @article{2018_0,
    author  = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},


### PR DESCRIPTION
The encoding is changed from ISO-8859-1 ( https://en.wikipedia.org/wiki/ISO/IEC_8859-1 ), which supports some special characters, to ASCII ( https://en.wikipedia.org/wiki/ASCII ), which does not. The intent is that Jabref will not allow files with special characters to be saved if the encoding does not allow it. This should help with detection if some anomalous characters slip into an entry (e.g. if entries are downloaded from DOI, e-print, etc.).

I understand that this is a bit hostile towards our European colleagues, but I think it will help ensure that all entries are rendered as intended. All special characters will thus need to be explicitly formed with tex commands. If it makes a difference, we already enforce this when `offline/publication_list.tex` is built.