### PR TITLE
remove newline in code block for bibtex entry

### DIFF
--- a/publications.include
+++ b/publications.include
@@ -41,8 +41,7 @@
         year    = {2019},
         DOI     = {10.1515/jnma-2019-0064},
         url     = {https://dealii.org/deal91-preprint.pdf}
-      }
-              </pre>
+      }</pre>
             </li>
 
             <li> W. Bangerth, R. Hartmann, G. Kanschat
@@ -66,8 +65,7 @@
         volume  = {33},
         number  = {4},
         pages   = {24/1--24/27}
-      }
-              </pre>
+      }</pre>
             </li>
           </ol>
 
@@ -105,8 +103,7 @@
         number  = {4},
         pages   = {173--183},
         doi     = {10.1515/jnma-2018-0054}
-      }
-              </pre>
+      }</pre>
 	      </li>
 
               <li>


### PR DESCRIPTION
There is a newline at the end of the <pre> block, that looks awkward.
Remove it.