### PR TITLE
Fix entry with no year field.

### DIFF
--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -110,7 +110,8 @@
 @article{2008_10,
    author  = {P. Ghysels and G. Samaey and B. Tijskens and H. Ramon and D. Roose},
    title   = {Multi-scale simulation of plant tissue deformation using a model for individual cell behavior},
-   journal = {Report TW 522, Department of Computer Science, K.U. Leuven, Belgium, 2008.}
+   journal = {Report TW 522, Department of Computer Science, K.U. Leuven, Belgium, 2008.},
+   year    = {2008},
 }
 
 @article{2008_10a,


### PR DESCRIPTION
This leads to this particular entry bubbling up to the top of the
HTML-rendered list.