### PR TITLE
Fix jabref formatting.

### DIFF
--- a/jabref-template/listrefs.layout
+++ b/jabref-template/listrefs.layout
@@ -29,7 +29,7 @@
         -->
 
          \begin{journal}\format[HTMLChars]{\journal}\end{journal}<!--
-    -->\begin{booktitle}, In: \format[HTMLChars]{\booktitle}.\end{booktitle}<!--
+    -->\begin{booktitle}, In: \format[HTMLChars]{\booktitle}\end{booktitle}<!--
  -->\begin{howpublished}, \howpublished\end{howpublished}<!--
        -->\begin{school}. Thesis at \format[HTMLChars]{\school}\end{school}<!--
       -->\begin{address}, \format[HTMLChars]{\address}\end{address}<!--


### PR DESCRIPTION
Specifically, we have punctuation marks at the beginning of the next entry; here,
we have one at the end and that may lead to two punctuation marks following each other.