### PR TITLE
Add the 2018 entries from Timo's list.

### DIFF
--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1314,7 +1314,7 @@ publisher={Society for Industrial and Applied Mathematics}
 }
 
 
-@article{Giuliani2018,
+@article{Giuliani2018a,
   doi = {10.1089/soro.2017.0099},
   url = {https://doi.org/10.1089/soro.2017.0099},
   year = {2018},
@@ -1483,6 +1483,185 @@ publisher={Society for Industrial and Applied Mathematics}
   author = {S. N. Verner and K. Garikipati},
   title = {A computational study of the mechanisms of growth-driven folding patterns on shells,  with application to the developing brain},
   journal = {Extreme Mechanics Letters}
+}
+
+
+@Phdthesis{Alhazmi2018,
+  author = {Alhazmi, M.},
+  title  = {{Exploring mechanisms for pattern formation through coupled bulk-surface PDEs}},
+  year   = {2018},
+  url    = {http://sro.sussex.ac.uk/id/eprint/78232/},
+  School = {University of Sussex}
+}
+
+@Phdthesis{Zhao2018b,
+  author = {Zhao, H.},
+  title  = {{FEM Based Multiphysics Analysis of Electromigration Voiding Process in Nanometer Integrated Circuits}},
+  year   = {2018},
+  url    = {https://cloudfront.escholarship.org/dist/prd/content/qt41f4p23x/qt41f4p23x.pdf},
+  School = {University of California, Davis}
+}
+
+
+@TechReport{Gulevich2018,
+  author = {Gulevich, D. R.},
+  title  = {{MiTMoJCo 1.2}},
+  year   = {2018},
+  url    = {https://www.researchgate.net/profile/D_Gulevich/publication/318380494_User_Guide_for_MiTMoJCo_12_Microscopic_Tunneling_Model_for_Josephson_Contacts/links/5ba4005d92851ca9ed1a09b1/User-Guide-for-MiTMoJCo-12-Microscopic-Tunneling-Model-for-Josephson-Contacts.pdf},
+}
+
+
+@Mastersthesis{Schuurmans2018,
+  author = {Schuurmans, L. F. J.},
+  title  = {{Numerical modelling of overriding plate deformation and slab rollback in the Western Mediterranean}},
+  School = {Utrecht University},
+  year   = {2018},
+  url    = {https://dspace.library.uu.nl/handle/1874/366408}
+}
+
+
+@incollection{Kronbichler2018,
+  doi = {10.1007/978-3-319-99654-7_7},
+  url = {https://doi.org/10.1007/978-3-319-99654-7_7},
+  year = {2018},
+  publisher = {Springer International Publishing},
+  pages = {89--110},
+  author = {Martin Kronbichler and Momme Allalen},
+  title = {Efficient High-Order Discontinuous Galerkin Finite Elements with Matrix-Free Implementations},
+  booktitle = {Progress in {IS}}
+}
+
+@article{Gassmller2018,
+  doi = {10.1029/2018gc007508},
+  url = {https://doi.org/10.1029/2018gc007508},
+  year = {2018},
+  month = sep,
+  publisher = {American Geophysical Union ({AGU})},
+  volume = {19},
+  number = {9},
+  pages = {3596--3604},
+  author = {Rene Gassm\"{o}ller and Harsha Lokavarapu and Eric Heien and Elbridge Gerry Puckett and Wolfgang Bangerth},
+  title = {Flexible and Scalable Particle-in-Cell Methods With Adaptive Mesh Refinement for Geodynamic Computations},
+  journal = {Geochemistry,  Geophysics,  Geosystems}
+}
+
+@incollection{Gantner2018,
+  doi = {10.1007/978-3-319-72456-0_18},
+  url = {https://doi.org/10.1007/978-3-319-72456-0_18},
+  year = {2018},
+  publisher = {Springer International Publishing},
+  pages = {373--405},
+  author = {Robert N. Gantner and Lukas Herrmann and Christoph Schwab},
+  title = {Multilevel {QMC} with Product Weights for Affine-Parametric,  Elliptic {PDEs}},
+  booktitle = {Contemporary Computational Mathematics - A Celebration of the 80th Birthday of Ian Sloan}
+}
+
+@article{Glerum2018,
+  doi = {10.5194/se-9-267-2018},
+  url = {https://doi.org/10.5194/se-9-267-2018},
+  year = {2018},
+  month = mar,
+  publisher = {Copernicus {GmbH}},
+  volume = {9},
+  number = {2},
+  pages = {267--294},
+  author = {Anne Glerum and Cedric Thieulot and Menno Fraters and Constantijn Blom and Wim Spakman},
+  title = {Nonlinear viscoplasticity in {ASPECT}: benchmarking and applications to subduction},
+  journal = {Solid Earth}
+}
+
+@Phdthesis{Lorca2018,
+  author = {Jose Pablo {Lucero Lorca}},
+  title  = {{Multilevel Schwarz methods for multigroup radiation transport problems}},
+  year   = {2018},
+  School = {Heidelberg University},
+  url    = {https://archiv.ub.uni-heidelberg.de/volltextserver/25216/},
+  Doi = {10.11588/heidok.00025216}
+}
+
+@article{Kerganer2019,
+  doi = {10.1016/j.camwa.2018.05.016},
+  url = {https://doi.org/10.1016/j.camwa.2018.05.016},
+  year = {2019},
+  month = oct,
+  publisher = {Elsevier {BV}},
+  volume = {78},
+  number = {7},
+  pages = {2338--2350},
+  author = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
+  title = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
+@article{Freund2018,
+  doi = {10.1016/j.jnnfm.2018.03.013},
+  url = {https://doi.org/10.1016/j.jnnfm.2018.03.013},
+  year = {2018},
+  month = jul,
+  publisher = {Elsevier {BV}},
+  volume = {257},
+  pages = {71--82},
+  author = {J.B. Freund and J. Kim and R.H. Ewoldt},
+  title = {Field sensitivity of flow predictions to rheological parameters},
+  journal = {Journal of Non-Newtonian Fluid Mechanics}
+}
+
+@article{GonzlezValverde2018,
+  doi = {10.1016/j.cma.2018.03.036},
+  url = {https://doi.org/10.1016/j.cma.2018.03.036},
+  year = {2018},
+  month = aug,
+  publisher = {Elsevier {BV}},
+  volume = {337},
+  pages = {246--262},
+  author = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{\i}}a-Aznar},
+  title = {Mechanical modeling of collective cell migration: An agent-based and continuum material approach},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@misc{fehn2018modern,
+    title={Modern discontinuous Galerkin methods for the simulation of transitional and turbulent flows in biomedical engineering: A comprehensive LES study of the FDA benchmark nozzle model},
+    author={Niklas Fehn and Wolfgang A. Wall and Martin Kronbichler},
+    year={2018},
+    eprint={1811.06752},
+    archivePrefix={arXiv},
+    primaryClass={physics.flu-dyn}
+}
+
+@misc{gulevich2018mitmojco,
+    title={MiTMoJCo: Microscopic Tunneling Model for Josephson Contacts},
+    author={Dmitry R. Gulevich},
+    year={2018},
+    eprint={1809.04706},
+    archivePrefix={arXiv},
+    primaryClass={cond-mat.supr-con}
+}
+
+@misc{maier2018homogenization,
+    title={Homogenization of plasmonic crystals: Seeking the epsilon-near-zero effect},
+    author={Matthias Maier and Marios Mattheakis and Efthimios Kaxiras and Mitchell Luskin and Dionisios Margetis},
+    year={2018},
+    eprint={1809.08276},
+    archivePrefix={arXiv},
+    primaryClass={math.NA}
+}
+
+@misc{bonito2018finite,
+    title={Finite element approximation of an obstacle problem for a class of integro-differential operators},
+    author={Andrea Bonito and Wenyu Lei and Abner J. Salgado},
+    year={2018},
+    eprint={1808.01576},
+    archivePrefix={arXiv},
+    primaryClass={math.NA}
+}
+
+@misc{bonito2018strain,
+    title={Finite Element Approximation of a Strain-Limiting Elastic Model},
+    author={Andrea Bonito and Vivette Girault and Endre Suli},
+    year={2018},
+    eprint={1805.04006},
+    archivePrefix={arXiv},
+    primaryClass={math.NA}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;} 


### PR DESCRIPTION
These are all 2018 entries from Timo's list that were found to have used deal.II for their numerical examples.