### PR TITLE
Unify the spelling of a number of names.

### DIFF
--- a/publications-2001.bib
+++ b/publications-2001.bib
@@ -1,7 +1,7 @@
 % Encoding: US-ASCII
 
 @Article{2001_0,
-  author    = {Arne Barinka and Titus Barsch and Philippe Charton and Albert Cohen and Stephan Dahlke and Wolfgang Dahmen and Karsten Urban},
+  author    = {Arne Barinka and Titus Barsch and Philippe Charton and Albert Cohen and Stephan Dahlke and W. Dahmen and Karsten Urban},
   title     = {Adaptive Wavelet Schemes for Elliptic Problems---Implementation and Numerical Experiments},
   journal   = {{SIAM} Journal on Scientific Computing},
   year      = {2001},
@@ -14,7 +14,7 @@
 }
 
 @Article{2001_1,
-  author    = {Wolfgang Bangerth and Rolf Rannacher},
+  author    = {W. Bangerth and Rolf Rannacher},
   title     = {Adaptive finite element techniques for the acoustic wave equation},
   journal   = {Journal of Computational Acoustics},
   year      = {2001},
@@ -39,7 +39,7 @@
 }
 
 @Article{2001_3,
-  author    = {Bernardo Cockburn and Guido Kanschat and Ilaria Perugia and Dominik Sch\"{o}tzau},
+  author    = {B. Cockburn and G. Kanschat and Ilaria Perugia and Dominik Sch\"{o}tzau},
   title     = {Superconvergence of the Local Discontinuous Galerkin Method for Elliptic Problems on Cartesian Grids},
   journal   = {{SIAM} Journal on Numerical Analysis},
   year      = {2001},

--- a/publications-2004.bib
+++ b/publications-2004.bib
@@ -34,7 +34,7 @@
 }
 
 @article{2004_3,
-   author  = {G. Carey and M. Anderson and B. Carnes and B. Kirk},
+   author  = {G. F. Carey and M. L. Anderson and B. Carnes and B. Kirk},
    title   = {Some aspects of adaptive grid technology related to boundary and interior layers},
    journal = {Journal of Computational and Applied Mathematics},
    year    = {2004},
@@ -45,7 +45,7 @@
 }
 
 @article{2004_4,
-   author  = {G. Carey and W. Barth and J. A. Woods and B. Kirk and M. Anderson and S. Chow and W. Bangerth},
+   author  = {G. F. Carey and W. L. Barth and J. A. Woods and B. Kirk and M. L. Anderson and S. Chow and W. Bangerth},
    title   = {Modeling error and constitutive relations in simulation of flow and transport},
    journal = {International Journal for Numerical Methods in Fluids},
    year    = {2004},
@@ -86,7 +86,7 @@
 }
 
 @article{2004_8,
-   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
+   author  = {A. Joshi and W. Bangerth and E. M. Sevick-Muraca},
    title   = {Adaptive finite element based tomography for fluorescence optical imaging in tissue},
    journal = {Optics Express, issue 22},
    year    = {2004},
@@ -97,7 +97,7 @@
 }
 
 @article{2004_9,
-   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca},
+   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. M. Sevick-Muraca},
    title   = {Adaptive finite element methods for fluorescence enhanced frequency domain optical tomography: Forward imaging problem},
    journal = {Proceedings of the 2004 IEEE International Symposium on Biomedical Imaging},
    year    = {2004},
@@ -108,7 +108,7 @@
 }
 
 @article{2004_10,
-   author  = {A. Joshi and A. B. Thompson and W. Bangerth and E. Sevick-Muraca},
+   author  = {A. Joshi and A. B. Thompson and W. Bangerth and E. M. Sevick-Muraca},
    title   = {Adaptive finite element methods for forward modeling in fluorescence enhanced frequency domain optical tomography},
    journal = {Proceedings of the 2004 OSA Biomedical Topical Meetings},
    year    = {2004},

--- a/publications-2005.bib
+++ b/publications-2005.bib
@@ -1,7 +1,7 @@
 % Encoding: US-ASCII
 
 @article{2005_0,
-   author  = {M. Anderson and W. Bangerth and G. Carey},
+   author  = {M. L. Anderson and W. Bangerth and G. F. Carey},
    title   = {Analysis of parameter sensitivity and experimental design for a class of nonlinear partial differential equations},
    journal = {International Journal for Numerical Methods in Fluids},
    year    = {2005},
@@ -12,7 +12,7 @@
 }
 
 @article{2005_1,
-   author  = {W. Bangerth and A. Joshi and E. Sevick-Muraca},
+   author  = {W. Bangerth and A. Joshi and E. M. Sevick-Muraca},
    title   = {Adaptive finite element methods for increased resolution in fluorescence optical tomography},
    journal = {Progress in Biomedical Optics and Imaging},
    year    = {2005},
@@ -97,7 +97,7 @@
 }
 
 @article{2005_9,
-   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca},
+   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. M. Sevick-Muraca},
    title   = {Experimental fluorescence optical tomography using adaptive finite elements and planar illumination with modulated excitation light},
    journal = {Progress in Biomedical Optics and Imaging},
    year    = {2005},
@@ -152,7 +152,7 @@
 }
 
 @article{2005_14,
-   author  = {B. Nestler and D. Danilov and P. Galenko},
+   author  = {B. Nestler and D. Danilov and P. K. Galenko},
    title   = {Crystal growth of pure substances: Phase-field simulations in comparison with analytical and experimental results},
    journal = {Journal of Computational Physics},
    year    = {2005},

--- a/publications-2006.bib
+++ b/publications-2006.bib
@@ -171,7 +171,7 @@
 }
 
 @article{2006_16,
-   author  = {K. Hwang and T. Pan and A. Joshi and J. C. Rasmussen and W. Bangerth and E. Sevick-Muraca},
+   author  = {K. Hwang and T. Pan and A. Joshi and J. C. Rasmussen and W. Bangerth and E. M. Sevick-Muraca},
    title   = {Influence of excitation light rejection on forward model mismatch in optical tomography},
    journal = {Phys. Med. Biol.},
    year    = {2006},
@@ -182,7 +182,7 @@
 }
 
 @article{2006_17,
-   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
+   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. M. Sevick-Muraca},
    title   = {Fully adaptive FEM based fluorescence optical tomography from time-dependent measurements with area illumination and detection},
    journal = {Med. Phys.},
    year    = {2006},
@@ -193,7 +193,7 @@
 }
 
 @article{2006_18,
-   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
+   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. M. Sevick-Muraca},
    title   = {Plane wave fluorescence tomography with adaptive finite elements},
    journal = {Optics Letters},
    year    = {2006},
@@ -204,7 +204,7 @@
 }
 
 @article{2006_19,
-   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
+   author  = {A. Joshi and W. Bangerth and E. M. Sevick-Muraca},
    title   = {Non-contact fluorescence optical tomography with scanning area illumination},
    journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA, 2006},
    year    = {2006},
