### PR TITLE
Add a template file for PhD theses.

### DIFF
--- a/jabref-template/listrefs.phdthesis.layout
+++ b/jabref-template/listrefs.phdthesis.layout
@@ -1,0 +1,100 @@
+\begingroup{year}
+  <tr class="show"><td><h3>\format[HTMLChars]{\year}</td></tr></h3>
+\endgroup{year}
+
+<tr id="\format{\bibtexkey}" class="entry">
+  <td>
+    \format[Authors(FirstFirst,Initials,Comma,Comma),HTMLChars]{\author}
+    <br>
+    <b>
+      \format[HTMLChars]{\title}
+    </b>
+
+    <br>
+
+   <!-- The following parts of each entry are all optional and may not
+        be present in all bibtex entries that are processed via the
+        current file. If present, the `\begin{field} ... \end{field}`
+        section will be expanded into something nonzero, and we will
+        do this with all of the following pieces of information about
+        each publication. Because we expect the first entry to always
+        be there, we add all following entries with a leading
+        comma. To avoid a space between the previous and current entry
+        (which starts with a comma), we end end each line with a
+        comment-start marker and begin the next line with the
+        comment-end marker. 
+
+        Everything is closed with a period after the last entry.
+
+        -->
+
+          \begin{school} PhD thesis, \format[HTMLChars]{\school}\end{school}<!--
+      -->\begin{address}, \format[HTMLChars]{\address}\end{address}<!--
+    -->\begin{publisher}, \format[HTMLChars]{\publisher}\end{publisher}<!--
+         -->\begin{year}, \format[HTMLChars]{\year}\end{year}<!--
+                     -->.
+
+    
+    <p class="infolinks">
+      \begin{review}
+        [<a href="javascript:toggleInfo('\format{\bibtexkey}','review')">Review</a>]
+      \end{review}
+
+      [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
+
+      \begin{doi}
+	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+      \end{doi}
+
+      \begin{url}
+        [<a href="\format{\url}" target="_blank">URL</a>]
+      \end{url}
+
+      \begin{file}
+        [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]
+      \end{file}
+    </p>
+
+    <br>
+  </td>
+</tr>
+
+\begin{abstract}
+  <tr id="abs_\format{\bibtexkey}" class="abstract noshow">
+    <td>
+      <b>Abstract</b>: \format[HTMLChars]{\abstract}
+    </td>
+  </tr>
+\end{abstract}
+
+\begin{review}
+  <tr id="rev_\format{\bibtexkey}" class="review noshow">
+    <td>
+      <b>Review</b>: \format[HTMLChars]{\review}
+    </td>
+  </tr>
+\end{review}
+
+
+<tr id="bib_\format{\bibtexkey}" class="bibtex noshow">
+<td><b>BibTeX</b>:
+<pre>
+@\format[ToLowerCase]{\bibtextype}{\bibtexkey,\begin{author}
+  author    = {\format[HTMLChars]{\author}}\end{author}\begin{editor},
+  editor    = {\format[HTMLChars]{\editor}}\end{editor}\begin{title},
+  title     = {\format[HTMLChars]{\title}}\end{title}\begin{booktitle},
+  booktitle = {\format[HTMLChars]{\booktitle}}\end{booktitle}\begin{journal},
+  journal   = {\format[HTMLChars]{\journal}}\end{journal}\begin{publisher},
+  publisher = {\format[HTMLChars]{\publisher}}\end{publisher}\begin{school},
+  school    = {\format[HTMLChars]{\school}}\end{school}\begin{year},
+  year      = {\format[HTMLChars]{\year}}\end{year}\begin{volume},
+  volume    = {\format[HTMLChars]{\volume}}\end{volume}\begin{number},
+  number    = {\format[HTMLChars]{\number}}\end{number}\begin{pages},
+  pages     = {\format[HTMLChars]{\pages}}\end{pages}\begin{edition},
+  edition   = {\format[HTMLChars]{\edition}}\end{edition}\begin{note},
+  note      = {\format[HTMLChars]{\note}}\end{note}\begin{url},
+  url       = {\format[HTMLChars]{\url}}\end{url}\begin{doi},
+  doi       = {\format[DOIStrip]{\doi}}\end{doi}
+}
+</pre></td>
+</tr>


### PR DESCRIPTION
As noted before, theses are printed awkwardly with a leading period. This
can be avoided by having a separate style file for PhD theses. This is a
starting point -- let's see what it renders. If this works, I can add a
similar file for `@mastersthesis` entries.