### PR TITLE
Clean up a few publications from 2018

### DIFF
--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -114,7 +114,7 @@
    url     = {},
    doi     = {}
 }
-  
+
 @article{2018_2,
    author  = {A. Basak and V. I. Levitas},
    title   = {Phase field study of surface-induced melting and solidification from a nanovoid: Effect of dimensionless width of void surface and void size},
@@ -321,6 +321,7 @@
   pages={32--54},
   year={2018},
   publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/fld.4511},
   doi={10.1002/fld.4511}
 }
 
@@ -332,6 +333,7 @@
   pages={667--693},
   year={2018},
   publisher={Elsevier},
+  url={https://doi.org/10.1016/j.jcp.2018.06.037},
   doi={10.1016/j.jcp.2018.06.037}
 }
 
@@ -438,34 +440,38 @@
 @article{2018_28,
    title     = {Direct Numerical Simulation of Flow over Periodic Hills up to Re$_{\textnormal{H}}$ = 10,595},
    author    = {Krank, Benjamin and Kronbichler, Martin and Wall, Wolfgang A},
-   journal   = {Flow, turbulence and combustion},
+   journal   = {Flow, Turbulence, and Combustion},
    volume    = {101},
    number    = {2},
    pages     = {521--551},
    year      = {2018},
    publisher = {Springer},
-   doi       =  {10.1007/s10494-018-9941-3}
+   url       = {https://doi.org/10.1007/s10494-018-9941-3},
+   doi       = {10.1007/s10494-018-9941-3}
 }
 
 @article{2018_29,
    author  = {B. Krank and M. Kronbichler and W. A. Wall},
    title   = {Wall modeling via function enrichment within a high-order DG method for RANS simulations of incompressible flow},
-   journal = {International Journal for Numerical Methods in Fluids 86(1)},
+   journal = {International Journal for Numerical Methods in Fluids},
    year    = {2018},
-   volume  = {},
+   volume  = {86},
+   number  = {1},
    pages   = {107--129},
    url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.4409},
    doi     = {10.1002/fld.4409}
 }
 