@@ -215,7 +215,7 @@
 }
 
 @article{2006_20,
-   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
+   author  = {A. Joshi and W. Bangerth and E. M. Sevick-Muraca},
    title   = {Non-contact fluorescence optical tomography with scanning patterned illumination},
    journal = {Optics Express},
    year    = {2006},
@@ -242,7 +242,7 @@
 }
 
 @article{2006_23,
-   author  = {T. Nielsen and T. Kohler},
+   author  = {T. Nielsen and T. Koehler},
    title   = {Impact of noise on image reconstruction for diffuse optical tomography},
    journal = {Phys. of Med. Imag., Proceedings of SPIE, doi: 10.1117/12.651297, Vol. 6142, 61420M},
    year    = {2006},
@@ -272,7 +272,7 @@
 }
 
 @article{2006_26,
-   author  = {R. Ziegler and T. Kohler and T. Nielsen and O. Steinkellner and D. Grosenick and H. Rinneberg},
+   author  = {R. Ziegler and T. Koehler and T. Nielsen and O. Steinkellner and D. Grosenick and H. Rinneberg},
    title   = {Spatial Resolution for Time-Resolved Optical Tomography in Slab Geometry},
    journal = {Nucl. Sci. Symp. Conf. IEEE,  Vol. 4, pp: 2578 - 2583},
    year    = {2006},

--- a/publications-2007.bib
+++ b/publications-2007.bib
@@ -42,7 +42,7 @@
 }
 
 @article{2007_4,
-   author  = {W. Bangerth and A. Joshi and E. Sevick},
+   author  = {W. Bangerth and A. Joshi and E. M. Sevick-Muraca},
    title   = {Inverse biomedical imaging using separately adapted meshes for parameters and forward model variables},
    journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
    year    = {2007},
@@ -242,7 +242,7 @@
 }
 
 @article{2007_23,
-   author  = {A. Joshi and W. Bangerth and R. Sharma and J. Rasmussen and W. Wang and E. Sevick},
+   author  = {A. Joshi and W. Bangerth and R. Sharma and J. Rasmussen and W. Wang and E. M. Sevick-Muraca},
    title   = {Molecular tomographic imaging of lymph nodes with NIR fluorescence},
    journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
    year    = {2007},

--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -200,7 +200,7 @@
 }
 
 @article{2008_18,
-   author  = {A. Joshi and W. Bangerth and E. Sevick},
+   author  = {A. Joshi and W. Bangerth and E. M. Sevick-Muraca},
    title   = {Non-Contact Fluorescence Optical Tomography with Adaptive Finite Element Methods},
    journal = {In: Mathematical Methods in Biomedical Imaging and Intensity-Modulated Radiation Therapy (IMRT), Y. Censor, M. Jiang and A.K. Louis (eds.), Birkh\"{a}user},
    year    = {2008},

--- a/publications-2009.bib
+++ b/publications-2009.bib
@@ -42,7 +42,7 @@
 }
 
 @article{2009_4,
-   author  = {S. Bartle and A. McBride and B. D. Reddy},
+   author  = {S. Bartle and A. T. McBride and B. D. Reddy},
    title   = {A discontinuous Galerkin formulation of a model of gradient plasticity at finite strains},
    journal = {Computer Methods in Applied Mechanics and Engineering},
    year    = {2009},
@@ -215,7 +215,7 @@
 }
 
 @article{2009_20,
-   author  = {D. Hyde and R. Schulz and D. Brooks and E. Miller and V. Ntziachristos},
+   author  = {D. Hyde and R. B. Schulz and D. Brooks and E. Miller and V. Ntziachristos},
    title   = {Performance dependence of hybrid x-ray computed tomography/fluorescence molecular tomography on the optical forward problem},
    journal = {J. Optical Soc. Amer.},
    year    = {2009},
@@ -226,7 +226,7 @@
 }
 
 @article{2009_21,
-   author  = {T. Jetzfellner and D. Razansky and A. Rosenthal and R. Schulz and K.-H. Englmeier and V. Ntziachristos},
+   author  = {T. Jetzfellner and Daniel Razansky and A. Rosenthal and R. B. Schulz and K.-H. Englmeier and V. Ntziachristos},
    title   = {Performance of iterative optoacoustic tomography with experimental data},
    journal = {Appl. Phys. Lett., pp. 013703/1-3},
    year    = {2009},
@@ -321,7 +321,7 @@
 }
 
 @article{2009_31,
-   author  = {M. Olshanskii and G. Lube and T. Heister and J. L\"{o}we},
+   author  = {M. A. Olshanskii and G. Lube and T. Heister and J. L\"{o}we},
    title   = {Grad-div stabilization and subgrid pressure models for the incompressible Navier--Stokes equations},
    journal = {Comp. Meth. Appl. Mech. Eng. V. 198},
    year    = {2009},
@@ -444,7 +444,7 @@
 }
 
 @article{2009_43,
-   author  = {Y. Wang and W. Bangerth and J. Ragusa},
+   author  = {Y. Wang and W. Bangerth and J. C. Ragusa},
    title   = {Three-dimensional h-adaptivity for the multigroup neutron diffusion equations},
    journal = {Progress in Nuclear Energy},
    year    = {2009},
@@ -463,7 +463,7 @@
 }
 
 @phdthesis{2009_45,
-   author  = {J. White},
+   author  = {J. A. White},
    title   = {Stabilized finite element methods for coupled flow and geomechanics},
    year    = {2009},
    school  = {Stanford University},
@@ -534,7 +534,7 @@
 }
 
 @article{2009_52,
-   author  = {R. Ziegler and T. Nielsen and T. Koehler and D. Grosnick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg},
+   author  = {R. Ziegler and T. Nielsen and T. Koehler and D. Grosenick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg},
    title   = {Nonlinear reconstruction of absorption and fluorescence contrast from measured diffuse transmittance and reflectance of a compressed-breast-simulating phantom},
    journal = {Applied Optics},
    year    = {2009},

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -56,7 +56,7 @@
 }
 
 @article{2010_5,
-   author  = {S. Bartle and A. McBride and B. D. Reddy},
+   author  = {S. Bartle and A. T. McBride and B. D. Reddy},
    title   = {Shell finite elements, with applications in biomechanics},
    journal = {In: Kok, S. (Ed.): Proceedings of 7th South African Conference on Computational and Applied Mechanics (University of Pretoria, Pretoria, South Africa)},
    year    = {2010},
@@ -89,7 +89,7 @@
 }
 
 @phdthesis{2010_8,
-   author  = {C. C. Chueh},
+   author  = {C.-C. Chueh},
    title   = {Integrated adaptive numerical methods for transient two-phase flow in heterogeneous porous medi},
    year    = {2010},
    school  = {University of Victoria},
@@ -97,7 +97,7 @@
 }
 
 @article{2010_9,
-   author  = {C. C. Chueh and M. Secanell and W. Bangerth and N. Djilali},
+   author  = {C.-C. Chueh and M. Secanell and W. Bangerth and N. Djilali},
    title   = {Multi-level Adaptive Simulation of Transient Two-phase Flow in Heterogeneous Porous Media},
    journal = {Computers and Fluids},
    year    = {2010},
@@ -149,7 +149,7 @@
 }
 
 @article{2010_14,
-   author  = {M. Freyer and A. Ale and R. Schulz and M. Zientkowska and V. Ntziachristos and K.-H. Englmeier},
+   author  = {M. Freyer and A. Ale and R. B. Schulz and M. Zientkowska and V. Ntziachristos and K.-H. Englmeier},
    title   = {Fast automatic segmentation of anatomical structures in x-ray computed tomography images to improve fluorescence molecular tomography reconstruction},
    journal = {Journal of Biomedical Optics, pp. 036006/1-8},
    year    = {2010},
@@ -193,7 +193,7 @@
 }
 
 @article{2010_18,
-   author  = {V. Girault and F. Murat and A. Salgado},
+   author  = {V. Girault and F. Murat and A. J. Salgado},
    title   = {Finite element discretization of Darcy's equations with pressure dependent porosity.},
    journal = {M2AN},
    year    = {2010},
@@ -465,7 +465,7 @@
 }
 
 @article{2010_44,
-   author  = {M. Myers and E.G. Fu and Michelle Myers and H. Wang and G. Xie and X. Wang and W-K. Chue and L. Shao},
+   author  = {M. Myers and E.G. Fu and M. Myers and H. Wang and G. Xie and X. Wang and W-K. Chue and L. Shao},
    title   = {An experimental and modeling study on the role of damage cascade formation in nanocrystalization of ion-irradiated Ni52.5Nb10Zr15Ti15Pt7.5 metallic glass},
    journal = {Scripta Materialia, Vol. 63 (11), pp: 1045--1048},
    year    = {2010},
@@ -566,7 +566,7 @@
 }
 
 @article{2010_54,
-   author  = {R. Schulz and A. Ale and A. Sarantopoulos and M. Freyer and E. Soehngen and M. Zientkowska and V. Ntziachristos},
+   author  = {R. B. Schulz and A. Ale and A. Sarantopoulos and M. Freyer and E. Soehngen and M. Zientkowska and V. Ntziachristos},
    title   = {Hybrid System for Simultaneous Fluorescence and X-Ray Computed Tomography},
    journal = {IEEE Trans. Medical Imaging},
    year    = {2010},

--- a/publications-2011.bib
+++ b/publications-2011.bib
@@ -64,7 +64,7 @@
 }
 
 @article{2011_6,
-   author  = {A. Buehler and A. Rosenthal and T. Jetzfellner and A. Dima and D. Razansky and V. Ntziachristos},
+   author  = {A. Buehler and A. Rosenthal and T. Jetzfellner and A. Dima and Daniel Razansky and V. Ntziachristos},
    title   = {Model-based optoacoustic inversions with incomplete projection data},
    journal = {Med. Phys.},
    year    = {2011},
@@ -97,7 +97,7 @@
 }
 
 @article{2011_9,
-   author  = {A. Cangiani and E. Georgoulis and M. Jensen},
+   author  = {A. Cangiani and E. H. Georgoulis and M. Jensen},
    title   = {Discontinuous Galerkin methods for convection-diffusion problems modelling mass transfer through semipermeable membranes.},
    journal = {Proceedings of the Congress on Numerical Methods in Engineering, Coimbra},
    year    = {2011},
@@ -230,7 +230,7 @@
 }
 
 @article{2011_22,
-   author  = {J. L. Guermond and A. Salgado},
+   author  = {J.-L. Guermond and A. J. Salgado},
    title   = {Error analysis of a fractional time-stepping technique for incompressible flows with variable density.},
    journal = {SIAM J. of Numerical Analysis},
    year    = {2011},
@@ -601,7 +601,7 @@
 }
 
 @article{2011_57,
-   author  = {J. White and R. I. Borja},
+   author  = {J. A. White and R. I. Borja},
    title   = {Block-preconditioned Newton--Krylov solvers for fully coupled flow and geomechanics},
    journal = {Comp. Geosc.},
    year    = {2011},

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -115,7 +115,7 @@
 }
 
 @article{2012_11,
-   author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
+   author  = {A. Cangiani and E. H. Georgoulis and S. Metcalfe},
    title   = {An a posteriori error estimator for discontinuous Galerkin methods for non-stationary convection-diffusion problems},
    journal = {},
    note = {Submitted},
@@ -127,7 +127,7 @@
 }
 
 @article{2012_12,
-   author  = {A. Cangiani and E. Georgoulis and M. Jensen},
+   author  = {A. Cangiani and E. H. Georgoulis and M. Jensen},
    title   = {Discontinuous Galerkin methods for mass transfer through semi-permeable membranes},
    journal = {},
    note = {Submitted},
@@ -210,7 +210,7 @@
 }
 
 @article{2012_20,
-   author  = {Y. Efendiev and J. Galvis and R. Lazarov and J. Willems},
+   author  = {Y. Efendiev and J. Galvis and R. D. Lazarov and J. Willems},
    title   = {Robust domain decomposition preconditioners for abstract symmetric positive definite bilinear forms},
    journal = {ESAIM: Mathematical Modelling and Numerical Analysis},
    year    = {2012},
@@ -221,7 +221,7 @@
 }
 
 @article{2012_21,
-   author  = {Y. Efendiev and J. Galvis and R. Lazarov and J. Willems},
+   author  = {Y. Efendiev and J. Galvis and R. D. Lazarov and J. Willems},
    title   = {Robust solvers for symmetric positive definite operators and weighted Poincar\'{e} inequalities},
    journal = {In I. Lirkov, S. Margenov, and J. Wasniewski, editors, Large-Scale Scientific Computing: 8th International Conference, LSSC 2011, Sozopol, Bulgaria, 43-51, Lecture Notes in Computer Science, Springer},
    year    = {2012},
@@ -262,7 +262,7 @@
 }
 
 @phdthesis{2012_25,
-   author  = {L. Ferguson},
+   author  = {L. A. Ferguson},
    title   = {Brittle fracture modeling with a surface tension excess property},
    year    = {2012},
    school  = {Texas A\&M University},
@@ -451,7 +451,7 @@
 }
 
 @phdthesis{2012_43,
-   author  = {S. Kramer},
+   author  = {S. C. Kramer},
    title   = {CUDA-based scientific computing tools and selected applications},
    year    = {2012},
    school  = {G\"{o}ttingen University, Germany},
@@ -573,7 +573,7 @@
 }
 
 @article{2012_55,
-   author  = {D. Riedlbauer and J. Mergheim and A. McBride and P. Steinmann},
+   author  = {D. Riedlbauer and J. Mergheim and A. T. McBride and P. Steinmann},
    title   = {Macroscopic modelling of the selective beam melting process},
    journal = {PAMM, p. 381-382},
    year    = {2012},
@@ -611,7 +611,7 @@
 }
 
 @article{2012_59,
-   author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
+   author  = {D. Sch\"{o}tzau and C. Schwab and T. P. Wihler and M. Wirz},
    title   = {Exponential convergence of the hp-DGFEM for elliptic problems in polyhedral domains},
    journal = {Research Report 2012-40, Seminar f\"{u}r Angewandte Mathematik, ETH Zurich},
    year    = {2012},
@@ -663,7 +663,7 @@
 }
 
 @article{2012_64,
-   author  = {S. Taylor and K. Dontsova and S. Bigl and C. Richardson and J. Lever and J. Pitt and J. P. Bradley and M. Walsh. J. Simunek},
+   author  = {S. Taylor and K. Dontsova and S. Bigl and C. Richardson and J. Lever and J. S. Pitt and J. P. Bradley and M. Walsh. J. Simunek},
    title   = {Dissolution Rate of Propellant Energetics from Nitrocellulose Matrices},
    journal = {Engineer Research and Development Center, Cold Regions Research and Engineering Laboratory, US Army Corps of Engineers, Technical Report ER-1691},
    year    = {2012},

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -165,7 +165,7 @@
 }
 
 @article{2013_16,
-   author  = {A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen},
+   author  = {A. Cangiani and J. Chapman and E. H. Georgoulis and M. Jensen},
    title   = {Implementation of the Continuous-Discontinuous Galerkin Finite Element Method},
    journal = {Numerical Mathematics and Advanced Applications 2011},
    year    = {2013},
@@ -198,7 +198,7 @@
 }
 
 @article{2013_19,
-   author  = {C. C. Chueh and N. Djilali and W. Bangerth},
+   author  = {C.-C. Chueh and N. Djilali and W. Bangerth},
    title   = {An h-adaptive Operator Splitting Method for Two-phase Flow in 3D Heterogeneous Porous Media},
    journal = {SIAM Journal on Scientific Computing, pp. B149-175},
    year    = {2013},
@@ -439,7 +439,7 @@
 }
 
 @article{2013_42,
-   author  = {M. Hinze and U. Mathes},
+   author  = {M. Hinze and U. Matthes},
    title   = {Model order reduction for networks of ODE and PDE systems},
    journal = {System Modeling and Optimization, IFIP Advances in Information and Communication Technology Vol. 391, pp 92-101},
    year    = {2013},
@@ -450,7 +450,7 @@
 }
 
 @article{2013_43,
-   author  = {S. Joshi and J and Walton},
+   author  = {S. Joshi and J. R. Walton},
    title   = {Reconstruction of the residual stresses in a hyperelastic body using ultrasound techniques},
    journal = {International Journal on Engineering Science},
    year    = {2013},
@@ -492,7 +492,7 @@
 }
 
 @article{2013_47,
-   author  = {S. Kramer},
+   author  = {S. C. Kramer},
    title   = {CUDA-based parallel preconditioning for RANS simulation of indoor airflow},
    journal = {Numerical Mathematics and Advanced Applications (Proceedings of the ENUMATH 2011 conference), Springer},
    year    = {2013},
@@ -503,7 +503,7 @@
 }
 
 @article{2013_48,
-   author  = {S. Kramer},
+   author  = {S. C. Kramer},
    title   = {Finite-element methods for spatially resolved mesoscopic electron transport},
    journal = {Physical Review B 88, 125308},
    year    = {2013},
@@ -992,7 +992,7 @@
 }
 
 @article{2013_95,
-   author  = {V. Zingan and J.-L. Guermond and J. Morel and B. Popov},
+   author  = {V. Zingan and J.-L. Guermond and J. E. Morel and B. Popov},
    title   = {Implementation of the entropy viscosity method with the Discontinuous Galerkin Method},
    journal = {Computer Methods in Applied Mechanics and Engineering},
    year    = {2013},

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -1,7 +1,7 @@
 % Encoding: US-ASCII
 
 @article{2014_0,
-   author  = {S. G. Abaimov and J. P. Cusumano},
+   author  = {S. G. Abaimov and J.P. Cusumano},
    title   = {Nucleation phenomena in an annealed damage model: Statistics of times to failure},
    journal = {Phys. Rev. E 90},
    year    = {2014},
@@ -171,7 +171,7 @@
 }
 
 @article{2014_16,
-   author  = {A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen},
+   author  = {A. Cangiani and J. Chapman and E. H. Georgoulis and M. Jensen},
    title   = {On local super-penalization of interior penalty discontinuous Galerkin methods},
    journal = {International Journal of Numerical Analysis \& Modeling},
    year    = {2014},
@@ -182,7 +182,7 @@
 }
 
 @article{2014_17,
-   author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
+   author  = {A. Cangiani and E. H. Georgoulis and S. Metcalfe},
    title   = {Adaptive discontinuous Galerkin methods for nonstationary convection--diffusion problems},
    journal = {IMA Journal of Numerical Analysis, Vol. 34, Issue 4},
    year    = {2014},
@@ -212,7 +212,7 @@
 }
 
 @article{2014_20,
-   author  = {C. C. Chueh and A. Bertei and J. Pharoah and C. Nicolella},
+   author  = {C.-C. Chueh and A. Bertei and J. Pharoah and C. Nicolella},
    title   = {Effective Conductivity in Random Porous Media with Convex and Non-Convex Porosity},
    journal = {International Journal of Heat and Mass Transfer},
    year    = {2014},
@@ -245,7 +245,7 @@
 }
 
 @Article{2014_23,
-  author    = {D. Davydov and J-P. Pelteret and P. Steinmann},
+  author    = {D. Davydov and J-P. V. Pelteret and P. Steinmann},
   title     = {Comparison of several staggered atomistic-to-continuum concurrent coupling strategies},
   journal   = {Computer Methods in Applied Mechanics and Engineering},
   year      = {2014},
@@ -345,7 +345,7 @@
 }
 
 @article{2014_32,
-   author  = {T. Fankhauser and T. Wihler and M. Wirz},
+   author  = {T. Fankhauser and T. P. Wihler and M. Wirz},
    title   = {The hp-adaptive FEM based on continuous Sobolev embeddings: Isotropic refinements},
    journal = {Computers \& Mathematics with Applications},
    year    = {2014},
@@ -367,8 +367,8 @@
 }
 
 @article{2014_34,
-   author  = {L. Ferguson and T. D. Breitzman},
-   title   = {Implementation and experimental validation of the Sendova-Walton theory for mode-I fracture},
+   author  = {L. A. Ferguson and T. D. Breitzman},
+   title   = {Implementation and experimental validation of the {Sendova-J.~R.~Walton} theory for mode-{I} fracture},
    journal = {Proceedings of the 11th World Congress on Computationa Mechnics (WCCM XI)},
    year    = {2014},
    volume  = {},
@@ -474,7 +474,7 @@
 }
 
 @article{2014_44,
-   author  = {S. Sh. Ghorashi and J. Amani and A. S. Bagherzadeh and T. Rabczuk},
+   author  = {S. S. Ghorashi and J. Amani and A. S. Bagherzadeh and T. Rabczuk},
    title   = {Goal-oriented error estimation and mesh adaptivity in three-dimensional elasticity problems},
    journal = {Proceedings of the 11th World Congress on Computational Mechnics (WCCM XI)},
    year    = {2014},
@@ -507,7 +507,7 @@
 }
 
 @article{2014_47,
-   author  = {A. Grayver and M. B\"{u}rg},
+   author  = {A. V. Grayver and M. B\"{u}rg},
    title   = {Robust and scalable 3-D geo-electromagnetic modelling approach using the finite element method},
    journal = {Geophysical Journal International 2014, published online (DOI 10.1093/gji/ggu119)},
    year    = {2014},
@@ -595,7 +595,7 @@
 }
 
 @article{2014_55,
-   author  = {B. Janssen and T. Wihler},
+   author  = {B. Janssen and T. P. Wihler},
    title   = {Existence Results for the Continuous and Discontinuous Galerkin Time Stepping Methods for Nonlinear Initial Value Problems},
    journal = {arXiv:1407.5520},
    year    = {2014},
@@ -628,7 +628,7 @@
 }
 
 @article{2014_58,
-   author  = {G. Kanschat and N. Sharma},
+   author  = {G. Kanschat and N. S. Sharma},
    title   = {Divergence-conforming Discontinuous Galerkin Methods and C$^{0}$ Interior Penalty Methods},
    journal = {SIAM J. Numer. Anal., no. 4},
    year    = {2014},
@@ -683,7 +683,7 @@
 }
 
 @article{2014_63,
-   author  = {S. Kramer and G. Lube},
+   author  = {S. C. Kramer and G. Lube},
    title   = {Finite Element-Boundary Element Methods for Accurate Modeling of Excluded Volume Effects in Dielectric Relaxation Spectroscopy},
    journal = {Preprint},
    year    = {2014},
@@ -765,7 +765,7 @@
 }
 
 @article{2014_71,
-   author  = {D. Malhotra and A. Gholami and G. Biros},
+   author  = {Dhairya Malhotra and A. Gholami and G. Biros},
    title   = {A volume integral equation Stokes solver for problems with variable coefficients},
    journal = {SC14: International Conference for High Performance Computing, Network, Storage and Analysis},
    year    = {2014},
@@ -776,7 +776,7 @@
 }
 
 @article{2014_72,
-   author  = {M. S. Mallikarjunaiah and J. Walton},
+   author  = {M. S. Mallikarjunaiah and J. R. Walton},
    title   = {On the direct numerical simulation (DNS) of an anti-plane shear crack in a new class of strain-limiting elastic bodies},
    journal = {Proceedings of the US National Congress on Theoretical and Applied Mechanics (USNTAM-14) to be held in Michigan State University-East Lansing, June 15-20},
    year    = {2014},
@@ -899,7 +899,7 @@
 }
 
 @Article{2014_84,
-  author    = {Jean-Paul V. Pelteret and Batmanathan D. Reddy},
+  author    = {J-P. V. Pelteret and B. D. Reddy},
   title     = {Development of a computational biomechanical model of the human upper-airway soft-tissues toward simulating obstructive sleep apnea},
   journal   = {Clinical Anatomy},
   year      = {2014},
@@ -1082,7 +1082,7 @@
 }
 
 @article{2014_101,
-   author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
+   author  = {D. Sch\"{o}tzau and C. Schwab and T. P. Wihler and M. Wirz},
    title   = {Exponential Convergence of hp-DGFEM for Elliptic Problems in Polyhedral Domains},
    journal = {Spectral and High Order Methods for Partial Differential Equations - ICOSAHOM 2012. Lecture Notes in Computational Science and Engineering Vol. 95, pp 57-73 },
    year    = {2014},
@@ -1104,7 +1104,7 @@
 }
 
 @article{2014_103,
-   author  = {J. Sheldon and S. Miller and J. Pitt},
+   author  = {J. Sheldon and WS. A. Miller and J. S. Pitt},
    title   = {Methodology for Comparing Coupling Algorithms for Fluid-Structure Interaction Problems},
    journal = {World Journal of Mathematics},
    year    = {2014},
@@ -1189,7 +1189,7 @@
 }
 
 @Article{2014_111,
-  author    = {F. Vogel and J.-P. Pelteret and S. Kaessmair and P. Steinmann},
+  author    = {F. Vogel and J-P. V. Pelteret and S. Kaessmair and P. Steinmann},
   title     = {Magnetic force and torque on particles subject to a magnetic field},
   journal   = {European Journal of Mechanics A/Solids},
   year      = {2014},
@@ -1212,7 +1212,7 @@
 }
 
 @InProceedings{2014_113,
-  author    = {B. Walter and P. Saxena and J.-P. V. Pelteret and J. Kaschta and D. Schubert and P. Steinmann},
+  author    = {B. Walter and Prashant Saxena and J-P. V. Pelteret and J. Kaschta and D. Schubert and P. Steinmann},
   title     = {On The Preparation, Characterisation, Modelling And Simulation Of Magneto-Sensitive Elastomers},
   booktitle = {Proceedings of the Second Seminar on the Mechanics of Multifunctional Materials},
   year      = {2014},

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -849,7 +849,7 @@
 }
 
 @article{2015_81,
-   author  = {M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking},
+   author  = {M. Klinsmann and Daniele Rosato and M. Kamlah and R. M. McMeeking},
    title   = {An assessment of the phase field formulation for crack growth},
    journal = {Computer Methods in Applied Mechanics and Engineering, Vol. 294},
    year    = {2015},
@@ -879,7 +879,7 @@
 }
 
 @article{2015_84,
-   author  = {P. A. Kuberry},
+   author  = {P. Kuberry},
    title   = {An Optimization-Based Approach to Decoupling Fluid-Structure Interaction},
    journal = {PhD dissertation, Clemson University},
    year    = {2015},
@@ -1012,7 +1012,7 @@
 }
 
 @article{2015_97,
-   author  = {A. McBride and A. Javili and P. Steinmann and B. D. Reddy},
+   author  = {A. T. McBride and A. Javili and P. Steinmann and B. D. Reddy},
    title   = {A finite element implementation of surface elasticity at finite strains in deal.II},
    journal = {arXiv 1506.01361},
    year    = {2015},
@@ -1120,7 +1120,7 @@
 }
 
 @article{2015_107,
-   author  = {L. H. Odsaeter and T. Kvamsdal and M. F. Wheeler},
+   author  = {L. H. Ods\ae{}ter and T. Kvamsdal and M. F. Wheeler},
    title   = {A postprocessing technique to produce locally conservative flux},
    journal = {28th Nordic Seminar on Computational Mechanics. CENS, Institute of Cybernetics at Tallinn University of Technology},
    year    = {2015},
@@ -1153,7 +1153,7 @@
 }
 
 @article{2015_110,
-   author  = {M. S. Pauletti and M. Martinelli and N. Cavallini and P. Antolin},
+   author  = {M.S. Pauletti and M. Martinelli and N. Cavallini and P. Antolin},
    title   = {Igatools: An Isogeometric Analysis Library },
    journal = {SIAM J. Sci. Comput., issue 4, pp. 465--496},
    year    = {2015},
@@ -1271,7 +1271,7 @@
 }
 
 @Article{2015_122,
-  author    = {Prashant Saxena and Jean-Paul Pelteret and Paul Steinmann},
+  author    = {Prashant Saxena and J-P. V. Pelteret and P. Steinmann},
   title     = {Modelling of iron-filled magneto-active polymers with a dispersed chain-like microstructure},
   journal   = {European Journal of Mechanics - A/Solids},
   year      = {2015},
@@ -1335,7 +1335,7 @@
 }
 
 @article{2015_128,
-   author  = {M. Stevens and C. Downs and D. Emerson and J. Adler and S. MacIachlan and T. E. Vandervelde},
+   author  = {M. A. Stevens and C. Downs and D. B. Emerson and J. H. Adler and S. P. MacLachlan and T. E. Vandervelde},
    title   = {Predicting V$_{\textnormal{OC}}$ at ultra-high solar concentration using computational numerical analysis},
    journal = {Proceedings of the 31st European Photovoltaic Solar Energy Conference (EUPVSC). Hamburg, Germany, Sept. 14--18},
    year    = {2015},
@@ -1346,7 +1346,7 @@
 }
 
 @article{2015_129,
-   author  = {M. A. Stevens and C. Downs and D. Emerson and J. Adler and S. Maclachlan and T. E. Vandervelde},
+   author  = {M. A. Stevens and C. Downs and D. B. Emerson and J. H. Adler and S. P. MacLachlan and T. E. Vandervelde},
    title   = {Studying anomalous open-circuit voltage drop-out in concentrated photovoltaics using computational numerical analysis},
    journal = {Proceedings of the 42nd Photovoltaic Specialist Conference (PVSC), 2015, . IEEE},
    year    = {2015},

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -232,7 +232,7 @@
 }
 
 @article{2016_22,
-   author  = {G. Bucci and Y. M. Chiang and W. C. Carter},
+   author  = {G. Bucci and Y.-M. Chiang and W. C. Carter},
    title   = {Formulation of the coupled electrochemical-mechanical boundary value problem, with applications to transport of multiple charged species},
    journal = {Acta Materialia Vol. 104},
    year    = {2016},
@@ -386,7 +386,7 @@
 }
 
 @article{2016_36,
-   author  = {B. S. M. Ebna Hai and M. Bause and P. A. Kuberry},
+   author  = {B. S. M. Ebna Hai and M. Bause and P. Kuberry},
    title   = {Finite Element Approximation of the eXtended Fluid-Structure Interaction (eXFSI) Problem},
    journal = {In proceedings of: the ASME 2016 Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2016-7506, pp. V01AT11A001/1--12, July 10--14, Washington, DC, USA},
    year    = {2016},
@@ -562,7 +562,7 @@
 }
 
 @article{2016_52,
-   author  = {D. K. Gupta and M. Langelaar and F. van Keulen},
+   author  = {Deepak K. Gupta and M. Langelaar and F. van Keulen},
    title   = {Combined mesh and penalization adaptivity based topology optimization},
    journal = {Proceedings of the 57th AIAA/ASCE/AHS/ASC Structures, Structural Dynamics, and Materials Conference, AIAA SciTech},
    year    = {2016},
@@ -726,7 +726,7 @@
 }
 
 @article{2016_68,
-   author  = {M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking},
+   author  = {M. Klinsmann and Daniele Rosato and M. Kamlah and R. M. McMeeking},
    title   = {Modeling Crack Growth during Li Extraction in Storage Particles Using a Fracture Phase Field Approach},
    journal = {Journal of The Electrochemical Society, Vol. 63(2), 102-118},
    year    = {2016},
@@ -737,7 +737,7 @@
 }
 
 @article{2016_69,
-   author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo and P. Zingano},
+   author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo and P R A Zingano},
    title   = {Numerical simulations with the finite element method for the Burgers' equation on the real line},
    journal = {arXiv:1605.01109},
    year    = {2016},
@@ -1069,7 +1069,7 @@
 }
 
 @Article{2016_101,
-  author    = {Jean-Paul Pelteret and Denis Davydov and Andrew McBride and Duc Khoi Vu and Paul Steinmann},
+  author    = {J-P. V. Pelteret and D. Davydov and A. T. McBride and Duc Khoi Vu and P. Steinmann},
   title     = {Computational electro-elasticity and magneto-elasticity for quasi-incompressible media immersed in free space},
   journal   = {International Journal for Numerical Methods in Engineering},
   year      = {2016},
@@ -1120,7 +1120,7 @@
 }
 
 @article{2016_107,
-   author  = {S. Lee and A. Salgado},
+   author  = {S. Lee and A. J. Salgado},
    title   = {Stability analysis of pressure correction schemes for the Navier-Stokes equations with traction boundary conditions},
    journal = {Computer Methods in Applied Mechanics and Engineering},
    year    = {2016},
@@ -1205,7 +1205,7 @@
 }
 
 @article{2016_115,
-   author  = {M. Stoll and J. Pearson and P. K. Maini},
+   author  = {M. Stoll and J. Pearson and Philip K. Maini},
    title   = {Fast solvers for optimal control problems from pattern formation},
    journal = {Journal of Computational Physics, Volume 304},
    year    = {2016},
@@ -1433,7 +1433,7 @@
 }
 
 @Article{Bonitoa,
-  author    = {Andrea Bonito and Joseph E. Pasciak},
+  author    = {A. Bonito and J. E. Pasciak},
   title     = {{Numerical approximation of fractional powers of regularly accretive operators}},
   journal   = {{IMA} Journal of Numerical Analysis},
   year      = {2016},
@@ -1453,7 +1453,7 @@
 }
 
 @Article{Cockburn,
-  author    = {Bernardo Cockburn and Alan Demlow},
+  author    = {B. Cockburn and A. Demlow},
   title     = {{Hybridizable discontinuous Galerkin and mixed finite element methods for elliptic problems on surfaces}},
   journal   = {Mathematics of Computation},
   year      = {2016},
@@ -1492,7 +1492,7 @@
 }
 
 @Article{Ervin,
-  author    = {V.J. Ervin and Hyesuk Lee and A.J. Salgado},
+  author    = {V. J. Ervin and H. Lee and A. J. Salgado},
   title     = {{Generalized Newtonian fluid flow through a porous medium}},
   journal   = {Journal of Mathematical Analysis and Applications},
   year      = {2016},
@@ -1557,7 +1557,7 @@
 }
 
 @Article{Klinsmanna,
-  author    = {Markus Klinsmann and Daniele Rosato and Marc Kamlah and Robert M. McMeeking},
+  author    = {M. Klinsmann and Daniele Rosato and M. Kamlah and R. M. McMeeking},
   title     = {{Modeling crack growth during Li insertion in storage particles using a fracture phase field approach}},
   journal   = {Journal of the Mechanics and Physics of Solids},
   year      = {2016},
@@ -1578,7 +1578,7 @@
 }
 
 @Article{Kuberry,
-  author    = {Paul Kuberry and Hyesuk Lee},
+  author    = {P. Kuberry and H. Lee},
   title     = {{Convergence of a fluid--structure interaction problem decoupled by a Neumann control over a single time step}},
   journal   = {Journal of Mathematical Analysis and Applications},
   year      = {2016},
@@ -1593,7 +1593,7 @@
 }
 
 @InProceedings{Lahnert,
-  author    = {Michael Lahnert and Carsten Burstedde and Christian Holm and Miriam Mehl and Georg Rempfer and Florian Weik},
+  author    = {Michael Lahnert and C. Burstedde and Christian Holm and Miriam Mehl and Georg Rempfer and Florian Weik},
   title     = {Towards Lattice--Boltzmann On Dynamically Adaptive Grids -- Minimally-invasive Grid Exchange In Espresso},
   booktitle = {Proceedings of the {VII} European Congress on Computational Methods in Applied Sciences and Engineering},
   year      = {2016},
@@ -1623,7 +1623,7 @@
 }
 
 @Article{Lemenager,
-  author    = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang},
+  author    = {Alexandre Lemenager and C. O'Neill and S. Zhang},
   title     = {{Numerical Modelling of the Sydney Basin Using Temperature Dependent Thermal Conductivity Measurements}},
   journal   = {{ASEG} Extended Abstracts},
   year      = {2016},
@@ -1673,7 +1673,7 @@
 }
 
 @Article{Mirzadeh,
-  author    = {Mohammad Mirzadeh and Arthur Guittet and Carsten Burstedde and Frederic Gibou},
+  author    = {Mohammad Mirzadeh and Arthur Guittet and C. Burstedde and Frederic Gibou},
   title     = {{Parallel level-set methods on adaptive tree-based grids}},
   journal   = {Journal of Computational Physics},
   year      = {2016},
@@ -1699,7 +1699,7 @@
 }
 
 @Article{Mitchell2016,
-  author    = {Florian Rathgeber and David A. Ham and Lawrence Mitchell and Michael Lange and Fabio Luporini and Andrew T. T. Mcrae and Gheorghe-Teodor Bercea and Graham R. Markall and Paul H. J. Kelly},
+  author    = {Florian Rathgeber and D. A. Ham and Lawrence Mitchell and Michael Lange and Fabio Luporini and A. T. T. McRae and G.-T. Bercea and Graham R. Markall and Paul H. J. Kelly},
   title     = {{Firedrake: automating the finite element method by composing abstractions}},
   journal   = {{ACM} Transactions on Mathematical Software},
   year      = {2016},
@@ -1729,7 +1729,7 @@
 }
 
 @InProceedings{Riedlbauer,
-  author    = {Riedlbauer, D and Steinmann, P and Mergheim, J},
+  author    = {Riedlbauer, D. and Steinmann, P. and Mergheim, J.},
   title     = {{Simulation of temperature distribution and mechanical material behaviour in selective beam melting processes}},
   booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
   year      = {2016},
@@ -1753,7 +1753,7 @@
 }
 
 @Article{Salinger_2016,
-  author    = {Andrew G. Salinger and Roscoe A. Bartlett and Andrew M. Bradley and Qiushi Chen and Irina P. Demeshko and Xujiao Gao and Glen A. Hansen and Alejandro Mota and Richard P. Muller and Erik Nielsen and Jakob T. Ostien and Roger P. Pawlowski and Mauro Perego and Eric T. Phipps and WaiChing Sun and Irina K. Tezaur},
+  author    = {Andrew G. Salinger and Roscoe A. Bartlett and Andrew M. Bradley and Qiushi Chen and Irina P. Demeshko and X. Gao and Glen A. Hansen and Alejandro Mota and Richard P. Muller and Erik Nielsen and Jakob T. Ostien and Roger P. Pawlowski and Mauro Perego and Eric T. Phipps and W.C. Sun and Irina K. Tezaur},
   title     = {{Albany: Using component-based design to develop a flexible, generic multiphysics analysis code}},
   journal   = {International Journal for Multiscale Computational Engineering},
   year      = {2016},
@@ -1835,7 +1835,7 @@
 }
 
 @Article{Turner_2016,
-  author    = {John A. Turner and Kevin Clarno and Matt Sieger and Roscoe Bartlett and Benjamin Collins and Roger Pawlowski and Rodney Schmidt and Randall Summers},
+  author    = {John A. Turner and Kevin Clarno and Matt Sieger and Roscoe A. Bartlett and Benjamin Collins and Roger P. Pawlowski and Rodney Schmidt and Randall Summers},
   title     = {{The Virtual Environment for Reactor Applications (VERA): Design and architecture}},
   journal   = {Journal of Computational Physics},
   year      = {2016},
@@ -1954,7 +1954,7 @@
 }
 
 @Article{Leibner2016,
-  author        = {Leibner, Tobias and Milk, Ren{\'{e}} and Schindler, Felix},
+  author        = {Leibner, Tobias and Milk, R. and Schindler, Felix},
   title         = {{Extending DUNE: The dune-xt modules}},
   journal       = {arxiv.org},
   year          = {2016},
@@ -2103,7 +2103,7 @@
 }
 
 @Article{2016_72,
-  author    = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
+  author    = {M. Kronbichler and Ababacar Diagne and H. Holmgren},
   title     = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
   journal   = {The International Journal of High Performance Computing Applications},
   year      = {2016},
@@ -2159,7 +2159,7 @@ author = "Z. Wang and S. Rudraraju and K. Garikipati"
 
 
 @Article{rudraraju16:_mechan,
-  author =       {Shiva Rudraraju and Anton Van der Ven and Krishna Garikipati},
+  author =       {S. Rudraraju and A. Van der Ven and K. Garikipati},
   title =        {Mechano-chemical spinodal decomposition: a phenomenological theory of phase transformations in multi-component, crystalline solids},
   journal =      {Computational Materials},
   year =         2016,

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -20,7 +20,7 @@
 }
 
 @article{2017_1,
-   author  = {R. Agelek and M. Anderson and W. Bangerth and W. L. Barth},
+   author  = {R. Agelek and M. L. Anderson and W. Bangerth and W. L. Barth},
    title   = {On orienting edges of unstructured two- and three-dimensional meshes},
    journal = {ACM Transactions on Mathematical Software, article 5},
    year    = {2017},
@@ -141,7 +141,7 @@
 }
 
 @article{2017_12,
-   author  = {M. Bause and F. Radu and U. K\"{o}cher},
+   author  = {M. Bause and F. A. Radu and U. K\"{o}cher},
    title   = {Error analysis for discretizations of parabolic problems using continuous finite elements in time and mixed finite elements in space},
    journal = {Numerische Mathematik},
    year    = {2017},
@@ -278,7 +278,7 @@
 }
 
 @article{2017_26,
-   author  = {J. Choo and W. C. Sun},
+   author  = {J. Choo and W.C. Sun},
    title   = {Coupled phase-field and plasticity modeling of geological materials: From brittle fracture to ductile flow},
    journal = {Computer Methods in Applied Mechanics and Engineering},
    year    = {2017},
@@ -309,7 +309,7 @@
 }
 
 @Article{2017_29,
-  author    = {Denis Davydov and Tymofiy Gerasimov and Jean-Paul Pelteret and Paul Steinmann},
+  author    = {D. Davydov and Tymofiy Gerasimov and J-P. V. Pelteret and P. Steinmann},
   title     = {Convergence study of the h-adaptive {PUM} and the hp-adaptive {FEM} applied to eigenvalue problems in quantum mechanics},
   journal   = {Advanced Modeling and Simulation in Engineering Sciences},
   year      = {2017},
@@ -353,7 +353,7 @@
 }
 
 @article{2017_33,
-   author  = {S. DeWitt and E. L. S. Solomon and A. R. Natarajan and V. Araulio-Peters and S. Rudrajaru and L. K. Aegesen and B. Puchala and E. A. Marquis and A. van der Ven and K. Thornton and J. E. Allison},
+   author  = {S. DeWitt and E. L. S. Solomon and A. R. Natarajan and V. Araullo-Peters and S. Rudraraju and L. K. Aegesen and B. Puchala and E. A. Marquis and A. van der Ven and K. Thornton and J. E. Allison},
    title   = {Misfit-driven {\ss}''' precipitate composition and morphology in Mg-Nd alloys},
    journal = {Acta Materialia},
    year    = {2017},
@@ -425,7 +425,7 @@
 }
 
 @article{2017_40,
-   author  = {V. J. Ervin and H. Lee and J. Ruiz-Ramirez},
+   author  = {V.J. Ervin and H. Lee and J. Ruiz-Ramirez},
    title   = {Nonlinear Darcy fluid flow with deposition},
    journal = {Journal of Computational and Applied Mathematics},
    year    = {2017},
@@ -592,7 +592,7 @@
 }
 
 @article{2017_56,
-   author  = {D. K. Gupta and G. J. van der Veen and A. M. Aragon and M. Langelaar and F. van Keulen},
+   author  = {Deepak K. Gupta and G. J. van der Veen and A. M. Aragon and M. Langelaar and F. van Keulen},
    title   = {Bounds for decoupled design and analysis discretizations in topology optimization},
    journal = {International Journal for Numerical Methods in Engineering},
    year    = {2017},
@@ -665,7 +665,7 @@
 }
 
 @article{2017_63,
-   author  = {G. Kanschat and R. Lazarov and Y. Mao},
+   author  = {G. Kanschat and R. D. Lazarov and Y. Mao},
    title   = {Geometric Multigrid for Darcy and Brinkman models of flows in highly heterogeneous porous media: A numerical study},
    journal = {Journal of Computational and Applied Mathematics},
    year    = {2017},
@@ -687,7 +687,7 @@
 }
 
 @article{2017_65,
-   author  = {A. Karrecha and F. Abbassi and H. Basarir and M. Attar},
+   author  = {A. Karrech and F. Abbassi and H. Basarir and M. Attar},
    title   = {Self-consistent fractal damage of natural geo-materials in finite strain},
    journal = {Mechanics of Materials, pp. 107--120},
    year    = {2017},
@@ -848,7 +848,7 @@
 }
 
 @article{2017_81,
-  author    = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
+  author    = {M. Maier and Dionisios Margetis and M. Luskin},
   title     = {Dipole excitation of surface plasmon on a conducting sheet: Finite element approximation and validation},
   journal   = {Journal of Computational Physics},
   year      = {2017},
@@ -880,7 +880,7 @@
 }
 
 @article{2017_84,
-   author  = {A. Mola and L. Heitai and A. DeSimone},
+   author  = {A. Mola and L. Heltai and A. DeSimone},
    title   = {Wet and Dry Transom Stern Treatment for Unsteady and Nonlinear Potential Flow Model for Naval Hydrodynamics Simulations},
    journal = {Journal of Ship Research, no. 1},
    year    = {2017},
@@ -1078,7 +1078,7 @@
 }
 
 @Article{2017_102,
-  author    = {A. Vidal-Ferr{\`{a}}ndiz and S. Gonz{\'{a}}lez-Pintor and D. Ginestar and G. Verd{\'{u}} and C. Demazi{\`{e}}re},
+  author    = {A. Vidal-Ferrandiz and S. Gonzalez-Pintor and D. Ginestar and G. Verd{\'{u}} and C. Demazi{\`{e}}re},
   title     = {Schwarz type preconditioners for the neutron diffusion equation},
   journal   = {Journal of Computational and Applied Mathematics},
   year      = {2017},
@@ -1136,7 +1136,7 @@
 }
 
 @article{2017_107,
-   author  = {J. Wilmers and A. McBride and S. Bargmann},
+   author  = {J. Wilmers and A. T. McBride and S. Bargmann},
    title   = {Interface elasticity effects in polymer-filled nanoporous metals},
    journal = {Journal of the Mechanics and Physics of Solids},
    year    = {2017},
@@ -1191,7 +1191,7 @@
 }
 
 @Article{AlmeidaKonzen2017a,
-  author    = {Pedro Henrique de Almeida Konzen and F S Azevedo and E Sauter and P R A Zingano},
+  author    = {P.H.A. Konzen and F.S. Azevedo and E Sauter and P R A Zingano},
   title     = {{Numerical Simulations with the Galerkin Least Squares Finite Element Method for the Burgers' Equation on the Real Line}},
   journal   = {Trends in Applied and Computational Mathematics},
   year      = {2017},
@@ -1227,7 +1227,7 @@
 }
 
 @Article{Chandrashekar2017a,
-  author    = {Praveen Chandrashekar and Markus Zenk},
+  author    = {P. Chandrashekar and M. Zenk},
   title     = {Well-Balanced Nodal Discontinuous Galerkin Method for Euler Equations with Gravity},
   journal   = {Journal of Scientific Computing},
   year      = {2017},

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -2,7 +2,7 @@
 
 @Article{dealII90,
   title     = {The \texttt{deal.II} Library, Version 9.0},
-  author    = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
+  author    = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassm{\"o}ller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J-P. V. Pelteret and B. Turcksin and D. Wells},
   journal   = {Journal of Numerical Mathematics},
   year      = {2018},
   volume    = {26},
@@ -94,7 +94,7 @@
 }
 
 @article{2018_8,
-   author  = {J. Choo and W. C. Sun},
+   author  = {J. Choo and W.C. Sun},
    title   = {Cracking and damage from crystallization in pores: Coupled chemo-hydro-mechanics and phase-field modeling},
    journal = {Computer Methods in Applied Mechanics and Engineering, pp. 347--379},
    year    = {2018},
@@ -105,7 +105,7 @@
 }
 
 @Article{2018_9,
-  author    = {Jinhyun Choo and Sanghyun Lee},
+  author    = {J. Choo and S. Lee},
   title     = {Enriched Galerkin finite elements for coupled poromechanics with local mass conservation},
   journal   = {Computer Methods in Applied Mechanics and Engineering},
   year      = {2018},
@@ -359,7 +359,7 @@
 }
 
 @article{2018_32,
-   author  = {M. Maier and D. Margetis and M. Luskin},
+   author  = {M. Maier and Dionisios Margetis and M. Luskin},
    title   = {Generation of surface plasmon-polaritons by edge effect},
    journal = {Communications in Mathematical Sciences, Vol. 16},
    year    = {2018},
@@ -392,7 +392,7 @@
 }
 
 @Article{2018_35,
-  author    = {Jean-Paul Pelteret and Bastian Walter and Paul Steinmann},
+  author    = {J-P. V. Pelteret and B. Walter and P. Steinmann},
   title     = {Application of metaheuristic algorithms to the identification of nonlinear magneto-viscoelastic constitutive parameters},
   journal   = {Journal of Magnetism and Magnetic Materials},
   year      = {2018},
@@ -480,7 +480,7 @@
 }
 
 @article{2018_43,
-   author  = {C. Van Duijn and A. Mikelic and M. Wheeler and T. Wick},
+   author  = {C. Van Duijn and A. Mikelic and M. F. Wheeler and T. Wick},
    title   = {Thermoporoelasticity via homogenization I. Modeling and formal two-scale expansions},
    journal = {Preprint},
    year    = {2018},
@@ -535,7 +535,7 @@
 }
 
 @Article{Wei_er_2018,
-  author    = {Steffen Wei{\ss}er and Thomas Wick},
+  author    = {Steffen Wei{\ss}er and T. Wick},
   title     = {The Dual-Weighted Residual Estimator Realized on Polygonal Meshes},
   journal   = {Computational Methods in Applied Mathematics},
   year      = {2018},
@@ -625,7 +625,7 @@
 }
 
 @Article{Choo2018a,
-  author    = {Jinhyun Choo},
+  author    = {J. Choo},
   title     = {Large deformation poromechanics with local mass conservation: An enriched Galerkin finite element framework},
   journal   = {International Journal for Numerical Methods in Engineering},
   year      = {2018},
@@ -646,7 +646,7 @@
 }
 
 @Article{Chandrashekar2018a,
-  author    = {Praveen Chandrashekar},
+  author    = {P. Chandrashekar},
   title     = {A global divergence conforming {DG} method for hyperbolic conservation laws with divergence constraint},
   journal   = {Journal of Scientific Computing},
   year      = {2018},
@@ -738,7 +738,7 @@
 }
 
 @Article{CharnyiHeisterOlshanksiiRebholzEMAC2018,
-  author    = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
+  author    = {Sergey Charnyi and T. Heister and M. A. Olshanskii and L. G. Rebholz},
   title     = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier-Stokes equations},
   journal   = {Applied Numerical Mathematics},
   year      = {2018},
@@ -749,7 +749,7 @@
 
 @Article{wick-parallel-cracks-2018,
   Title                    = {Parallel solution, adaptivity, computational convergence, and open-source code of 2d and 3d pressurized phase-field fracture problems},
-  Author                   = {Timo Heister and Thomas Wick},
+  Author                   = {T. Heister and T. Wick},
   Journal                  = {Proc. Appl. Math. Mech.},
   Year                     = {2018},
   Number                   = {1},
@@ -776,7 +776,7 @@
   note =         {submitted}}
 
 @Article{Na2018a,
-  author    = {SeonHong Na and WaiChing Sun},
+  author    = {S. H. Na and W.C. Sun},
   title     = {Computational thermomechanics of crystalline rock, Part I: A combined multi-phase-field/crystal plasticity approach for single crystal simulations},
   journal   = {Computer Methods in Applied Mechanics and Engineering},
   year      = {2018},
@@ -788,7 +788,7 @@
 }
 
 @Article{Bryant2018a,
-  author    = {Eric C. Bryant and WaiChing Sun},
+  author    = {Eric C. Bryant and W.C. Sun},
   title     = {A mixed-mode phase field fracture model in anisotropic rocks with consistent kinematics},
   journal   = {Computer Methods in Applied Mechanics and Engineering},
   year      = {2018},
@@ -800,7 +800,7 @@
 }
 
 @Article{Choo2018b,
-  author    = {Jinhyun Choo and WaiChing Sun},
+  author    = {J. Choo and W.C. Sun},
   title     = {Coupled phase-field and plasticity modeling of geological materials: From brittle fracture to ductile flow},
   journal   = {Computer Methods in Applied Mechanics and Engineering},
   year      = {2018},
@@ -829,7 +829,7 @@
 
 
 @Article{aagesen18:_prism,
-  author =       {L. K. Aagesen and J. F. Adams and J. E. Allison and W. B. Andrews and
+  author =       {L. K. Aegesen and J. F. Adams and J. E. Allison and W. B. Andrews and
                   V. Araullo-Peters and T. Berman and Z. Chen and S. Daly and
                   S. Das and S. DeWitt and S. Ganesan and K. Garikipati and V. Gavini
                   and A. Githens and M. Hedstrom and Z. Huang and H. V. Jagadish and

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -1,7 +1,7 @@
 % Encoding: US-ASCII
 
 @Article{Basak2019a,
-  author    = {Anup Basak and Valery I. Levitas},
+  author    = {A. Basak and V. I. Levitas},
   title     = {Finite element procedure and simulations for a multiphase phase field approach to martensitic phase transformations at large strains and with interfacial stresses},
   journal   = {Computer Methods in Applied Mechanics and Engineering},
   year      = {2019},
@@ -42,7 +42,7 @@
 
 
 @Article{qinami19:_circum,
-  author =       {A. Qinami and E. C. Bryant and W. Sun and M. Kaliske},
+  author =       {A. Qinami and Eric C. Bryant and W.C. Sun and M. Kaliske},
   title =        {Circumventing mesh bias by r-and h-adaptive techniques for variational eigenfracture},
   journal =      {International Journal of Fracture},
   year =         2019,
@@ -127,7 +127,7 @@
 
 
 @Article{ZhaoHeisterVVH2019,
-  author =       {Liang Zhao and Timo Heister},
+  author =       {Liang Zhao and T. Heister},
   title =        {A preconditioner for the incompressible Navier-Stokes equations in velocity-vorticity form},
   journal =      {submitted},
   year =         {2019},
@@ -136,7 +136,7 @@
 
 @Article{clevenger_par_gmg,
   Title                    = {A Flexible, Parallel, Adaptive Geometric Multigrid method for FEM},
-  Author                   = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
+  Author                   = {Thomas C. Clevenger and T. Heister and G. Kanschat and M. Kronbichler},
   Journal                  = {submitted},
   Year                     = {2019},
   Url                      = {https://arxiv.org/abs/1904.03317},


### PR DESCRIPTION
On the website, it doesn't matter much that we now have some first names
abbreviated in the bibtex entries and others not, since the website
abbreviates all. The point is simply to make writing scripts easier.