### PR TITLE
replace 9.0 bibtex with link

### DIFF
--- a/publications.include
+++ b/publications.include
@@ -90,20 +90,7 @@
 	      (<a href="https://dealii.org/deal90-preprint.pdf"
                   target="_top">preprint</a>)
               <br>
-              <pre>
-      @article{dealII90,
-        title   = {The \texttt{deal.II} Library, Version 9.0},
-        author  = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and
-                   B. Brands and D. Davydov and R. Gassmoeller and T. Heister and
-                   L. Heltai and K. Kormann and M. Kronbichler and M. Maier and
-                   J.-P. Pelteret and B. Turcksin and D. Wells},
-        journal = {Journal of Numerical Mathematics},
-        year    = {2018},
-        volume  = {26},
-        number  = {4},
-        pages   = {173--183},
-        doi     = {10.1515/jnma-2018-0054}
-      }</pre>
+	      <a href="https://github.com/dealii/publication-list/blob/7f166e339a7c82342a5acaca575e67c54ca13d1b/publications-2018.bib#L96-L105">bibtex</a>
 	      </li>
 
               <li>


### PR DESCRIPTION
We don't need the old bibtex here anymore, I think. The link to the
bibtex might be useful, though?