### PR TITLE
switch pdf to utf8

### DIFF
--- a/offline/publication_list.tex
+++ b/offline/publication_list.tex
@@ -10,6 +10,8 @@
 %
 
 \documentclass[]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
 \usepackage[
   backend=biber,
   sorting=ydnt,


### PR DESCRIPTION
fixes hundreds of warnings like
```'
WARN - The entry '1998_0' has characters which cannot be encoded in
'ascii'. Recoding problematic characters into macros.
```