### PR TITLE
Fix entries for theses.

### DIFF
--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -439,7 +439,7 @@
    author  = {K. Kormann},
    title   = {Efficient and Reliable Simulation of Quantum Molecular Dynamics},
    year    = {2012},
-   school  = {Doctoral thesis, Uppsala University},
+   school  = {Uppsala University},
    url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A549981&dswid=6393}
 }
 

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -550,11 +550,12 @@
    doi     = {}
 }
 
-@phdthesis{2013_53,
+@mastersthesis{2013_53,
    author  = {S. H. Lim},
    title   = {Numerical Simulation of Two-phase Heat Flow and Transient Partial Melting in the Lower Crust with Adaptive Mesh Refinement},
    year    = {2013},
-   school  = {Undergraduate honors thesis, University of Michigan, Ann Arbor},
+   school  = {University of Michigan, Ann Arbor},
+   note    = {Undergraduate honors thesis},
    url     = {}
 }
 
@@ -781,11 +782,12 @@
    doi     = {}
 }
 
-@phdthesis{2013_76,
+@mastersthesis{2013_76,
    author  = {P. Siehr},
    title   = {Stabilisierungsmethoden f\"{u}r die Stokes-Gleichungen},
    year    = {2013},
-   school  = {Bachelor thesis, University of Heidelberg, Germany},
+   school  = {University of Heidelberg, Germany},
+   note    = {Bachelor thesis},
    url     = {}
 }
 

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -597,11 +597,12 @@
    url     = {http://hdl.handle.net/1721.1/101348}
 }
 
-@phdthesis{2015_57,
+@mastersthesis{2015_57,
    author  = {E. Furst},
    title   = {Parallel Preconditioners for Finite Element Computations},
    year    = {2015},
-   school  = {Honors thesis, Saint John's University},
+   school  = {Saint John's University},
+   note    = {Honors thesis},
    url     = {http://digitalcommons.csbsju.edu/cgi/viewcontent.cgi?article=1065&context=honors_theses}
 }
 
@@ -742,11 +743,12 @@
    doi     = {}
 }
 
-@phdthesis{2015_71,
+@mastersthesis{2015_71,
    author  = {D. Heilmann},
    title   = {Magneto-statics in multi-material media},
    year    = {2015},
-   school  = {Bachelor thesis, Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   note    = {Bachelor thesis},
    url     = {}
 }
 
@@ -961,11 +963,12 @@
    doi     = {}
 }
 
-@phdthesis{2015_92,
+@mastersthesis{2015_92,
    author  = {K. Ljungkvist},
    title   = {Techniques for finite element methods on modern processors},
    year    = {2015},
-   school  = {IT licentiate thesis, University of Uppsala, Sweden},
+   school  = {University of Uppsala, Sweden},
+   note    = {IT licentiate thesis},
    url     = {}
 }
 
@@ -992,7 +995,7 @@
    author  = {M. Maier},
    title   = {Duality-based adaptivity of model and discretization in multiscale finite-element methods},
    year    = {2015},
-   school  = {Doctoral thesis, Heidelberg University, Germany},
+   school  = {Heidelberg University, Germany},
    url     = {}
 }
 

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -148,11 +148,12 @@
    doi     = {}
 }
 
-@phdthesis{2016_14,
+@mastersthesis{2016_14,
    author  = {C. Beez},
    title   = {Funktionsinterpolation: Alternativen zu EIM/DEIM},
    year    = {2016},
-   school  = {Project thesis, Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   note    = {Project thesis},
    url     = {}
 }
 

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -615,11 +615,12 @@
    url     = {}
 }
 
-@phdthesis{2017_58,
+@mastersthesis{2017_58,
    author  = {C. Hanowski},
    title   = {Numerical Homogenisation of Magneto-Active Materials},
    year    = {2017},
-   school  = {Project thesis, Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+   note    = {Project thesis},
    url     = {}
 }
 
@@ -832,11 +833,12 @@
    doi     = {}
 }
 
-@phdthesis{2017_79,
+@mastersthesis{2017_79,
    author  = {S. Lin},
    title   = {High Performance Techniques Applied in Partial Differential Equations Library},
    year    = {2017},
-   school  = {Honors thesis, St. Johns University},
+   school  = {St. Johns University},
+   note    = {Honors thesis},
    url     = {}
 }
 


### PR DESCRIPTION
In preparation for dealing with anything other than PhD theses. I will
want to print the kind of thesis in some way, though I don't know yet.
Either way, it needs to be in a different field than in the school.

I also fix up a few PhD theses. It is not necessary to say 'Doctoral
thesis' -- that's already implied by the '@phdthesis' tag.

Finally, some of the existing thesis entries are misclassified as
phd theses. bibtex only knows two kinds of theses: @phdthesis and
@mastersthesis, so I'm lumping everything that's not a PhD into the
latter category.