### PR TITLE
Fix unicode error for local builds.

### DIFF
--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -721,7 +721,7 @@
   volume = {74},
   number = {6},
   pages = {1288--1310},
-  author = {Raimund B\"{u}rger and Sudarshan Kumar Kenettinkara and David Zor{\'{\i}}o},
+  author = {Raimund B\"{u}rger and Sudarshan Kumar Kenettinkara and David Zor{\'{i}}o},
   title = {Approximate Lax-Wendroff discontinuous Galerkin methods for hyperbolic conservation laws},
   journal = {Computers {\&} Mathematics with Applications}
 }
@@ -757,7 +757,7 @@
   volume = {84},
   number = {9},
   pages = {543--565},
-  author = {Vadym Aizinger and Adam Kos{\'{\i}}k and Dmitri Kuzmin and Balthasar Reuter},
+  author = {Vadym Aizinger and Adam Kos{\'{i}}k and Dmitri Kuzmin and Balthasar Reuter},
   title = {Anisotropic slope limiting for discontinuous Galerkin methods},
   journal = {International Journal for Numerical Methods in Fluids}
 }

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1677,7 +1677,7 @@ year = {2016}
   publisher = {Elsevier {BV}},
   volume = {337},
   pages = {246--262},
-  author = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{\i}}a-Aznar},
+  author = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
   title = {Mechanical modeling of collective cell migration: An agent-based and continuum material approach},
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
@@ -2507,7 +2507,7 @@ year = {2018}
   publisher = {Elsevier {BV}},
   volume = {319},
   pages = {681--692},
-  author = {Pavel Karban and Petr Krop{\'{\i}}k and V{\'{a}}clav Kotlan and Ivo Dole{\v{z}}el},
+  author = {Pavel Karban and Petr Krop{\'{i}}k and V{\'{a}}clav Kotlan and Ivo Dole{\v{z}}el},
   title = {Bayes approach to solving T.E.A.M. benchmark problems 22 and 25 and its comparison with other optimization techniques},
   journal = {Applied Mathematics and Computation}
 }

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -70,7 +70,7 @@ year = {2019}
   volume = {6},
   number = {1},
   pages = {85--96},
-  author = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{\i}}a-Aznar},
+  author = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
   title = {An agent-based and {FE} approach to simulate cell jamming and collective motion in epithelial layers},
   journal = {Computational Particle Mechanics}
 }
@@ -1681,7 +1681,7 @@ year = {2019}
   volume = {6},
   number = {1},
   pages = {85--96},
-  author = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{\i}}a-Aznar},
+  author = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
   title = {An agent-based and {FE} approach to simulate cell jamming and collective motion in epithelial layers},
   journal = {Computational Particle Mechanics}
 }

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -803,7 +803,7 @@ doi="10.1002/9781119528609.ch15"
   month = aug,
   publisher = {Frontiers Media {SA}},
   volume = {11},
-  author = {James M. Wakeling and Stephanie A. Ross and David S. Ryan and Bart Bolsterlee and Ryan Konno and Sebasti{\'{a}}n Dom{\'{\i}}nguez and Nilima Nigam},
+  author = {James M. Wakeling and Stephanie A. Ross and David S. Ryan and Bart Bolsterlee and Ryan Konno and Sebasti{\'{a}}n Dom{\'{i}}nguez and Nilima Nigam},
   title = {The Energy of Muscle Contraction. I. Tissue Force and Deformation During Fixed-End Contractions},
   journal = {Frontiers in Physiology}
 }
@@ -814,7 +814,7 @@ doi="10.1002/9781119528609.ch15"
   month = nov,
   publisher = {Frontiers Media {SA}},
   volume = {11},
-  author = {David S. Ryan and Sebasti{\'{a}}n Dom{\'{\i}}nguez and Stephanie A. Ross and Nilima Nigam and James M. Wakeling},
+  author = {David S. Ryan and Sebasti{\'{a}}n Dom{\'{i}}nguez and Stephanie A. Ross and Nilima Nigam and James M. Wakeling},
   title = {The Energy of Muscle Contraction. {II}. Transverse Compression and Work},
   journal = {Frontiers in Physiology}
 }
@@ -1037,7 +1037,7 @@ doi="10.1002/9781119528609.ch15"
   volume = {42},
   number = {6},
   pages = {C436--C468},
-  author = {Santiago Badia and Alberto F. Mart{\'{\i}}n and Eric Neiva and Francesc Verdugo},
+  author = {Santiago Badia and Alberto F. Mart{\'{i}}n and Eric Neiva and Francesc Verdugo},
   title = {A Generic Finite Element Framework on Parallel Tree-Based Adaptive Meshes},
   journal = {{SIAM} Journal on Scientific Computing}
 }


### PR DESCRIPTION
```
! LaTeX Error: Unicode character ́ (U+0301)
               not set up for use with LaTeX.
```

That's the corresponding symbol: https://www.compart.com/en/unicode/U+0301

`\i` removes the dot over the i. It appears that combining `\'{\i}` leads to troubles. `\'{i}` yields the desired symbol.