### PR TITLE
Fix year for 9.3 entry.

### DIFF
--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -10,7 +10,7 @@
                Simon and Bruno Turcksin and David Wells and Jiaqi
                Zhang},
   journal   = {Journal of Numerical Mathematics},
-  year      = {2021, accepted for publication},
+  year      = {2021},
   url       = {https://dealii.org/deal93-preprint.pdf},
   doi = {10.1515/jnma-2021-0081},
   volume    = {29},


### PR DESCRIPTION
See bottom of https://www.dealii.org/publications.html

The 9.3 entry is listed with a separate "year"
![image](https://user-images.githubusercontent.com/18285973/153651202-fb7e665a-a5e1-4986-91d6-47a0ba3d5f28.png)