### PR TITLE
Fixed duplicate entry keys for 2018.

### DIFF
--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -2560,7 +2560,7 @@ year = {2018}
   volume = {121},
   pages = {513--524},
   author = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
-  title = {Block hybrid multilevel method to compute the dominant $\uplambda$-modes of the neutron diffusion equation},
+  title = {Block hybrid multilevel method to compute the dominant $\lambda$-modes of the neutron diffusion equation},
   journal = {Annals of Nuclear Energy}
 }
 

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -15,19 +15,6 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@article{Zhang2018,
-  doi = {10.1016/j.amc.2018.06.017},
-  url = {https://doi.org/10.1016/j.amc.2018.06.017},
-  year = {2018},
-  month = dec,
-  publisher = {Elsevier {BV}},
-  volume = {338},
-  pages = {274--289},
-  author = {Hong Zhang and Paul Andries Zegeling},
-  title = {Simulation of thin film flows with a moving mesh mixed finite element method},
-  journal = {Applied Mathematics and Computation}
-}
-
 @article{Carraro2018,
   doi = {10.1007/s10957-018-1242-4},
   url = {https://doi.org/10.1007/s10957-018-1242-4},
@@ -81,21 +68,6 @@
    month={Mar},
    pages={19--46}
 }
-
-@article{Cangiani2018,
-  doi = {10.1098/rspa.2017.0608},
-  url = {https://doi.org/10.1098/rspa.2017.0608},
-  year = {2018},
-  month = may,
-  publisher = {The Royal Society},
-  volume = {474},
-  number = {2213},
-  pages = {20170608},
-  author = {A. Cangiani and E. H. Georgoulis and A. Yu. Morozov and O. J. Sutton},
-  title = {Revealing new dynamical patterns in a reaction-diffusion model with cyclic competition via a novel computational framework},
-  journal = {Proceedings of the Royal Society A: Mathematical,  Physical and Engineering Sciences}
-}
-
 
 @article{Dorschner2018,
   doi = {10.1103/physreve.97.023305},
@@ -414,7 +386,7 @@ year = {2018}
   journal = {Journal of Petroleum Science and Engineering}
 }
 
-@article{Guo2018,
+@article{Guo2018b,
   doi = {10.2118/189974-pa},
   url = {https://doi.org/10.2118/189974-pa},
   year = {2018},
@@ -428,6 +400,24 @@ year = {2018}
   journal = {{SPE} Journal}
 }
 
+@inproceedings{Guo2018c,
+  doi = {10.15530/urtec-2018-2874464},
+  url = {https://doi.org/10.15530/urtec-2018-2874464},
+  year = {2018},
+  publisher = {American Association of Petroleum Geologists},
+  author = {Xuyang Guo and Kan Wu and John Killough and Jizhou Tang},
+  title = {Understanding the Mechanism of Interwell Fracturing Interference Based on Reservoir-Geomechanics-Fracturing Modeling in Eagle Ford Shale},
+  booktitle = {Proceedings of the 6th Unconventional Resources Technology Conference}
+}
+
+@phdthesis{Guo2018d,
+author = {Guo, X.},
+title = {{A Study of Interwell Interference and Well Performance in Unconventional Reservoirs Based on Coupled Flow and Geomechanics Modeling with Improved}},
+url = {https://oaktrust.library.tamu.edu/handle/1969.1/173772},
+publisher={Texas A\&M University},
+year = {2018}
+}
+
 @article{2018_24,
    author  = {L. Hov Ods\ae{}ter and T. Kvamsdal and M. G Larson},
    title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
@@ -437,20 +427,6 @@ year = {2018}
    pages   = {},
    url     = {},
    doi     = {}
-}
-
-@article{Jodlbauer2018,
-  doi = {10.1002/nme.5970},
-  url = {https://doi.org/10.1002/nme.5970},
-  year = {2018},
-  month = oct,
-  publisher = {Wiley},
-  volume = {117},
-  number = {6},
-  pages = {623--643},
-  author = {D. Jodlbauer and U. Langer and T. Wick},
-  title = {Parallel block-preconditioned monolithic solvers for fluid-structure interaction problems},
-  journal = {International Journal for Numerical Methods in Engineering}
 }
 
 @misc{kcher2018mixed,
@@ -743,7 +719,7 @@ year = {2018}
   url       = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf},
 }
 
-@InProceedings{Deolmi2018,
+@InProceedings{Deolmi2018a,
   author    = {Deolmi, G. and Dahmen, W. and M{\"{u}}ller, S. and Albers, M. and Meysonnat, P. S. and Schr{\"{o}}der, W.},
   title     = {{Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface}},
   booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
@@ -754,6 +730,19 @@ year = {2018}
   publisher = {Springer International Publishing},
   doi       = {10.1007/978-3-319-91545-6_36},
   journal   = {Springer},
+}
+
+@article{Deolmi2018b,
+  doi = {10.1016/j.matcom.2018.02.008},
+  url = {https://doi.org/10.1016/j.matcom.2018.02.008},
+  year = {2018},
+  month = aug,
+  publisher = {Elsevier {BV}},
+  volume = {150},
+  pages = {49--65},
+  author = {G. Deolmi and S. M\"{u}ller},
+  title = {A two-step model order reduction method to simulate a compressible flow over an extended rough surface},
+  journal = {Mathematics and Computers in Simulation}
 }
 
 @InProceedings{Chandrashekar2018,
@@ -1891,7 +1880,7 @@ year = {2016}
   journal = {Journal of Fluid Mechanics}
 }
 
-@article{Wang2018,
+@article{Wang2018a,
   doi = {10.1149/2.0141811jes},
   url = {https://doi.org/10.1149/2.0141811jes},
   year = {2018},
@@ -1904,6 +1893,19 @@ year = {2016}
   journal = {Journal of The Electrochemical Society}
 }
 
+@article{Wang2018b,
+  doi = {10.1017/jfm.2018.808},
+  url = {https://doi.org/10.1017/jfm.2018.808},
+  year = {2018},
+  month = nov,
+  publisher = {Cambridge University Press ({CUP})},
+  volume = {859},
+  pages = {691--730},
+  author = {Zhicheng Wang and Michael S. Triantafyllou and Yiannis Constantinides and George Em Karniadakis},
+  title = {An entropy-viscosity large eddy simulation study of turbulent flow in a flexible pipe},
+  journal = {Journal of Fluid Mechanics}
+}
+
 @article{https://doi.org/10.13140/rg.2.2.30755.14885,
   doi = {10.13140/RG.2.2.30755.14885},
   url = {http://rgdoi.net/10.13140/RG.2.2.30755.14885},
@@ -1912,17 +1914,6 @@ year = {2016}
   title = {Acousto-Elastic Interactions in High-Pressure Centrifugal Compressors},
   publisher = {Unpublished},
   year = {2018}
-}
-
-@incollection{Carreo2018,
-  doi = {10.1007/978-3-319-93701-4_67},
-  url = {https://doi.org/10.1007/978-3-319-93701-4_67},
-  year = {2018},
-  publisher = {Springer International Publishing},
-  pages = {846--855},
-  author = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
-  title = {The Solution of the Lambda Modes Problem Using Block Iterative Eigensolvers},
-  booktitle = {Lecture Notes in Computer Science}
 }
 
 @incollection{Evgrafov2018,
@@ -1937,7 +1928,7 @@ year = {2016}
   booktitle = {{EngOpt} 2018 Proceedings of the 6th International Conference on Engineering Optimization}
 }
 
-@article{Cheng2018,
+@article{Cheng2018a,
   doi = {10.4208/aamm.oa-2017-0060},
   url = {https://doi.org/10.4208/aamm.oa-2017-0060},
   year = {2018},
@@ -1949,6 +1940,19 @@ year = {2016}
   author = {Jian Cheng},
   title = {A Direct Discontinuous Galerkin Method with Interface Correction for the Compressible Navier-Stokes Equations on Unstructured Grids},
   journal = {Advances in Applied Mathematics and Mechanics}
+}
+
+@article{Cheng2018b,
+  doi = {10.1016/j.jcp.2018.02.031},
+  url = {https://doi.org/10.1016/j.jcp.2018.02.031},
+  year = {2018},
+  month = jun,
+  publisher = {Elsevier {BV}},
+  volume = {362},
+  pages = {305--326},
+  author = {Jian Cheng and Huiqiang Yue and Shengjiao Yu and Tiegang Liu},
+  title = {Analysis and development of adjoint-based h-adaptive direct discontinuous Galerkin method for the compressible Navier--Stokes equations},
+  journal = {Journal of Computational Physics}
 }
 
 @article{Wei2018,
@@ -2014,20 +2018,6 @@ year = {2016}
   author = {Anup Basak and Valery I. Levitas},
   title = {Nanoscale Phase Field Modeling and Simulations of Martensitic Phase Transformations and Twinning at Finite Strains},
   booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
-}
-
-@article{Zhang2018b,
-  doi = {10.1002/nme.5737},
-  url = {https://doi.org/10.1002/nme.5737},
-  year = {2018},
-  month = jan,
-  publisher = {Wiley},
-  volume = {114},
-  number = {2},
-  pages = {128--146},
-  author = {Shanglong Zhang and Arun L. Gain and Juli{\'{a}}n A. Norato},
-  title = {A geometry projection method for the topology optimization of curved plate structures with placement bounds},
-  journal = {International Journal for Numerical Methods in Engineering}
 }
 
 @incollection{Babaei2018,
@@ -2228,14 +2218,6 @@ title = {3D Grainstructure simulation in powder bed additive manufacturing},
 booktitle = {NAFEMS Konferenz 2018}
 }
 
-@phdthesis{Guo2018b,
-author = {Guo, X.},
-title = {{A Study of Interwell Interference and Well Performance in Unconventional Reservoirs Based on Coupled Flow and Geomechanics Modeling with Improved}},
-url = {https://oaktrust.library.tamu.edu/handle/1969.1/173772},
-publisher={Texas A\&M University},
-year = {2018}
-}
-
 @phdthesis{Aggul2018,
 author = {Aggul, Mustafa},
 title = {High Accuracy Methods and Regularization Techniques for Fluid Flows and Fluid-Fluid interactions},
@@ -2406,16 +2388,6 @@ year = {2018}
   booktitle = {Lecture Notes in Civil Engineering}
 }
 
-@inproceedings{Guo2018,
-  doi = {10.15530/urtec-2018-2874464},
-  url = {https://doi.org/10.15530/urtec-2018-2874464},
-  year = {2018},
-  publisher = {American Association of Petroleum Geologists},
-  author = {Xuyang Guo and Kan Wu and John Killough and Jizhou Tang},
-  title = {Understanding the Mechanism of Interwell Fracturing Interference Based on Reservoir-Geomechanics-Fracturing Modeling in Eagle Ford Shale},
-  booktitle = {Proceedings of the 6th Unconventional Resources Technology Conference}
-}
-
 @article{Zheng2017,
   doi = {10.1080/00295639.2017.1407592},
   url = {https://doi.org/10.1080/00295639.2017.1407592},
@@ -2457,34 +2429,7 @@ year = {2018}
 }
 
 
-@article{Deolmi2018,
-  doi = {10.1016/j.matcom.2018.02.008},
-  url = {https://doi.org/10.1016/j.matcom.2018.02.008},
-  year = {2018},
-  month = aug,
-  publisher = {Elsevier {BV}},
-  volume = {150},
-  pages = {49--65},
-  author = {G. Deolmi and S. M\"{u}ller},
-  title = {A two-step model order reduction method to simulate a compressible flow over an extended rough surface},
-  journal = {Mathematics and Computers in Simulation}
-}
-
-@article{Cheng2018,
-  doi = {10.1016/j.jcp.2018.02.031},
-  url = {https://doi.org/10.1016/j.jcp.2018.02.031},
-  year = {2018},
-  month = jun,
-  publisher = {Elsevier {BV}},
-  volume = {362},
-  pages = {305--326},
-  author = {Jian Cheng and Huiqiang Yue and Shengjiao Yu and Tiegang Liu},
-  title = {Analysis and development of adjoint-based h-adaptive direct discontinuous Galerkin method for the compressible Navier--Stokes equations},
-  journal = {Journal of Computational Physics}
-}
-
-
-@article{Cangiani2018,
+@article{Cangiani2018a,
   doi = {10.1090/mcom/3322},
   url = {https://doi.org/10.1090/mcom/3322},
   year = {2018},
@@ -2496,6 +2441,21 @@ year = {2018}
   author = {Andrea Cangiani and Emmanuil H. Georgoulis and Younis A. Sabawi},
   title = {Adaptive discontinuous Galerkin methods for elliptic interface problems},
   journal = {Mathematics of Computation}
+}
+
+
+@article{Cangiani2018b,
+  doi = {10.1098/rspa.2017.0608},
+  url = {https://doi.org/10.1098/rspa.2017.0608},
+  year = {2018},
+  month = may,
+  publisher = {The Royal Society},
+  volume = {474},
+  number = {2213},
+  pages = {20170608},
+  author = {A. Cangiani and E. H. Georgoulis and A. Yu. Morozov and O. J. Sutton},
+  title = {Revealing new dynamical patterns in a reaction-diffusion model with cyclic competition via a novel computational framework},
+  journal = {Proceedings of the Royal Society A: Mathematical,  Physical and Engineering Sciences}
 }
 
 
@@ -2538,8 +2498,7 @@ year = {2018}
   journal = {Journal of Mechanical Design}
 }
 
-
-@inproceedings{Zhang2018,
+@inproceedings{ZhangNorato2018a,
   doi = {10.1115/detc2018-86116},
   url = {https://doi.org/10.1115/detc2018-86116},
   year = {2018},
@@ -2550,6 +2509,32 @@ year = {2018}
   booktitle = {Volume 2B: 44th Design Automation Conference}
 }
 
+@article{ZhangNorato2018b,
+  doi = {10.1002/nme.5737},
+  url = {https://doi.org/10.1002/nme.5737},
+  year = {2018},
+  month = jan,
+  publisher = {Wiley},
+  volume = {114},
+  number = {2},
+  pages = {128--146},
+  author = {Shanglong Zhang and Arun L. Gain and Juli{\'{a}}n A. Norato},
+  title = {A geometry projection method for the topology optimization of curved plate structures with placement bounds},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@article{ZhangZegeling2018,
+  doi = {10.1016/j.amc.2018.06.017},
+  url = {https://doi.org/10.1016/j.amc.2018.06.017},
+  year = {2018},
+  month = dec,
+  publisher = {Elsevier {BV}},
+  volume = {338},
+  pages = {274--289},
+  author = {Hong Zhang and Paul Andries Zegeling},
+  title = {Simulation of thin film flows with a moving mesh mixed finite element method},
+  journal = {Applied Mathematics and Computation}
+}
 
 @article{Qiao2018,
   doi = {10.1051/jnwpu/20183610057},
@@ -2566,7 +2551,7 @@ year = {2018}
 }
 
 
-@article{Carreo2018,
+@article{Carreo2018a,
   doi = {10.1016/j.anucene.2018.08.010},
   url = {https://doi.org/10.1016/j.anucene.2018.08.010},
   year = {2018},
@@ -2577,6 +2562,18 @@ year = {2018}
   author = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
   title = {Block hybrid multilevel method to compute the dominant $\uplambda$-modes of the neutron diffusion equation},
   journal = {Annals of Nuclear Energy}
+}
+
+
+@incollection{Carreo2018b,
+  doi = {10.1007/978-3-319-93701-4_67},
+  url = {https://doi.org/10.1007/978-3-319-93701-4_67},
+  year = {2018},
+  publisher = {Springer International Publishing},
+  pages = {846--855},
+  author = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
+  title = {The Solution of the Lambda Modes Problem Using Block Iterative Eigensolvers},
+  booktitle = {Lecture Notes in Computer Science}
 }
 
 
@@ -2643,20 +2640,6 @@ url = {https://mohebujjaman.github.io/Second_order_ensembleMHD_Mohebujjaman.pdf}
   author = {Chenchen Liu and Celia Reina},
   title = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
   journal = {Computational Mechanics}
-}
-
-
-@article{Wang2018,
-  doi = {10.1017/jfm.2018.808},
-  url = {https://doi.org/10.1017/jfm.2018.808},
-  year = {2018},
-  month = nov,
-  publisher = {Cambridge University Press ({CUP})},
-  volume = {859},
-  pages = {691--730},
-  author = {Zhicheng Wang and Michael S. Triantafyllou and Yiannis Constantinides and George Em Karniadakis},
-  title = {An entropy-viscosity large eddy simulation study of turbulent flow in a flexible pipe},
-  journal = {Journal of Fluid Mechanics}
 }
 
 


### PR DESCRIPTION
Same as #385, but for 2018
```
WARN - Duplicate entry key: 'Jodlbauer2018' in file '../publications-2018.bib', skipping ...
WARN - Duplicate entry key: 'Guo2018' in file '../publications-2018.bib', skipping ...
WARN - Duplicate entry key: 'Deolmi2018' in file '../publications-2018.bib', skipping ...
WARN - Duplicate entry key: 'Cheng2018' in file '../publications-2018.bib', skipping ...
WARN - Duplicate entry key: 'Cangiani2018' in file '../publications-2018.bib', skipping ...
WARN - Duplicate entry key: 'Zhang2018' in file '../publications-2018.bib', skipping ...
WARN - Duplicate entry key: 'Carreo2018' in file '../publications-2018.bib', skipping ...
WARN - Duplicate entry key: 'Wang2018' in file '../publications-2018.bib', skipping ...
```