### PR TITLE
robust diagram display

### DIFF
--- a/jabref-template/listrefs.end.layout
+++ b/jabref-template/listrefs.end.layout
@@ -51,18 +51,32 @@
 
     var tbl = document.getElementById("qs_table");
     var allrows = tbl.getElementsByTagName("tr");
-    var curyear="-1";
+    var curyear=NaN;
     for(i = 0;i < allrows.length; i++)
     {
 	if (allrows[i].className=="show")
 	{
-	  //console.log("year: " + allrows[i].innerText);
-	  curyear=allrows[i].innerText;
+	  curyear=parseInt(allrows[i].innerText,10);
+	  //console.log("parsed '" + allrows[i].innerText + "' as " + curyear);
 	}
 	else if (allrows[i].className=="entry")
 	{
-	  //  console.log("entry");
-	  table[curyear-first_year+1][1] += 1;
+	  if (isNaN(curyear))
+	  {
+	    console.log("broken entry " + allrows[i].innerText);
+	  }
+	  else
+	  {
+	    var index = curyear-first_year+1;
+	    if (index < 0 || index > table.length-1)
+	    {
+	      console.log("invalid year " + curyear + " for  entry " + allrows[i]);
+	    }
+	    else
+	    {
+	      table[curyear-first_year+1][1] += 1;
+	    }
+	  }
 	}
 	else if (allrows[i].className.indexOf("bibtex")!=-1)
 	{


### PR DESCRIPTION
ignore invalid bib entries in the html page (without or with an incorrect year) that would break displaying
the pretty diagram.