### PR TITLE
Remove some duplicate publications

### DIFF
--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -539,20 +539,6 @@
   journal = {{TEMA} (S{\~{a}}o Carlos)}
 }
 
-@article{Kronbichler2018,
-  doi = {10.1137/16m110455x},
-  url = {https://doi.org/10.1137/16m110455x},
-  year = {2018},
-  month = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume = {40},
-  number = {5},
-  pages = {A3423--A3448},
-  author = {Martin Kronbichler and Wolfgang A. Wall},
-  title = {A Performance Comparison of Continuous and Discontinuous Galerkin Methods with Fast Multigrid Solvers},
-  journal = {{SIAM} Journal on Scientific Computing}
-}
-
 @article{Karban2017,
   doi = {10.1007/s00202-017-0629-9},
   url = {https://doi.org/10.1007/s00202-017-0629-9},
@@ -1520,40 +1506,6 @@
    doi     = {}
 }
 
-@article{2017_68,
-   author  = {B. Krank and M. Kronbichler and W. A. Wall},
-   title   = {A multiscale approach to hybrid RANS/LES wall modeling},
-   journal = {arxiv.org:/1705.08813},
-   year    = {2017},
-   volume  = {},
-   pages   = {},
-   url     = {},
-   doi     = {}
-}
-
-@article{2017_69,
-   author  = {B. Krank and M. Kronbichler and W. A. Wall},
-   title   = {Direct numerical simulation of flow over periodic hills up to Re$_{\textnormal{H}}$=10,595},
-   journal = {},
-   note = {Submitted},
-   year    = {2017},
-   volume  = {},
-   pages   = {},
-   url     = {},
-   doi     = {}
-}
-
-@article{2017_70,
-   author  = {B. Krank and M. Kronbichler and W. A. Wall},
-   title   = {Wall modeling via function enrichment: extension to detached-eddy simulation},
-   journal = {arxiv.org:1712.08469},
-   year    = {2017},
-   volume  = {},
-   pages   = {},
-   url     = {},
-   doi     = {}
-}
-
 @article{2017_72,
    author  = {M. Kronbichler and K. Kormann and I. Pasichnyk and M. Allalen},
    title   = {Fast matrix-free discontinuous Galerkin kernels on modern computer architectures},
@@ -1640,7 +1592,7 @@
  acmid = {3108097},
  publisher = {Society for Computer Simulation International},
  address = {San Diego, CA, USA}
-} 
+}
 
 
 @article{2017_81,
@@ -2140,7 +2092,7 @@
   Title                    = {A Continuous-Discontinuous Hybrid Finite Element Method for $S_N$ Transport},
   year                  = {2017},
   Booktitle = {Proceedings of the ANS Annual Meeting, San Francisco},
-  Pages = {647--649}, 
+  Pages = {647--649},
   Url                      = {https://www.researchgate.net/profile/Weixiong_Zheng/publication/317620866_A_Continuous-Discontinuous_Hybrid_Finite_Element_Method_for_SN_Transport/links/5944120e45851525f890a9be/A-Continuous-Discontinuous-Hybrid-Finite-Element-Method-for-SN-Transport.pdf}
 }
 

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1308,7 +1308,7 @@ publisher={Society for Industrial and Applied Mathematics}
 	journal = {SIAM Journal on Scientific Computing},
 	volume = {40},
 	number = {5},
-	pages = {A3423-A3448},
+	pages = {A3423--A3448},
 	year = {2018},
 	doi = {10.1137/16M110455X},
 	url = { https://doi.org/10.1137/16M110455X}
@@ -1596,7 +1596,7 @@ publisher={Society for Industrial and Applied Mathematics}
 }
 
 
-@incollection{Kronbichler2018,
+@inproceedings{Kronbichler2018,
   doi = {10.1007/978-3-319-99654-7_7},
   url = {https://doi.org/10.1007/978-3-319-99654-7_7},
   year = {2018},
@@ -1604,7 +1604,9 @@ publisher={Society for Industrial and Applied Mathematics}
   pages = {89--110},
   author = {Martin Kronbichler and Momme Allalen},
   title = {Efficient High-Order Discontinuous Galerkin Finite Elements with Matrix-Free Implementations},
-  booktitle = {Progress in {IS}}
+  booktitle = {Advances and New Trends in Environmental Informatics},
+  editor = {Bungartz, Hans-Joachim and Kranzlm\"uller, Dieter and Weinberg, Volker and Weism\"uller, Jens and Wohlgemuth, Volker},
+  series = {Progress in {IS}}
 }
 
 @article{Gassmller2018,


### PR DESCRIPTION
I noticed a few duplicates of my publications (some were preprints and published in 2018/2019, the SISC paper was simply listed twice).