### PR TITLE
Makefile: ignore other bib files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ latex: Makefile
 publications.html: Makefile
 	rm -rf temp/ publications.html
 	mkdir temp
-	cat publications-*.bib >temp/aspect.bib
+	cat publications-????.bib >temp/aspect.bib
 	cp jabref-template/* temp/
 	docker run --rm -v "$(PWD)/temp:/home/bob/source" tjhei/dealii-java-jabref
 	sed '/publications.include/q' temp/output.html >publications.html


### PR DESCRIPTION
The local make target for the html page would paste all .bib files in
the folder together, not only the ones that are supposed to exist. Fix
this.