### PR TITLE
Fix subheading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ the `note` tag as in the following example:
 Please make sure that you complete as many of these fields as possible. 
 It is a particular help to us to get the [DOI number](http://www.doi.org/) or a URL corresponding to your contribution.
 
-- Adding notes to publications
+#### Adding notes to publications
 If you would like to add a contribution that has not yet been formally accepted, please add a comment to the note field indicating the status of your contribution.
 This may be one of the following:
 - for items that have been submitted but not yet reviewed:


### PR DESCRIPTION
A subheading was added in #44, but it erroneously appears as a bullet point. This change fixes that.