### PR TITLE
Print 'note' fields.

### DIFF
--- a/jabref-template/listrefs.layout
+++ b/jabref-template/listrefs.layout
@@ -36,7 +36,8 @@
        -->\begin{volume}, vol. \volume\end{volume}<!--
        -->\begin{number}(\format[FormatPagesForHTML]{\number})\end{number}<!--
         -->\begin{pages}, pp. \format[FormatPagesForHTML]{\pages}\end{pages}<!--
-    -->\begin{publisher}. \format[HTMLChars]{\publisher}\end{publisher}<!--
+         -->\begin{note}  (\format[HTMLChars]{\note})\end{note}<!--
+    -->\begin{publisher}, \format[HTMLChars]{\publisher}\end{publisher}<!--
          -->\begin{year}, \format[HTMLChars]{\year}\end{year}<!--
                      -->.
 


### PR DESCRIPTION
This should print notes such as 'submitted' or 'accepted' or 'in print'
in parentheses after everything else but before the year. In most cases,
submitted/accepted/in print papers don't have a volume and pages yet,
so this will print the note text in parentheses right after the journal.

There are of course going to be cases where there is no journal. In
that case, '(Submitted), 2018' will be all that's printed. That
is going to look a little funny. If one of you don't like it, any
other suggestions?