### PR TITLE
Remove a duplicate citation.

### DIFF
--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -151,17 +151,6 @@
    doi     = {10.1007/s00211-017-0894-6}
 }
 
-@article{2017_13,
-   author  = {L. C. Berselli and D. Wells and X. Xie and T. Iliescu},
-   title   = {Spatial filtering for reduced order modeling},
-   journal = {arXiv.org preprint 1707.04133},
-   year    = {2017},
-   volume  = {},
-   pages   = {},
-   url     = {https://arxiv.org/abs/1707.04133},
-   doi     = {}
-}
-
 @article{2017_14,
    author  = {D. Biermann and H. Blum and I. Iovkov and A. Rademacher and K. Rosin and F.-T. Suttmeier},
    title   = {Modelling, Simulation and Compensation of Thermomechanically Induced Deviations in Deep-Hole Drilling with Minimum Quantity Lubrication},


### PR DESCRIPTION
The final citation is available in the 2019 page so we can delete the preprint reference.

Followup to #60; I thought that looked familiar.