-@article{2018_31,
-   author  = {M. Kronbichler and B. Krank and N. Fehn and S. Legat and W. A. Wall},
-   title   = {A new high-order discontinuous Galerkin solver for DNS and LES of turbulent incompressible flow},
-   journal = {New Results in Numerical and Experimental Fluid Mechanics XI},
+@inproceedings{2018_31,
+   author  = {Martin Kronbichler and Benjamin Krank and Niklas Fehn and Stefan Legat and Wolfgang A. Wall},
+   title   = {A new high-order discontinuous Galerkin solver for {DNS} and {LES} of turbulent incompressible flow},
+   editor  = {Andreas Dillmann and Gerd Heller and Ewald Kr\"amer and Claus Wagner and Stephan Bansmer and Rolf Radespiel and Richard Semaan},
+   booltitle = {New Results in Numerical and Experimental Fluid Mechanics},
+   series  = {Notes on Numerical Fluid Mechanics and Multidisciplinary Design},
+   volume  = {136},
    year    = {2018},
-   volume  = {},
    pages   = {467--477},
-   url     = {},
+   url     = {https://doi.org/10.1007/978-3-319-64519-3_42},
    doi     = {10.1007/978-3-319-64519-3_42}
 }
 
@@ -537,27 +543,39 @@
 }
 
 @article{2018_38,
-  title={Efficient explicit time stepping of high order discontinuous Galerkin schemes for waves},
-  author={Schoeder, Svenja and Kormann, Katharina and Wall, Wolfgang A and Kronbichler, Martin},
-  journal={SIAM Journal on Scientific Computing},
-  volume={40},
-  number={6},
-  pages={C803--C826},
-  year={2018},
-  publisher={SIAM},
-  doi={10.1137/18M1185399}
+   title   = {Efficient explicit time stepping of high order discontinuous {G}alerkin schemes for waves},
+   author  = {Schoeder, Svenja and Kormann, Katharina and Wall, Wolfgang A and Kronbichler, Martin},
+   journal = {SIAM Journal on Scientific Computing},
+   volume  = {40},
+   number  = {6},
+   pages   = {C803--C826},
+   year    = {2018},
+   publisher = {SIAM},
+   url     = {http://www.siam.org/journals/sisc/40-6/M118539.html},
+   doi     = {10.1137/18M1185399}
 }
 
 @article{2018_39,
-  title={Arbitrary high-order explicit hybridizable discontinuous Galerkin methods for the acoustic wave equation},
-  author={Schoeder, Svenja and Kronbichler, Martin and Wall, Wolfgang A},
-  journal={Journal of Scientific Computing},
-  volume={76},
-  number={2},
-  pages={969--1006},
-  year={2018},
-  publisher={Springer},
-  doi={10.1007/s10915-018-0649-2},
+    title  = {Arbitrary high-order explicit hybridizable discontinuous {G}alerkin methods for the acoustic wave equation},
+   author  = {Schoeder, Svenja and Kronbichler, Martin and Wall, Wolfgang A},
+   journal = {Journal of Scientific Computing},
+   volume  = {76},
+   pages   = {969--1006},
+   year    = {2018},
+   publisher = {Springer},
+   url     = {https://doi.org/10.1007/s10915-018-0649-2},
+   doi     = {10.1007/s10915-018-0649-2}
+}
+
+@article{schoeder2018optoacoustic,
+   author  = {Svenja Schoeder and Ivan Olefir and Martin Kronbichler and Vasilis Ntziachristos and Wolfgang A. Wall},
+   title   = {Optoacoustic image reconstruction: the full inverse problem with variable bases},
+   journal = {Proceedings of the Royal Society A},
+   year    = {2018},
+   volume  = {474},
+   pages   = {20180369},
+   url     = {https://doi.org/10.1098/rspa.2018.0369},
+   doi     = {10.1098/rspa.2018.0369}
 }
 
 @article{2018_40,
@@ -1233,7 +1251,7 @@ publisher={Society for Industrial and Applied Mathematics}
 
 
 @phdthesis{phdthesis,
-	author       = {Filippo Guido Davide Sacco}, 
+	author       = {Filippo Guido Davide Sacco},
 	title        = {A 3D adaptive boundary element method for potential flow with nonlinear Kutta condition},
 	school       = {Politecnico di Milano},
 	year         = {2017},
@@ -1285,7 +1303,7 @@ publisher={Society for Industrial and Applied Mathematics}
 }
 
 @article{doi:10.1137/16M110455X,
-	author = {Kronbichler, M. and Wall, W.},
+	author = {Kronbichler, Martin and Wall, Wolfgang A.},
 	title = {A Performance Comparison of Continuous and Discontinuous Galerkin Methods with Fast Multigrid Solvers},
 	journal = {SIAM Journal on Scientific Computing},
 	volume = {40},
@@ -1335,7 +1353,7 @@ publisher={Society for Industrial and Applied Mathematics}
 }
 
 @phdthesis{phdthesis-kauffman,
-	author       = {Kauffman, Justin}, 
+	author       = {Kauffman, Justin},
 	title        = {An Overset Mesh Framework for the Hybridizable Discontinuous Galerkin Finite Element Method},
 	school       = {Pennsylvania State University},
 	year         = {2018},
@@ -1737,7 +1755,7 @@ publisher={Society for Industrial and Applied Mathematics}
 
 
 @MastersThesis{ Munch2018,
-  author={M\"unch, Peter}, 
+  author={M\"unch, Peter},
   title={An efficient hybrid multigrid solver for high-order discontinuous Galerkin methods},
   school={Technical University of Munich},
   year={2018},
@@ -1746,4 +1764,4 @@ publisher={Society for Industrial and Applied Mathematics}
 }
 
 
-@Comment{jabref-meta: databaseType:bibtex;} 
+@Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -21,7 +21,7 @@
 }
 
 @phdthesis{Bzowski2019,
-  author       = {Krzysztof Bzowski}, 
+  author       = {Krzysztof Bzowski},
   title        = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
   school       = {AGH University of Science and Technology},
   year         = {2019},
@@ -488,7 +488,7 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   doi = {10.1145/3295500.3357157},
   publisher = {ACM},
   address = {New York, NY, USA}
-} 
+}
 
 @article{Maday_2019,
   title={Regularity and hp discontinuous Galerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
@@ -776,15 +776,50 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   url = {https://mediatum.ub.tum.de/1451984}
 }
 
-@inbook{kronbichler2019fast,
-author = {Kronbichler, Martin and Kormann, Katharina and Wall, Wolfgang},
-year = {2019},
-month = {01},
-pages = {581-589},
-title = {Fast Matrix-Free Evaluation of Hybridizable Discontinuous Galerkin Operators},
-isbn = {978-3-319-96414-0},
-doi = {10.1007/978-3-319-96415-7_53}
+@inproceedings{Kronbichler19HDG,
+   author  = {Martin Kronbichler and Katharina Kormann and Wolfgang A. Wall},
+   title   = {Fast matrix-free evaluation of hybridizable discontinuous Galerkin operators},
+   editor  = {Florin A. Radu and Kundan Kumar and Inga Berre and Jan M. Nordbotten and Iuliu S. Pop},
+   booktitle = {Numerical Mathematics and Advanced Applications: ENUMATH 2017},
+   volume  = {126},
+   series  = {Lecture Notes in Computational Science and Engineering},
+   year    = {2019},
+   pages   = {581--589},
+   url     = {https://dx.doi.org/10.1007/978-3-319-96415-7_53},
+   doi     = {10.1007/978-3-319-96415-7_53},
 }
 
+@article{Krank2019Wall,
+  doi = {10.1016/j.compfluid.2018.07.019},
+  url = {https://doi.org/10.1016/j.compfluid.2018.07.019},
+  year = {2019},
+  publisher = {Elsevier {BV}},
+  volume = {179},
+  pages = {718--725},
+  author = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
+  title = {Wall modeling via function enrichment: Extension to detached-eddy simulation},
+  journal = {Computers {\&} Fluids}
+}
+
+@article{Krank2019Multiscale,
+  doi = {10.1002/fld.4712},
+  url = {https://doi.org/10.1002/fld.4712},
+  year = {2019},
+  publisher = {Wiley},
+  volume = {90},
+  number = {2},
+  pages = {81--113},
+  author = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
+  title = {A multiscale approach to hybrid {RANS}/{LES} wall modeling within a high-order discontinuous {G}alerkin scheme using function enrichment},
+  journal = {International Journal for Numerical Methods in Fluids}
+}
+
+@PhdThesis{Wichmann2019Phd,
+  author = {Wichmann, Karl-Robert Klaus},
+  title = {Performance Aspects of Incompressible {N}avier-{S}tokes Solvers: {L}attice-{B}oltzmann Method vs. Finite Difference Method},
+  school = {Technical University of Munich},
+  year = {2019},
+  url = {https://mediatum.ub.tum.de/1437209}
+}
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
this cleans up a few publications where we had only listed preprints, and adds three more publications from 2018/2019 that were missing and are not in #186.