### PR TITLE
Fix spelling of 'Texas A&M'.

### DIFF
--- a/publications-2005.bib
+++ b/publications-2005.bib
@@ -92,7 +92,7 @@
    author  = {A. Joshi},
    title   = {Adaptive finite element methods for fluorescence enhanced optical tomography},
    year    = {2005},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 

--- a/publications-2009.bib
+++ b/publications-2009.bib
@@ -248,7 +248,7 @@
    author  = {S. Kim},
    title   = {Analysis of a PML method applied to computation of resonances in open systems and acoustic scattering problems},
    year    = {2009},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -439,7 +439,7 @@
    author  = {Y. Wang},
    title   = {Adaptive mesh refinement solution techniques for the multigrid S$_{\textnormal{N}}$ transport equation using a higher-order discontinuous finite element method},
    year    = {2009},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -547,7 +547,7 @@
 @article{2009_53,
    author  = {V. N. Zingan},
    title   = {Discontinuous Galerkin Finite Element Method for the Nonlinear Hyperbolic Problems with Entropy-Bases Artificial Viscosity Stabilization},
-   journal = {PhD dissertation, Texas A \& M University},
+   journal = {PhD dissertation, Texas A\&M University},
    year    = {2009},
    volume  = {},
    pages   = {},

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -561,7 +561,7 @@
    author  = {A. J. Salgado},
    title   = {Approximation Techniques for Incompressible Flows with Heterogeneous Properties},
    year    = {2010},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 

--- a/publications-2011.bib
+++ b/publications-2011.bib
@@ -15,7 +15,7 @@
    author  = {M. Allmaras},
    title   = {Modeling aspects and computational methods for some recent problems of tomographic imaging},
    year    = {2011},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -261,7 +261,7 @@
    author  = {L. Ferguson},
    title   = {Brittle fracture modeling with a surface tension excess property},
    year    = {2012},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -412,7 +412,7 @@
    author  = {S. Joshi},
    title   = {A model for the estimation of residual stresses in soft tissues},
    year    = {2012},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -239,7 +239,7 @@
    author  = {K. Dugan},
    title   = {Dynamic adaptive multimesh refinement for coupled physics applicable to nuclear engineering},
    year    = {2013},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -1226,7 +1226,7 @@
    author  = {F. Wang},
    title   = {Regularizing Inverse Problems},
    year    = {2014},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -1234,7 +1234,7 @@
    author  = {K. Wang},
    title   = {Parallel Markov Chain Monte Carlo Methods for Large Scale Inverse Problems},
    year    = {2014},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -1371,7 +1371,7 @@
    author  = {Y. Zhang},
    title   = {SP$_{\textnormal{N}}$ Model Error and Iterative Solution Techniques},
    year    = {2014},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -4,7 +4,7 @@
    author  = {F. S. Alrashed},
    title   = {Parallel multiphase Navier-Stokes solver},
    year    = {2015},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf}
 }
 
@@ -672,7 +672,7 @@
    author  = {J. Gong},
    title   = {Formation of Physical Sedimentary Structure in the Presence of Microbial Communities},
    year    = {2015},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -1073,7 +1073,7 @@
 @article{2015_103,
    author  = {M. S. Muddamallappa},
    title   = {On Two Theories for Brittle Fracture: Modeling and Direct Numerical Simulations},
-   journal = {PhD dissertation, Texas A \& M University.},
+   journal = {PhD dissertation, Texas A\&M University.},
    year    = {2015},
    volume  = {},
    pages   = {},

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1094,7 +1094,7 @@
    author  = {M. Quezada de Luna},
    title   = {High-order and maximum principle preserving (MPP) techniques for solving conservation laws with applications on multiphase flow},
    year    = {2016},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -1316,7 +1316,7 @@
    author  = {Y. Yang},
    title   = {Continuous finite element approximation of hyperbolic systems},
    year    = {2016},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {https://oaktrust.library.tamu.edu/handle/1969.1/157976}
 }
 
@@ -2116,7 +2116,7 @@
 @PhdThesis{2016_130,
   author    = {Zheng, Weixiong},
   title     = {Least-Squares and Other Residual Based Techniques for Radiation Transport Calculations},
-  school    = {Texas A \& M University},
+  school    = {Texas A\&M University},
   year      = {2016},
   url       = {https://oaktrust.library.tamu.edu/handle/1969.1/159075},
 }

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -284,7 +284,7 @@
    author  = {H.-C. Chu},
    title   = {Application of the fictitious domain method to flow problems with complex geometries},
    year    = {2017},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 
@@ -518,7 +518,7 @@
    author  = {A. Ghesmati},
    title   = {Residual and goal-oriented h- and hp-adaptive finite element; application for elliptic and saddle point problems},
    year    = {2017},
-   school  = {Texas A \& M University},
+   school  = {Texas A\&M University},
    url     = {}
 }
 


### PR DESCRIPTION
The name is generally spelled without a space to the left and right of the ampersand.