### PR TITLE
Find a better way to limit the size of the graph's y-axis.

### DIFF
--- a/jabref-template/listrefs.end.layout
+++ b/jabref-template/listrefs.end.layout
@@ -91,6 +91,11 @@
 	    console.log("unknown: " + allrows[i].className);
     }
 
+    var max_per_year = 0;
+    for (i=1; i<table.length; ++i)
+      if (table[i][1] > max_per_year)
+        max_per_year = table[i][1];
+
     google.load("visualization", "1", {packages:["corechart"]});
     google.setOnLoadCallback(drawChart);
     function drawChart() {
@@ -102,7 +107,7 @@
               showTextEvery: '2',
               textStyle: {fontSize:'9'}},
       vAxis: {minValue: 0,
-              maxValue: 250},
+              viewWindow: { max : max_per_year}   },
       legend: {position: 'none'}
     };
 


### PR DESCRIPTION
Turns out that my last PR doesn't actually work -- the graph object just has its own ideas of how you can set the max size. But there is a different parameter one can set, and I'm now setting this parameter to simply the maximum number of publications we've seen per year. That's also future-proof.

Tested locally to actually work, so I have hope that it will also on the website.