### PR TITLE
Remove a 'width:' statement that messes up the page layout.

### DIFF
--- a/jabref-template/listrefs.begin.layout
+++ b/jabref-template/listrefs.begin.layout
@@ -356,7 +356,7 @@ function toggleSettings(){
 -->
 </script>
 <style type="text/css">
-body { background-color: white; font-family: Arial, sans-serif; font-size: 13px; line-height: 1.2; padding: 1em; color: #2E2E2E; width: 50em; margin: auto auto; }
+body { background-color: white; font-family: Arial, sans-serif; font-size: 13px; line-height: 1.2; padding: 1em; color: #2E2E2E; margin: auto auto; }
 
 form#quicksearch { width: auto; border-style: solid; border-color: gray; border-width: 1px 0px; padding: 0.7em 0.5em; display:none; position:relative; }
 span#searchstat {padding-left: 1em;}


### PR DESCRIPTION
This statement is responsible for the broken layout of the page. There are
other issues (textual, further layout, etc) that can be addressed in follow-up
PRs, but this is the key to getting the page look halfway reasonable.