### PR TITLE
Use less vertical space for the 9.2 entry.

### DIFF
--- a/publications.include
+++ b/publications.include
@@ -45,23 +45,11 @@
               <pre>
 @article{dealII92,
   title   = {The \texttt{deal.II} Library, Version 9.2},
-  author  = {Daniel Arndt and
-             Wolfgang Bangerth and
-             Bruno Blais and
-             Thomas C. Clevenger and
-             Marc Fehling and
-             Alexander V. Grayver and
-             Timo Heister and
-             Luca Heltai and
-             Martin Kronbichler and
-             Matthias Maier and
-             Peter Munch and
-             Jean-Paul Pelteret and
-             Reza Rastak and
-             Ignacio Thomas and
-             Bruno Turcksin and
-             Zhuoran Wang and
-             David Wells},
+  author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and
+             Thomas C. Clevenger and Marc Fehling and Alexander V. Grayver and
+             Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and
+             Peter Munch and Jean-Paul Pelteret and Reza Rastak and
+             Ignacio Thomas and Bruno Turcksin and Zhuoran Wang and David Wells},
   journal = {submitted},
   year    = {2020}
 }


### PR DESCRIPTION
Using more vertical space reduces the visibility of the entries below. Be a bit more
moderate.