### PR TITLE
Fix bibtex field separators.

### DIFF
--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -2150,7 +2150,7 @@ url = {https://www.airitilibrary.com/Publication/alDetailedMesh?DocID=U0001-0508
   reportid = {FZJ-2016-05448},
   pages    = {xv, 63 p.},
   year     = {2016},
-  url      = {https://juser.fz-juelich.de/record/819869},
+  url      = {https://juser.fz-juelich.de/record/819869}
 }
 
 

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -2052,7 +2052,7 @@
   reportid = {FZJ-2018-00798},
   pages    = {63 p.},
   year     = {2017},
-  url      = {https://juser.fz-juelich.de/record/842585},
+  url      = {https://juser.fz-juelich.de/record/842585}
 }
 
 

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -210,7 +210,7 @@ year = {2020}
   title        = {High Performance Computing in Basin Modeling: Simulating
                   Mechanical Compaction with the Level Set Method},
   school       = {Rheinische Friedrich-Wilhelms-Universit{\"a}t Bonn},
-  year         = {2020}
+  year         = {2020},
   url          = {https://bonndoc.ulb.uni-bonn.de/xmlui/handle/20.500.11811/8443}
 }
 
@@ -227,7 +227,7 @@ year = {2020}
   series       = {Schriften des Forschungszentrums J{\"u}lich IAS Series},
   volume       = {43},
   pages        = {vii, 78 pp},
-  urn          = {urn:nbn:de:0001-2020071402},
+  urn          = {urn:nbn:de:0001-2020071402}
 }
 
 


### PR DESCRIPTION
Follow up to #224.

I just realized that I forgot to add a `,` in Sean's dissertation, and decided to also remove the redundant separators in the other entries.

Sorry about that :(