### PR TITLE
Some housekeeping for 2019 - 2022.

### DIFF
--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -1,8 +1,7 @@
 % Encoding: US-ASCII
 
-@article{Heron2018,
+@article{Heron2019,
   doi = {10.1130/g45690.1},
-  url = {https://doi.org/10.1130/g45690.1},
   year = {2019},
   month = dec,
   publisher = {Geological Society of America},
@@ -29,7 +28,6 @@ doi = {10.1093/gji/ggy466}
 
 @incollection{Guermond2019,
   doi = {10.1007/978-3-319-78325-3_14},
-  url = {https://doi.org/10.1007/978-3-319-78325-3_14},
   year = {2019},
   publisher = {Springer International Publishing},
   pages = {251--272},
@@ -47,8 +45,7 @@ doi = {10.1093/gji/ggy466}
   pages={877--881},
   year={2019},
   publisher={Oxford University Press},
-  doi={10.1093/nsr/nwz123},
-  url={https://doi.org/10.1093/nsr/nwz123}
+  doi={10.1093/nsr/nwz123}
 }
 
 @article{heron2019segmentation,
@@ -67,7 +64,6 @@ year = {2019}
 
 @article{GonzlezValverde2019,
   doi = {10.1007/s40571-018-0199-2},
-  url = {https://doi.org/10.1007/s40571-018-0199-2},
   year = {2019},
   month = jan,
   publisher = {Springer Science and Business Media {LLC}},
@@ -81,7 +77,6 @@ year = {2019}
 
 @article{Fu2019,
   doi = {10.1093/imanum/dry001},
-  url = {https://doi.org/10.1093/imanum/dry001},
   year = {2019},
   month = apr,
   publisher = {Oxford University Press ({OUP})},
@@ -95,7 +90,6 @@ year = {2019}
 
 @article{Heinlein2019,
   doi = {10.1002/pamm.201900337},
-  url = {https://doi.org/10.1002/pamm.201900337},
   year = {2019},
   month = nov,
   publisher = {Wiley},
@@ -108,7 +102,6 @@ year = {2019}
 
 @article{EbnaHai2019,
   doi = {10.1016/j.apm.2019.07.007},
-  url = {https://doi.org/10.1016/j.apm.2019.07.007},
   year = {2019},
   month = nov,
   publisher = {Elsevier {BV}},
@@ -121,7 +114,6 @@ year = {2019}
 
 @article{Hagstrom2019,
   doi = {10.1007/s00211-018-1012-0},
-  url = {https://doi.org/10.1007/s00211-018-1012-0},
   year = {2019},
   month = jan,
   publisher = {Springer Science and Business Media {LLC}},
@@ -143,7 +135,6 @@ year = {2019}
 
 @article{Guo2019,
   doi = {10.2118/194493-pa},
-  url = {https://doi.org/10.2118/194493-pa},
   year = {2019},
   month = feb,
   publisher = {Society of Petroleum Engineers ({SPE})},
@@ -169,7 +160,6 @@ year = {2019}
 
 @article{Gulevich2019,
   doi = {10.1103/physrevb.99.060501},
-  url = {https://doi.org/10.1103/physrevb.99.060501},
   year = {2019},
   month = feb,
   publisher = {American Physical Society ({APS})},
@@ -182,7 +172,6 @@ year = {2019}
 
 @article{German2019,
   doi = {10.1016/j.anucene.2019.05.049},
-  url = {https://doi.org/10.1016/j.anucene.2019.05.049},
   year = {2019},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -213,7 +202,6 @@ year = {2019}
 
 @article{Deolmi2019,
   doi = {10.1016/j.amc.2018.11.059},
-  url = {https://doi.org/10.1016/j.amc.2018.11.059},
   year = {2019},
   month = may,
   publisher = {Elsevier {BV}},
@@ -226,7 +214,6 @@ year = {2019}
 
 @article{Vassaux2019,
   doi = {10.1002/adts.201800168},
-  url = {https://doi.org/10.1002/adts.201800168},
   year = {2019},
   month = feb,
   publisher = {Wiley},
@@ -240,7 +227,6 @@ year = {2019}
 
 @article{Freddi2019,
   doi = {10.1016/j.mechrescom.2019.01.009},
-  url = {https://doi.org/10.1016/j.mechrescom.2019.01.009},
   year = {2019},
   month = mar,
   publisher = {Elsevier {BV}},
@@ -253,7 +239,6 @@ year = {2019}
 
 @article{Bzowski2019,
   doi = {10.1088/1757-899x/627/1/012018},
-  url = {https://doi.org/10.1088/1757-899x/627/1/012018},
   year = {2019},
   month = oct,
   publisher = {{IOP} Publishing},
@@ -276,7 +261,6 @@ year = {2019}
 
 @article{Basak2019,
   doi = {10.1016/j.cma.2018.08.006},
-  url = {https://doi.org/10.1016/j.cma.2018.08.006},
   year = {2019},
   month = jan,
   publisher = {Elsevier {BV}},
@@ -302,7 +286,6 @@ year = {2019}
 
 @article{Arbogast2019,
   doi = {10.1007/s10596-019-09871-2},
-  url = {https://doi.org/10.1007/s10596-019-09871-2},
   year = {2019},
   month = aug,
   publisher = {Springer Science and Business Media {LLC}},
@@ -327,7 +310,6 @@ year = {2019}
 
 @article{Alarydah2019,
   doi = {10.1016/j.camwa.2018.08.001},
-  url = {https://doi.org/10.1016/j.camwa.2018.08.001},
   year = {2019},
   month = mar,
   publisher = {Elsevier {BV}},
@@ -346,7 +328,7 @@ journal = {PAMM},
 volume = {19},
 number = {1},
 pages = {e201900231},
-doi = {https://doi.org/10.1002/pamm.201900231},
+doi = {10.1002/pamm.201900231},
 url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.201900231},
 eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.201900231},
 year = {2019}
@@ -357,13 +339,12 @@ year = {2019}
   title     = {Scalable adaptive simulation of organic thin-film transistors},
   school    = {Politecnico di Milano},
   year      = {2019},
-  month     = {feb},
+  month     = feb,
   url       = {http://hdl.handle.net/10589/144819},
 }
 
 @article{Yaghoobi2019,
   doi = {10.1016/j.commatsci.2019.109078},
-  url = {https://doi.org/10.1016/j.commatsci.2019.109078},
   year = {2019},
   month = nov,
   publisher = {Elsevier {BV}},
@@ -376,7 +357,6 @@ year = {2019}
 
 @article{Rom2019,
   doi = {10.1016/j.triboint.2018.12.030},
-  url = {https://doi.org/10.1016/j.triboint.2018.12.030},
   year = {2019},
   month = may,
   publisher = {Elsevier {BV}},
@@ -389,7 +369,6 @@ year = {2019}
 
 @inproceedings{Arbogast2019,
   doi = {10.2118/193817-ms},
-  url = {https://doi.org/10.2118/193817-ms},
   year = {2019},
   publisher = {Society of Petroleum Engineers},
   author = {Todd Arbogast and Chieh-Sen Huang and Xikai Zhao},
@@ -399,7 +378,6 @@ year = {2019}
 
 @article{Bonito2019,
   doi = {10.1007/s00211-019-01025-x},
-  url = {https://doi.org/10.1007/s00211-019-01025-x},
   year = {2019},
   month = feb,
   publisher = {Society for Mining,  Metallurgy and Exploration Inc.},
@@ -414,7 +392,6 @@ year = {2019}
 
 @article{Guo2019,
   doi = {10.2118/195580-pa},
-  url = {https://doi.org/10.2118/195580-pa},
   year = {2019},
   month = aug,
   publisher = {Society of Petroleum Engineers ({SPE})},
@@ -428,7 +405,6 @@ year = {2019}
 
 @article{Hagstrom2019,
   doi = {10.1007/s00211-018-1012-0},
-  url = {https://doi.org/10.1007/s00211-018-1012-0},
   year = {2019},
   month = jan,
   publisher = {Springer Science and Business Media {LLC}},
@@ -442,7 +418,6 @@ year = {2019}
 
 @article{Luo2019,
   doi = {10.1007/s00170-019-03947-0},
-  url = {https://doi.org/10.1007/s00170-019-03947-0},
   year = {2019},
   month = jun,
   publisher = {Springer Science and Business Media {LLC}},
@@ -456,7 +431,6 @@ year = {2019}
 
 @article{Carreo2019,
   doi = {10.1016/j.pnucene.2019.03.040},
-  url = {https://doi.org/10.1016/j.pnucene.2019.03.040},
   year = {2019},
   month = aug,
   publisher = {Elsevier {BV}},
@@ -469,7 +443,6 @@ year = {2019}
 
 @article{Schtz2019,
   doi = {10.1039/c9lc00149b},
-  url = {https://doi.org/10.1039/c9lc00149b},
   year = {2019},
   publisher = {Royal Society of Chemistry ({RSC})},
   volume = {19},
@@ -483,7 +456,6 @@ year = {2019}
 
 @article{Bryant2019,
   doi = {10.1016/j.cma.2019.05.003},
-  url = {https://doi.org/10.1016/j.cma.2019.05.003},
   year = {2019},
   month = sep,
   publisher = {Elsevier {BV}},
@@ -497,7 +469,6 @@ year = {2019}
 
 @article{White2019,
   doi = {10.1016/j.cma.2019.112575},
-  url = {https://doi.org/10.1016/j.cma.2019.112575},
   year = {2019},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -511,7 +482,6 @@ year = {2019}
 
 @article{Odster2019,
   doi = {10.1016/j.cma.2018.09.003},
-  url = {https://doi.org/10.1016/j.cma.2018.09.003},
   year = {2019},
   month = jan,
   publisher = {Elsevier {BV}},
@@ -538,7 +508,6 @@ doi = {10.1038/s41467-019-09335-2},
 journal = {Nature Communications},
 pages = {1309},
 title = {{Aborted propagation of the Ethiopian rift caused by linkage with the Kenyan rift}},
-url = {https://doi.org/10.1038/s41467-019-09335-2},
 volume = {10},
 year = {2019}
 }
@@ -564,7 +533,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{LiuYin2019,
   doi = {10.1007/s10915-019-01038-6},
-  url = {https://doi.org/10.1007/s10915-019-01038-6},
   year = {2019},
   month = aug,
   publisher = {Springer Science and Business Media {LLC}},
@@ -579,7 +547,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{Hochbruck2019,
   doi = {10.1137/18m1234072},
-  url = {https://doi.org/10.1137/18m1234072},
   year = {2019},
   month = jan,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
@@ -594,7 +561,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{Stoop2019,
   doi = {10.1016/j.jnnfm.2019.05.002},
-  url = {https://doi.org/10.1016/j.jnnfm.2019.05.002},
   year = {2019},
   month = jun,
   publisher = {Elsevier {BV}},
@@ -608,7 +574,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{Kim2019,
   doi = {10.1051/m2an/2019026},
-  url = {https://doi.org/10.1051/m2an/2019026},
   year = {2019},
   month = jul,
   publisher = {{EDP} Sciences},
@@ -623,7 +588,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{EbnaHai2019,
   doi = {10.1016/j.jfluidstructs.2019.04.014},
-  url = {https://doi.org/10.1016/j.jfluidstructs.2019.04.014},
   year = {2019},
   month = jul,
   publisher = {Elsevier {BV}},
@@ -637,7 +601,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{Aggul2019,
   doi = {10.1016/j.amc.2018.12.074},
-  url = {https://doi.org/10.1016/j.amc.2018.12.074},
   year = {2019},
   month = oct,
   publisher = {Elsevier {BV}},
@@ -651,7 +614,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{PonceBobadilla2019,
   doi = {10.1007/s11538-019-00625-w},
-  url = {https://doi.org/10.1007/s11538-019-00625-w},
   year = {2019},
   month = jun,
   publisher = {Springer Science and Business Media {LLC}},
@@ -666,7 +628,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{EbnaHai2019b,
   doi = {10.1016/j.camwa.2019.01.009},
-  url = {https://doi.org/10.1016/j.camwa.2019.01.009},
   year = {2019},
   month = nov,
   publisher = {Elsevier {BV}},
@@ -681,22 +642,12 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @incollection{Wang2019,
   doi = {10.1007/978-3-030-22747-0_37},
-  url = {https://doi.org/10.1007/978-3-030-22747-0_37},
   year = {2019},
   publisher = {Springer International Publishing},
   pages = {495--509},
   author = {Zhuoran Wang and Graham Harper and Patrick O'Leary and Jiangguo Liu and Simon Tavener},
   title = {deal.{II} Implementation of a Weak Galerkin Finite Element Solver for Darcy Flow},
   booktitle = {Lecture Notes in Computer Science}
-}
-
-@misc{heltai2019using,
-    title={Using exact geometry information in finite element computations},
-    author={Luca Heltai and Wolfgang Bangerth and Martin Kronbichler and Andrea Mola},
-    year={2019},
-    eprint={1910.09824},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
 }
 
 @phdthesis{Bzowski2019,
@@ -709,7 +660,6 @@ school = {Otto-von-Guericke-Universit{\"a}t Magdeburg}
 
 @article{Mikeli2019,
   doi = {10.1007/s13137-019-0113-y},
-  url = {https://doi.org/10.1007/s13137-019-0113-y},
   year = {2019},
   month = jan,
   publisher = {Springer Science and Business Media {LLC}},
@@ -733,7 +683,6 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
 
 @article{vanDuijn2019,
   doi = {10.1016/j.ijengsci.2019.02.005},
-  url = {https://doi.org/10.1016/j.ijengsci.2019.02.005},
   year = {2019},
   month = may,
   publisher = {Elsevier {BV}},
@@ -744,39 +693,18 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
   journal = {International Journal of Engineering Science}
 }
 
-
-@article{Wick2019OptimizationWN,
-  title={Optimization with nonstationary, nonlinear monolithic fluid-structure interaction},
-  author={Thomas Wick and Winnifried Wollner},
-  journal={ArXiv},
-  year={2019},
-  volume={abs/1910.03424},
-  url={https://arxiv.org/abs/1910.03424}
-}
-
 @article{Noii_2019,
    title={A phase-field description for pressurized and non-isothermal propagating fractures},
    volume={351},
    ISSN={0045-7825},
-   url={http://dx.doi.org/10.1016/j.cma.2019.03.058},
    DOI={10.1016/j.cma.2019.03.058},
    journal={Computer Methods in Applied Mechanics and Engineering},
    publisher={Elsevier BV},
    author={Noii, Nima and Wick, Thomas},
    year={2019},
-   month={Jul},
+   month=jul,
    pages={860--890}
 }
-
-@misc{cabarcas2019spurious,
-    title={On spurious solutions encountered in Helmholtz scattering resonance computations in $R^d$ with applications to nano-photonics and acoustics},
-    author={Ara\'{u}jo, Juan C. and Engstr{\"o}m, Christian},
-    year={2019},
-    eprint={1904.08812},
-    archivePrefix={arXiv},
-    primaryClass={math-ph}
-}
-
 
 @article{Mehnert2019,
   doi = {10.1016/j.euromechsol.2019.103797},
@@ -798,7 +726,7 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
   year      = {2019},
   volume    = {343},
   pages     = {368--406},
-  month     = {jan},
+  month     = jan,
   doi       = {10.1016/j.cma.2018.08.006},
   publisher = {Elsevier {BV}},
   url       = {https://www.researchgate.net/profile/Anup_Basak/publication/326847352_Finite_element_procedure_and_simulations_for_a_multiphase_phase_field_approach_to_martensitic_phase_transformations_at_large_strains_and_with_interfacial_stresses/links/5baae99da6fdccd3cb733c04/Finite-element-procedure-and-simulations-for-a-multiphase-phase-field-approach-to-martensitic-phase-transformations-at-large-strains-and-with-interfacial-stresses.pdf},
@@ -820,9 +748,8 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
 
 @article{Qinami2019,
   doi = {10.1007/s10704-019-00349-x},
-  url = {https://doi.org/10.1007/s10704-019-00349-x},
   year = {2019},
-  month = {feb},
+  month = feb,
   publisher = {Springer Science and Business Media {LLC}},
   author = {Aurel Qinami and Eric Cushman Bryant and WaiChing Sun and Michael Kaliske},
   title = {Circumventing mesh bias by r- and h-adaptive techniques for variational eigenfracture},
@@ -859,7 +786,6 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
   journal = {bioRxiv}
 }
 
-
 @PhdThesis{Mou19,
   author =       {Naeim Mousavi},
   title =        {Crustal and (sub)lithospheric structure beneath the Iranian
@@ -869,29 +795,23 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
   url = {https://macau.uni-kiel.de/receive/diss_mods_00025884}
 }
 
-
 @article{Rudraraju2019,
-	archivePrefix = {arXiv},
-	arxivId = {1901.00497},
-	author = {Rudraraju, Shiva and Moulton, Derek E. and Chirat, R{\'{e}}gis and Goriely, Alain and Garikipati, Krishna},
-	doi = {10.1371/journal.pcbi.1007213},
-	eprint = {1901.00497},
-	issn = {15537358},
-	journal = {PLoS Computational Biology},
-	month = {jul},
-	number = {7},
-	publisher = {Public Library of Science},
-	title = {{A computational framework for the morpho-elastic development of molluskan shells by surface and volume growth}},
-	volume = {15},
-	year = {2019}
+  doi = {10.1371/journal.pcbi.1007213},
+  url = {https://arxiv.org/abs/1901.00497},
+  year = {2019},
+  month = jul,
+  publisher = {Public Library of Science ({PLoS})},
+  volume = {15},
+  number = {7},
+  pages = {e1007213},
+  author = {Shiva Rudraraju and Derek E. Moulton and R{\'{e}}gis Chirat and Alain Goriely and Krishna Garikipati},
+  editor = {Qing Nie},
+  title = {A computational framework for the morpho-elastic development of molluskan shells by surface and volume growth},
+  journal = {{PLOS} Computational Biology}
 }
-
-
-
 
 @article{Jiang2019,
   doi = {10.1007/s11538-019-00577-1},
-  url = {https://doi.org/10.1007/s11538-019-00577-1},
   year = {2019},
   month = feb,
   publisher = {Springer Science and Business Media {LLC}},
@@ -902,8 +822,6 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
   title = {A Diffuse Interface Framework for Modeling the Evolution of Multi-cell Aggregates as a Soft Packing Problem Driven by the Growth and Division of Cells},
   journal = {Bulletin of Mathematical Biology}
 }
-
-
 
 @article{grayver2019,
   title={Three-dimensional magnetotelluric modelling in spherical {Earth}},
@@ -946,15 +864,13 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
   volume    = {77},
   number    = {6},
   pages     = {1527--1540},
-  doi       = {10.1016/j.camwa.2018.08.067},
-  url       = {https://doi.org/10.1016/j.camwa.2018.08.067},
+  doi       = {10.1016/j.camwa.2018.08.067}
 }
 
 @article{Grayver2019b,
   doi = {10.1029/2019gl082400},
-  url = {https://doi.org/10.1029/2019gl082400},
   year = {2019},
-  month = {apr},
+  month = apr,
   publisher = {American Geophysical Union ({AGU})},
   volume = {46},
   number = {8},
@@ -978,7 +894,6 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
 
 @article{Freddi2019,
   doi = {10.1016/j.mechrescom.2019.01.009},
-  url = {https://doi.org/10.1016/j.mechrescom.2019.01.009},
   year = {2019},
   month = mar,
   publisher = {Elsevier {BV}},
@@ -1008,7 +923,6 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
 
 @inproceedings{Dong2019,
   doi = {10.2118/193862-ms},
-  url = {https://doi.org/10.2118/193862-ms},
   year = {2019},
   publisher = {Society of Petroleum Engineers},
   author = {Rencheng Dong and Sanghyun Lee and Mary Wheeler},
@@ -1018,7 +932,6 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
 
 @inproceedings{Wheeler2019,
   doi = {10.2118/193830-ms},
-  url = {https://doi.org/10.2118/193830-ms},
   year = {2019},
   publisher = {Society of Petroleum Engineers},
   author = {Mary F. Wheeler and Sanjay Srinivasan and Sanghyun Lee and Manik Singh},
@@ -1042,7 +955,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Adler2019,
   doi = {10.1016/j.camwa.2018.09.051},
-  url = {https://doi.org/10.1016/j.camwa.2018.09.051},
   year = {2019},
   month = jan,
   publisher = {Elsevier {BV}},
@@ -1067,7 +979,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Sticko2019,
   doi = {10.1007/s10915-019-01004-2},
-  url = {https://doi.org/10.1007/s10915-019-01004-2},
   year = {2019},
   month = jul,
   publisher = {Springer Science and Business Media {LLC}},
@@ -1079,17 +990,8 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   journal = {Journal of Scientific Computing}
 }
 
-@Article{ZC19,
-  author =       {Y. Zhao and J. Choo},
-  title =        {Stabilized material point methods for coupled large deformation and fluid flow in porous materials},
-  note =      {submitted},
-  year =         {2019},
-  url =       {https://arxiv.org/abs/1905.00671}
-}
-
 @article{Soldner2019,
   doi = {10.1016/j.camwa.2018.04.036},
-  url = {https://doi.org/10.1016/j.camwa.2018.04.036},
   year = {2019},
   month = oct,
   publisher = {Elsevier {BV}},
@@ -1101,10 +1003,8 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-
 @article{Ghesmati2019,
   doi = {10.1515/jnma-2018-0047},
-  url = {https://doi.org/10.1515/jnma-2018-0047},
   year = {2019},
   month = dec,
   publisher = {Walter de Gruyter {GmbH}},
@@ -1129,7 +1029,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   pages = {2:1--2:11},
   articleno = {2},
   numpages = {11},
-  url = {http://doi.acm.org/10.1145/3295500.3357157},
   doi = {10.1145/3295500.3357157},
   publisher = {ACM},
   address = {New York, NY, USA}
@@ -1137,7 +1036,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Maday2019,
   doi = {10.1142/s0218202519500295},
-  url = {https://doi.org/10.1142/s0218202519500295},
   year = {2019},
   month = jul,
   publisher = {World Scientific Pub Co Pte Lt},
@@ -1151,7 +1049,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Wick2019,
   doi = {10.1007/s00021-019-0439-0},
-  url = {https://doi.org/10.1007/s00021-019-0439-0},
   year = {2019},
   month = jun,
   publisher = {Springer Science and Business Media {LLC}},
@@ -1167,7 +1064,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
     {S}tabilized {F}inite {E}lement {M}ethods},
   ISBN={9783030142445},
   ISSN={2197-7100},
-  url={http://dx.doi.org/10.1007/978-3-030-14244-5_5},
   DOI={10.1007/978-3-030-14244-5_5},
   journal={Advanced Finite Element Methods with Applications},
   publisher={Springer International Publishing},
@@ -1178,7 +1074,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Heltai2019,
   doi = {10.1002/cnm.3264},
-  url = {https://doi.org/10.1002/cnm.3264},
   year = {2019},
   month = dec,
   publisher = {Wiley},
@@ -1189,18 +1084,8 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   journal = {International Journal for Numerical Methods in Biomedical Engineering}
 }
 
-
-@misc{mcbride2019modelling,
-    title={Modelling the flexoelectric effect in solids: a micromorphic approach},
-    author={Andrew McBride and Denis Davydov and Paul Steinmann},
-    year={2019},
-    note={arXiv:1909.08695, submitted},
-    url =       {https://arxiv.org/abs/1909.08695}
-}
-
 @article{Njinju2019,
   doi = {10.1029/2019tc005549},
-  url = {https://doi.org/10.1029/2019tc005549},
   year = {2019},
   month = oct,
   publisher = {American Geophysical Union ({AGU})},
@@ -1211,7 +1096,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{dannberg2019new,
   doi = {10.1093/gji/ggz190},
-  url = {https://doi.org/10.1093/gji/ggz190},
   title={A new formulation for coupled magma/mantle dynamics},
   author={Dannberg, Juliane and Gassm{\"o}ller, Rene and Grove, Ryan and Heister, Timo},
   journal={Geophysical Journal International},
@@ -1221,43 +1105,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   year={2019},
   publisher={Oxford University Press}
 }
-
-@misc{witte2019fast,
-    title={Fast Tensor Product Schwarz Smoothers for High-Order Discontinuous Galerkin Methods},
-    author={Julius Witte and Daniel Arndt and Guido Kanschat},
-    year={2019},
-    eprint={1910.11239},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-@misc{brun2019iterative,
-    title={An iterative staggered scheme for phase field brittle fracture propagation with stabilizing parameters},
-    author={Mats Kirkes{\ae}ther Brun and Thomas Wick and Inga Berre and Jan Martin Nordbotten and Florin Adrian Radu},
-    year={2019},
-    eprint={1903.08717},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-@misc{endtmayer2019multigoaloriented,
-    title={Multigoal-oriented optimal control problems with nonlinear PDE constraints},
-    author={Bernhard Endtmayer and Ulrich Langer and Ira Neitzel and Thomas Wick and Winnifried Wollner},
-    year={2019},
-    eprint={1903.02799},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-@misc{jodlbauer2019matrixfree,
-    title={Matrix-free multigrid solvers for phase-field fracture problems},
-    author={Daniel Jodlbauer and Ulrich Langer and Thomas Wick},
-    year={2019},
-    eprint={1902.08112},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
 
 @misc{Mang2019a,
   doi = {10.15488/5129},
@@ -1274,7 +1121,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Mang2019b,
   doi = {10.1007/s00466-019-01752-w},
-  url = {https://doi.org/10.1007/s00466-019-01752-w},
   year = {2019},
   month = jul,
   publisher = {Springer Science and Business Media {LLC}},
@@ -1289,7 +1135,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Mang2019c,
   doi = {10.1002/gamm.202000003},
-  url = {https://doi.org/10.1002/gamm.202000003},
   year = {2019},
   month = aug,
   publisher = {Wiley},
@@ -1298,30 +1143,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   author = {K. Mang and M. Walloth and T. Wick and W. Wollner},
   title = {Mesh adaptivity for quasi-static phase-field fractures based on a residual-type a posteriori error estimator},
   journal = {{GAMM}-Mitteilungen}
-}
-
-
-@misc{endtmayer2018twoside,
-    title={Two-side a posteriori error estimates for the DWR method},
-    author={Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
-    year={2018},
-    eprint={1811.07586},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-@article{Fu2018,
-  doi = {10.1093/imanum/dry001},
-  url = {https://doi.org/10.1093/imanum/dry001},
-  year = {2018},
-  month = mar,
-  publisher = {Oxford University Press ({OUP})},
-  volume = {39},
-  number = {2},
-  pages = {957--982},
-  author = {Guosheng Fu and Yanyi Jin and Weifeng Qiu},
-  title = {Parameter-free superconvergent H(div)-conforming {HDG} methods for the {B}rinkman equations},
-  journal = {{IMA} Journal of Numerical Analysis}
 }
 
 @Book{Pelteret2019a,
@@ -1345,7 +1166,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Fei2019,
   doi = {10.1002/nme.6242},
-  url = {https://doi.org/10.1002/nme.6242},
   year = {2019},
   month = nov,
   publisher = {Wiley},
@@ -1448,13 +1268,11 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
    series  = {Lecture Notes in Computational Science and Engineering},
    year    = {2019},
    pages   = {581--589},
-   url     = {https://dx.doi.org/10.1007/978-3-319-96415-7_53},
    doi     = {10.1007/978-3-319-96415-7_53},
 }
 
 @article{Krank2019Wall,
   doi = {10.1016/j.compfluid.2018.07.019},
-  url = {https://doi.org/10.1016/j.compfluid.2018.07.019},
   year = {2019},
   publisher = {Elsevier {BV}},
   volume = {179},
@@ -1466,7 +1284,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 
 @article{Krank2019Multiscale,
   doi = {10.1002/fld.4712},
-  url = {https://doi.org/10.1002/fld.4712},
   year = {2019},
   publisher = {Wiley},
   volume = {90},
@@ -1509,14 +1326,13 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
   title     = {Iterative solvers for poromechanics},
   school    = {Department of Mathematics, University of Bergen},
   year      = {2019},
-  month     = {August},
+  month     = aug,
   url       = {http://bora.uib.no/handle/1956/21143},
 }
 
 
 @InProceedings{10.1007/978-3-319-96415-7_49,
   doi = {10.1007/978-3-319-96415-7_49},
-  url = {https://doi.org/10.1007/978-3-319-96415-7_49},
 author="Borregales, Manuel
 and Radu, Florin Adrian",
 editor="Radu, Florin Adrian
@@ -1537,7 +1353,6 @@ pages="541--549",
 
 @article{Borregales2019c,
   doi = {10.1016/j.camwa.2018.09.005},
-  url = {https://doi.org/10.1016/j.camwa.2018.09.005},
   year = {2019},
   month = mar,
   publisher = {Elsevier {BV}},
@@ -1549,47 +1364,6 @@ pages="541--549",
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-
-@misc{bonito2019dg,
-    title={DG Approach to Large Bending Plate Deformations with Isometry Constraint},
-    author={Andrea Bonito and Ricardo H. Nochetto and Dimitrios Ntogkas},
-    year={2019},
-    eprint={1912.03812},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-
-@misc{klein2019sequential,
-    title={Sequential subspace optimization for recovering stored energy functions in hyperelastic materials from time-dependent data},
-    author={Rebecca Klein and Thomas Schuster and Anne Wald},
-    year={2019},
-    eprint={1911.04855},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-
-@misc{liu2019balancing,
-    title={Balancing truncation and round-off errors in practical FEM: one-dimensional analysis},
-    author={Jie Liu and Matthias M{\"o}ller and Henk M. Schuttelaars},
-    year={2019},
-    eprint={1912.08004},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-
-@misc{anselmann2019higher,
-    title={Higher order Galerkin-collocation time discretization with Nitsche's method for the Navier-Stokes equations},
-    author={Mathias Anselmann and Markus Bause},
-    year={2019},
-    eprint={1912.07426},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-
 @misc{holmgren2019hydrodynamic,
     title={A Hydrodynamic Model of Movement of a Contact Line Over a Curved Wall},
     author={Hanna Holmgren and Gunilla Kreiss},
@@ -1599,25 +1373,13 @@ pages="541--549",
     primaryClass={physics.flu-dyn}
 }
 
-@misc{murphy2019moving,
-    title={A moving grid finite element method applied to a mechanobiochemical model for 3D cell migration},
-    author={Laura Murphy and Anotida Madzvamuse},
-    year={2019},
-    eprint={1903.09535},
-    archivePrefix={arXiv},
-    primaryClass={q-bio.CB}
-}
-
-
-@misc{alex2019modeling,
+@mastersthesis{alex2019modeling,
     title={Modeling and simulation of heat source trajectories through phase-change materials},
     author={Alexander Gary Zimmerman},
     year={2019},
-    eprint={1909.08882},
-    archivePrefix={arXiv},
-    primaryClass={cs.CE}
+    school={RWTH Aachen},
+    url={https://arxiv.org/abs/1909.08882}
 }
-
 
 @misc{he2019simulating,
     title={Simulating the scattering of low-frequency Gravitational Waves by compact objects using the finite element method},
@@ -1628,50 +1390,8 @@ pages="541--549",
     primaryClass={gr-qc}
 }
 
-
-@misc{welper2019transformed,
-    title={Transformed Snapshot Interpolation with High Resolution Transforms},
-    author={G. Welper},
-    year={2019},
-    eprint={1901.01322},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-
-@misc{badia2019generic,
-    title={A generic finite element framework on parallel tree-based adaptive meshes},
-    author={Santiago Badia and Alberto F. Mart{\'i}n and Eric Neiva and Francesc Verdugo},
-    year={2019},
-    eprint={1907.03709},
-    archivePrefix={arXiv},
-    primaryClass={cs.MS}
-}
-
-
-@misc{endtmayer2019hierarchical,
-    title={Hierarchical DWR Error Estimates for the Navier Stokes Equation: $h$ and $p$ Enrichment},
-    author={B. Endtmayer and U. Langer and J. P. Thiele and T. Wick},
-    year={2019},
-    eprint={1912.04819},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-
-@misc{engwer2019dynamic,
-    title={Dynamic and weighted stabilizations of the $L$-scheme applied to a phase-field model for fracture propagation},
-    author={Christian Engwer and Iuliu Sorin Pop and Thomas Wick},
-    year={2019},
-    eprint={1912.07096},
-    archivePrefix={arXiv},
-    primaryClass={math.NA}
-}
-
-
 @article{Aulisa2019,
   doi = {10.1137/18m1175409},
-  url = {https://doi.org/10.1137/18m1175409},
   year = {2019},
   month = jan,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
@@ -1686,7 +1406,6 @@ pages="541--549",
 
 @article{Brands2019,
   doi = {10.3390/mca24010020},
-  url = {https://doi.org/10.3390/mca24010020},
   year = {2019},
   month = feb,
   publisher = {{MDPI} {AG}},
@@ -1701,7 +1420,6 @@ pages="541--549",
 
 @article{Kcher2019,
   doi = {10.1016/j.softx.2019.100239},
-  url = {https://doi.org/10.1016/j.softx.2019.100239},
   year = {2019},
   month = jul,
   publisher = {Elsevier {BV}},
@@ -1722,7 +1440,6 @@ pages="541--549",
 
 @article{Ma2019,
   doi = {10.1021/acs.jpcc.9b05561},
-  url = {https://doi.org/10.1021/acs.jpcc.9b05561},
   year = {2019},
   month = sep,
   publisher = {American Chemical Society ({ACS})},
@@ -1737,7 +1454,6 @@ pages="541--549",
 
 @article{Giuliani2019,
   doi = {10.1016/j.cpc.2018.10.005},
-  url = {https://doi.org/10.1016/j.cpc.2018.10.005},
   year = {2019},
   month = feb,
   publisher = {Elsevier {BV}},
@@ -1751,7 +1467,6 @@ pages="541--549",
 
 @article{Alarydah2019,
   doi = {10.1016/j.camwa.2018.08.001},
-  url = {https://doi.org/10.1016/j.camwa.2018.08.001},
   year = {2019},
   month = mar,
   publisher = {Elsevier {BV}},
@@ -1766,7 +1481,6 @@ pages="541--549",
 
 @article{Koepf2019,
   doi = {10.1016/j.commatsci.2019.03.004},
-  url = {https://doi.org/10.1016/j.commatsci.2019.03.004},
   year = {2019},
   month = may,
   publisher = {Elsevier {BV}},
@@ -1780,7 +1494,6 @@ pages="541--549",
 
 @article{Walker2019,
   doi = {10.1002/cpe.5265},
-  url = {https://doi.org/10.1002/cpe.5265},
   year = {2019},
   month = apr,
   publisher = {Wiley},
@@ -1793,7 +1506,6 @@ pages="541--549",
 
 @article{Babaei2019a,
   doi = {10.1007/s00466-019-01699-y},
-  url = {https://doi.org/10.1007/s00466-019-01699-y},
   year = {2019},
   month = apr,
   publisher = {Springer Science and Business Media {LLC}},
@@ -1808,7 +1520,6 @@ pages="541--549",
 
 @article{Babaei2019b,
   doi = {10.1016/j.actamat.2019.07.021},
-  url = {https://doi.org/10.1016/j.actamat.2019.07.021},
   year = {2019},
   month = sep,
   publisher = {Elsevier {BV}},
@@ -1822,7 +1533,6 @@ pages="541--549",
 
 @article{Zhao2019,
   doi = {10.1016/j.aml.2019.05.029},
-  url = {https://doi.org/10.1016/j.aml.2019.05.029},
   year = {2019},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -1836,7 +1546,6 @@ pages="541--549",
 
 @article{Hao2019,
   doi = {10.1051/m2an/2018046},
-  url = {https://doi.org/10.1051/m2an/2018046},
   year = {2019},
   month = aug,
   publisher = {{EDP} Sciences},
@@ -1851,7 +1560,6 @@ pages="541--549",
 
 @article{Dang2019,
   doi = {10.1155/2019/7560724},
-  url = {https://doi.org/10.1155/2019/7560724},
   year = {2019},
   month = feb,
   publisher = {Hindawi Limited},
@@ -1865,7 +1573,6 @@ pages="541--549",
 
 @article{Carreo2019,
   doi = {10.3390/mca24010009},
-  url = {https://doi.org/10.3390/mca24010009},
   year = {2019},
   month = jan,
   publisher = {{MDPI} {AG}},
@@ -1893,17 +1600,15 @@ year = {2019}
     number = {2},
     pages = {873-894},
     year = {2019},
-    month = {04},
+    month = apr,
     issn = {0956-540X},
     doi = {10.1093/gji/ggz183},
-    url = {https://doi.org/10.1093/gji/ggz183},
     eprint = {http://oup.prod.sis.lan/gji/article-pdf/218/2/873/28693654/ggz183.pdf},
 }
 
 
 @article{Bucci2019,
   doi = {10.1016/j.jpowsour.2019.227186},
-  url = {https://doi.org/10.1016/j.jpowsour.2019.227186},
   year = {2019},
   month = nov,
   publisher = {Elsevier {BV}},
@@ -1917,7 +1622,6 @@ year = {2019}
 
 @article{Knig2019,
   doi = {10.2514/1.t5457},
-  url = {https://doi.org/10.2514/1.t5457},
   year = {2019},
   month = apr,
   publisher = {American Institute of Aeronautics and Astronautics ({AIAA})},
@@ -1932,7 +1636,6 @@ year = {2019}
 
 @article{Vassaux2019,
   doi = {10.1098/rsta.2018.0150},
-  url = {https://doi.org/10.1098/rsta.2018.0150},
   year = {2019},
   month = feb,
   publisher = {The Royal Society},
@@ -1947,7 +1650,6 @@ year = {2019}
 
 @article{DeSantis2019,
   doi = {10.1016/j.anucene.2019.02.049},
-  url = {https://doi.org/10.1016/j.anucene.2019.02.049},
   year = {2019},
   month = aug,
   publisher = {Elsevier {BV}},
@@ -1961,7 +1663,6 @@ year = {2019}
 
 @article{Choo2019,
   doi = {10.1016/j.cma.2019.112568},
-  url = {https://doi.org/10.1016/j.cma.2019.112568},
   year = {2019},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -1975,7 +1676,6 @@ year = {2019}
 
 @article{GonzlezValverde2018,
   doi = {10.1007/s40571-018-0199-2},
-  url = {https://doi.org/10.1007/s40571-018-0199-2},
   year = {2018},
   month = jun,
   publisher = {Springer Science and Business Media {LLC}},
@@ -1990,7 +1690,6 @@ year = {2019}
 
 @article{Konschin2019,
   doi = {10.1088/1361-6420/ab1c66},
-  url = {https://doi.org/10.1088/1361-6420/ab1c66},
   year = {2019},
   month = oct,
   publisher = {{IOP} Publishing},
@@ -2005,7 +1704,6 @@ year = {2019}
 
 @article{Kottapalli2019,
   doi = {10.1016/j.anucene.2019.01.001},
-  url = {https://doi.org/10.1016/j.anucene.2019.01.001},
   year = {2019},
   month = jun,
   publisher = {Elsevier {BV}},
@@ -2019,7 +1717,6 @@ year = {2019}
 
 @article{Steinmann2019,
   doi = {10.1016/j.jmps.2019.103680},
-  url = {https://doi.org/10.1016/j.jmps.2019.103680},
   year = {2019},
   month = nov,
   publisher = {Elsevier {BV}},
@@ -2033,7 +1730,6 @@ year = {2019}
 
 @article{Dang2019,
   doi = {10.1155/2019/4034860},
-  url = {https://doi.org/10.1155/2019/4034860},
   year = {2019},
   month = jul,
   publisher = {Hindawi Limited},
@@ -2047,7 +1743,6 @@ year = {2019}
 
 @article{Khler2019,
   doi = {10.1002/pamm.201900292},
-  url = {https://doi.org/10.1002/pamm.201900292},
   year = {2019},
   month = nov,
   publisher = {Wiley},
@@ -2067,13 +1762,12 @@ publisher = {Nature Publishing Group},
 title = {Widespread volcanism in the {G}reenland-{N}orth {A}tlantic region explained by the {I}celand plume},
 volume = {12},
 year = {2019},
-doi = {https://doi.org/10.1038/s41561-018-0251-0}
+doi = {10.1038/s41561-018-0251-0}
 }
 
 
 @article{Cerroni2019,
   doi = {10.3390/geosciences9110465},
-  url = {https://doi.org/10.3390/geosciences9110465},
   year = {2019},
   month = oct,
   publisher = {{MDPI} {AG}},
@@ -2088,7 +1782,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Han2019,
   doi = {10.1080/15361055.2018.1554391},
-  url = {https://doi.org/10.1080/15361055.2018.1554391},
   year = {2019},
   month = feb,
   publisher = {Informa {UK} Limited},
@@ -2103,7 +1796,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Samii2019,
   doi = {10.1007/s10915-019-01007-z},
-  url = {https://doi.org/10.1007/s10915-019-01007-z},
   year = {2019},
   month = jul,
   publisher = {Springer Science and Business Media {LLC}},
@@ -2125,7 +1817,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Na2019,
   doi = {10.1016/j.cma.2019.112572},
-  url = {https://doi.org/10.1016/j.cma.2019.112572},
   year = {2019},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -2139,7 +1830,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Robey2019,
   doi = {10.1016/j.compfluid.2019.05.015},
-  url = {https://doi.org/10.1016/j.compfluid.2019.05.015},
   year = {2019},
   month = aug,
   publisher = {Elsevier {BV}},
@@ -2153,7 +1843,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Charnyi2019,
   doi = {10.1016/j.apnum.2018.11.013},
-  url = {https://doi.org/10.1016/j.apnum.2018.11.013},
   year = {2019},
   month = jul,
   publisher = {Elsevier {BV}},
@@ -2167,7 +1856,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Zhang2019,
   doi = {10.1016/j.cma.2019.04.037},
-  url = {https://doi.org/10.1016/j.cma.2019.04.037},
   year = {2019},
   month = aug,
   publisher = {Elsevier {BV}},
@@ -2181,7 +1869,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Heltai2019,
   doi = {10.1016/j.camwa.2019.05.029},
-  url = {https://doi.org/10.1016/j.camwa.2019.05.029},
   year = {2019},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -2196,7 +1883,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Teichert2019,
   doi = {10.1016/j.cma.2018.10.025},
-  url = {https://doi.org/10.1016/j.cma.2018.10.025},
   year = {2019},
   month = feb,
   publisher = {Elsevier {BV}},
@@ -2210,7 +1896,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Kim2019,
   doi = {10.1016/j.jnnfm.2019.07.002},
-  url = {https://doi.org/10.1016/j.jnnfm.2019.07.002},
   year = {2019},
   month = sep,
   publisher = {Elsevier {BV}},
@@ -2224,7 +1909,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{LiuKing2019,
   doi = {10.1093/gji/ggz036},
-  url = {https://doi.org/10.1093/gji/ggz036},
   year = {2019},
   month = jan,
   publisher = {Oxford University Press ({OUP})},
@@ -2239,7 +1923,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Gong2019,
   doi = {10.1016/j.ijheatmasstransfer.2019.01.104},
-  url = {https://doi.org/10.1016/j.ijheatmasstransfer.2019.01.104},
   year = {2019},
   month = jun,
   publisher = {Elsevier {BV}},
@@ -2253,7 +1936,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Roelofs2019,
   doi = {10.1016/j.nucengdes.2019.110322},
-  url = {https://doi.org/10.1016/j.nucengdes.2019.110322},
   year = {2019},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -2267,7 +1949,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @inproceedings{Kauffman2019,
   doi = {10.2514/6.2019-1986},
-  url = {https://doi.org/10.2514/6.2019-1986},
   year = {2019},
   month = jan,
   publisher = {American Institute of Aeronautics and Astronautics},
@@ -2279,7 +1960,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Gedicke2019,
   doi = {10.1007/s00211-019-01095-x},
-  url = {https://doi.org/10.1007/s00211-019-01095-x},
   year = {2019},
   month = dec,
   publisher = {Springer Science and Business Media {LLC}},
@@ -2294,7 +1974,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Ambartsumyan2019,
   doi = {10.1142/s0218202519500167},
-  url = {https://doi.org/10.1142/s0218202519500167},
   year = {2019},
   month = jun,
   publisher = {World Scientific Pub Co Pte Lt},
@@ -2309,7 +1988,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Boddu2019,
   doi = {10.1007/s42493-019-00027-z},
-  url = {https://doi.org/10.1007/s42493-019-00027-z},
   year = {2019},
   month = oct,
   publisher = {Springer Science and Business Media {LLC}},
@@ -2323,7 +2001,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Bonito2019,
   doi = {10.1137/18m1169278},
-  url = {https://doi.org/10.1137/18m1169278},
   year = {2019},
   month = jan,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
@@ -2337,7 +2014,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @incollection{Carreo2019,
   doi = {10.1007/978-3-030-22750-0_68},
-  url = {https://doi.org/10.1007/978-3-030-22750-0_68},
   year = {2019},
   publisher = {Springer International Publishing},
   pages = {702--709},
@@ -2348,7 +2024,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Vassaux2019,
   doi = {10.1002/adts.201800168},
-  url = {https://doi.org/10.1002/adts.201800168},
   year = {2019},
   month = feb,
   publisher = {Wiley},
@@ -2394,7 +2069,7 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
   URL = {https://hal.inria.fr/tel-02064216},
   SCHOOL = {{Inria Paris, Sobonne Universit{\'e}}},
   YEAR = {2019},
-  MONTH = Mar,
+  MONTH = mar,
   KEYWORDS = {Agent-based models ; Cell migration ; Cell mechanics ; Mod{\`e}les {\`a} base d'agents ; Mechanique cellulaire},
   TYPE = {Habilitation {\`a} diriger des recherches},
   PDF = {https://hal.inria.fr/tel-02064216/file/HDR_pvl.pdf},
@@ -2405,9 +2080,8 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Bzowski_2019,
   doi = {10.1088/1757-899x/627/1/012018},
-  url = {https://doi.org/10.1088%2F1757-899x%2F627%2F1%2F012018},
   year = 2019,
-  month = {oct},
+  month = oct,
   publisher = {{IOP} Publishing},
   volume = {627},
   pages = {012018},
@@ -2504,7 +2178,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Hochbruck2020,
   doi = {10.1553/etna_vol53s522},
-  url = {https://doi.org/10.1553/etna_vol53s522},
   year = {2020},
   publisher = {Osterreichische Akademie der Wissenschaften},
   volume = {53},
@@ -2549,13 +2222,11 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
   year      = {2019},
   publisher = {Kassel University Press},
   pages     = {441--444},
-  doi       = {10.19211/KUP978737650939},
-  url       = {https://doi.org/10.19211/KUP978737650939},
+  doi       = {10.19211/KUP978737650939}
 }
 
 @inproceedings{Kazemi2019,
   doi = {10.1115/detc2019-97370},
-  url = {https://doi.org/10.1115/detc2019-97370},
   year = {2019},
   month = aug,
   publisher = {American Society of Mechanical Engineers},
@@ -2567,7 +2238,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Gupta2019,
   doi = {10.1002/nme.6217},
-  url = {https://doi.org/10.1002/nme.6217},
   year = {2019},
   month = oct,
   publisher = {Wiley},
@@ -2582,7 +2252,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Maier2019,
   doi = {10.1098/rspa.2019.0220},
-  url = {https://doi.org/10.1098/rspa.2019.0220},
   year = {2019},
   month = oct,
   publisher = {The Royal Society},
@@ -2597,7 +2266,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Neitzel2019,
   doi = {10.1137/18m122385x},
-  url = {https://doi.org/10.1137/18m122385x},
   year = {2019},
   month = jan,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
@@ -2627,7 +2295,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Schoeder2019,
   doi = {10.1016/j.softx.2019.01.001},
-  url = {https://doi.org/10.1016/j.softx.2019.01.001},
   year = {2019},
   month = jan,
   publisher = {Elsevier {BV}},
@@ -2645,7 +2312,7 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
   URL = {http://hdl.handle.net/20.500.11767/103102},
   SCHOOL = {{Scuola Internazionale Superiore di Studi Avanzati (SISSA)}},
   YEAR = {2019},
-  MONTH = Sep,
+  MONTH = sep,
   PDF = {https://iris.sissa.it/retrieve/handle/20.500.11767/103102/107276/PhD_thesis_dissertation_Mulita.pdf},
 }
 
@@ -2656,14 +2323,13 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
   URL = {https://hdl.handle.net/1969.1/186463},
   SCHOOL = {{Texas A{\&}M University}},
   YEAR = {2019},
-  MONTH = Jul,
+  MONTH = jul,
   PDF = {https://oaktrust.library.tamu.edu/bitstream/handle/1969.1/186463/PRINCE-DISSERTATION-2019.pdf},
 }
 
 
 @techreport{Sun2019,
   doi = {10.2172/1604128},
-  url = {https://doi.org/10.2172/1604128},
   year = {2019},
   month = dec,
   publisher = {Office of Scientific and Technical Information  ({OSTI})},
@@ -2677,7 +2343,7 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
   title = {Topology Optimization of Space Frames via Geometry Projection},
   url = {https://opencommons.uconn.edu/gs_theses/1325},
   year = {2019},
-  month = Mar,
+  month = mar,
   school = {University of Connecticut}
 }
 
@@ -2690,7 +2356,7 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
   number = {24},
   pages = {943--952},
   year = {2019},
-  month = Nov,
+  month = nov,
   url = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/view/5882},
   pdf = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/download/5882/5869}
 }
@@ -2710,7 +2376,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Khattatov2019,
   doi = {10.1051/m2an/2019057},
-  url = {https://doi.org/10.1051/m2an/2019057},
   year = {2019},
   month = nov,
   publisher = {{EDP} Sciences},
@@ -2725,7 +2390,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Schussnig2019,
   doi = {10.1002/pamm.201900100},
-  url = {https://doi.org/10.1002/pamm.201900100},
   year = {2019},
   month = sep,
   publisher = {Wiley},
@@ -2739,7 +2403,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{LiuReina2019,
   doi = {10.1007/s00466-018-1662-x},
-  url = {https://doi.org/10.1007/s00466-018-1662-x},
   year = {2019},
   month = jul,
   publisher = {Springer Science and Business Media {LLC}},
@@ -2754,7 +2417,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Pitton2019,
   doi = {10.1002/nla.2211},
-  url = {https://doi.org/10.1002/nla.2211},
   year = {2019},
   month = jan,
   publisher = {Wiley},
@@ -2769,7 +2431,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @article{Potschka2019,
   doi = {10.1007/s11075-018-0539-6},
-  url = {https://doi.org/10.1007/s11075-018-0539-6},
   year = {2019},
   month = may,
   publisher = {Springer Science and Business Media {LLC}},
@@ -2783,7 +2444,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @incollection{Both2019,
   doi = {10.1007/978-3-319-96415-7_74},
-  url = {https://doi.org/10.1007/978-3-319-96415-7_74},
   year = {2019},
   publisher = {Springer International Publishing},
   pages = {789--797},
@@ -2794,7 +2454,6 @@ doi = {https://doi.org/10.1038/s41561-018-0251-0}
 
 @incollection{Kocher2019,
   doi = {10.1007/978-3-319-96415-7_18},
-  url = {https://doi.org/10.1007/978-3-319-96415-7_18},
   year = {2019},
   publisher = {Springer International Publishing},
   pages = {215--223},

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -797,7 +797,6 @@ url = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
 
 @article{Rudraraju2019,
   doi = {10.1371/journal.pcbi.1007213},
-  url = {https://arxiv.org/abs/1901.00497},
   year = {2019},
   month = jul,
   publisher = {Public Library of Science ({PLoS})},

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -73,7 +73,6 @@ pages = "113431",
 year = "2020",
 issn = "0045-7825",
 doi = "10.1016/j.cma.2020.113431",
-url = "https://arxiv.org/abs/1902.08112",
 author = "D. Jodlbauer and U. Langer and T. Wick"
 }
 
@@ -123,7 +122,7 @@ number = {},
 pages = {1-20},
 keywords = {gradient-based optimization, monolithic formulation, optimal control, optimal design, unsteady nonlinear fluid-structure interaction},
 doi = {10.1002/nme.6372},
-url = {https://arxiv.org/abs/1910.03424},
+url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.6372},
 eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6372}
 }
 
@@ -149,7 +148,6 @@ pages = "3001 - 3026",
 year = "2020",
 issn = "0898-1221",
 doi = "10.1016/j.camwa.2020.01.005",
-url = "https://arxiv.org/abs/1903.02799",
 author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
 }
 
@@ -515,7 +513,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{Zhao2020,
   doi = {10.1016/j.cma.2019.112742},
-  url = {https://arxiv.org/abs/1905.00671},
   year = {2020},
   month = apr,
   publisher = {Elsevier {BV}},
@@ -878,7 +875,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{McBride2020,
   doi = {10.1016/j.cma.2020.113320},
-  url = {https://arxiv.org/abs/1909.08695},
   year = {2020},
   month = nov,
   publisher = {Elsevier {BV}},
@@ -965,7 +961,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{Witte2020,
   doi = {10.1515/cmam-2020-0078},
-  url = {https://arxiv.org/abs/1910.11239},
   year = {2020},
   month = nov,
   publisher = {Walter de Gruyter {GmbH}},
@@ -978,7 +973,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{KirkestherBrun2020,
   doi = {10.1016/j.cma.2019.112752},
-  url = {https://arxiv.org/abs/1903.08717},
   year = {2020},
   month = apr,
   publisher = {Elsevier {BV}},
@@ -991,7 +985,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{Endtmayer2020,
   doi = {10.1137/18m1227275},
-  url = {https://arxiv.org/abs/1811.07586},
   year = {2020},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume = {42},
@@ -1004,7 +997,6 @@ doi="10.1002/9781119528609.ch15"
 
 @incollection{Endtmayer2020b,
   doi = {10.1007/978-3-030-55874-1_35},
-  url = {https://arxiv.org/abs/1912.04819},
   year = {2020},
   month = aug,
   publisher = {Springer International Publishing},
@@ -1016,7 +1008,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{Murphy2020,
   doi = {10.1016/j.apnum.2020.08.004},
-  url = {https://arxiv.org/abs/1903.09535},
   year = {2020},
   month = dec,
   publisher = {Elsevier {BV}},
@@ -1029,7 +1020,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{Welper2020,
   doi = {10.1137/19m126356x},
-  url = {https://arxiv.org/abs/1901.01322},
   year = {2020},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume = {42},
@@ -1042,7 +1032,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{Badia2020,
   doi = {10.1137/20m1328786},
-  url = {https://arxiv.org/abs/1907.03709},
   year = {2020},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume = {42},
@@ -1055,7 +1044,6 @@ doi="10.1002/9781119528609.ch15"
 
 @incollection{Engwer2020,
   doi = {10.1007/978-3-030-55874-1_117},
-  url = {https://arxiv.org/abs/1912.07096},
   year = {2020},
   month = aug,
   publisher = {Springer International Publishing},

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -49,7 +49,7 @@ year = {2020}
       publisher = "De Gruyter",
       address = "Berlin, Boston",
       isbn = "978-3-11-049739-7",
-      doi = "https://doi.org/10.1515/9783110497397",
+      doi = "10.1515/9783110497397",
       url = "https://www.degruyter.com/view/title/523232"
 }
 
@@ -60,7 +60,7 @@ volume = "6",
 pages = "100045",
 year = "2020",
 issn = "2665-9638",
-doi = "https://doi.org/10.1016/j.simpa.2020.100045",
+doi = "10.1016/j.simpa.2020.100045",
 url = "http://www.sciencedirect.com/science/article/pii/S2665963820300361",
 author = "Timo Heister and Thomas Wick"
 }
@@ -72,8 +72,8 @@ volume = "372",
 pages = "113431",
 year = "2020",
 issn = "0045-7825",
-doi = "https://doi.org/10.1016/j.cma.2020.113431",
-url = "http://www.sciencedirect.com/science/article/pii/S0045782520306162",
+doi = "10.1016/j.cma.2020.113431",
+url = "https://arxiv.org/abs/1902.08112",
 author = "D. Jodlbauer and U. Langer and T. Wick"
 }
 
@@ -86,8 +86,7 @@ author = "D. Jodlbauer and U. Langer and T. Wick"
   pages={474--506},
   year={2020},
   publisher={Oxford University Press},
-  doi={10.1093/gji/ggaa141},
-  url={https://doi.org/10.1093/gji/ggaa141}
+  doi={10.1093/gji/ggaa141}
 }
 
 
@@ -99,7 +98,7 @@ volume = {25},
 number = {3},
 pages = {40},
 year = {2020},
-doi = {https://doi.org/10.3390/mca25030040}
+doi = {10.3390/mca25030040}
 }
 
 @Article{WheWiLee20,
@@ -109,7 +108,7 @@ volume = "367",
 pages = "113124",
 year = "2020",
 issn = "0045-7825",
-doi = "https://doi.org/10.1016/j.cma.2020.113124",
+doi = "10.1016/j.cma.2020.113124",
 url = "http://www.sciencedirect.com/science/article/pii/S0045782520303091",
 author = "Mary F. Wheeler and Thomas Wick and Sanghyun Lee"
 }
@@ -124,7 +123,7 @@ number = {},
 pages = {1-20},
 keywords = {gradient-based optimization, monolithic formulation, optimal control, optimal design, unsteady nonlinear fluid-structure interaction},
 doi = {10.1002/nme.6372},
-url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.6372},
+url = {https://arxiv.org/abs/1910.03424},
 eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6372}
 }
 
@@ -141,14 +140,6 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6372}
 	journal = {Geological Society, London, Special Publications}
 }
 
-@misc{BaMaWaWiWo20,
-author = {Seshadri Basava and Katrin Mang and Mirjam Walloth and Thomas Wick and Winnifried Wollner},
-title = {Adaptive and Pressure-Robust Discretization of Incompressible Pressure-Driven Phase-Field Fracture},
-howpublished = {DFG-SPP 1748 final report, book article},
-note={Accepted},
-year = {2020}
-}
-
 @Article{EndtNeiLaWiWo20,
 title = "Multigoal-oriented optimal control problems with nonlinear PDE constraints",
 journal = "Computers {\&} Mathematics with Applications",
@@ -157,8 +148,8 @@ number = "10",
 pages = "3001 - 3026",
 year = "2020",
 issn = "0898-1221",
-doi = "https://doi.org/10.1016/j.camwa.2020.01.005",
-url = "http://www.sciencedirect.com/science/article/pii/S0898122120300122",
+doi = "10.1016/j.camwa.2020.01.005",
+url = "https://arxiv.org/abs/1903.02799",
 author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
 }
 
@@ -177,7 +168,6 @@ author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
 
 @article{Farangitakis2020,
   doi = {10.1016/j.epsl.2020.116277},
-  url = {https://doi.org/10.1016/j.epsl.2020.116277},
   year = {2020},
   month = jul,
   publisher = {Elsevier {BV}},
@@ -190,7 +180,6 @@ author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
 
 @article{Cobb2020,
   doi = {10.1088/1748-9326/aba867},
-  url = {https://doi.org/10.1088%2F1748-9326%2Faba867},
   year = {2020},
   month = oct,
   publisher = {{IOP} Publishing},
@@ -211,8 +200,7 @@ author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
   pages={e2019GC008895},
   year={2020},
   publisher={Wiley Online Library},
-  doi={10.1029/2019GC008895},
-  url={https://doi.org/10.1029/2019GC008895}
+  doi={10.1029/2019GC008895}
 }
 
 @article{lesher2020iron,
@@ -224,13 +212,11 @@ author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
   pages={382--386},
   year={2020},
   publisher={Nature Publishing Group},
-  doi={10.1038/s41561-020-0560-y},
-  url={https://doi.org/10.1038/s41561-020-0560-y}
+  doi={10.1038/s41561-020-0560-y}
 }
 
 @article{SchuhSenlis2020,
   doi = {10.5194/se-11-1909-2020},
-  url = {https://doi.org/10.5194/se-11-1909-2020},
   year = {2020},
   month = oct,
   publisher = {Copernicus {GmbH}},
@@ -244,7 +230,6 @@ author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
 
 @article{Anzt2020,
   doi = {10.21105/joss.02260},
-  url = {https://doi.org/10.21105/joss.02260},
   year = {2020},
   month = aug,
   publisher = {The Open Journal},
@@ -258,7 +243,6 @@ author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
 
 @article{Benbow2020,
   doi = {10.3390/cryst10090767},
-  url = {https://doi.org/10.3390/cryst10090767},
   year = {2020},
   month = aug,
   publisher = {{MDPI} {AG}},
@@ -270,14 +254,6 @@ author = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
   journal = {Crystals}
 }
 
-@article{Fehn2020anomalous,
-  title={Numerical evidence of anomalous energy dissipation in incompressible {E}uler flows: {T}owards grid-converged results for the inviscid {T}aylor--{G}reen problem},
-  author={Fehn, Niklas and Kronbichler, Martin and Munch, Peter and Wall, Wolfgang A},
-  journal={arXiv preprint arXiv:2007.01656},
-  year={2020},
-  url={https://arxiv.org/abs/2007.01656}
-}
-
 @article{https://doi.org/10.1029/2019JB018726,
 author = {Heyn, Bj{\"o}rn H. and Conrad, Clinton P. and Tr{\o}nnes, Reidar G.},
 title = {How Thermochemical Piles Can (Periodically) Generate Plumes at Their Edges},
@@ -285,15 +261,14 @@ journal = {Journal of Geophysical Research: Solid Earth},
 volume = {125},
 number = {6},
 pages = {e2019JB018726},
-doi = {https://doi.org/10.1029/2019JB018726},
+doi = {10.1029/2019JB018726},
 url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019JB018726},
 year = {2020}
 }
 
 @article{Njinju2020,
   doi = {10.1002/essoar.10503939.1},
-  url = {https://doi.org/10.1002/essoar.10503939.1},
-	pages = {37},
+  pages = {37},
   year = {2020},
   month = aug,
   journal = {Earth and Space Science Open Archive},
@@ -310,7 +285,8 @@ year={2020},
 publisher={Springer International Publishing},
 address={Cham},
 pages={189--224},
-isbn={978-3-030-47956-5}
+isbn={978-3-030-47956-5},
+doi={10.1007/978-3-030-47956-5_8}
 }
 
 @article{HEYN2020116358,
@@ -320,7 +296,7 @@ isbn={978-3-030-47956-5}
 	pages = "116358",
 	year = "2020",
 	issn = "0012-821X",
-	doi = "https://doi.org/10.1016/j.epsl.2020.116358",
+	doi = "10.1016/j.epsl.2020.116358",
 	url = "http://www.sciencedirect.com/science/article/pii/S0012821X20303022",
 	author = "Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes"
 }
@@ -331,7 +307,7 @@ author = {Wilde, Dominik and Kr{\"{a}}mer, Andreas and Reith, Dirk and Foysi, Ho
 doi = {10.1103/PhysRevE.101.053306},
 issn = {24700053},
 journal = {Phys. Rev. E},
-month = {may},
+month = may,
 number = {5},
 pages = {1--11},
 publisher = {American Physical Society},
@@ -350,7 +326,6 @@ number = {1},
 pages = {34--54},
 publisher = {Elsevier Ltd},
 title = {{Lattice Boltzmann simulations on irregular grids: Introduction of the NATriuM library}},
-url = {https://doi.org/10.1016/j.camwa.2018.10.041},
 volume = {79},
 year = {2020}
 }
@@ -371,14 +346,12 @@ year = {2020}
   issn = {14320924},
   journal = {Computational Mechanics},
   title = {{Assessment of an isogeometric approach with Catmull-Clark subdivision surfaces using the Laplace-Beltrami problems}},
-  url = {https://doi.org/10.1007/s00466-020-01877-3},
   year = {2020}
 }
 
 
 @article{Grieshaber2020,
   doi = {10.1016/j.cma.2020.113233},
-  url = {https://doi.org/10.1016/j.cma.2020.113233},
   year = {2020},
   month = oct,
   publisher = {Elsevier {BV}},
@@ -412,14 +385,12 @@ volume = {48},
 number = {1},
 pages = {585-621},
 year = {2020},
-doi = {10.1146/annurev-earth-082517-010225},
-url = {https://doi.org/10.1146/annurev-earth-082517-010225}
+doi = {10.1146/annurev-earth-082517-010225}
 }
 
 
 @incollection{dePaula2020,
   doi = {10.1007/978-3-030-50436-6_2},
-  url = {https://doi.org/10.1007/978-3-030-50436-6_2},
   year = {2020},
   publisher = {Springer International Publishing},
   pages = {18--31},
@@ -433,12 +404,11 @@ url = {https://doi.org/10.1146/annurev-earth-082517-010225}
 doi = {10.1016/J.CMA.2020.113128},
 issn = {0045-7825},
 journal = {Computer Methods in Applied Mechanics and Engineering},
-month = {sep},
+month = sep,
 pages = {113128},
 publisher = {North-Holland},
 author = {Ester Comellas and Silvia Budday and Jean-Paul Pelteret and Gerhard A. Holzapfel and Paul Steinmann},
 title = {Modeling the porous and viscous responses of human brain tissue behavior},
-url = {https://doi.org/10.1016/J.CMA.2020.113128},
 volume = {369},
 year = {2020}
 }
@@ -452,13 +422,11 @@ number = {5},
 pages = {806-827},
 keywords = {deal.II, FSI, LES, OpenFOAM, strongly coupled},
 doi = {10.1002/nme.6245},
-url = {https://doi.org/10.1002/nme.6245},
 year = {2020}
 }
 
 @article{Lee2020,
   doi = {10.5757/asct.2020.29.3.062},
-  url = {https://doi.org/10.5757/asct.2020.29.3.062},
   year = {2020},
   month = may,
   publisher = {The Korean Vacuum Society},
@@ -489,7 +457,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{Motamarri2020,
   doi = {10.1016/j.cpc.2019.07.016},
-  url = {https://doi.org/10.1016/j.cpc.2019.07.016},
   year = {2020},
   month = jan,
   publisher = {Elsevier {BV}},
@@ -509,8 +476,7 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
   pages={Art--No},
   year={2020},
   publisher={American Geophysical Union},
-  doi={10.1029/2019JB018560},
-  url={https://doi.org/10.1029/2019JB018560}
+  doi={10.1029/2019JB018560}
 }
 
 
@@ -523,7 +489,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
   pages={1002--1028},
   year={2020},
   publisher={Oxford University Press},
-  url = {https://doi.org/10.1093/gji/ggaa039},
   doi = {10.1093/gji/ggaa039}
 }
 
@@ -537,17 +502,20 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{fischer2020scalability,
   doi = {10.1177/1094342020915762},
-  url = {https://doi.org/10.1177/1094342020915762},
-  author = {Fischer, Paul and Min, Misun and Rathnayake, Thilina and Dutta, Som and Kolev, Tzanio and Dobrev, Veselin and Camier, Jean-Sylvain and Kronbichler, Martin and Warburton, Tim and \'Swirydowicz, Kasia and Brown, Jed},
-  title = {Scalability of High-Performance {PDE} Solvers},
-  journal = {The International Journal on High Performance Computing Applications},
   year = {2020},
-  volume = {in press}
+  month = jun,
+  publisher = {{SAGE} Publications},
+  volume = {34},
+  number = {5},
+  pages = {562--586},
+  author = {Paul Fischer and Misun Min and Thilina Rathnayake and Som Dutta and Tzanio Kolev and Veselin Dobrev and Jean-Sylvain Camier and Martin Kronbichler and Tim Warburton and Kasia {\'{S}}wirydowicz and Jed Brown},
+  title = {Scalability of high-performance {PDE} solvers},
+  journal = {The International Journal of High Performance Computing Applications}
 }
 
 @article{Zhao2020,
   doi = {10.1016/j.cma.2019.112742},
-  url = {https://doi.org/10.1016/j.cma.2019.112742},
+  url = {https://arxiv.org/abs/1905.00671},
   year = {2020},
   month = apr,
   publisher = {Elsevier {BV}},
@@ -560,7 +528,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{Davydov2020matrixfree,
   doi = {10.1002/nme.6336},
-  url = {https://doi.org/10.1002/nme.6336},
   year = {2020},
   month = jul,
   publisher = {Wiley},
@@ -575,7 +542,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{Schoeder2020cut,
   doi = {10.1002/nme.6343},
-  url = {https://doi.org/10.1002/nme.6343},
   year = {2020},
   month = jul,
   publisher = {Wiley},
@@ -590,7 +556,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{DeWitt2020,
   doi = {10.1038/s41524-020-0298-5},
-  url = {https://doi.org/10.1038/s41524-020-0298-5},
   year = {2020},
   month = mar,
   publisher = {Springer Science and Business Media {LLC}},
@@ -607,7 +572,7 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
                   Mechanical Compaction with the Level Set Method},
   school       = {Rheinische Friedrich-Wilhelms-Universit{\"a}t Bonn},
   year         = {2020},
-  url          = {https://bonndoc.ulb.uni-bonn.de/xmlui/handle/20.500.11811/8443}
+  url          = {https://hdl.handle.net/20.500.11811/8443}
 }
 
 @phdthesis{fehling2020,
@@ -631,13 +596,13 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
   author       = {Zhuoran Wang},
   title        = {Two-field finite element solvers for poroelasticity},
   school       = {Colorado State University},
-  year         = {2020}
+  year         = {2020},
+  url          = {https://hdl.handle.net/10217/211801}
 }
 
 
 @article{davydov2020algorithms,
   doi={10.1145/3399736},
-  url={https://doi.org/10.1145/3399736},
   title={Algorithms and data structures for matrix-free finite element operators with MPI-parallel sparse multi-vectors},
   author={Davydov, Denis and Kronbichler, Martin},
   journal={ACM Transactions on Parallel Computing},
@@ -645,13 +610,12 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
   number={3},
   pages={20:1--20:30},
   year={2020},
-  month={jun}
+  month=jun
 }
 
 
 @article{fehn2020hybrid,
   doi = {10.1016/j.jcp.2020.109538},
-  url = {https://doi.org/10.1016/j.jcp.2020.109538},
   year = {2020},
   month = aug,
   publisher = {Elsevier {BV}},
@@ -664,7 +628,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{Kim2020,
   doi = {10.1016/j.cam.2019.112458},
-  url = {https://doi.org/10.1016/j.cam.2019.112458},
   year = {2020},
   month = mar,
   publisher = {Elsevier {BV}},
@@ -683,7 +646,7 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
   volume = {418},
   pages={109636},
   year={2020},
-  doi ={https://doi.org/10.1016/j.jcp.2020.109636},
+  doi ={10.1016/j.jcp.2020.109636},
   url = {http://www.sciencedirect.com/science/article/pii/S0021999120304101},
   publisher={Elsevier}
  }
@@ -694,7 +657,7 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
   title={Finite-element simulations of interfacial flows with moving contact lines},
   author={Zhang, Jiaqi},
   year={2020},
-  month = {June},
+  month = jun,
   url = {http://hdl.handle.net/10919/99058},
   school={Virginia Tech}
  }
@@ -719,7 +682,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{BrunaRosso2020,
   doi = {10.1177/0954406220943225},
-  url = {https://doi.org/10.1177/0954406220943225},
   year = {2020},
   month = aug,
   publisher = {{SAGE} Publications},
@@ -731,7 +693,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{Nayak2020,
   doi = {10.1177/1094342020946814},
-  url = {https://doi.org/10.1177/1094342020946814},
   year = {2020},
   month = aug,
   publisher = {{SAGE} Publications},
@@ -743,7 +704,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 
 @article{Blais2020,
   doi = {10.1016/j.softx.2020.100579},
-  url = {https://doi.org/10.1016/j.softx.2020.100579},
   year = {2020},
   month = jul,
   publisher = {Elsevier {BV}},
@@ -755,16 +715,20 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
 }
 
 @article{wang_tamr_20,
- journal = {Computer Graphics Forum},
- title = {{CPU Ray Tracing of Tree-Based Adaptive Mesh Refinement Data}},
- author = {Wang, Feng and Marshak, Nathan and Usher, Will and Burstedde, Carsten and Knoll, Aaron and Heister, Timo and Johson, Chris R.},
- DOI = {10.1111/cgf.13958},
+ doi = {10.1111/cgf.13958},
  year = {2020},
+ month = jun,
+ publisher = {Wiley},
+ volume = {39},
+ number = {3},
+ pages = {1--12},
+ author = {Feng Wang and Nathan Marshak and Will Usher and Carsten Burstedde and Aaron Knoll and Timo Heister and Chris R. Johnson},
+ title = {{CPU} Ray Tracing of Tree-Based Adaptive Mesh Refinement Data},
+ journal = {Computer Graphics Forum}
 }
 
 @article{Gassmoeller2020,
   doi = {10.1093/gji/ggaa078},
-  url = {https://doi.org/10.1093/gji/ggaa078},
   year = {2020},
   month = feb,
   publisher = {Oxford University Press ({OUP})},
@@ -774,19 +738,6 @@ url="https://www.mdpi.com/2075-163X/10/11/985"
   author = {Rene Gassm\"{o}ller and Juliane Dannberg and Wolfgang Bangerth and Timo Heister and Robert Myhill},
   title = {On formulations of compressible mantle convection},
   journal = {Geophysical Journal International}
-}
-
-
-@Article{clevenger_par_gmg,
-  Title                    = {{A Flexible, Parallel, Adaptive Geometric Multigrid Method for FEM}},
-  Author                   = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
-  Journal                  = {ACM Trans. Math. Softw.},
-  Year                     = {2020},
-  Month                    = {Dec},
-  Number                   = {1},
-  Volume                   = {47},
-  doi                      = {10.1145/3425193},
-  Url                      = {https://arxiv.org/abs/1904.03317}
 }
 
 @Inbook{Hoggard_etal2021,
@@ -809,8 +760,7 @@ doi="10.1002/9781119528609.ch15"
   Author                   = {Schr\"{o}der, J\"{o}rg and Wick, Thomas and Reese, Stefanie and Wriggers, Peter and M\"{u}ller, Ralf and Kollmannsberger, Stefan and K\"{a}stner, Markus and Schwarz, Alexander and Igelb\"{u}scher, Maximilian and Viebahn, Nils and Bayat, Hamid Reza and Wulfinghoff, Stephan and Mang, Katrin and Rank, Ernst and Bog, Tino and D'Angella, Davide and Elhaddad, Mohamed and Hennig, Paul and D\"{u}ster, Alexander and Garhuom, Wadhah and Hubrich, Simeon and Walloth, Mirjam and Wollner, Winnifried and Kuhn, Charlotte and Heister, Timo},
   Journal                  = {Archives of Computational Methods in Engineering},
   Year                     = {2020},
-  Doi                      = {10.1007/s11831-020-09477-3},
-  Url                      = {https://doi.org/10.1007/s11831-020-09477-3}
+  Doi                      = {10.1007/s11831-020-09477-3}
 }
 
 
@@ -829,7 +779,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{Cangiani2020,
   doi = {10.1007/s10915-020-01130-2},
-  url = {https://doi.org/10.1007/s10915-020-01130-2},
   year = {2020},
   month = jan,
   publisher = {Springer Science and Business Media {LLC}},
@@ -848,13 +797,11 @@ doi="10.1002/9781119528609.ch15"
   volume={1},
   year={2020},
   publisher={De Gruyter},
-  doi = {10.1515/cmam-2020-0159},
-  url = {https://doi.org/10.1515/cmam-2020-0159}
+  doi = {10.1515/cmam-2020-0159}
 }
 
 @article{Wakeling2020,
   doi = {10.3389/fphys.2020.00813},
-  url = {https://doi.org/10.3389/fphys.2020.00813},
   year = {2020},
   month = aug,
   publisher = {Frontiers Media {SA}},
@@ -866,7 +813,6 @@ doi="10.1002/9781119528609.ch15"
 
 @article{Ryan2020,
   doi = {10.3389/fphys.2020.538522},
-  url = {https://doi.org/10.3389/fphys.2020.538522},
   year = {2020},
   month = nov,
   publisher = {Frontiers Media {SA}},
@@ -884,7 +830,7 @@ doi="10.1002/9781119528609.ch15"
   pages = {109220},
   year = {2020},
   issn = {0021-9991},
-  doi = {https://doi.org/10.1016/j.jcp.2019.109220},
+  doi = {10.1016/j.jcp.2019.109220},
   url = {http://www.sciencedirect.com/science/article/pii/S0021999119309258}
 }
 
@@ -907,7 +853,6 @@ doi="10.1002/9781119528609.ch15"
 	title = {High-order cut finite elements for the elastic wave equation},
 	volume = {46},
 	issn = {1572-9044},
-	url = {https://doi.org/10.1007/s10444-020-09785-z},
 	doi = {10.1007/s10444-020-09785-z},
 	language = {en},
 	number = {3},
@@ -918,10 +863,8 @@ doi="10.1002/9781119528609.ch15"
 	pages = {45}
 }
 
-
 @article{BorregalesRevern2020,
   doi = {10.1007/s10596-020-09983-0},
-  url = {https://doi.org/10.1007/s10596-020-09983-0},
   year = {2020},
   month = jul,
   publisher = {Springer Science and Business Media {LLC}},
@@ -933,10 +876,9 @@ doi="10.1002/9781119528609.ch15"
   journal = {Computational Geosciences}
 }
 
-
 @article{McBride2020,
   doi = {10.1016/j.cma.2020.113320},
-  url = {https://doi.org/10.1016/j.cma.2020.113320},
+  url = {https://arxiv.org/abs/1909.08695},
   year = {2020},
   month = nov,
   publisher = {Elsevier {BV}},
@@ -956,13 +898,11 @@ doi="10.1002/9781119528609.ch15"
   pages={e3377},
   year={2020},
   publisher={Wiley Online Library},
-  doi = {10.1002/cnm.3377}, 
-  url = {https://doi.org/10.1002/cnm.3377}
+  doi = {10.1002/cnm.3377}
 }
 
 @article{Choi2020,
   doi = {10.1016/j.apnum.2019.09.010},
-  url = {https://doi.org/10.1016/j.apnum.2019.09.010},
   year = {2020},
   month = apr,
   publisher = {Elsevier {BV}},
@@ -998,7 +938,7 @@ doi="10.1002/9781119528609.ch15"
   author = {D. Khimin},
   title  = {Numerische Modellierung von Optimalsteuerungsproblemen f{\"u}r Phasenfeld-Riss-Ausbreitung},
   school = {Leibniz University Hannover},
-  month  = {Jun},
+  month  = jun,
   year   = {2020}
 }
 
@@ -1009,7 +949,6 @@ doi="10.1002/9781119528609.ch15"
   title = {Multiscale modeling of fiber reinforced materials via non-matching immersed methods},
   volume = {239},
   year = {2020},
-  url = {https://doi.org/10.1016/j.compstruc.2020.106334},
   doi = {10.1016/j.compstruc.2020.106334}
 }
 
@@ -1021,8 +960,109 @@ doi="10.1002/9781119528609.ch15"
   title = {A priori error estimates of regularized elliptic problems},
   volume = {146},
   year = {2020},
-  url = {https://doi.org/10.1007/s00211-020-01152-w},
   doi = {10.1007/s00211-020-01152-w}
+}
+
+@article{Witte2020,
+  doi = {10.1515/cmam-2020-0078},
+  url = {https://arxiv.org/abs/1910.11239},
+  year = {2020},
+  month = nov,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume = {0},
+  number = {0},
+  author = {Julius Witte and Daniel Arndt and Guido Kanschat},
+  title = {Fast Tensor Product Schwarz Smoothers for High-Order Discontinuous Galerkin Methods},
+  journal = {Computational Methods in Applied Mathematics}
+}
+
+@article{KirkestherBrun2020,
+  doi = {10.1016/j.cma.2019.112752},
+  url = {https://arxiv.org/abs/1903.08717},
+  year = {2020},
+  month = apr,
+  publisher = {Elsevier {BV}},
+  volume = {361},
+  pages = {112752},
+  author = {Mats Kirkes{\ae}ther Brun and Thomas Wick and Inga Berre and Jan Martin Nordbotten and Florin Adrian Radu},
+  title = {An iterative staggered scheme for phase field brittle fracture propagation with stabilizing parameters},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@article{Endtmayer2020,
+  doi = {10.1137/18m1227275},
+  url = {https://arxiv.org/abs/1811.07586},
+  year = {2020},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume = {42},
+  number = {1},
+  pages = {A371--A394},
+  author = {B. Endtmayer and U. Langer and T. Wick},
+  title = {Two-Side a Posteriori Error Estimates for the Dual-Weighted Residual Method},
+  journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@incollection{Endtmayer2020b,
+  doi = {10.1007/978-3-030-55874-1_35},
+  url = {https://arxiv.org/abs/1912.04819},
+  year = {2020},
+  month = aug,
+  publisher = {Springer International Publishing},
+  pages = {363--372},
+  author = {B. Endtmayer and U. Langer and J. P. Thiele and T. Wick},
+  title = {Hierarchical {DWR} Error Estimates for the Navier-Stokes Equations: h and p Enrichment},
+  booktitle = {Lecture Notes in Computational Science and Engineering}
+}
+
+@article{Murphy2020,
+  doi = {10.1016/j.apnum.2020.08.004},
+  url = {https://arxiv.org/abs/1903.09535},
+  year = {2020},
+  month = dec,
+  publisher = {Elsevier {BV}},
+  volume = {158},
+  pages = {336--359},
+  author = {Laura Murphy and Anotida Madzvamuse},
+  title = {A moving grid finite element method applied to a mechanobiochemical model for 3D cell migration},
+  journal = {Applied Numerical Mathematics}
+}
+
+@article{Welper2020,
+  doi = {10.1137/19m126356x},
+  url = {https://arxiv.org/abs/1901.01322},
+  year = {2020},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume = {42},
+  number = {4},
+  pages = {A2037--A2061},
+  author = {G. Welper},
+  title = {Transformed Snapshot Interpolation with High Resolution Transforms},
+  journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@article{Badia2020,
+  doi = {10.1137/20m1328786},
+  url = {https://arxiv.org/abs/1907.03709},
+  year = {2020},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume = {42},
+  number = {6},
+  pages = {C436--C468},
+  author = {Santiago Badia and Alberto F. Mart{\'{\i}}n and Eric Neiva and Francesc Verdugo},
+  title = {A Generic Finite Element Framework on Parallel Tree-Based Adaptive Meshes},
+  journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@incollection{Engwer2020,
+  doi = {10.1007/978-3-030-55874-1_117},
+  url = {https://arxiv.org/abs/1912.07096},
+  year = {2020},
+  month = aug,
+  publisher = {Springer International Publishing},
+  pages = {1177--1184},
+  author = {Christian Engwer and Iuliu Sorin Pop and Thomas Wick},
+  title = {Dynamic and Weighted Stabilizations of the L-scheme Applied to a Phase-Field Model for Fracture Propagation},
+  booktitle = {Lecture Notes in Computational Science and Engineering}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -379,8 +379,7 @@ author = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pier
   Pages                    = {407-422},
   Volume                   = {81},
   Doi                      = {10.1016/j.camwa.2020.02.022},
-  ISSN                     = {0898-1221},
-  Url                      = {https://arxiv.org/abs/1910.13247}
+  ISSN                     = {0898-1221}
 }
 
 @article{samrock2021integrated,
@@ -446,8 +445,7 @@ doi = {10.1029/2020JA028672}
   pages = {110024},
   year = {2021},
   issn = {0021-9991},
-  doi = {10.1016/j.jcp.2020.110024},
-  url = {https://arxiv.org/abs/1904.08812}
+  doi = {10.1016/j.jcp.2020.110024}
 }
 
 @article{Herrnbck2021,
@@ -590,13 +588,11 @@ doi = {10.1029/2020JA028672}
   Year                     = {2021},
   Month                    = mar,
   Doi                      = {10.1002/nla.2375},
-  Publisher                = {Wiley},
-  Url                      = {https://arxiv.org/abs/1907.06696}
+  Publisher                = {Wiley}
 }
 
 @Article{clevenger_par_gmg,
   doi = {10.1145/3425193},
-  url = {https://arxiv.org/abs/1904.03317},
   year = {2021},
   month = mar,
   publisher = {Association for Computing Machinery ({ACM})},
@@ -654,7 +650,6 @@ series = {SC '21}
 
 @article{fehn2021anomalous,
   doi = {10.1017/jfm.2021.1003},
-  url = {https://arxiv.org/abs/2007.01656},
   year = {2021},
   month = dec,
   publisher = {Cambridge University Press ({CUP})},
@@ -909,8 +904,7 @@ doi={10.1007/978-3-030-87312-7_24}
   title = {Propagating geometry information to finite element computations},
   volume = {47},
   year = {2021},
-  url = {https://arxiv.org/abs/1910.09824},
-  doi = {10.1145/3468428},
+  doi = {10.1145/3468428}
 }
 
 @article{heltai2021vascualar,
@@ -986,7 +980,6 @@ doi={10.1007/978-3-030-87312-7_24}
 
 @article{Bonito2021,
   doi = {10.1142/s0218202521500044},
-  url = {https://arxiv.org/abs/1912.03812},
   year = {2021},
   publisher = {World Scientific Pub Co Pte Lt},
   volume = {31},
@@ -999,7 +992,6 @@ doi={10.1007/978-3-030-87312-7_24}
 
 @incollection{Klein2021,
   doi = {10.1007/978-3-030-57784-1_6},
-  url = {https://arxiv.org/abs/1911.04855},
   year = {2021},
   publisher = {Springer International Publishing},
   pages = {165--190},
@@ -1010,7 +1002,6 @@ doi={10.1007/978-3-030-87312-7_24}
 
 @article{Liu2021,
   doi = {10.1016/j.cam.2020.113219},
-  url = {https://arxiv.org/abs/1912.08004},
   year = {2021},
   month = apr,
   publisher = {Elsevier {BV}},
@@ -1023,7 +1014,6 @@ doi={10.1007/978-3-030-87312-7_24}
 
 @article{Anselmann2021,
   doi = {10.1016/j.matcom.2020.10.027},
-  url = {https://arxiv.org/abs/1912.07426},
   year = {2021},
   month = nov,
   publisher = {Elsevier {BV}},

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -26,7 +26,7 @@
   number={1},
   pages={79},
   year={2021},
-  doi={https://doi.org/10.3390/pr10010079},
+  doi={10.3390/pr10010079},
   publisher={MDPI}
 }
 
@@ -58,7 +58,6 @@ journal = {Frontiers in Mechanical Engineering},
 number = {708350},
 pages = {1--18},
 title = {Poro-Viscoelastic Effects During Biomechanical Testing of Human Brain Tissue},
-url = {https://doi.org/10.3389/fmech.2021.708350},
 volume = {7},
 year = {2021}
 }
@@ -90,8 +89,7 @@ and Strecker, M. R.",
 title="The influence of variations in crustal composition and lithospheric strength on the evolution of deformation processes in the southern Central Andes: insights from geodynamic models",
 journal="International Journal of Earth Sciences",
 year="2021",
-doi="10.1007/s00531-021-01982-5",
-url="https://doi.org/10.1007/s00531-021-01982-5"
+doi="10.1007/s00531-021-01982-5"
 }
 
 @article{10.1093/gji/ggab051,
@@ -102,9 +100,8 @@ url="https://doi.org/10.1007/s00531-021-01982-5"
     number = {3},
     pages = {1624-1636},
     year = {2021},
-    month = {03},
-    doi = {10.1093/gji/ggab051},
-    url = {https://doi.org/10.1093/gji/ggab051}
+    month = mar,
+    doi = {10.1093/gji/ggab051}
 }
 
 @article{10.1029/2020GC009577,
@@ -114,7 +111,7 @@ journal = {Geochemistry, Geophysics, Geosystems},
 volume = {22},
 number = {3},
 pages = {e2020GC009577},
-doi = {https://doi.org/10.1029/2020GC009577},
+doi = {10.1029/2020GC009577},
 url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020GC009577},
 year = {2021}
 }
@@ -126,7 +123,7 @@ journal = {Geochemistry, Geophysics, Geosystems},
 volume = {21},
 number = {4},
 pages = {e2019GC008809},
-doi = {https://doi.org/10.1029/2019GC008809},
+doi = {10.1029/2019GC008809},
 url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
 eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
 note = {e2019GC008809 10.1029/2019GC008809},
@@ -135,7 +132,6 @@ year = {2020}
 
 @article{Camargo2021,
   doi = {10.1007/s10596-020-09964-3},
-  url = {https://doi.org/10.1007/s10596-020-09964-3},
   year = {2021},
   month = apr,
   publisher = {Springer Science and Business Media {LLC}},
@@ -153,8 +149,7 @@ year = {2020}
   journal   = {GAMM-Mitteilungen},
   year      = {2021},
   pages     = {e202100014},
-  doi       = {https://doi.org/10.1002/gamm.202100014},
-  url       = {https://onlinelibrary.wiley.com/doi/abs/10.1002/gamm.202100014}
+  doi       = {10.1002/gamm.202100014}
 }
 
 @MastersThesis{Roth2021,
@@ -162,13 +157,12 @@ year = {2020}
   title     = {Proper Orthogonal Decomposition for Fluid Mechanics Problems},
   school    = {Leibniz Universit{\"a}t Hannover},
   year      = {2021},
-  month     = {aug},
+  month     = aug,
   url       = {https://julianroth.org/res/Master_Thesis_Julian_Roth.pdf},
 }
 
 @Article{Fan2021,
 doi = {10.1007/s00366-021-01423-6},
-url = {https://doi.org/10.1007/s00366-021-01423-6},
 author = {M. Fan and Y. Jin and T. Wick},
 title  = {A quasi-monolithic phase-field description for mixed-mode fracture using predictor-corrector mesh adaptivity},
 journal= {Engineering with Computers (EWCO)},
@@ -178,7 +172,6 @@ year   = {2021}
 
 @article{Wick2021,
   doi = {10.1515/cmam-2020-0038},
-  url = {https://doi.org/10.1515/cmam-2020-0038},
   year = {2021},
   month = jun,
   publisher = {Walter de Gruyter {GmbH}},
@@ -197,7 +190,7 @@ volume = {8},
 pages = {100070},
 year = {2021},
 issn = {2665-9638},
-doi = {https://doi.org/10.1016/j.simpa.2021.100070},
+doi = {10.1016/j.simpa.2021.100070},
 url = {https://www.sciencedirect.com/science/article/pii/S266596382100018X},
 author = {Stefan Frei and Thomas Richter and Thomas Wick},
 keywords = {Locally modified finite elements, Fitted finite elements, Interface problems, Deal.II}
@@ -205,8 +198,7 @@ keywords = {Locally modified finite elements, Fitted finite elements, Interface 
 
 @Article{EndtLaWi21_smart,
 author = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
-doi = {doi:10.1515/cmam-2020-0036},
-url = {https://doi.org/10.1515/cmam-2020-0036},
+doi = {10.1515/cmam-2020-0036},
 title = {Reliability and Efficiency of DWR-Type A Posteriori Error Estimates with Smart Sensitivity Weight Recovering},
 journal = {Computational Methods in Applied Mathematics},
 volume = {21},
@@ -222,7 +214,7 @@ pages = {176-191},
 year = {2021},
 note = {Robust and Reliable Finite Element Methods in Poromechanics},
 issn = {0898-1221},
-doi = {https://doi.org/10.1016/j.camwa.2020.11.009},
+doi = {10.1016/j.camwa.2020.11.009},
 url = {https://www.sciencedirect.com/science/article/pii/S089812212030434X},
 author = {Mohamad Jammoul and Mary F. Wheeler and Thomas Wick},
 keywords = {Phase-field fracture, Porous media, Multirate, Iterative coupling, Benchmarks},
@@ -239,7 +231,6 @@ url       = {https://www.scipedia.com/public/Mang_Wick_2021a}
 
 @article{Mang2021,
   doi = {10.1016/j.tafmec.2021.103076},
-  url = {https://doi.org/10.1016/j.tafmec.2021.103076},
   year = {2021},
   month = aug,
   publisher = {Elsevier {BV}},
@@ -264,7 +255,7 @@ journal = {PAMM},
 volume = {20},
 number = {1},
 pages = {e202000335},
-doi = {https://doi.org/10.1002/pamm.202000335},
+doi = {10.1002/pamm.202000335},
 url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202000335},
 eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202000335},
 year = {2021}
@@ -277,18 +268,7 @@ year = {2021}
   year      = {2021},
   volume    = {67},
   pages     = {265-287},
-  doi       = {10.1007/s00466-020-01931-0},
-  url       = {https://doi.org/10.1007/s00466-020-01931-0},
-}
-
-article{10.1002/essoar.10506103.1,
-author = {Sandiford, Dan and Brune, Sascha and Glerum, Anne and Naliboff, John and Whittaker, Joanne M},
-title = {Kinematics of footwall exhumation at oceanic detachment faults: solid-block rotation and apparent unbending},
-journal = {Earth and Space Science Open Archive},
-pages = {25},
-year = {2021},
-DOI = {10.1002/essoar.10506103.1},
-url = {https://doi.org/10.1002/essoar.10506103.1}
+  doi       = {10.1007/s00466-020-01931-0}
 }
 
 @article{FACCENNA2021116905,
@@ -298,7 +278,7 @@ volume = {564},
 pages = {116905},
 year = {2021},
 issn = {0012-821X},
-doi = {https://doi.org/10.1016/j.epsl.2021.116905},
+doi = {10.1016/j.epsl.2021.116905},
 url = {https://www.sciencedirect.com/science/article/pii/S0012821X21001643},
 author = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pierre Brun}
 }
@@ -368,7 +348,6 @@ author = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pier
 
 @article{Neuharth2021,
   doi = {10.1029/2020gc009615},
-  url = {https://doi.org/10.1029/2020gc009615},
   year = {2021},
   month = apr,
   publisher = {American Geophysical Union ({AGU})},
@@ -388,8 +367,7 @@ author = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pier
   number = {1},
   pages = {4653},
   issn = {2041-1723},
-  doi = {10.1038/s41467-021-24945-5},
-  url = {https://doi.org/10.1038/s41467-021-24945-5}
+  doi = {10.1038/s41467-021-24945-5}
 }
 
 
@@ -422,12 +400,11 @@ journal = {Journal of Geophysical Research: Space Physics},
 volume = {129},
 year = {2021},
 pages = {e2020JA028672},
-doi = {https://doi.org/10.1029/2020JA028672},
+doi = {10.1029/2020JA028672}
 }
 
 @article{Ross2021,
   doi = {10.3389/fphys.2021.628819},
-  url = {https://doi.org/10.3389/fphys.2021.628819},
   year = {2021},
   month = apr,
   publisher = {Frontiers Media {SA}},
@@ -447,8 +424,7 @@ doi = {https://doi.org/10.1029/2020JA028672},
   series    = {Lecture Notes in Computational Science and Engineering},
   publisher = {Springer, Cham},
   pages     = {245--253},
-  doi       = {10.1007/978-3-030-55874-1_23},
-  url       = {https://doi.org/10.1007/978-3-030-55874-1_23},
+  doi       = {10.1007/978-3-030-55874-1_23}
 }
 
 @Article{Araujo2021a,
@@ -456,7 +432,7 @@ doi = {https://doi.org/10.1029/2020JA028672},
   title = {Shape optimization for the strong directional scattering of dielectric nanorods},
   journal = {International Journal for Numerical Methods in Engineering},
   volume = {in press},
-  doi = {https://doi.org/10.1002/nme.6677},
+  doi = {10.1002/nme.6677},
   year = {2021},
   url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.6677},
   eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6677}
@@ -470,13 +446,12 @@ doi = {https://doi.org/10.1029/2020JA028672},
   pages = {110024},
   year = {2021},
   issn = {0021-9991},
-  doi = {https://doi.org/10.1016/j.jcp.2020.110024},
-  url = {https://www.sciencedirect.com/science/article/pii/S0021999120307981}
+  doi = {10.1016/j.jcp.2020.110024},
+  url = {https://arxiv.org/abs/1904.08812}
 }
 
 @article{Herrnbck2021,
   doi = {10.1007/s00466-020-01957-4},
-  url = {https://doi.org/10.1007/s00466-020-01957-4},
   year = {2021},
   month = feb,
   publisher = {Springer Science and Business Media {LLC}},
@@ -496,8 +471,7 @@ doi = {https://doi.org/10.1029/2020JA028672},
   volume    = {9},
   number    = {6},
   pages     = {2000835},
-  doi       = {10.1002/ente.202000835},
-  url       = {https://doi.org/10.1002/ente.202000835},
+  doi       = {10.1002/ente.202000835}
 }
 
 @article{veszelka2021impact,
@@ -508,8 +482,7 @@ doi = {https://doi.org/10.1029/2020JA028672},
   volume    = {9},
   number    = {6},
   pages     = {2000906},
-  doi       = {10.1002/ente.202000906},
-  url       = {https://doi.org/10.1002/ente.202000906},
+  doi       = {10.1002/ente.202000906}
 }
 
 @MastersThesis{Rocha2021,
@@ -517,13 +490,12 @@ doi = {https://doi.org/10.1029/2020JA028672},
   title     = {Bifurcating solutions of anisotropic disk problem in a constrained minimization theory of elasticity},
   school    = {University of S{\~{a}}o Paulo},
   year      = {2021},
-  month     = {mar},
+  month     = mar,
   url       = {http://web.set.eesc.usp.br/static/media/producao/2021ME_LucasAlmeidaRocha.pdf},
 }
 
 @article{He2021,
   doi = {10.1093/mnras/stab2080},
-  url = {https://doi.org/10.1093/mnras/stab2080},
   year = {2021},
   month = jul,
   publisher = {Oxford University Press ({OUP})},
@@ -559,7 +531,6 @@ doi = {https://doi.org/10.1029/2020JA028672},
 
 @article{Wilde2021,
   doi = {10.1103/physreve.104.025301},
-  url = {https://doi.org/10.1103/physreve.104.025301},
   year = {2021},
   month = aug,
   publisher = {American Physical Society ({APS})},
@@ -580,7 +551,6 @@ doi = {https://doi.org/10.1029/2020JA028672},
     volume = {47},
     number = {4},
     issn = {0098-3500},
-    url = {https://doi.org/10.1145/3469720},
     doi = {10.1145/3469720},
     journal = {ACM Trans. Math. Softw.},
     month = sep,
@@ -590,7 +560,6 @@ doi = {https://doi.org/10.1029/2020JA028672},
 
 @article{Magni2021,
   doi = {10.3390/geosciences11110475},
-  url = {https://doi.org/10.3390/geosciences11110475},
   year = {2021},
   month = nov,
   publisher = {{MDPI} {AG}},
@@ -604,7 +573,6 @@ doi = {https://doi.org/10.1029/2020JA028672},
 
 @article{Fraters2021,
   doi = {10.1029/2021gc009846},
-  url = {https://doi.org/10.1029/2021gc009846},
   year = {2021},
   month = oct,
   publisher = {American Geophysical Union ({AGU})},
@@ -615,7 +583,7 @@ doi = {https://doi.org/10.1029/2020JA028672},
   journal = {Geochemistry,  Geophysics,  Geosystems}
 }
 
-@Article{clevenger_stokes19,
+@Article{clevenger_stokes21,
   Title                    = {Comparison Between Algebraic and Matrix-free Geometric Multigrid for a {S}tokes Problem on an Adaptive Mesh with Variable Viscosity},
   Author                   = {Thomas C. Clevenger and Timo Heister},
   Journal                  = {Numerical Linear Algebra with Applications},
@@ -626,9 +594,23 @@ doi = {https://doi.org/10.1029/2020JA028672},
   Url                      = {https://arxiv.org/abs/1907.06696}
 }
 
+@Article{clevenger_par_gmg,
+  doi = {10.1145/3425193},
+  url = {https://arxiv.org/abs/1904.03317},
+  year = {2021},
+  month = mar,
+  publisher = {Association for Computing Machinery ({ACM})},
+  volume = {47},
+  number = {1},
+  pages = {1--27},
+  author = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
+  title = {A Flexible, Parallel, Adaptive Geometric Multigrid Method for {FEM}},
+  journal = {{ACM} Transactions on Mathematical Software}
+}
+
 @article{pagani2021computational,
   title={A computational study of the electrophysiological substrate in patients suffering from atrial fibrillation},
-  author={Pagani, S. and Dede, L. and Frontera, A. and Salvador, M. and Limite, L.R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. Quarteroni, A.},
+  author={Pagani, S. and Ded{\`{e}}, L. and Frontera, A. and Salvador, M. and Limite, L.R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. Quarteroni, A.},
   journal={Frontiers in Physiology},
   volume={12},
   year={2021},
@@ -654,7 +636,6 @@ year = {2021},
 isbn = {9781450384421},
 publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
-url = {https://doi.org/10.1145/3458817.3476171},
 doi = {10.1145/3458817.3476171},
 booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis},
 articleno = {21},
@@ -671,13 +652,24 @@ series = {SC '21}
   url={https://mediatum.ub.tum.de/1601025}
 }
 
+@article{fehn2021anomalous,
+  doi = {10.1017/jfm.2021.1003},
+  url = {https://arxiv.org/abs/2007.01656},
+  year = {2021},
+  month = dec,
+  publisher = {Cambridge University Press ({CUP})},
+  volume = {932},
+  author = {Niklas Fehn and Martin Kronbichler and Peter Munch and Wolfgang A. Wall},
+  title = {Numerical evidence of anomalous energy dissipation in incompressible Euler flows: towards grid-converged results for the inviscid Taylor{\textendash}Green problem},
+  journal = {Journal of Fluid Mechanics}
+}
+
 @PhdThesis{castelli2021numerical,
   author    = {Castelli, G. F.},
   title     = {Numerical Investigation of {Cahn--Hilliard}-Type Phase-Field Models for Battery Active Particles},
   school    = {Karlsruhe Institute of Technology (KIT)},
   year      = {2021},
-  month     = {},
-  url       = {https://doi.org/10.5445/IR/1000141249},
+  doi       = {10.5445/IR/1000141249}
 }
 
 @article{castelli2021parallel,
@@ -688,8 +680,7 @@ series = {SC '21}
   volume    = {21},
   number    = {1},
   pages     = {e202100169},
-  doi       = {10.1002/pamm.202100169},
-  url       = {https://doi.org/10.1002/pamm.202100169},
+  doi       = {10.1002/pamm.202100169}
 }
 
 @Article{HeisterMangWickSchur2021,
@@ -701,8 +692,7 @@ series = {SC '21}
   number    = {1},
   month     = dec,
   doi       = {10.1002/pamm.202100065},
-  publisher = {Wiley},
-  url       = {https://doi.org/10.1002/pamm.202100065},
+  publisher = {Wiley}
 }
 
 @article{maier21a,
@@ -801,8 +791,7 @@ address={Cham},
 pages={247--255},
 abstract={In this work, we present an algorithmic realization for computing optimal control problems with quasi-static phase-field fracture as a PDE constraint. The phase-field fracture problem is formulated in a quasi-monolithic approach resulting in a nonlinear forward problem. The optimization problem is formulated within a reduced approach, where the state variable is eliminated. To this end, a globalized reduced Newton algorithm is employed. Our algorithmic developments are substantiated with a numerical example.},
 isbn={978-3-030-87312-7},
-doi={10.1007/978-3-030-87312-7_24},
-url={https://doi.org/10.1007/978-3-030-87312-7_24}
+doi={10.1007/978-3-030-87312-7_24}
 }
 
 @article{https://doi.org/10.1002/pamm.202100151,
@@ -909,7 +898,6 @@ url={https://doi.org/10.1007/978-3-030-87312-7_24}
   title = {Smoothed-adaptive perturbed inverse iteration for elliptic eigenvalue problems},
   volume = {21},
   year = {2021},
-  url = {https://doi.org/10.1515/cmam-2020-0027},
   doi = {10.1515/cmam-2020-0027}
 }
 
@@ -921,7 +909,7 @@ url={https://doi.org/10.1007/978-3-030-87312-7_24}
   title = {Propagating geometry information to finite element computations},
   volume = {47},
   year = {2021},
-  url = {https://dx.doi.org/10.1145/3468428},
+  url = {https://arxiv.org/abs/1910.09824},
   doi = {10.1145/3468428},
 }
 
@@ -932,13 +920,11 @@ url={https://doi.org/10.1007/978-3-030-87312-7_24}
   year = {2021},
   volume = {49},
   pages = {3243-3254},
-  url = {https://doi.org/10.1007/s10439-021-02804-0},
   doi = {10.1007/s10439-021-02804-0}
 }
 
 @article{englUluocak2021,
   doi = {10.1029/2021tc007031},
-  url = {https://doi.org/10.1029/2021tc007031},
   year = {2021},
   month = dec,
   publisher = {American Geophysical Union ({AGU})},
@@ -954,10 +940,9 @@ url={https://doi.org/10.1007/978-3-030-87312-7_24}
     title = "{Contributions from lithospheric and upper-mantle heterogeneities to upper crustal seismicity in the {K}orean {P}eninsula}",
     journal = {Geophysical Journal International},
     year = {2021},
-    month = 12,
+    month = dec,
     issn = {0956-540X},
     doi = {10.1093/gji/ggab527},
-    url = {https://doi.org/10.1093/gji/ggab527},
     note = {ggab527},
     eprint = {https://academic.oup.com/gji/advance-article-pdf/doi/10.1093/gji/ggab527/41971016/ggab527.pdf},
 }
@@ -978,7 +963,6 @@ url={https://doi.org/10.1007/978-3-030-87312-7_24}
 
 @article{Comeau2021,
   doi = {10.1029/2020jb021304},
-  url = {https://doi.org/10.1029/2020jb021304},
   year = {2021},
   month = may,
   publisher = {American Geophysical Union ({AGU})},
@@ -992,14 +976,62 @@ url={https://doi.org/10.1007/978-3-030-87312-7_24}
 @article{mulita2021safem,
   author = {Ornela Mulita and Stefano Giani and Luca Heltai},
   journal = {{SIAM} Journal on Scientific Computing},
-  month = jan,
   number = {3},
   pages = {A2211--A2241},
   title = {Quasi-Optimal Mesh Sequence Construction through Smoothed Adaptive Finite Element Methods},
   volume = {43},
   year = {2021},
-  url = {https://doi.org/10.1137/19m1262097},
   doi = {10.1137/19m1262097}
+}
+
+@article{Bonito2021,
+  doi = {10.1142/s0218202521500044},
+  url = {https://arxiv.org/abs/1912.03812},
+  year = {2021},
+  publisher = {World Scientific Pub Co Pte Lt},
+  volume = {31},
+  number = {01},
+  pages = {133--175},
+  author = {Andrea Bonito and Ricardo H. Nochetto and Dimitrios Ntogkas},
+  title = {{DG} approach to large bending plate deformations with isometry constraint},
+  journal = {Mathematical Models and Methods in Applied Sciences}
+}
+
+@incollection{Klein2021,
+  doi = {10.1007/978-3-030-57784-1_6},
+  url = {https://arxiv.org/abs/1911.04855},
+  year = {2021},
+  publisher = {Springer International Publishing},
+  pages = {165--190},
+  author = {Rebecca Klein and Thomas Schuster and Anne Wald},
+  title = {Sequential Subspace Optimization for Recovering Stored Energy Functions in Hyperelastic Materials from Time-Dependent Data},
+  booktitle = {Time-dependent Problems in Imaging and Parameter Identification}
+}
+
+@article{Liu2021,
+  doi = {10.1016/j.cam.2020.113219},
+  url = {https://arxiv.org/abs/1912.08004},
+  year = {2021},
+  month = apr,
+  publisher = {Elsevier {BV}},
+  volume = {386},
+  pages = {113219},
+  author = {Jie Liu and Matthias M\"{o}ller and Henk M. Schuttelaars},
+  title = {Balancing truncation and round-off errors in {FEM}: One-dimensional analysis},
+  journal = {Journal of Computational and Applied Mathematics}
+}
+
+@article{Anselmann2021,
+  doi = {10.1016/j.matcom.2020.10.027},
+  url = {https://arxiv.org/abs/1912.07426},
+  year = {2021},
+  month = nov,
+  publisher = {Elsevier {BV}},
+  volume = {189},
+  pages = {141--162},
+  author = {Mathias Anselmann and Markus Bause},
+  title = {Higher order Galerkin{\textendash}collocation time discretization with Nitsche's method for the Navier{\textendash}Stokes equations},
+  journal = {Mathematics and Computers in Simulation}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -608,7 +608,6 @@ keywords = {Forearc collision, Sangihe Arc, Halmahera Arc, Forearc thrusting, Nu
 
 @incollection{BaMaWaWiWo22,
   doi = {10.1007/978-3-030-92672-4_8},
-  url = {https://arxiv.org/abs/2006.16566},
   year = {2022},
   publisher = {Springer International Publishing},
   pages = {191--215},

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -9,12 +9,14 @@
 }
 
 @article{piersanti2022bivEM,
+    doi={10.1016/j.cma.2022.114607},
     title={3D--0D closed-loop model for the simulation of cardiac biventricular electromechanics},
     author={Piersanti, Roberto and Regazzoni, Francesco and Salvador, Matteo and Corno, Antonio F and Vergara, Christian and Quarteroni, Alfio and others},
     journal={Computer Methods in Applied Mechanics and Engineering},
     volume={391},
     pages={114607},
     year={2022},
+    month=mar,
     publisher={Elsevier}
 }
 
@@ -22,7 +24,11 @@
     author = {Vergara, Christian and Stella, Simone and Maines, Massimiliano and Africa, Pasquale Claudio and Catanzariti, Domenico and Dematt\`{e}, Cristina and Centonze, Maurizio and Nobile, Fabio and Quarteroni, Alfio and Del Greco, Maurizio},
     title = {Computational electrophysiology of the coronary sinus branches based on electro-anatomical mapping for the prediction of the latest activated region},
     journal = {Medical \& Biological Engineering \& Computing},
+    volume = {60},
+    number = {8},
+    pages = {2307--2319},
     year = {2022},
+    month = jun,
     doi = {10.1007/s11517-022-02610-3}
 }
 
@@ -32,56 +38,69 @@
     journal = {Discrete and Continuous Dynamical Systems - S},
     volume = {15},
     number = {8},
-    pages = {2391-2427},
+    pages = {2391--2427},
     year = {2022},
     doi = {10.3934/dcdss.2022052}
 }
 
 @article{regazzoni2022emcirculation,
-    author = {F. Regazzoni and M. Salvador and P.C. Africa and M. Fedele and L. Dede' and A. Quarteroni},
+    doi = {10.1016/j.jcp.2022.111083},
+    author = {F. Regazzoni and M. Salvador and P.C. Africa and M. Fedele and L. Dede{\`{e}} and A. Quarteroni},
     title = {A cardiac electromechanical model coupled with a lumped-parameter model for closed-loop blood circulation},
     journal = {Journal of Computational Physics},
     volume = {457},
     pages = {111083},
-    year = {2022}
+    year = {2022},
+    month = may,
+    publisher = {Elsevier {BV}}
 }
 
 @article{salvador2022role,
+    doi={10.1016/j.compbiomed.2021.105203},
     title={The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
     author={Salvador, Matteo and Regazzoni, Francesco and Pagani, Stefano and Dede', Luca and Trayanova, Natalia and Quarteroni, Alfio},
     journal={Computers in Biology and Medicine},
+    volume={142},
     pages={105203},
     year={2022},
+    month=mar,
     publisher={Elsevier}
 }
 
 @article{fumagalli2022image,
+    doi={10.3389/fphys.2021.787082},
     title={Image-based computational hemodynamics analysis of systolic obstruction in hypertrophic cardiomyopathy},
     author={Fumagalli, Ivan and Vitullo, Piermario and Vergara, Christian and Fedele, Marco and Corno, Antonio F and Ippolito, Sonia and Scrofani, Roberto and Quarteroni, Alfio},
     journal={Frontiers in Physiology},
+    volume={12},
     pages={2437},
     year={2022},
     publisher={Frontiers}
 }
 
 @article{regazzoni2022machine,
+    doi={10.1016/j.cma.2022.114825},
     title={A machine learning method for real-time numerical simulations of cardiac electromechanics},
     author={Regazzoni, Francesco and Salvador, Matteo and Dede', Luca and Quarteroni, Alfio},
     journal={Computer Methods in Applied Mechanics and Engineering},
     volume={393},
     pages={114825},
     year={2022},
+    month=apr,
     publisher={Elsevier}
 }
 
 @article{quarteroni2022modeling,
+    doi={10.1090/bull/1738},
     title={Modeling the cardiac electromechanical function: A mathematical journey},
-    author={Quarteroni, Alfio and Dede', Luca and Regazzoni, Francesco},
+    author={Quarteroni, Alfio and Dede{\`{e}}, Luca and Regazzoni, Francesco},
     journal={Bulletin of the American Mathematical Society},
     volume={59},
     number={3},
     pages={371--403},
-    year={2022}
+    year={2022},
+    month=feb,
+    publisher={American Mathematical Society ({AMS})}
 }
 
 @MastersThesis {lorencioabriljoseantonio2022,
@@ -89,7 +108,7 @@
     title  = "Un modelo en elementos finitos para estudiar las deformaciones del tejido mamario",
     school = "Universidad de Murcia",
     year   = "2022",
-    month  = "July",
+    month  = jul,
     url    = "https://github.com/Lorenc1o/University_Notes/blob/main/ComputerScience/TFG/TFG_FEM.pdf",
     note   = "Bachelor's Thesis"
 }
@@ -208,20 +227,21 @@ URL = {https://se.copernicus.org/articles/13/849/2022/},
 DOI = {10.5194/se-13-849-2022}
 }
 
-@mastersthesis { quiroga2022numericalm,
-  author = {Quiroga, David },
-	title = {Numerical Models of Lithosphere Removal in the {S}ierra {N}evada de {S}anta {M}arta, {C}olombia},
-	pages = {178},
-	school = {University of Alberta},
-	year = {2022}
+@mastersthesis{quiroga2022numericalm,
+  author = {Quiroga, David},
+  title = {Numerical Models of Lithosphere Removal in the {S}ierra {N}evada de {S}anta {M}arta, {C}olombia},
+  pages = {178},
+  school = {University of Alberta},
+  year = {2022},
+  doi = {10.7939/r3-6mk4-sj26}
 }
 
-@phdthesis { 2022numericalm,
+@phdthesis{2022numericalm,
   author = {Janbakhsh, Payman},
-	title = {Numerical Modeling Of Tectonic Plates \& Application of Artificial Neural Networks in Earthquake Seismology},
-	school = {University of Toronto},
+  title = {Numerical Modeling Of Tectonic Plates \& Application of Artificial Neural Networks in Earthquake Seismology},
+  school = {University of Toronto},
   url = {https://hdl.handle.net/1807/123260},
-	year = {2022}
+  year = {2022}
 }
 
 @article{https://doi.org/10.1029/2021GC009808,
@@ -269,7 +289,7 @@ DOI = {10.5194/gmd-15-5127-2022}
   journal={Computational Particle Mechanics},
   pages={1--20},
   year={2022},
-  url = {https://doi.org/10.1007/s40571-022-00478-6},
+  doi = {10.1007/s40571-022-00478-6},
   publisher={Springer}
 }
 
@@ -287,22 +307,20 @@ year = {2022}
 
 @article{Salvador2022,
   doi = {10.1016/j.compbiomed.2021.105203},
-  url = {https://doi.org/10.1016/j.compbiomed.2021.105203},
   year = {2022},
   month = mar,
   publisher = {Elsevier {BV}},
   volume = {142},
   pages = {105203},
-  author = {Matteo Salvador and Francesco Regazzoni and Stefano Pagani and Luca Dede' and Natalia Trayanova and Alfio Quarteroni},
+  author = {Matteo Salvador and Francesco Regazzoni and Stefano Pagani and Luca Ded{\`{e}} and Natalia Trayanova and Alfio Quarteroni},
   title = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
   journal = {Computers in Biology and Medicine}
 }
 
 @article{Tsagkari_2022,
         doi = {10.1038/s41522-022-00300-4},
-        url = {https://doi.org/10.1038%2Fs41522-022-00300-4},
         year = 2022,
-        month = {apr},
+        month = apr,
         publisher = {Springer Science and Business Media {LLC}},
         volume = {8},
         number = {1},
@@ -316,23 +334,22 @@ year = {2022}
   title={Neural network guided adjoint computations in dual weighted residual error estimation},
   journal={SN Applied Sciences},
   year={2022},
-  month={Jan},
+  month=jan,
   day={31},
   volume={4},
   number={2},
   pages={62},
   abstract={In this work, we are concerned with neural network guided goal-oriented a posteriori error estimation and adaptivity using the dual weighted residual method. The primal problem is solved using classical Galerkin finite elements. The adjoint problem is solved in strong form with a feedforward neural network using two or three hidden layers. The main objective of our approach is to explore alternatives for solving the adjoint problem with greater potential of a numerical cost reduction. The proposed algorithm is based on the general goal-oriented error estimation theorem including both linear and nonlinear stationary partial differential equations and goal functionals. Our developments are substantiated with some numerical experiments that include comparisons of neural network computed adjoints and classical finite element solutions of the adjoints. In the programming software, the open-source library deal.II is successfully coupled with LibTorch, the PyTorch C++ application programming interface.},
   issn={2523-3971},
-  doi={10.1007/s42452-022-04938-9},
-  url={https://doi.org/10.1007/s42452-022-04938-9}
+  doi={10.1007/s42452-022-04938-9}
 }
 
 @phdthesis{mang2022dissertation,
   title={Phase-field fracture modeling, numerical solution, and simulations for compressible and incompressible solids},
   author={Mang, Katrin},
   year={2022},
-  month     = {feb},
-  url       = {https://doi.org/10.15488/11928},
+  month     = feb,
+  doi       = {10.15488/11928},
   school={Hannover: Institutionelles Repositorium der Leibniz Universit{\"a}t Hannover}
 }
 
@@ -358,7 +375,6 @@ year = {2022}
 
 @article{Sabanskis2022,
   doi = {10.3390/cryst12020174},
-  url = {https://doi.org/10.3390/cryst12020174},
   year = {2022},
   month = jan,
   publisher = {{MDPI} {AG}},
@@ -456,7 +472,6 @@ author = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   title = {A coupled multiphase Lagrangian-Eulerian fluid-dynamics framework for numerical simulation of Laser Metal Deposition process},
   volume = {120},
   year = {2022},
-  url = {https://doi.org/10.1007/s00170-022-08763-7},
   doi = {10.1007/s00170-022-08763-7}
 }
 
@@ -503,8 +518,7 @@ author = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   year      = {2022},
   publisher = {Springer International Publishing},
   pages     = {133--152},
-  doi       = {10.1007/978-3-031-07312-0_7},
-  url       = {https://doi.org/10.1007/978-3-031-07312-0_7}
+  doi       = {10.1007/978-3-031-07312-0_7}
 }
 
 @article{munch2022spirk,
@@ -527,7 +541,6 @@ author = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   journal = {International Journal for Numerical Methods in Engineering},
   title = {Vibration Analysis of Piezoelectric {Kirchhoff-Love} shells based on {Catmull-Clark} Subdivision Surfaces},
   year = {2022},
-  url = {https://doi.org/10.1002/nme.7010},
   doi = {10.1002/nme.7010}
 }
 
@@ -538,7 +551,6 @@ author = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   title = {Model hierarchies and higher-order discretisation of time-dependent thin-film free boundary problems with dynamic contact angle},
   volume = {464},
   year = {2022},
-  url = {https://doi.org/10.1016/j.jcp.2022.111325},
   doi = {10.1016/j.jcp.2022.111325}
 }
 
@@ -591,7 +603,18 @@ keywords = {Forearc collision, Sangihe Arc, Halmahera Arc, Forearc thrusting, Nu
   number = {22027},
   url    = {http://urn.kb.se/resolve?urn=urn:nbn:se:uu:diva-478600},
   year   = {2022},
-  month  = {June}
+  month  = jun
+}
+
+@incollection{BaMaWaWiWo22,
+  doi = {10.1007/978-3-030-92672-4_8},
+  url = {https://arxiv.org/abs/2006.16566},
+  year = {2022},
+  publisher = {Springer International Publishing},
+  pages = {191--215},
+  author = {Seshadri Basava and Katrin Mang and Mirjam Walloth and Thomas Wick and Winnifried Wollner},
+  title = {Adaptive and Pressure-Robust Discretization of Incompressible Pressure-Driven Phase-Field Fracture},
+  booktitle = {Non-standard Discretisation Methods in Solid Mechanics}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
- Fix `month` entries (see Q13 of [bibtex FAQ](https://ctan.org/pkg/bibtex?lang=en))
- Fix `doi` entries (no urls)
- Remove `url` if information redundant to `doi` field
- Update preprints if published in the meantime. Let `url` still point to arxiv preprint.

There are tons of additional `arxiv` preprints for previous years through which we need to go. Part of #289.