### PR TITLE
Capitalize a first name.

### DIFF
--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -20,7 +20,7 @@ doi="10.1007/s00466-019-01752-w"
 }
 
 @inproceedings{FanWickJin2019,
-author="meng Fan and Thomas Wick and Yan Jin",
+author="Meng Fan and Thomas Wick and Yan Jin",
 editor="Tobias Gleim and Stephan Lange",
 title="A phase-field model for mixed-mode fracture",
 booktitle="8th GACM Colloquium on Computational Mechanics",


### PR DESCRIPTION
Fixes a typo in #157.