### PR TITLE
bibtool: enable sorting

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -8,3 +8,5 @@ print.indent = 2
 print.line.length = 999
 print.use.tab = off
 print.wide.equal = on
+
+sort = on

--- a/publications-2001.bib
+++ b/publications-2001.bib
@@ -1,18 +1,5 @@
 % Encoding: US-ASCII
 
-@Article{barinka.barsch.ea:adaptive,
-  author  = {Arne Barinka and Titus Barsch and Philippe Charton and Albert Cohen and Stephan Dahlke and Wolfgang Dahmen and Karsten Urban},
-  title   = {Adaptive Wavelet Schemes for Elliptic Problems---Implementation and Numerical Experiments},
-  journal = {{SIAM} Journal on Scientific Computing},
-  year    = {2001},
-  volume  = {23},
-  number  = {3},
-  pages   = {910--939},
-  month   = {jan},
-  doi     = {10.1137/s1064827599365501},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
-}
-
 @Article{bangerth.rannacher:adaptive,
   author  = {Wolfgang Bangerth and Rolf Rannacher},
   title   = {Adaptive finite element techniques for the acoustic wave equation},
@@ -24,6 +11,19 @@
   month   = {jun},
   doi     = {10.1142/s0218396x01000668},
   publisher = {World Scientific Pub Co Pte Lt}
+}
+
+@Article{barinka.barsch.ea:adaptive,
+  author  = {Arne Barinka and Titus Barsch and Philippe Charton and Albert Cohen and Stephan Dahlke and Wolfgang Dahmen and Karsten Urban},
+  title   = {Adaptive Wavelet Schemes for Elliptic Problems---Implementation and Numerical Experiments},
+  journal = {{SIAM} Journal on Scientific Computing},
+  year    = {2001},
+  volume  = {23},
+  number  = {3},
+  pages   = {910--939},
+  month   = {jan},
+  doi     = {10.1137/s1064827599365501},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{becker.rannacher:optimal,

--- a/publications-2003.bib
+++ b/publications-2003.bib
@@ -8,17 +8,6 @@
   url     = {}
 }
 
-@Article{bangerth:starting,
-  author  = {W. Bangerth},
-  title   = {Starting threads in a C++ compatible fashion},
-  journal = {C/C++ Users Journal},
-  year    = {2003},
-  volume  = {},
-  pages   = {21--24},
-  url     = {},
-  doi     = {}
-}
-
 @Article{bangerth.rannacher:adaptive,
   author  = {W. Bangerth and R. Rannacher},
   title   = {Adaptive Finite Element Methods for Solving Differential Equations},
@@ -26,6 +15,17 @@
   year    = {2003},
   volume  = {},
   pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{bangerth:starting,
+  author  = {W. Bangerth},
+  title   = {Starting threads in a C++ compatible fashion},
+  journal = {C/C++ Users Journal},
+  year    = {2003},
+  volume  = {},
+  pages   = {21--24},
   url     = {},
   doi     = {}
 }
@@ -68,17 +68,6 @@
   doi     = {}
 }
 
-@Article{gopalakrishnan.kanschat:multilevel,
-  author  = {J. Gopalakrishnan and G. Kanschat},
-  title   = {A Multilevel Discontinuous Galerkin Method},
-  journal = {Numer. Math.},
-  year    = {2003},
-  volume  = {95},
-  pages   = {527--550},
-  url     = {},
-  doi     = {}
-}
-
 @Article{gopalakrishnan.kanschat:application,
   author  = {J. Gopalakrishnan and G. Kanschat},
   title   = {Application of unified DG analysis to preconditioning DG methods},
@@ -97,6 +86,17 @@
   year    = {2003},
   volume  = {},
   pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{gopalakrishnan.kanschat:multilevel,
+  author  = {J. Gopalakrishnan and G. Kanschat},
+  title   = {A Multilevel Discontinuous Galerkin Method},
+  journal = {Numer. Math.},
+  year    = {2003},
+  volume  = {95},
+  pages   = {527--550},
   url     = {},
   doi     = {}
 }

--- a/publications-2004.bib
+++ b/publications-2004.bib
@@ -1,16 +1,5 @@
 % Encoding: US-ASCII
 
-@Article{bangerth:framework,
-  author  = {W. Bangerth and },
-  title   = {A framework for the adaptive finite element solution of large inverse problems. I. Basic techniques},
-  journal = {ICES Report 2004-39},
-  year    = {2004},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{bangerth.grote.ea:finite,
   author  = {W. Bangerth and M. Grote and C. Hohenegger},
   title   = {Finite Element Method For Time Dependent Scattering: Nonreflecting Boundary Condition, Adaptivity, and Energy Decay},
@@ -18,6 +7,17 @@
   year    = {2004},
   volume  = {193},
   pages   = {2453--2482},
+  url     = {},
+  doi     = {}
+}
+
+@Article{bangerth:framework,
+  author  = {W. Bangerth and },
+  title   = {A framework for the adaptive finite element solution of large inverse problems. I. Basic techniques},
+  journal = {ICES Report 2004-39},
+  year    = {2004},
+  volume  = {},
+  pages   = {},
   url     = {},
   doi     = {}
 }
@@ -118,17 +118,6 @@
   doi     = {}
 }
 
-@Article{kanschat:multi-level,
-  author  = {G. Kanschat},
-  title   = {Multi-level methods for discontinuous Galerkin FEM on locally refined meshes},
-  journal = {Comput. \& Struct.},
-  year    = {2004},
-  volume  = {82},
-  pages   = {2437--2445},
-  url     = {},
-  doi     = {}
-}
-
 @Article{kanschat.meinkohn:multi-model,
   author  = {G. Kanschat and E. Meinkohn},
   title   = {Multi-model preconditioning for radiative transfer problems, 2004.},
@@ -137,6 +126,17 @@
   volume  = {},
   pages   = {},
   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.87.169&rep=rep1&type=pdf},
+  doi     = {}
+}
+
+@Article{kanschat:multi-level,
+  author  = {G. Kanschat},
+  title   = {Multi-level methods for discontinuous Galerkin FEM on locally refined meshes},
+  journal = {Comput. \& Struct.},
+  year    = {2004},
+  volume  = {82},
+  pages   = {2437--2445},
+  url     = {},
   doi     = {}
 }
 

--- a/publications-2005.bib
+++ b/publications-2005.bib
@@ -55,17 +55,6 @@
   doi     = {}
 }
 
-@Article{cockburn.kanschat.ea:locally,
-  author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
-  title   = {A locally conservative LDG method for the incompressible Navier-Stokes equations},
-  journal = {Math. Comput.},
-  year    = {2005},
-  volume  = {74},
-  pages   = {1067--1095},
-  url     = {},
-  doi     = {}
-}
-
 @Article{cockburn.kanschat.ea:local,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {The Local Discontinuous Galerkin Method for Linear Incomressible Fluid Flow: a Review},
@@ -73,6 +62,17 @@
   year    = {2005},
   volume  = {34},
   pages   = {491--506},
+  url     = {},
+  doi     = {}
+}
+
+@Article{cockburn.kanschat.ea:locally,
+  author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
+  title   = {A locally conservative LDG method for the incompressible Navier-Stokes equations},
+  journal = {Math. Comput.},
+  year    = {2005},
+  volume  = {74},
+  pages   = {1067--1095},
   url     = {},
   doi     = {}
 }
@@ -88,14 +88,6 @@
   doi     = {}
 }
 
-@PhDThesis{joshi:adaptive,
-  author  = {A. Joshi},
-  title   = {Adaptive finite element methods for fluorescence enhanced optical tomography},
-  year    = {2005},
-  school  = {Texas A\&M University},
-  url     = {}
-}
-
 @Article{joshi.bangerth.ea:experimental,
   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca},
   title   = {Experimental fluorescence optical tomography using adaptive finite elements and planar illumination with modulated excitation light},
@@ -105,6 +97,14 @@
   pages   = {351--358},
   url     = {},
   doi     = {}
+}
+
+@PhDThesis{joshi:adaptive,
+  author  = {A. Joshi},
+  title   = {Adaptive finite element methods for fluorescence enhanced optical tomography},
+  year    = {2005},
+  school  = {Texas A\&M University},
+  url     = {}
 }
 
 @Article{kanschat:block,

--- a/publications-2006.bib
+++ b/publications-2006.bib
@@ -41,17 +41,6 @@
   doi     = {}
 }
 
-@Article{bangtsson.neytcheva:numerical,
-  author  = {E. B\"{a}ngtsson and M. Neytcheva},
-  title   = {Numerical simulations of glacial rebound using preconditioned iterative solution methods},
-  journal = {Applications of Mathematics},
-  year    = {2006},
-  volume  = {50},
-  pages   = {183--201},
-  url     = {},
-  doi     = {}
-}
-
 @Article{bangtsson.neytcheva:agglomerate,
   author  = {E. B\"{a}ngtsson and M. Neytcheva},
   title   = {An agglomerate multilevel preconditioner for linear isostasy saddle point problems},
@@ -59,6 +48,17 @@
   year    = {2006},
   volume  = {},
   pages   = {113--120},
+  url     = {},
+  doi     = {}
+}
+
+@Article{bangtsson.neytcheva:numerical,
+  author  = {E. B\"{a}ngtsson and M. Neytcheva},
+  title   = {Numerical simulations of glacial rebound using preconditioned iterative solution methods},
+  journal = {Applications of Mathematics},
+  year    = {2006},
+  volume  = {50},
+  pages   = {183--201},
   url     = {},
   doi     = {}
 }
@@ -107,6 +107,28 @@
   doi     = {}
 }
 
+@Article{hartmann.houston:symmetric,
+  author  = {R. Hartmann and P. Houston},
+  title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations I: Method Formulation},
+  journal = {Int. J. Numer. Anal. Model.},
+  year    = {2006},
+  volume  = {3},
+  pages   = {1--20},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hartmann.houston:symmetric*1,
+  author  = {R. Hartmann and P. Houston},
+  title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations II: Goal-Oriented A Posteriori Error Estimation},
+  journal = {Int. J. Numer. Anal. Model.},
+  year    = {2006},
+  volume  = {3},
+  pages   = {141--162},
+  url     = {},
+  doi     = {}
+}
+
 @Article{hartmann:adaptive,
   author  = {R. Hartmann},
   title   = {Adaptive discontinuous Galerkin methods with shock-capturing for the compressible Navier-Stokes equations},
@@ -136,28 +158,6 @@
   year    = {2006},
   volume  = {},
   pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hartmann.houston:symmetric,
-  author  = {R. Hartmann and P. Houston},
-  title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations I: Method Formulation},
-  journal = {Int. J. Numer. Anal. Model.},
-  year    = {2006},
-  volume  = {3},
-  pages   = {1--20},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hartmann.houston:symmetric*1,
-  author  = {R. Hartmann and P. Houston},
-  title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations II: Goal-Oriented A Posteriori Error Estimation},
-  journal = {Int. J. Numer. Anal. Model.},
-  year    = {2006},
-  volume  = {3},
-  pages   = {141--162},
   url     = {},
   doi     = {}
 }
@@ -192,17 +192,6 @@
   doi     = {}
 }
 
-@Article{joshi.bangerth.ea:plane,
-  author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
-  title   = {Plane wave fluorescence tomography with adaptive finite elements},
-  journal = {Optics Letters},
-  year    = {2006},
-  volume  = {31},
-  pages   = {193--195},
-  url     = {},
-  doi     = {}
-}
-
 @Article{joshi.bangerth.ea:non-contact,
   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
   title   = {Non-contact fluorescence optical tomography with scanning area illumination},
@@ -221,6 +210,17 @@
   year    = {2006},
   volume  = {14},
   pages   = {6516--6534},
+  url     = {},
+  doi     = {}
+}
+
+@Article{joshi.bangerth.ea:plane,
+  author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
+  title   = {Plane wave fluorescence tomography with adaptive finite elements},
+  journal = {Optics Letters},
+  year    = {2006},
+  volume  = {31},
+  pages   = {193--195},
   url     = {},
   doi     = {}
 }

--- a/publications-2007.bib
+++ b/publications-2007.bib
@@ -97,17 +97,6 @@
   doi     = {}
 }
 
-@Article{carnes.djilali:analysis,
-  author  = {B. Carnes and N. Djilali},
-  title   = {Analysis of coupled proton and water transport in a PEM fuel cell using the binary friction membrane model},
-  journal = {Electrochimica Acta},
-  year    = {2007},
-  volume  = {52},
-  pages   = {1038--1052},
-  url     = {},
-  doi     = {}
-}
-
 @Article{carnes.carey:estimating,
   author  = {B. R. Carnes and G. F. Carey},
   title   = {Estimating spatial and parameter error in parameterized nonlinear reaction-diffusion equations},
@@ -116,6 +105,17 @@
   volume  = {23},
   pages   = {835--854},
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/cnm.928/abstract},
+  doi     = {}
+}
+
+@Article{carnes.djilali:analysis,
+  author  = {B. Carnes and N. Djilali},
+  title   = {Analysis of coupled proton and water transport in a PEM fuel cell using the binary friction membrane model},
+  journal = {Electrochimica Acta},
+  year    = {2007},
+  volume  = {52},
+  pages   = {1038--1052},
+  url     = {},
   doi     = {}
 }
 
@@ -185,17 +185,6 @@
   doi     = {}
 }
 
-@Article{hartmann:error,
-  author  = {R. Hartmann},
-  title   = {Error estimation and adjoint based refinement for an adjoint consistent DG discretization of the compressible Euler equations},
-  journal = {Int. J. Computing Science and Mathematics},
-  year    = {2007},
-  volume  = {1},
-  pages   = {207--220},
-  url     = {},
-  doi     = {}
-}
-
 @Article{hartmann:dg,
   author  = {R. Hartmann},
   title   = {DG discretizations for compressible flows: Adjoint consistency analysis, error estimation and adaptivity},
@@ -207,31 +196,23 @@
   doi     = {}
 }
 
+@Article{hartmann:error,
+  author  = {R. Hartmann},
+  title   = {Error estimation and adjoint based refinement for an adjoint consistent DG discretization of the compressible Euler equations},
+  journal = {Int. J. Computing Science and Mathematics},
+  year    = {2007},
+  volume  = {1},
+  pages   = {207--220},
+  url     = {},
+  doi     = {}
+}
+
 @MastersThesis{hepperger:pod-basierter,
   author  = {P. Hepperger},
   title   = {Ein POD-basierter Ansatz zur numerischen L\"{o}sung eines Datenassimilationsproblems am Beispiel einer linearen Diffusions-Konvektions-Gleichung},
   year    = {2007},
   school  = {Technical University of Munich, Germany},
   url     = {}
-}
-
-@MastersThesis{kamm:posteriori,
-  author  = {C. D. Kamm},
-  title   = {A posteriori error estimation in numerical methods for solving self-adjoint eigenvalue problems},
-  year    = {2007},
-  school  = {TU Berlin, Germany},
-  url     = {}
-}
-
-@Article{kayser-herold.matthies:unified,
-  author  = {O. Kayser-Herold and H.G. Matthies},
-  title   = {A unified least-squares formulation for fluid-structure interaction problems},
-  journal = {Computers and Structures},
-  year    = {2007},
-  volume  = {85},
-  pages   = {998--1011},
-  url     = {},
-  doi     = {}
 }
 
 @MastersThesis{janssen:vergleich,
@@ -249,6 +230,25 @@
   year    = {2007},
   volume  = {},
   pages   = {564--567},
+  url     = {},
+  doi     = {}
+}
+
+@MastersThesis{kamm:posteriori,
+  author  = {C. D. Kamm},
+  title   = {A posteriori error estimation in numerical methods for solving self-adjoint eigenvalue problems},
+  year    = {2007},
+  school  = {TU Berlin, Germany},
+  url     = {}
+}
+
+@Article{kayser-herold.matthies:unified,
+  author  = {O. Kayser-Herold and H.G. Matthies},
+  title   = {A unified least-squares formulation for fluid-structure interaction problems},
+  journal = {Computers and Structures},
+  year    = {2007},
+  volume  = {85},
+  pages   = {998--1011},
   url     = {},
   doi     = {}
 }
@@ -316,6 +316,14 @@
   doi     = {}
 }
 
+@PhDThesis{renda:discontinuous,
+  author  = {S. M. Renda},
+  title   = {Discontinuous Galerkin Methods for all speed flows},
+  year    = {2007},
+  school  = {University of Calabria},
+  url     = {}
+}
+
 @MastersThesis{rohe:residuale,
   author  = {L. R\"{o}he},
   title   = {Residuale Stabilisierung f\"{u}r Finite Elemente Verfahren bei inkompressiblen Str\"{o}mungen},
@@ -365,17 +373,6 @@
   doi     = {}
 }
 
-@Article{steigemann.fulland:on,
-  author  = {M. Steigemann and M. Fulland},
-  title   = {On the computation of the pure Neumann problem in 2-dimensional elasticity},
-  journal = {International Journal of Fracture},
-  year    = {2007},
-  volume  = {146},
-  pages   = {265--277},
-  url     = {},
-  doi     = {}
-}
-
 @Article{steigemann.fulland.ea:simulation,
   author  = {M. Steigemann and M. Fulland and M. Specovius-Neugebauer and H. A. Richard},
   title   = {Simulation of crack paths in functionally graded materials},
@@ -383,6 +380,17 @@
   year    = {2007},
   volume  = {7},
   pages   = {4030029--4030030},
+  url     = {},
+  doi     = {}
+}
+
+@Article{steigemann.fulland:on,
+  author  = {M. Steigemann and M. Fulland},
+  title   = {On the computation of the pure Neumann problem in 2-dimensional elasticity},
+  journal = {International Journal of Fracture},
+  year    = {2007},
+  volume  = {146},
+  pages   = {265--277},
   url     = {},
   doi     = {}
 }
@@ -396,14 +404,6 @@
   pages   = {},
   url     = {},
   doi     = {}
-}
-
-@PhDThesis{renda:discontinuous,
-  author  = {S. M. Renda},
-  title   = {Discontinuous Galerkin Methods for all speed flows},
-  year    = {2007},
-  school  = {University of Calabria},
-  url     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -1,16 +1,5 @@
 % Encoding: US-ASCII
 
-@Article{bangerth:framework,
-  author  = {W. Bangerth},
-  title   = {A framework for the adaptive finite element solution of large-scale inverse problems},
-  journal = {SIAM J. Sci. Comput},
-  year    = {2008},
-  volume  = {30},
-  pages   = {2965--2989},
-  url     = {},
-  doi     = {}
-}
-
 @Article{bangerth.joshi:adaptive,
   author  = {W. Bangerth and A. Joshi},
   title   = {Adaptive finite element methods for the solution of inverse problems in optical tomography},
@@ -18,6 +7,17 @@
   year    = {2008},
   volume  = {24},
   pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{bangerth:framework,
+  author  = {W. Bangerth},
+  title   = {A framework for the adaptive finite element solution of large-scale inverse problems},
+  journal = {SIAM J. Sci. Comput},
+  year    = {2008},
+  volume  = {30},
+  pages   = {2965--2989},
   url     = {},
   doi     = {}
 }
@@ -44,17 +44,6 @@
   doi     = {}
 }
 
-@Article{brendel.ziegler.ea:algebraic,
-  author  = {B. Brendel and R. Ziegler and T. Nielsen},
-  title   = {Algebraic reconstruction techniques for spectral reconstruction in diffuse optical tomography},
-  journal = {Applied Optics},
-  year    = {2008},
-  volume  = {47},
-  pages   = {6392--6403},
-  url     = {},
-  doi     = {}
-}
-
 @Article{boffi.gastaldi.ea:on,
   author  = {D. Boffi and L. Gastaldi and L. Heltai and C. S. Peskin},
   title   = {On the hyper-elastic formulation of the immersed boundary method},
@@ -62,6 +51,17 @@
   year    = {2008},
   volume  = {197},
   pages   = {2210--2231},
+  url     = {},
+  doi     = {}
+}
+
+@Article{brendel.ziegler.ea:algebraic,
+  author  = {B. Brendel and R. Ziegler and T. Nielsen},
+  title   = {Algebraic reconstruction techniques for spectral reconstruction in diffuse optical tomography},
+  journal = {Applied Optics},
+  year    = {2008},
+  volume  = {47},
+  pages   = {6392--6403},
   url     = {},
   doi     = {}
 }
@@ -136,6 +136,17 @@
   doi     = {}
 }
 
+@Article{hartmann.houston:optimal,
+  author  = {R. Hartmann and P. Houston},
+  title   = {An optimal order interior penalty discontinuous Galerkin discretization of the compressible Navier-Stokes equations},
+  journal = {J. Comput. Phys., no. 22},
+  year    = {2008},
+  volume  = {227},
+  pages   = {9670--9685},
+  url     = {},
+  doi     = {}
+}
+
 @Article{hartmann:error,
   author  = {R. Hartmann},
   title   = {Error estimation and adjoint-based refinement for multiple force coefficients in aerodynamic flow simulations},
@@ -165,17 +176,6 @@
   year    = {2008},
   volume  = {},
   pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hartmann.houston:optimal,
-  author  = {R. Hartmann and P. Houston},
-  title   = {An optimal order interior penalty discontinuous Galerkin discretization of the compressible Navier-Stokes equations},
-  journal = {J. Comput. Phys., no. 22},
-  year    = {2008},
-  volume  = {227},
-  pages   = {9670--9685},
   url     = {},
   doi     = {}
 }
@@ -210,17 +210,6 @@
   doi     = {}
 }
 
-@Article{kanschat:robust,
-  author  = {G. Kanschat},
-  title   = {Robust smoothers for high order discontinuous Galerkin discretizations of advection-diffusion problems},
-  journal = {J. Comput. Appl. Math.},
-  year    = {2008},
-  volume  = {218},
-  pages   = {53--60},
-  url     = {http://www.isc.tamu.edu/publications-reports/tr/0701.pdf},
-  doi     = {}
-}
-
 @Article{kanschat.schotzau:energy,
   author  = {G. Kanschat and D. Sch\"{o}tzau},
   title   = {Energy norm a-posteriori error estimation for divergence-free discontinuous Galerkin approximations of the Navier-Stokes equations},
@@ -230,6 +219,17 @@
   pages   = {1093--1113},
   url     = {},
   doi     = {10.1002/fld.1795}
+}
+
+@Article{kanschat:robust,
+  author  = {G. Kanschat},
+  title   = {Robust smoothers for high order discontinuous Galerkin discretizations of advection-diffusion problems},
+  journal = {J. Comput. Appl. Math.},
+  year    = {2008},
+  volume  = {218},
+  pages   = {53--60},
+  url     = {http://www.isc.tamu.edu/publications-reports/tr/0701.pdf},
+  doi     = {}
 }
 
 @Article{khalmanova.costanzo:space-time,
@@ -278,6 +278,19 @@
   year    = {2008},
   school  = {University of G\"{o}ttingen, Germany},
   url     = {}
+}
+
+@Article{lube.tews:optimal,
+  author  = {G. Lube and B. Tews},
+  title   = {Optimal control of singularly perturbed advection-diffusion-reaction problems},
+  journal = {Math. Model. Meths. Appl. Sc.},
+  year    = {2010},
+  volume  = {20},
+  number  = {3},
+  pages   = {375--395},
+  url     = {},
+  doi     = {10.1142/S0218202510004271},
+  comment = {Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G\"{o}ttingen, Germany}
 }
 
 @Article{neytcheva.bangtsson:preconditioning,
@@ -351,14 +364,6 @@
   url     = {}
 }
 
-@PhDThesis{ziegler:modeling,
-  author  = {R. Ziegler},
-  title   = {Modeling photon transport and reconstruction of optical properties for performance assessment of laser and fluorescence mammographs and analysis of clinical data},
-  year    = {2008},
-  school  = {Freie Universit\"{a}t Berlin},
-  url     = {}
-}
-
 @Article{ziegler.brendel.ea:nonlinear,
   author  = {R. Ziegler and B. Brendel and A. Ziegler and T. Nielsen and H. Rinneberg},
   title   = {Nonlinear Reconstruction of Continuous Wave Diffuse Optical Tomography Using Fitted Diffusion Coefficients},
@@ -370,17 +375,12 @@
   doi     = {}
 }
 
-@Article{lube.tews:optimal,
-  author  = {G. Lube and B. Tews},
-  title   = {Optimal control of singularly perturbed advection-diffusion-reaction problems},
-  journal = {Math. Model. Meths. Appl. Sc.},
-  year    = {2010},
-  volume  = {20},
-  number  = {3},
-  pages   = {375--395},
-  url     = {},
-  doi     = {10.1142/S0218202510004271},
-  comment = {Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G\"{o}ttingen, Germany}
+@PhDThesis{ziegler:modeling,
+  author  = {R. Ziegler},
+  title   = {Modeling photon transport and reconstruction of optical properties for performance assessment of laser and fluorescence mammographs and analysis of clinical data},
+  year    = {2008},
+  school  = {Freie Universit\"{a}t Berlin},
+  url     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2009.bib
+++ b/publications-2009.bib
@@ -33,14 +33,6 @@
   doi     = {}
 }
 
-@MastersThesis{bartle:shell,
-  author  = {S. Bartle},
-  title   = {Shell finite elements with applications in biomechanics},
-  year    = {2009},
-  school  = {University of Cape Town, South Africa},
-  url     = {}
-}
-
 @Article{bartle.mcbride.ea:discontinuous,
   author  = {S. Bartle and A. McBride and B. D. Reddy},
   title   = {A discontinuous Galerkin formulation of a model of gradient plasticity at finite strains},
@@ -50,6 +42,14 @@
   pages   = {1805--1820},
   url     = {},
   doi     = {}
+}
+
+@MastersThesis{bartle:shell,
+  author  = {S. Bartle},
+  title   = {Shell finite elements with applications in biomechanics},
+  year    = {2009},
+  school  = {University of Cape Town, South Africa},
+  url     = {}
 }
 
 @Article{bassi.bartolo.ea:discontinuous,
@@ -244,14 +244,6 @@
   url     = {}
 }
 
-@PhDThesis{kim:analysis,
-  author  = {S. Kim},
-  title   = {Analysis of a PML method applied to computation of resonances in open systems and acoustic scattering problems},
-  year    = {2009},
-  school  = {Texas A\&M University},
-  url     = {}
-}
-
 @Article{kim.pasciak:computation,
   author  = {S. Kim and J. E. Pasciak},
   title   = {The computation of resonances in open systems using a perfectly matched layer},
@@ -261,6 +253,14 @@
   pages   = {1375--1398},
   url     = {},
   doi     = {}
+}
+
+@PhDThesis{kim:analysis,
+  author  = {S. Kim},
+  title   = {Analysis of a PML method applied to computation of resonances in open systems and acoustic scattering problems},
+  year    = {2009},
+  school  = {Texas A\&M University},
+  url     = {}
 }
 
 @MastersThesis{klein:modelladaptive,
@@ -435,14 +435,6 @@
   url     = {}
 }
 
-@PhDThesis{wang:adaptive,
-  author  = {Y. Wang},
-  title   = {Adaptive mesh refinement solution techniques for the multigrid S$_{\textnormal{N}}$ transport equation using a higher-order discontinuous finite element method},
-  year    = {2009},
-  school  = {Texas A\&M University},
-  url     = {}
-}
-
 @Article{wang.bangerth.ea:three-dimensional,
   author  = {Y. Wang and W. Bangerth and J. Ragusa},
   title   = {Three-dimensional h-adaptivity for the multigroup neutron diffusion equations},
@@ -452,6 +444,14 @@
   pages   = {543--555},
   url     = {},
   doi     = {}
+}
+
+@PhDThesis{wang:adaptive,
+  author  = {Y. Wang},
+  title   = {Adaptive mesh refinement solution techniques for the multigrid S$_{\textnormal{N}}$ transport equation using a higher-order discontinuous finite element method},
+  year    = {2009},
+  school  = {Texas A\&M University},
+  url     = {}
 }
 
 @MastersThesis{wanka:grundkonzepte,

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -88,14 +88,6 @@
   doi     = {}
 }
 
-@PhDThesis{chueh:integrated,
-  author  = {C. C. Chueh},
-  title   = {Integrated adaptive numerical methods for transient two-phase flow in heterogeneous porous medi},
-  year    = {2010},
-  school  = {University of Victoria},
-  url     = {}
-}
-
 @Article{chueh.secanell.ea:multi-level,
   author  = {C. C. Chueh and M. Secanell and W. Bangerth and N. Djilali},
   title   = {Multi-level Adaptive Simulation of Transient Two-phase Flow in Heterogeneous Porous Media},
@@ -105,6 +97,14 @@
   pages   = {1585--1596},
   url     = {},
   doi     = {}
+}
+
+@PhDThesis{chueh:integrated,
+  author  = {C. C. Chueh},
+  title   = {Integrated adaptive numerical methods for transient two-phase flow in heterogeneous porous medi},
+  year    = {2010},
+  school  = {University of Victoria},
+  url     = {}
 }
 
 @MastersThesis{dally:fe-modelladaptivitat,
@@ -269,17 +269,6 @@
   doi     = {}
 }
 
-@Article{heister.lube.ea:on,
-  author  = {T. Heister and G. Lube and G. Rapin},
-  title   = {On robust parallel preconditioning for incompressible flow problems},
-  journal = {In Numerical Mathematics and Advanced Applications, ENUMATH 2009. Springer, Berlin},
-  year    = {2010},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{heister.kronbichler.ea:generic,
   author  = {T. Heister and M. Kronbichler and W. Bangerth},
   title   = {Generic Finite Element programming for massively parallel flow simulations},
@@ -298,6 +287,17 @@
   year    = {2010},
   volume  = {6305},
   pages   = {122--131},
+  url     = {},
+  doi     = {}
+}
+
+@Article{heister.lube.ea:on,
+  author  = {T. Heister and G. Lube and G. Rapin},
+  title   = {On robust parallel preconditioning for incompressible flow problems},
+  journal = {In Numerical Mathematics and Advanced Applications, ENUMATH 2009. Springer, Berlin},
+  year    = {2010},
+  volume  = {},
+  pages   = {},
   url     = {},
   doi     = {}
 }
@@ -513,17 +513,6 @@
   doi     = {}
 }
 
-@Article{rupp:symbolic,
-  author  = {K. Rupp},
-  title   = {Symbolic integration at compile time in finite element methods},
-  journal = {Proceedings of the 2010 International Symposium on Symbolic and Algebraic Computation, 347-354},
-  year    = {2010},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{rees.stoll.ea:all-at-once,
   author  = {T. Rees and M. Stoll and A. Wathen},
   title   = {All-at-once preconditioning in PDE-constrained optimization},
@@ -553,6 +542,17 @@
   year    = {2010},
   volume  = {199},
   pages   = {2331--2342},
+  url     = {},
+  doi     = {}
+}
+
+@Article{rupp:symbolic,
+  author  = {K. Rupp},
+  title   = {Symbolic integration at compile time in finite element methods},
+  journal = {Proceedings of the 2010 International Symposium on Symbolic and Algebraic Computation, 347-354},
+  year    = {2010},
+  volume  = {},
+  pages   = {},
   url     = {},
   doi     = {}
 }

--- a/publications-2011.bib
+++ b/publications-2011.bib
@@ -11,14 +11,6 @@
   doi     = {}
 }
 
-@PhDThesis{allmaras:modeling,
-  author  = {M. Allmaras},
-  title   = {Modeling aspects and computational methods for some recent problems of tomographic imaging},
-  year    = {2011},
-  school  = {Texas A\&M University},
-  url     = {}
-}
-
 @Article{allmaras.bangerth:reconstructions,
   author  = {M. Allmaras and W. Bangerth},
   title   = {Reconstructions in ultrasound modulated optical tomography},
@@ -28,6 +20,14 @@
   pages   = {801--823},
   url     = {},
   doi     = {}
+}
+
+@PhDThesis{allmaras:modeling,
+  author  = {M. Allmaras},
+  title   = {Modeling aspects and computational methods for some recent problems of tomographic imaging},
+  year    = {2011},
+  school  = {Texas A\&M University},
+  url     = {}
 }
 
 @Article{alouges.desimone.ea:numerical,
@@ -74,17 +74,6 @@
   doi     = {}
 }
 
-@Article{burg:hp-efficient,
-  author  = {M. B\"{u}rg},
-  title   = {An hp-Efficient Residual-Based A Posteriori Error Estimator for Maxwell's Equations},
-  journal = {Proc. Appl. Math. Mech. Vol. 11, pp: 869 -- 870},
-  year    = {2011},
-  volume  = {},
-  pages   = {},
-  url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201110421/abstract},
-  doi     = {}
-}
-
 @Article{burg.dorfler:convergence,
   author  = {M. B\"{u}rg and W. D\"{o}rfler},
   title   = {Convergence of an adaptive hp finite element strategy in higher space-dimensions},
@@ -93,6 +82,17 @@
   volume  = {},
   pages   = {1132--1146},
   url     = {},
+  doi     = {}
+}
+
+@Article{burg:hp-efficient,
+  author  = {M. B\"{u}rg},
+  title   = {An hp-Efficient Residual-Based A Posteriori Error Estimator for Maxwell's Equations},
+  journal = {Proc. Appl. Math. Mech. Vol. 11, pp: 869 -- 870},
+  year    = {2011},
+  volume  = {},
+  pages   = {},
+  url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201110421/abstract},
   doi     = {}
 }
 
@@ -388,14 +388,6 @@
   doi     = {}
 }
 
-@PhDThesis{kronbichler:computational,
-  author  = {M. Kronbichler},
-  title   = {Computational Techniques for Coupled Flow-Transport Problems},
-  year    = {2011},
-  school  = {Uppsala University, Uppsala, Sweden},
-  url     = {}
-}
-
 @Article{kronbichler.walker.ea:multiscale,
   author  = {M. Kronbichler and C. Walker and G. Kreiss and B. M\"{u}ller},
   title   = {Multiscale modeling of capillary-driven contact line dynamics},
@@ -406,6 +398,14 @@
   pages   = {},
   url     = {},
   doi     = {}
+}
+
+@PhDThesis{kronbichler:computational,
+  author  = {M. Kronbichler},
+  title   = {Computational Techniques for Coupled Flow-Transport Problems},
+  year    = {2011},
+  school  = {Uppsala University, Uppsala, Sweden},
+  url     = {}
 }
 
 @Article{layton.rohe.ea:explicitly,
@@ -588,6 +588,14 @@
   doi     = {}
 }
 
+@PhDThesis{wick:adaptive,
+  author  = {T. Wick},
+  title   = {Adaptive finite element simulation of fluid-structure interaction},
+  year    = {2011},
+  school  = {University of Heidelberg, Germany},
+  url     = {}
+}
+
 @Article{wick:fluid-structure,
   author  = {T. Wick},
   title   = {Fluid-structure interactions using different mesh motion techniques},
@@ -597,14 +605,6 @@
   pages   = {1456--1467},
   url     = {},
   doi     = {}
-}
-
-@PhDThesis{wick:adaptive,
-  author  = {T. Wick},
-  title   = {Adaptive finite element simulation of fluid-structure interaction},
-  year    = {2011},
-  school  = {University of Heidelberg, Germany},
-  url     = {}
 }
 
 @Article{young:qualitative,

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -20,6 +20,14 @@
   doi     = {}
 }
 
+@PhDThesis{alcalde:parallel,
+  author  = {E. Romero Alcalde},
+  title   = {Parallel implementation of Davidson-type methods for large-scale eigenvalue problems},
+  year    = {2012},
+  school  = {Universitat Politecnica de Valencia},
+  url     = {}
+}
+
 @Article{alexe.sandu:fully,
   author  = {M. Alexe and A. Sandu},
   title   = {A fully discrete framework for the adaptive solution of inverse problems },
@@ -95,17 +103,6 @@
   doi     = {}
 }
 
-@Article{burg:residual-based,
-  author  = {M. B\"{u}rg},
-  title   = {A Residual-Based A Posteriori Error Estimator for the $hp$-Finite Element Method for Maxwell's Equations},
-  journal = {Appl. Numer. Math.},
-  year    = {2012},
-  volume  = {62},
-  pages   = {922--940},
-  url     = {},
-  doi     = {}
-}
-
 @PhDThesis{burg:fully,
   author  = {M. B\"{u}rg},
   title   = {A Fully Automatic $hp$-Adaptive Refinement Strategy},
@@ -114,14 +111,13 @@
   url     = {}
 }
 
-@Article{cangiani.georgoulis.ea:posteriori,
-  author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
-  title   = {An a posteriori error estimator for discontinuous Galerkin methods for non-stationary convection-diffusion problems},
-  journal = {},
-  note    = {Submitted},
+@Article{burg:residual-based,
+  author  = {M. B\"{u}rg},
+  title   = {A Residual-Based A Posteriori Error Estimator for the $hp$-Finite Element Method for Maxwell's Equations},
+  journal = {Appl. Numer. Math.},
   year    = {2012},
-  volume  = {},
-  pages   = {},
+  volume  = {62},
+  pages   = {922--940},
   url     = {},
   doi     = {}
 }
@@ -135,6 +131,18 @@
   volume  = {},
   pages   = {},
   url     = {http://www2.le.ac.uk/departments/mathematics/extranet/staff-material/staff-profiles/eg64/publications},
+  doi     = {}
+}
+
+@Article{cangiani.georgoulis.ea:posteriori,
+  author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
+  title   = {An a posteriori error estimator for discontinuous Galerkin methods for non-stationary convection-diffusion problems},
+  journal = {},
+  note    = {Submitted},
+  year    = {2012},
+  volume  = {},
+  pages   = {},
+  url     = {},
   doi     = {}
 }
 
@@ -190,25 +198,6 @@
   doi     = {}
 }
 
-@MastersThesis{hai:numerical,
-  author  = {B. S. M. Ebna Hai},
-  title   = {Numerical approximation of fluid structure interaction (FSI) problem and simplified model for the vertical vibrations of the aircraft wing},
-  year    = {2012},
-  school  = {University of Hamburg, Germany and University of L'Aquila, Italy},
-  url     = {}
-}
-
-@Article{hai:numerical*1,
-  author  = {B. S. M. Ebna Hai},
-  title   = {Numerical approximation of fluid structure interaction (FSI) problem: simplified model for the vertical vibrations of the aircraft wing},
-  journal = {Lambert Academic Publishing, ISBN: 978-3-659-30284-8},
-  year    = {2012},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{efendiev.galvis.ea:robust,
   author  = {Y. Efendiev and J. Galvis and R. Lazarov and J. Willems},
   title   = {Robust domain decomposition preconditioners for abstract symmetric positive definite bilinear forms},
@@ -242,14 +231,6 @@
   doi     = {}
 }
 
-@MastersThesis{fankhauser:hp-adaptive,
-  author  = {T. Fankhauser},
-  title   = {An hp-adaptive strategy based on smoothness estimation in 2d},
-  year    = {2012},
-  school  = {University of Bern, Switzerland},
-  url     = {}
-}
-
 @Article{fankhauser.wihler.ea:hp-adaptive,
   author  = {T. Fankhauser and T. P. Wihler and M. Wirz},
   title   = {hp-adaptive FEM based on continuous Sobolev embeddings: isotropic refinements},
@@ -259,6 +240,14 @@
   pages   = {},
   url     = {},
   doi     = {}
+}
+
+@MastersThesis{fankhauser:hp-adaptive,
+  author  = {T. Fankhauser},
+  title   = {An hp-adaptive strategy based on smoothness estimation in 2d},
+  year    = {2012},
+  school  = {University of Bern, Switzerland},
+  url     = {}
 }
 
 @PhDThesis{ferguson:brittle,
@@ -284,6 +273,25 @@
   author  = {J. J. Gaitero and J. S. Dolado and C. Neuen and F. Heber and E. Koenders},
   title   = {Computational 3d simulation of Calcium leaching in cement matrices},
   journal = {Institut f\"{u}r numerische Simulation, Rheinische Friedrich-Wilhelms-Universit\"{a}t Bonn, INS Preprint 1203},
+  year    = {2012},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@MastersThesis{hai:numerical,
+  author  = {B. S. M. Ebna Hai},
+  title   = {Numerical approximation of fluid structure interaction (FSI) problem and simplified model for the vertical vibrations of the aircraft wing},
+  year    = {2012},
+  school  = {University of Hamburg, Germany and University of L'Aquila, Italy},
+  url     = {}
+}
+
+@Article{hai:numerical*1,
+  author  = {B. S. M. Ebna Hai},
+  title   = {Numerical approximation of fluid structure interaction (FSI) problem: simplified model for the vertical vibrations of the aircraft wing},
+  journal = {Lambert Academic Publishing, ISBN: 978-3-659-30284-8},
   year    = {2012},
   volume  = {},
   pages   = {},
@@ -335,14 +343,14 @@
   doi     = {}
 }
 
-@Article{hinze.kunkel:discrete,
-  author  = {M. Hinze and M. Kunkel},
-  title   = {Discrete empirical interpolation in POD Model Order Reduction of Drift-Diffusion Equations in Electrical Networks},
-  journal = {Scientific Computing in Electrical Engineering, SCEE 2010 Mathematics in Industry, part 5},
+@Article{hinze.kunkel.ea:model,
+  author  = {M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel},
+  title   = {Model order reduction of coupled circuit-device systems},
+  journal = {International Journal of Numerical Modelling: Electronic Networks, Devices and Fields},
   year    = {2012},
-  volume  = {16},
-  pages   = {423--431},
-  url     = {http://link.springer.com/chapter/10.1007%2F978-3-642-22453-9_45},
+  volume  = {25},
+  pages   = {362--377},
+  url     = {},
   doi     = {}
 }
 
@@ -357,14 +365,14 @@
   doi     = {}
 }
 
-@Article{hinze.kunkel.ea:model,
-  author  = {M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel},
-  title   = {Model order reduction of coupled circuit-device systems},
-  journal = {International Journal of Numerical Modelling: Electronic Networks, Devices and Fields},
+@Article{hinze.kunkel:discrete,
+  author  = {M. Hinze and M. Kunkel},
+  title   = {Discrete empirical interpolation in POD Model Order Reduction of Drift-Diffusion Equations in Electrical Networks},
+  journal = {Scientific Computing in Electrical Engineering, SCEE 2010 Mathematics in Industry, part 5},
   year    = {2012},
-  volume  = {25},
-  pages   = {362--377},
-  url     = {},
+  volume  = {16},
+  pages   = {423--431},
+  url     = {http://link.springer.com/chapter/10.1007%2F978-3-642-22453-9_45},
   doi     = {}
 }
 
@@ -399,6 +407,14 @@
   url     = {}
 }
 
+@PhDThesis{kormann:efficient,
+  author  = {K. Kormann},
+  title   = {Efficient and Reliable Simulation of Quantum Molecular Dynamics},
+  year    = {2012},
+  school  = {Uppsala University},
+  url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A549981&dswid=6393}
+}
+
 @PhDThesis{kormann:on,
   author  = {K. Kormann},
   title   = {On Numerical Solution Methods for Block-Structured Discrete Systems},
@@ -418,14 +434,6 @@
   doi     = {}
 }
 
-@PhDThesis{kormann:efficient,
-  author  = {K. Kormann},
-  title   = {Efficient and Reliable Simulation of Quantum Molecular Dynamics},
-  year    = {2012},
-  school  = {Uppsala University},
-  url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A549981&dswid=6393}
-}
-
 @PhDThesis{kramer:cuda-based,
   author  = {S. Kramer},
   title   = {CUDA-based scientific computing tools and selected applications},
@@ -443,6 +451,19 @@
   pages   = {12--29},
   url     = {},
   doi     = {}
+}
+
+@Article{kronbichler.kormann:generic,
+  doi     = {10.1016/j.compfluid.2012.04.012},
+  url     = {https://doi.org/10.1016/j.compfluid.2012.04.012},
+  year    = {2012},
+  month   = jun,
+  publisher = {Elsevier {BV}},
+  volume  = {63},
+  pages   = {135--147},
+  author  = {Martin Kronbichler and Katharina Kormann},
+  title   = {A generic interface for parallel cell-based finite element operator application},
+  journal = {Computers {\&} Fluids}
 }
 
 @PhDThesis{kunkel:nonsmooth,
@@ -570,14 +591,6 @@
   doi     = {}
 }
 
-@PhDThesis{alcalde:parallel,
-  author  = {E. Romero Alcalde},
-  title   = {Parallel implementation of Davidson-type methods for large-scale eigenvalue problems},
-  year    = {2012},
-  school  = {Universitat Politecnica de Valencia},
-  url     = {}
-}
-
 @PhDThesis{roy:numerical,
   author  = {S. Roy},
   title   = {Numerical simulation using the generalized immersed boundary method: An application to Hydrocephalus},
@@ -616,17 +629,6 @@
   url     = {}
 }
 
-@Article{stoll.wathen:preconditioning,
-  author  = {M. Stoll and A. Wathen},
-  title   = {Preconditioning for partial differential equation constrained optimization with control constraints},
-  journal = {Numerical Linear Algebra with Applications},
-  year    = {2012},
-  volume  = {19},
-  pages   = {53--71},
-  url     = {},
-  doi     = {}
-}
-
 @Article{stoll.wathen:all-at-once,
   author  = {M. Stoll and A. Wathen},
   title   = {All-at-once solution of time-dependent Stokes control},
@@ -634,6 +636,17 @@
   year    = {2012},
   volume  = {232},
   pages   = {498--515},
+  url     = {},
+  doi     = {}
+}
+
+@Article{stoll.wathen:preconditioning,
+  author  = {M. Stoll and A. Wathen},
+  title   = {Preconditioning for partial differential equation constrained optimization with control constraints},
+  journal = {Numerical Linear Algebra with Applications},
+  year    = {2012},
+  volume  = {19},
+  pages   = {53--71},
   url     = {},
   doi     = {}
 }
@@ -765,19 +778,6 @@
   pages   = {},
   url     = {},
   doi     = {}
-}
-
-@Article{kronbichler.kormann:generic,
-  doi     = {10.1016/j.compfluid.2012.04.012},
-  url     = {https://doi.org/10.1016/j.compfluid.2012.04.012},
-  year    = {2012},
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = {63},
-  pages   = {135--147},
-  author  = {Martin Kronbichler and Katharina Kormann},
-  title   = {A generic interface for parallel cell-based finite element operator application},
-  journal = {Computers {\&} Fluids}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -57,17 +57,6 @@
   doi     = {}
 }
 
-@Article{bangerth.heister:what,
-  author  = {W. Bangerth and T. Heister},
-  title   = {What makes computational open source software libraries successful?},
-  journal = {Computational Science \& Discovery, article 015010},
-  year    = {2013},
-  volume  = {6},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{bangerth.heister.ea:deal-ii,
   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
   title   = {The \texttt{deal.II} Library, Version 8.1},
@@ -87,6 +76,17 @@
   volume  = {},
   pages   = {},
   url     = {http://arxiv.org/abs/1312.2266v3},
+  doi     = {}
+}
+
+@Article{bangerth.heister:what,
+  author  = {W. Bangerth and T. Heister},
+  title   = {What makes computational open source software libraries successful?},
+  journal = {Computational Science \& Discovery, article 015010},
+  year    = {2013},
+  volume  = {6},
+  pages   = {},
+  url     = {},
   doi     = {}
 }
 
@@ -243,39 +243,6 @@
   url     = {}
 }
 
-@Article{hai.bause:numerical,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Numerical Approximation of Fluid Structure Interaction (FSI) Problem},
-  journal = {In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2013-16013, pp. V01AT02A001/1-10, July 7--11, Incline Village, Nevada, USA},
-  year    = {2013},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hai.bause:adaptive,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Adaptive Multigrid Methods for Fluid-Structure Interaction (FSI) Optimization in an Aircraft and Design of Integrated Structural Health Monitoring (SHM) Systems},
-  journal = {Proceedings of The 2nd ECCOMAS Young Investigators Conference (YIC2013), At Bordeaux, France},
-  year    = {2013},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hai.bause:finite,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Finite Element Approximation of Fluid Structure Interaction (FSI) Optimization in Arbitrary Lagrangian-Eulerian Coordinates},
-  journal = {In proceedings of: the ASME International Mechanical Engineering Congress \& Exposition, Vol. 7B, No. IMECE2013-62291, pp. V07BT08A034/1--8, Nov 13--21, San Diego, California, USA},
-  year    = {2013},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{efendiev.galvis.ea:multiscale,
   author  = {Y. Efendiev and J. Galvis and S. Pauletti},
   title   = {Multiscale finite element methods for flows on rough surfaces},
@@ -390,6 +357,39 @@
   volume  = {39},
   pages   = {69--99},
   url     = {http://link.springer.com/article/10.1007%2Fs10444-011-9270-8},
+  doi     = {}
+}
+
+@Article{hai.bause:adaptive,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Adaptive Multigrid Methods for Fluid-Structure Interaction (FSI) Optimization in an Aircraft and Design of Integrated Structural Health Monitoring (SHM) Systems},
+  journal = {Proceedings of The 2nd ECCOMAS Young Investigators Conference (YIC2013), At Bordeaux, France},
+  year    = {2013},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hai.bause:finite,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Finite Element Approximation of Fluid Structure Interaction (FSI) Optimization in Arbitrary Lagrangian-Eulerian Coordinates},
+  journal = {In proceedings of: the ASME International Mechanical Engineering Congress \& Exposition, Vol. 7B, No. IMECE2013-62291, pp. V07BT08A034/1--8, Nov 13--21, San Diego, California, USA},
+  year    = {2013},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hai.bause:numerical,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Numerical Approximation of Fluid Structure Interaction (FSI) Problem},
+  journal = {In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2013-16013, pp. V01AT02A001/1-10, July 7--11, Incline Village, Nevada, USA},
+  year    = {2013},
+  volume  = {},
+  pages   = {},
+  url     = {},
   doi     = {}
 }
 
@@ -645,18 +645,6 @@
   doi     = {}
 }
 
-@Article{richter.wick:solid,
-  author  = {T. Richter and T. Wick},
-  title   = {Solid growth and clogging in fluid-structure interaction computed in ALE and fully Eulerian coordinates},
-  journal = {},
-  note    = {Submitted},
-  year    = {2013},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{richter.wick:on,
   author  = {T. Richter and T. Wick},
   title   = {On time discretizations of fluid-structure interactions},
@@ -675,6 +663,18 @@
   journal = {SIAM J. Sci. Comput., pp. B1085-B1104},
   year    = {2013},
   volume  = {35},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{richter.wick:solid,
+  author  = {T. Richter and T. Wick},
+  title   = {Solid growth and clogging in fluid-structure interaction computed in ALE and fully Eulerian coordinates},
+  journal = {},
+  note    = {Submitted},
+  year    = {2013},
+  volume  = {},
   pages   = {},
   url     = {},
   doi     = {}
@@ -732,17 +732,6 @@
   doi     = {}
 }
 
-@Article{salgado:framework,
-  author  = {A. J. Salgado},
-  title   = {A framework for the implementation of coupled multiphase flow problems using the deal.II library and its application to electrowetting},
-  journal = {Archive of Numerical Software, article 2},
-  year    = {2013},
-  volume  = {1},
-  pages   = {1--19},
-  url     = {},
-  doi     = {}
-}
-
 @Article{salgado:diffuse,
   author  = {A. J. Salgado},
   title   = {A diffuse interface fractional time-stepping technique for incompressible two-phase flows with moving contact lines},
@@ -750,6 +739,17 @@
   year    = {2013},
   volume  = {47},
   pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{salgado:framework,
+  author  = {A. J. Salgado},
+  title   = {A framework for the implementation of coupled multiphase flow problems using the deal.II library and its application to electrowetting},
+  journal = {Archive of Numerical Software, article 2},
+  year    = {2013},
+  volume  = {1},
+  pages   = {1--19},
   url     = {},
   doi     = {}
 }
@@ -890,17 +890,6 @@
   doi     = {}
 }
 
-@Article{wick:solving,
-  author  = {T. Wick},
-  title   = {Solving Monolithic Fluid-Structure Interaction Problems in Arbitrary Lagrangian Eulerian Coordinates with the deal.II Library},
-  journal = {Archive of Numerical Software, article 1},
-  year    = {2013},
-  volume  = {1},
-  pages   = {1--19},
-  url     = {},
-  doi     = {}
-}
-
 @Article{wick:fully,
   author  = {T. Wick},
   title   = {Fully Eulerian fluid-structure interaction for time-dependent problems},
@@ -908,6 +897,17 @@
   year    = {2013},
   volume  = {255},
   pages   = {14--26},
+  url     = {},
+  doi     = {}
+}
+
+@Article{wick:solving,
+  author  = {T. Wick},
+  title   = {Solving Monolithic Fluid-Structure Interaction Problems in Arbitrary Lagrangian Eulerian Coordinates with the deal.II Library},
+  journal = {Archive of Numerical Software, article 1},
+  year    = {2013},
+  volume  = {1},
+  pages   = {1--19},
   url     = {},
   doi     = {}
 }
@@ -945,17 +945,6 @@
   doi     = {}
 }
 
-@Article{young:finite,
-  author  = {T. D. Young},
-  title   = {A finite basis grid analysis of the Hartree-Fock wavefunction method for one- and two-electron atoms},
-  journal = {AIP Conf. Proc., pp. 1524},
-  year    = {2013},
-  volume  = {1558},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{young.romero.ea:parallel,
   author  = {T. D. Young and E. Romero and J. E. Roman},
   title   = {Parallel finite element density functional theory exploiting grid refinement and subspace recycling},
@@ -963,6 +952,17 @@
   year    = {2013},
   volume  = {184},
   pages   = {66--72},
+  url     = {},
+  doi     = {}
+}
+
+@Article{young:finite,
+  author  = {T. D. Young},
+  title   = {A finite basis grid analysis of the Hartree-Fock wavefunction method for one- and two-electron atoms},
+  journal = {AIP Conf. Proc., pp. 1524},
+  year    = {2013},
+  volume  = {1558},
+  pages   = {},
   url     = {},
   doi     = {}
 }

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -57,6 +57,20 @@
   doi     = {}
 }
 
+@Article{albert.schwarz:dynamics,
+  doi     = {10.1016/j.bpj.2014.04.036},
+  url     = {https://doi.org/10.1016/j.bpj.2014.04.036},
+  year    = {2014},
+  month   = jun,
+  publisher = {Elsevier {BV}},
+  volume  = {106},
+  number  = {11},
+  pages   = {2340--2352},
+  author  = {Philipp~J. Albert and Ulrich~S. Schwarz},
+  title   = {Dynamics of Cell Shape and Forces on Micropatterned Substrates Predicted by a Cellular Potts Model},
+  journal = {Biophysical Journal}
+}
+
 @Article{alexe.sandu:space-time,
   author  = {M. Alexe and A. Sandu},
   title   = {Space--time adaptive solution of inverse problems with the discrete adjoint method},
@@ -112,14 +126,6 @@
   doi     = {}
 }
 
-@PhDThesis{bhaiya:open-source,
-  author  = {M. Bhaiya},
-  title   = {An open-source two-phase non-isothermal mathematical model of a polymer electrolyte membrane fuel cell},
-  year    = {2014},
-  school  = {University of Alberta, Edmonton},
-  url     = {}
-}
-
 @Article{bhaiya.putz.ea:analysis,
   author  = {M. Bhaiya and A. Putz and M. Secanell},
   title   = {Analysis of non-isothermal effects on polymer electrolyte fuel cell electrode assemblies},
@@ -129,6 +135,14 @@
   pages   = {294--309},
   url     = {},
   doi     = {}
+}
+
+@PhDThesis{bhaiya:open-source,
+  author  = {M. Bhaiya},
+  title   = {An open-source two-phase non-isothermal mathematical model of a polymer electrolyte membrane fuel cell},
+  year    = {2014},
+  school  = {University of Alberta, Edmonton},
+  url     = {}
 }
 
 @Article{bonito.glowinski:on,
@@ -280,17 +294,6 @@
   doi     = {}
 }
 
-@Article{dorostkar.lukarski.ea:parallel,
-  author  = {A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt},
-  title   = {Parallel performance study of block-preconditioned iterative methods on multicore computer systems},
-  journal = {Technical Report 2014-007, Department of Information Technology, Uppsala University},
-  year    = {2014},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{dorostkar.lukarski.ea:cpu,
   author  = {A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt},
   title   = {CPU and GPU Performance of Large Scale Numerical Simulations in Geophysics},
@@ -299,6 +302,17 @@
   volume  = {},
   pages   = {},
   url     = {http://link.springer.com/chapter/10.1007/978-3-319-14325-5_2#page-1},
+  doi     = {}
+}
+
+@Article{dorostkar.lukarski.ea:parallel,
+  author  = {A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt},
+  title   = {Parallel performance study of block-preconditioned iterative methods on multicore computer systems},
+  journal = {Technical Report 2014-007, Department of Information Technology, Uppsala University},
+  year    = {2014},
+  volume  = {},
+  pages   = {},
+  url     = {},
   doi     = {}
 }
 
@@ -387,6 +401,15 @@
   url     = {}
 }
 
+@MastersThesis{fraters:thermo-mechanically-coupled-subduction-modelling-with-aspect,
+  author  = {Fraters, Menno},
+  number  = {August},
+  school  = {Utrecht University},
+  title   = {{Thermo-mechanically coupled subduction modelling with ASPECT}},
+  url     = {https://dspace.library.uu.nl/handle/1874/297347},
+  year    = {2014}
+}
+
 @Article{freddi.royer-carfagni:plastic,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {Plastic flow as an energy minimization problem. Numerical Experiments},
@@ -409,17 +432,6 @@
   doi     = {}
 }
 
-@Article{frei.richter.ea:solid,
-  author  = {S. Frei and T. Richter and T. Wick},
-  title   = {Solid growth and clogging in fluid-structure interaction using ALE and fully Eulerian coordinates},
-  journal = {RICAM, research report},
-  year    = {2014},
-  volume  = {},
-  pages   = {},
-  url     = {https://www.ricam.oeaw.ac.at/people/member/?firstname=Thomas&lastname=Wick&show=publications},
-  doi     = {}
-}
-
 @Article{frei.richter.ea:eulerian,
   author  = {S. Frei and T. Richter and T. Wick},
   title   = {Eulerian Techniques for Fluid-Structure Interactions - Part I: Modeling and Simulation},
@@ -439,6 +451,17 @@
   volume  = {},
   pages   = {},
   url     = {},
+  doi     = {}
+}
+
+@Article{frei.richter.ea:solid,
+  author  = {S. Frei and T. Richter and T. Wick},
+  title   = {Solid growth and clogging in fluid-structure interaction using ALE and fully Eulerian coordinates},
+  journal = {RICAM, research report},
+  year    = {2014},
+  volume  = {},
+  pages   = {},
+  url     = {https://www.ricam.oeaw.ac.at/people/member/?firstname=Thomas&lastname=Wick&show=publications},
   doi     = {}
 }
 
@@ -640,6 +663,16 @@
   doi     = {10.1137/120902975}
 }
 
+@Article{kim:analysis,
+  author  = {S. Kim},
+  title   = {Analysis of the convected Helmholtz equation with a uniform mean flow in a waveguide with complete radiation boundary conditions},
+  journal = {Journal of Mathematical Analysis and Applications},
+  year    = {2014},
+  volume  = {410},
+  pages   = {275--291},
+  doi     = {10.1016/j.jmaa.2013.08.018}
+}
+
 @Article{kim:cartesian,
   author  = {S. Kim},
   title   = {Cartesian PML approximation to resonances in open systems in R$^{2}$},
@@ -649,16 +682,6 @@
   pages   = {50--75},
   url     = {},
   doi     = {}
-}
-
-@Article{kim:analysis,
-  author  = {S. Kim},
-  title   = {Analysis of the convected Helmholtz equation with a uniform mean flow in a waveguide with complete radiation boundary conditions},
-  journal = {Journal of Mathematical Analysis and Applications},
-  year    = {2014},
-  volume  = {410},
-  pages   = {275--291},
-  doi     = {10.1016/j.jmaa.2013.08.018}
 }
 
 @Article{kocher.bause:variational,
@@ -694,14 +717,6 @@
   doi     = {}
 }
 
-@PhDThesis{krehel:aggregation,
-  author  = {O. Krehel},
-  title   = {Aggregation and fragmentation in reaction-diffusion systems posed in heterogeneous domains},
-  year    = {2014},
-  school  = {Friedrich Alexander University ErlangenNuremberg, Germany Oct},
-  url     = {http://alexandria.tue.nl/extra2/780944.pdf}
-}
-
 @Article{krehel.muntean.ea:multiscale,
   author  = {O. Krehel and A. Muntean and P. Knabner},
   title   = {Multiscale modeling of colloidal dynamics in porous media: Capturing aggregation and deposition effects},
@@ -711,6 +726,14 @@
   pages   = {},
   url     = {http://arxiv.org/abs/1404.4207},
   doi     = {}
+}
+
+@PhDThesis{krehel:aggregation,
+  author  = {O. Krehel},
+  title   = {Aggregation and fragmentation in reaction-diffusion systems posed in heterogeneous domains},
+  year    = {2014},
+  school  = {Friedrich Alexander University ErlangenNuremberg, Germany Oct},
+  url     = {http://alexandria.tue.nl/extra2/780944.pdf}
 }
 
 @Article{kumar.noorden.ea:ale-based,
@@ -732,17 +755,6 @@
   url     = {}
 }
 
-@Article{lube.arndt.ea:understanding,
-  author  = {G. Lube and D. Arndt and H. Dallmann},
-  title   = {Understanding the limits of inf-sup stable Galerkin-FEM for incompressible flows},
-  journal = {BAIL 2014 - Boundary and Interior Layers},
-  year    = {2014},
-  volume  = {},
-  pages   = {},
-  url     = {http://www.mathsim.eu/~darndt/},
-  doi     = {10.1007/978-3-319-25727-3}
-}
-
 @Article{liebenstein.sandfeld.ea:higher,
   author  = {S. Liebenstein and S. Sandfeld and M. Zaiser},
   title   = {Higher Order Continuum Modelling for Predicting the Mechanical Behaviour of Solid Foams},
@@ -752,6 +764,17 @@
   pages   = {},
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410145/abstract},
   doi     = {}
+}
+
+@Article{lube.arndt.ea:understanding,
+  author  = {G. Lube and D. Arndt and H. Dallmann},
+  title   = {Understanding the limits of inf-sup stable Galerkin-FEM for incompressible flows},
+  journal = {BAIL 2014 - Boundary and Interior Layers},
+  year    = {2014},
+  volume  = {},
+  pages   = {},
+  url     = {http://www.mathsim.eu/~darndt/},
+  doi     = {10.1007/978-3-319-25727-3}
 }
 
 @Article{madzvamuse.chung:fully,
@@ -866,17 +889,6 @@
   doi     = {}
 }
 
-@Article{nochetto.salgado.ea:micropolar,
-  author  = {R. H. Nochetto and A. J. Salgado and I. Tomas},
-  title   = {The micropolar Navier-Stokes equations: A priori error analysis},
-  journal = {Mathematical Models and Methods in Applied Sciences},
-  year    = {2014},
-  volume  = {24},
-  pages   = {1237--1264},
-  url     = {},
-  doi     = {}
-}
-
 @Article{nochetto.salgado.ea:diffuse,
   author  = {R. H. Nochetto and A. J. Salgado and S. W. Walker},
   title   = {A diffuse interface model for electrowetting with moving contact lines},
@@ -885,6 +897,17 @@
   volume  = {24},
   pages   = {},
   url     = {http://www.worldscientific.com/doi/abs/10.1142/S0218202513500474?journalCode=m3as},
+  doi     = {}
+}
+
+@Article{nochetto.salgado.ea:micropolar,
+  author  = {R. H. Nochetto and A. J. Salgado and I. Tomas},
+  title   = {The micropolar Navier-Stokes equations: A priori error analysis},
+  journal = {Mathematical Models and Methods in Applied Sciences},
+  year    = {2014},
+  volume  = {24},
+  pages   = {1237--1264},
+  url     = {},
   doi     = {}
 }
 
@@ -942,6 +965,25 @@
   doi     = {}
 }
 
+@PhDThesis{quinquis:a-numerical-study-of-subduction-zone-dynamics-using-linear-viscous-to-thermo-mechanical-model-setups-including-dehydration-processes,
+  author  = {Quinquis, M.},
+  school  = {Charles University},
+  title   = {{A numerical study of subduction zone dynamics using linear viscous to thermo-mechanical model setups including (de)hydration processes}},
+  year    = {2014},
+  url     = {http://hdl.handle.net/20.500.11956/66505}
+}
+
+@Article{rahemi.nigam.ea:regionalizing,
+  author  = {H. Rahemi and N. Nigam and J. M. Wakeling},
+  title   = {Regionalizing muscle activity causes changes to the magnitude and direction of the force from whole muscles -- A modelling study},
+  journal = {Frontiers in Physiology (Integrative Physiology), article 298},
+  year    = {2014},
+  volume  = {5},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
 @Article{rapson.hamilton.ea:on,
   doi     = {10.1121/1.4883382},
   url     = {https://doi.org/10.1121/1.4883382},
@@ -954,17 +996,6 @@
   author  = {Michael J. Rapson and Tara J. Hamilton and Jonathan C. Tapson},
   title   = {On the fluid-structure interaction in the cochlea},
   journal = {The Journal of the Acoustical Society of America}
-}
-
-@Article{rahemi.nigam.ea:regionalizing,
-  author  = {H. Rahemi and N. Nigam and J. M. Wakeling},
-  title   = {Regionalizing muscle activity causes changes to the magnitude and direction of the force from whole muscles -- A modelling study},
-  journal = {Frontiers in Physiology (Integrative Physiology), article 298},
-  year    = {2014},
-  volume  = {5},
-  pages   = {},
-  url     = {},
-  doi     = {}
 }
 
 @Article{reinhardt.scacchi.ea:microrheology,
@@ -1085,17 +1116,6 @@
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/17780/}
 }
 
-@Article{schotzau.schwab.ea:exponential,
-  author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
-  title   = {Exponential Convergence of hp-DGFEM for Elliptic Problems in Polyhedral Domains},
-  journal = {Spectral and High Order Methods for Partial Differential Equations - ICOSAHOM 2012. Lecture Notes in Computational Science and Engineering Vol. 95, pp 57-73 },
-  year    = {2014},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{schoenawa.hartmann:discontinuous,
   author  = {S. Schoenawa and R. Hartmann},
   title   = {Discontinuous Galerkin discretization of the Reynolds-averaged Navier-Stokes equations with the shear-stress transport model},
@@ -1103,6 +1123,17 @@
   year    = {2014},
   volume  = {262},
   pages   = {194--216},
+  url     = {},
+  doi     = {}
+}
+
+@Article{schotzau.schwab.ea:exponential,
+  author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
+  title   = {Exponential Convergence of hp-DGFEM for Elliptic Problems in Polyhedral Domains},
+  journal = {Spectral and High Order Methods for Partial Differential Equations - ICOSAHOM 2012. Lecture Notes in Computational Science and Engineering Vol. 95, pp 57-73 },
+  year    = {2014},
+  volume  = {},
+  pages   = {},
   url     = {},
   doi     = {}
 }
@@ -1226,17 +1257,17 @@
   address = {Bad Honnef, Germany}
 }
 
-@PhDThesis{wang:regularizing,
-  author  = {F. Wang},
-  title   = {Regularizing Inverse Problems},
+@PhDThesis{wang:parallel,
+  author  = {K. Wang},
+  title   = {Parallel Markov Chain Monte Carlo Methods for Large Scale Inverse Problems},
   year    = {2014},
   school  = {Texas A\&M University},
   url     = {}
 }
 
-@PhDThesis{wang:parallel,
-  author  = {K. Wang},
-  title   = {Parallel Markov Chain Monte Carlo Methods for Large Scale Inverse Problems},
+@PhDThesis{wang:regularizing,
+  author  = {F. Wang},
+  title   = {Regularizing Inverse Problems},
   year    = {2014},
   school  = {Texas A\&M University},
   url     = {}
@@ -1283,17 +1314,6 @@
   doi     = {}
 }
 
-@Article{wick:modeling,
-  author  = {T. Wick},
-  title   = {Modeling, Discretization, Optimization, and Simulation of Fluid-Structure Interaction},
-  journal = {Lecture notes (177 pages), IWR Heidelberg},
-  year    = {2014},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{wick.singh.ea:pressurized-fracture,
   author  = {T. Wick and G. Singh and M. F. Wheeler},
   title   = {Pressurized-Fracture propagation using a phase-field approach coupled to a reservoir simulator},
@@ -1309,6 +1329,17 @@
   author  = {T. Wick and W. Wollner},
   title   = {On the differentiability of fluid-structure interaction problems with respect to the problem data},
   journal = {RICAM report 2014-16},
+  year    = {2014},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{wick:modeling,
+  author  = {T. Wick},
+  title   = {Modeling, Discretization, Optimization, and Simulation of Fluid-Structure Interaction},
+  journal = {Lecture notes (177 pages), IWR Heidelberg},
   year    = {2014},
   volume  = {},
   pages   = {},
@@ -1377,37 +1408,6 @@
   year    = {2014},
   school  = {Texas A\&M University},
   url     = {}
-}
-
-@Article{albert.schwarz:dynamics,
-  doi     = {10.1016/j.bpj.2014.04.036},
-  url     = {https://doi.org/10.1016/j.bpj.2014.04.036},
-  year    = {2014},
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = {106},
-  number  = {11},
-  pages   = {2340--2352},
-  author  = {Philipp~J. Albert and Ulrich~S. Schwarz},
-  title   = {Dynamics of Cell Shape and Forces on Micropatterned Substrates Predicted by a Cellular Potts Model},
-  journal = {Biophysical Journal}
-}
-
-@PhDThesis{quinquis:a-numerical-study-of-subduction-zone-dynamics-using-linear-viscous-to-thermo-mechanical-model-setups-including-dehydration-processes,
-  author  = {Quinquis, M.},
-  school  = {Charles University},
-  title   = {{A numerical study of subduction zone dynamics using linear viscous to thermo-mechanical model setups including (de)hydration processes}},
-  year    = {2014},
-  url     = {http://hdl.handle.net/20.500.11956/66505}
-}
-
-@MastersThesis{fraters:thermo-mechanically-coupled-subduction-modelling-with-aspect,
-  author  = {Fraters, Menno},
-  number  = {August},
-  school  = {Utrecht University},
-  title   = {{Thermo-mechanically coupled subduction modelling with ASPECT}},
-  url     = {https://dspace.library.uu.nl/handle/1874/297347},
-  year    = {2014}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -1,11 +1,14 @@
 % Encoding: US-ASCII
 
-@PhDThesis{alrashed:parallel,
-  author  = {F. S. Alrashed},
-  title   = {Parallel multiphase Navier-Stokes solver},
+@Article{adler.atherton.ea:energy,
+  author  = {J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan},
+  title   = {Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects},
+  journal = {SIAM Journal on Scientific Computing, 37(5), pp. S157-S176},
   year    = {2015},
-  school  = {Texas A\&M University},
-  url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf}
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
 }
 
 @Article{adler.atherton.ea:energy-minimization,
@@ -19,15 +22,12 @@
   doi     = {}
 }
 
-@Article{adler.atherton.ea:energy,
-  author  = {J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan},
-  title   = {Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects},
-  journal = {SIAM Journal on Scientific Computing, 37(5), pp. S157-S176},
+@PhDThesis{alrashed:parallel,
+  author  = {F. S. Alrashed},
+  title   = {Parallel multiphase Navier-Stokes solver},
   year    = {2015},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
+  school  = {Texas A\&M University},
+  url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf}
 }
 
 @Article{alvarez.flores:existence,
@@ -96,15 +96,15 @@
   doi     = {}
 }
 
-@Article{bangerth:simulating,
-  author  = {W. Bangerth},
-  title   = {Simulating Complex Flows in the Earth Mantle},
-  journal = {The 18th International Conference on Finite Elements in Flow Problems, Taiwan},
+@Article{bangerth.heister.ea:deal-ii,
+  author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
+  title   = {The \texttt{deal.II} Library, Version 8.2},
+  journal = {Archive of Numerical Software},
   year    = {2015},
-  volume  = {},
+  volume  = {3},
   pages   = {},
-  url     = {http://www.fef2015.tw/Files/E%20Abstracts/J-007.pdf},
-  doi     = {}
+  url     = {},
+  doi     = {10.11588/ans.2015.100.18031}
 }
 
 @Article{bangerth:finite,
@@ -118,15 +118,15 @@
   doi     = {}
 }
 
-@Article{bangerth.heister.ea:deal-ii,
-  author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
-  title   = {The \texttt{deal.II} Library, Version 8.2},
-  journal = {Archive of Numerical Software},
+@Article{bangerth:simulating,
+  author  = {W. Bangerth},
+  title   = {Simulating Complex Flows in the Earth Mantle},
+  journal = {The 18th International Conference on Finite Elements in Flow Problems, Taiwan},
   year    = {2015},
-  volume  = {3},
+  volume  = {},
   pages   = {},
-  url     = {},
-  doi     = {10.11588/ans.2015.100.18031}
+  url     = {http://www.fef2015.tw/Files/E%20Abstracts/J-007.pdf},
+  doi     = {}
 }
 
 @MastersThesis{bardelloni:high,
@@ -447,50 +447,6 @@
   doi     = {}
 }
 
-@Article{hai.bause:finite,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Finite Element Approximation of Wave Propa- gation in Composite Material with Asymptotic Homogenization},
-  journal = {In proceedings of: the ASME Turbo Expo 2014: Turbine Technical Conference and Exposition, Vol. 7A, No. GT2014-26314, pp. V07AT28A009/1-10, June 16-20, D\"{u}sseldorf, Germany},
-  year    = {2015},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hai.bause:finite*1,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Finite Element Model-based Structural Health Monitoring (SHM) Systems for Composite Material under Fluid-Structure Interaction (FSI) Effect},
-  journal = {In proceedings of: the 7 th European Workshop on Structural Health Monitoring, July 08--11, Nantes, France. In: The e-Journal of Nondestructive Testing (NDT), NDT.net issue, ISSN: 1435-4934, HAL Id: hal-01021185, Vol. 20, Issue 2 (Feb 2015), pp. 1380--1387},
-  year    = {2015},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hai.bause:adaptive,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Adaptive Finite Elements Simulation Methods and Applications for Monolithic Fluid-Structure Interaction (FSI) Problem},
-  journal = {In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1B, No. FEDSM2014-21379, pp. V01BT12A003/1--10, August 3--7, Chicago, USA},
-  year    = {2015},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hai.bause:adaptive*1,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Adaptive multigrid methods for extended fluid-structure interaction (EXFSI) problem -- part 1: Mathematical modelling},
-  journal = {In proceedings of: the ASME 2015 International Mechanical Engineering Congress \& Expo, IMECE2015, Houston, TX},
-  year    = {2015},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{el-kurdi.gross.ea:parallel,
   author  = {Y. El-Kurdi and W. J. Gross and M. M. Dehnavi and D. Giannacopoulos},
   title   = {Parallel finite element technique using Gaussian belief propagation},
@@ -639,14 +595,14 @@
   doi     = {}
 }
 
-@Article{goldschmidt:modeling,
-  author  = {F. Goldschmidt},
-  title   = {Modeling and simulation of adhesive bounded joints with a gradient in the mechanical properties},
-  journal = {PhD dissertation, University of des Saarlandes},
+@Article{goldschmidt.diebels:modeling,
+  author  = {F. Goldschmidt and S. Diebels},
+  title   = {Modeling the moisture and temperature dependent material behavior of adhesive bonds },
+  journal = {Proc. Appl. Math. Mech. Vol. 15, issue 1, pp: 295-296},
   year    = {2015},
   volume  = {},
   pages   = {},
-  url     = {http://scidok.sulb.uni-saarland.de/volltexte/2015/6197/},
+  url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410157/abstract},
   doi     = {}
 }
 
@@ -661,15 +617,29 @@
   doi     = {}
 }
 
-@Article{goldschmidt.diebels:modeling,
-  author  = {F. Goldschmidt and S. Diebels},
-  title   = {Modeling the moisture and temperature dependent material behavior of adhesive bonds },
-  journal = {Proc. Appl. Math. Mech. Vol. 15, issue 1, pp: 295-296},
+@Article{goldschmidt:modeling,
+  author  = {F. Goldschmidt},
+  title   = {Modeling and simulation of adhesive bounded joints with a gradient in the mechanical properties},
+  journal = {PhD dissertation, University of des Saarlandes},
   year    = {2015},
   volume  = {},
   pages   = {},
-  url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410157/abstract},
+  url     = {http://scidok.sulb.uni-saarland.de/volltexte/2015/6197/},
   doi     = {}
+}
+
+@Article{goll.rannacher.ea:damped,
+  doi     = {10.21314/jcf.2015.301},
+  url     = {https://doi.org/10.21314/jcf.2015.301},
+  year    = {2015},
+  month   = jun,
+  publisher = {Infopro Digital Services Limited},
+  volume  = {18},
+  number  = {4},
+  pages   = {1--37},
+  author  = {Christian Goll and Wolf Rannacher and Winnifried Woolner},
+  title   = {The damped {Crank--Nicolson} time-marching scheme for the adaptive solution of the {Black--Scholes} equation},
+  journal = {The Journal of Computational Finance}
 }
 
 @PhDThesis{gong:formation,
@@ -709,6 +679,50 @@
   year    = {2015},
   volume  = {53},
   pages   = {2255--2278},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hai.bause:adaptive,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Adaptive Finite Elements Simulation Methods and Applications for Monolithic Fluid-Structure Interaction (FSI) Problem},
+  journal = {In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1B, No. FEDSM2014-21379, pp. V01BT12A003/1--10, August 3--7, Chicago, USA},
+  year    = {2015},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hai.bause:adaptive*1,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Adaptive multigrid methods for extended fluid-structure interaction (EXFSI) problem -- part 1: Mathematical modelling},
+  journal = {In proceedings of: the ASME 2015 International Mechanical Engineering Congress \& Expo, IMECE2015, Houston, TX},
+  year    = {2015},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hai.bause:finite,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Finite Element Approximation of Wave Propa- gation in Composite Material with Asymptotic Homogenization},
+  journal = {In proceedings of: the ASME Turbo Expo 2014: Turbine Technical Conference and Exposition, Vol. 7A, No. GT2014-26314, pp. V07AT28A009/1-10, June 16-20, D\"{u}sseldorf, Germany},
+  year    = {2015},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hai.bause:finite*1,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Finite Element Model-based Structural Health Monitoring (SHM) Systems for Composite Material under Fluid-Structure Interaction (FSI) Effect},
+  journal = {In proceedings of: the 7 th European Workshop on Structural Health Monitoring, July 08--11, Nantes, France. In: The e-Journal of Nondestructive Testing (NDT), NDT.net issue, ISSN: 1435-4934, HAL Id: hal-01021185, Vol. 20, Issue 2 (Feb 2015), pp. 1380--1387},
+  year    = {2015},
+  volume  = {},
+  pages   = {},
   url     = {},
   doi     = {}
 }
@@ -851,6 +865,15 @@
   doi     = {}
 }
 
+@PhDThesis{kircheis:structure*1,
+  author  = {Robert Kircheis},
+  title   = {Structure Exploiting Parameter Estimation and Optimum Experimental Design Methods and Applications in Microbial Enhanced Oil Recovery},
+  school  = {Heidelberg University},
+  year    = {2015},
+  doi     = {10.11588/heidok.00022098},
+  url     = {http://www.ub.uni-heidelberg.de/archiv/22098}
+}
+
 @Article{klinsmann.rosato.ea:assessment,
   author  = {M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking},
   title   = {An assessment of the phase field formulation for crack growth},
@@ -868,6 +891,17 @@
   year    = {2015},
   school  = {Department of Mechanical Engineering of the Helmut-Schmidt-University, University of the German Federal Armed Forces Hamburg},
   url     = {http://nbn-resolving.de/urn:nbn:de:gbv:705-opus-31129}
+}
+
+@Article{kramer.hagemann:scipal,
+  author  = {S. C. Kramer and J. Hagemann},
+  title   = {SciPAL: Expression templates and composition closure objects for high performance computational physics with CUDA and OpenMP},
+  journal = {ACM Transactions on Parallel Computing, 1(2), p. 15},
+  year    = {2015},
+  volume  = {},
+  pages   = {},
+  url     = {http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short},
+  doi     = {}
 }
 
 @Article{kriemann.borne:h-fainv,
@@ -911,17 +945,6 @@
   volume  = {},
   pages   = {},
   url     = {http://am2015.math.cas.cz/proceedings/contributions/kus.pdf},
-  doi     = {}
-}
-
-@Article{kramer.hagemann:scipal,
-  author  = {S. C. Kramer and J. Hagemann},
-  title   = {SciPAL: Expression templates and composition closure objects for high performance computational physics with CUDA and OpenMP},
-  journal = {ACM Transactions on Parallel Computing, 1(2), p. 15},
-  year    = {2015},
-  volume  = {},
-  pages   = {},
-  url     = {http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short},
   doi     = {}
 }
 
@@ -1036,20 +1059,6 @@
   doi     = {}
 }
 
-@Article{mikelic.wheeler.ea:quasi-static,
-  doi     = {10.1088/0951-7715/28/5/1371},
-  url     = {https://doi.org/10.1088/0951-7715/28/5/1371},
-  year    = {2015},
-  month   = apr,
-  publisher = {{IOP} Publishing},
-  volume  = {28},
-  number  = {5},
-  pages   = {1371--1399},
-  author  = {Andro Mikeli{\'{c}} and Mary F Wheeler and Thomas Wick},
-  title   = {A quasi-static phase-field approach to pressurized fractures},
-  journal = {Nonlinearity}
-}
-
 @Article{mikelic.wheeler.ea:phase-field,
   author  = {A. Mikelic and M. F. Wheeler and T. Wick},
   title   = {A phase-field method for propagating fluid-filled fractures coupled to a surrounding porous medium},
@@ -1070,6 +1079,20 @@
   pages   = {1171--1195},
   url     = {http://link.springer.com/article/10.1007%2Fs10596-015-9532-5},
   doi     = {}
+}
+
+@Article{mikelic.wheeler.ea:quasi-static,
+  doi     = {10.1088/0951-7715/28/5/1371},
+  url     = {https://doi.org/10.1088/0951-7715/28/5/1371},
+  year    = {2015},
+  month   = apr,
+  publisher = {{IOP} Publishing},
+  volume  = {28},
+  number  = {5},
+  pages   = {1371--1399},
+  author  = {Andro Mikeli{\'{c}} and Mary F Wheeler and Thomas Wick},
+  title   = {A quasi-static phase-field approach to pressurized fractures},
+  journal = {Nonlinearity}
 }
 
 @MastersThesis{mital:enriched,
@@ -1480,6 +1503,17 @@
   doi     = {}
 }
 
+@Article{wallraff.hartmann.ea:multigrid,
+  author  = {M. Wallraff and R. Hartmann and T. Leicht},
+  title   = {Multigrid solver algorithms for DG methods and applications to aerodynamic flows},
+  journal = {In N. Kroll and C. Hirsch and F. Bassi and C. Johnston and K. Hillewaert, editors, IDIHOM - Industrialization of High-Order Methods - A Top Down Approach, Vol. 128 of Notes on Numerical Fluid Mechanics and Multidisciplinary Design, pages 153-178, Springer},
+  year    = {2015},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
 @PhDThesis{wallraff:investigation,
   author  = {M. Wallraff},
   title   = {An investigation of multigrid algorithms for a higher order Discontinuous Galerkin RANS solver},
@@ -1488,10 +1522,10 @@
   url     = {}
 }
 
-@Article{wallraff.hartmann.ea:multigrid,
-  author  = {M. Wallraff and R. Hartmann and T. Leicht},
-  title   = {Multigrid solver algorithms for DG methods and applications to aerodynamic flows},
-  journal = {In N. Kroll and C. Hirsch and F. Bassi and C. Johnston and K. Hillewaert, editors, IDIHOM - Industrialization of High-Order Methods - A Top Down Approach, Vol. 128 of Notes on Numerical Fluid Mechanics and Multidisciplinary Design, pages 153-178, Springer},
+@Article{wells.wang.ea:regularized,
+  author  = {D. Wells and Z. Wang and X. Xie and T. Iliescu},
+  title   = {Regularized Reduced Order Models},
+  journal = {arXiv:1506.07555},
   year    = {2015},
   volume  = {},
   pages   = {},
@@ -1507,17 +1541,6 @@
   volume  = {},
   pages   = {},
   url     = {https://vtechworks.lib.vt.edu/handle/10919/52960},
-  doi     = {}
-}
-
-@Article{wells.wang.ea:regularized,
-  author  = {D. Wells and Z. Wang and X. Xie and T. Iliescu},
-  title   = {Regularized Reduced Order Models},
-  journal = {arXiv:1506.07555},
-  year    = {2015},
-  volume  = {},
-  pages   = {},
-  url     = {},
   doi     = {}
 }
 
@@ -1576,14 +1599,6 @@
   doi     = {}
 }
 
-@MastersThesis{zelst:mantle,
-  author  = {I. van Zelst},
-  title   = {Mantle dynamics on Venus: insights from numerical modelling},
-  year    = {2015},
-  school  = {University of Utrecht, The Netherlands},
-  url     = {http://dspace.library.uu.nl/bitstream/handle/1874/316227/Iris_van_Zelst_final_master_thesis.pdf}
-}
-
 @Article{zareei.alam:cloaking,
   author  = {A. Zareei and M.-R. Alam},
   title   = {Cloaking in shallow-water waves via nonlinear medium transformation},
@@ -1593,6 +1608,14 @@
   pages   = {273--287},
   url     = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=9886676&fileId=S002211201500350X},
   doi     = {}
+}
+
+@MastersThesis{zelst:mantle,
+  author  = {I. van Zelst},
+  title   = {Mantle dynamics on Venus: insights from numerical modelling},
+  year    = {2015},
+  school  = {University of Utrecht, The Netherlands},
+  url     = {http://dspace.library.uu.nl/bitstream/handle/1874/316227/Iris_van_Zelst_final_master_thesis.pdf}
 }
 
 @Article{zheng.mcclarren:non-oscillatory,
@@ -1615,29 +1638,6 @@
   pages   = {},
   url     = {},
   doi     = {}
-}
-
-@PhDThesis{kircheis:structure*1,
-  author  = {Robert Kircheis},
-  title   = {Structure Exploiting Parameter Estimation and Optimum Experimental Design Methods and Applications in Microbial Enhanced Oil Recovery},
-  school  = {Heidelberg University},
-  year    = {2015},
-  doi     = {10.11588/heidok.00022098},
-  url     = {http://www.ub.uni-heidelberg.de/archiv/22098}
-}
-
-@Article{goll.rannacher.ea:damped,
-  doi     = {10.21314/jcf.2015.301},
-  url     = {https://doi.org/10.21314/jcf.2015.301},
-  year    = {2015},
-  month   = jun,
-  publisher = {Infopro Digital Services Limited},
-  volume  = {18},
-  number  = {4},
-  pages   = {1--37},
-  author  = {Christian Goll and Wolf Rannacher and Winnifried Woolner},
-  title   = {The damped {Crank--Nicolson} time-marching scheme for the adaptive solution of the {Black--Scholes} equation},
-  journal = {The Journal of Computational Finance}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1,70 +1,14 @@
 % Encoding: US-ASCII
 
-@Article{kanschat.lorca:weakly,
-  doi     = {10.1515/cmam-2016-0023},
-  url     = {https://doi.org/10.1515/cmam-2016-0023},
+@Article{adler.emerson.ea:constrained,
+  author  = {J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel},
+  title   = {Constrained Optimization for Liquid Crystal Equilibria},
+  journal = {SIAM J. Sci. Comput., (1), B50-B76},
   year    = {2016},
-  month   = jan,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {16},
-  number  = {4},
-  pages   = {563--577},
-  author  = {Guido Kanschat and Jos{\'{e}} Pablo Lucero Lorca},
-  title   = {A Weakly Penalized Discontinuous Galerkin Method for Radiation in Dense, Scattering Media},
-  journal = {Computational Methods in Applied Mathematics}
-}
-
-@Article{kormann:time-space,
-  doi     = {10.4208/cicp.101214.021015a},
-  url     = {https://doi.org/10.4208/cicp.101214.021015a},
-  year    = {2016},
-  month   = jun,
-  publisher = {Global Science Press},
-  volume  = {20},
-  number  = {1},
-  pages   = {60--85},
-  author  = {Katharina Kormann},
-  title   = {A Time-Space Adaptive Method for the Schr\"{o}dinger Equation},
-  journal = {Communications in Computational Physics}
-}
-
-@InProceedings{voll.stollenwerk.ea:computing,
-  doi     = {10.1117/12.2220292},
-  url     = {https://doi.org/10.1117/12.2220292},
-  year    = {2016},
-  month   = mar,
-  publisher = {{SPIE}},
-  author  = {Annika V\"{o}ll and Jochen Stollenwerk and Peter Loosen},
-  editor  = {Friedhelm Dorsch and Stefan Kaierle},
-  title   = {Computing specific intensity distributions for laser material processing by solving an inverse heat conduction problem},
-  booktitle = {High-Power Laser Materials Processing: Lasers, Beam Delivery, Diagnostics, and Applications V}
-}
-
-@Article{vidal-ferrandiz.fayez.ea:moving,
-  doi     = {10.1016/j.cam.2015.03.040},
-  url     = {https://doi.org/10.1016/j.cam.2015.03.040},
-  year    = {2016},
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = {291},
-  pages   = {197--208},
-  author  = {A. Vidal-Ferr{\`{a}}ndiz and R. Fayez and D. Ginestar and G. Verd{\'{u}}},
-  title   = {Moving meshes to solve the time-dependent neutron diffusion equation in hexagonal geometry},
-  journal = {Journal of Computational and Applied Mathematics}
-}
-
-@Article{maier.bardelloni.ea:linearoperator-a,
-  doi     = {10.1016/j.camwa.2016.04.024},
-  url     = {https://doi.org/10.1016/j.camwa.2016.04.024},
-  year    = {2016},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {72},
-  number  = {1},
-  pages   = {1--24},
-  author  = {Matthias Maier and Mauro Bardelloni and Luca Heltai},
-  title   = {{LinearOperator}---A generic, high-level expression syntax for linear algebra},
-  journal = {Computers {\&} Mathematics with Applications}
+  volume  = {38},
+  pages   = {},
+  url     = {http://epubs.siam.org/doi/abs/10.1137/141001846},
+  doi     = {}
 }
 
 @Article{adler.emerson.ea:deflation,
@@ -75,17 +19,6 @@
   volume  = {},
   pages   = {},
   url     = {http://arxiv.org/abs/1601.07383},
-  doi     = {}
-}
-
-@Article{adler.emerson.ea:constrained,
-  author  = {J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel},
-  title   = {Constrained Optimization for Liquid Crystal Equilibria},
-  journal = {SIAM J. Sci. Comput., (1), B50-B76},
-  year    = {2016},
-  volume  = {38},
-  pages   = {},
-  url     = {http://epubs.siam.org/doi/abs/10.1137/141001846},
   doi     = {}
 }
 
@@ -100,12 +33,33 @@
   doi     = {}
 }
 
+@Misc{arndt.lucero.ea:a-parallel-multigrid-matrix-free-solver-using-schwarz-smoothers,
+  author  = {Arndt, D and Lucero, P and Witte, J and Kanschat, PEG},
+  title   = {{A Parallel Multigrid Matrix-Free Solver using Schwarz Smoothers}},
+  howpublished = {PDE Software Frameworks 2016},
+  year    = {2016},
+  url     = {http://www.mathsim.eu/~darndt/files/PDESoft2016Arndt.pdf}
+}
+
 @PhDThesis{arndt:stabilized,
   author  = {D. Arndt},
   title   = {Stabilized Finite Element Methods for Coupled Incompressible Flow},
   year    = {2016},
   school  = {Georg-August-Universit\"{a}t G\"{o}ttingen, Germany},
   url     = {}
+}
+
+@Article{assier.poon.ea:spectral-study-of-the-laplace-beltrami-operator-arising-in-the-problem-of-acoustic-wave-scattering-by-a-quarter-plane,
+  author  = {Assier, RC and Poon, C and Peake, N},
+  title   = {{Spectral study of the Laplace--Beltrami operator arising in the problem of acoustic wave scattering by a quarter-plane}},
+  journal = {The Quarterly Journal of Mechanics and Applied Mathematics},
+  year    = {2016},
+  volume  = {69},
+  number  = {3},
+  pages   = {281--317},
+  month   = {aug},
+  doi     = {10.1093/qjmam/hbw008},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @Article{axelsson.farouq.ea:comparison,
@@ -171,6 +125,21 @@
   doi     = {}
 }
 
+@Article{bauman.stogner:grins--a-multiphysics-framework-based-on-the-libmesh-finite-element-library,
+  author  = {Bauman, Paul T. and Stogner, Roy H.},
+  title   = {{GRINS: A Multiphysics Framework Based on the libMesh Finite Element Library}},
+  journal = {{SIAM} Journal on Scientific Computing},
+  year    = {2016},
+  volume  = {38},
+  number  = {5},
+  pages   = {S78--S100},
+  month   = {jan},
+  issn    = {1064-8275},
+  doi     = {10.1137/15M1026110},
+  note    = {Unconfirmed citation},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
+}
+
 @Article{bause.kocher:iterative,
   author  = {M. Bause and U. K\"{o}cher},
   title   = {Iterative coupling of variational space-time methods for Biot's system of poroelasticity},
@@ -219,6 +188,19 @@
   pages   = {53--75},
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.4071/full},
   doi     = {}
+}
+
+@Article{bonito.pasciak:numerical-approximation-of-fractional-powers-of-regularly-accretive-operators,
+  author  = {Andrea Bonito and Joseph E. Pasciak},
+  title   = {{Numerical approximation of fractional powers of regularly accretive operators}},
+  journal = {{IMA} Journal of Numerical Analysis},
+  year    = {2016},
+  volume  = {37},
+  number  = {3},
+  pages   = {1245--1273},
+  month   = {aug},
+  doi     = {10.1093/imanum/drw042},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @Article{bosch:fast,
@@ -276,6 +258,21 @@
   doi     = {}
 }
 
+@Article{burstedde.holke:a-tetrahedral-space-filling-curve-for-nonconforming-adaptive-meshes,
+  author  = {Burstedde, Carsten and Holke, Johannes},
+  title   = {{A Tetrahedral Space-Filling Curve for Nonconforming Adaptive Meshes}},
+  journal = {{SIAM} Journal on Scientific Computing},
+  year    = {2016},
+  volume  = {38},
+  number  = {5},
+  pages   = {C471--C503},
+  month   = {jan},
+  issn    = {1064-8275},
+  doi     = {10.1137/15M1040049},
+  note    = {Unconfirmed citation},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
+}
+
 @MastersThesis{bystricky:using,
   author  = {L. Bystricky},
   title   = {Using deal.ii to solve problems in computational fluid dynamics},
@@ -328,6 +325,20 @@
   doi     = {}
 }
 
+@MastersThesis{castelli:numerische,
+  author  = {Castelli, G. F.},
+  title   = {Die Numerische Simulation eines Mikroskalenmodells f{\"u}r Li-Ionen-Batterien},
+  school  = {Karlsruhe Institute of Technology (KIT)},
+  year    = {2016}
+}
+
+@Manual{chen.ladenheim.ea:the-manchester-thermal-analyzer,
+  title   = {{The Manchester Thermal Analyzer}},
+  author  = {Chen, Yi-Chung and Ladenheim, Scott and Mihajlovi{\'{c}}, Milan and Pavlidis, Vasilis},
+  year    = {2016},
+  url     = {https://pdfs.semanticscholar.org/853e/b3362f9d2670680f21dc7ed280e745fa6a9f.pdf}
+}
+
 @Article{chidyagwai.ladenheim.ea:constraint-preconditioning-for-the-coupled-stokes-darcy-system,
   author  = {Chidyagwai, Prince and Ladenheim, Scott and Szyld, Daniel B.},
   title   = {{Constraint Preconditioning for the Coupled Stokes--Darcy System}},
@@ -367,12 +378,51 @@
   doi     = {}
 }
 
+@Article{cockburn.demlow:hybridizable-discontinuous-galerkin-and-mixed-finite-element-methods-for-elliptic-problems-on-surfaces,
+  author  = {Bernardo Cockburn and Alan Demlow},
+  title   = {{Hybridizable discontinuous Galerkin and mixed finite element methods for elliptic problems on surfaces}},
+  journal = {Mathematics of Computation},
+  year    = {2016},
+  volume  = {85},
+  number  = {302},
+  pages   = {2609--2638},
+  month   = {mar},
+  doi     = {10.1090/mcom/3093},
+  publisher = {American Mathematical Society ({AMS})}
+}
+
 @PhDThesis{cox:adaptive,
   author  = {S. Cox},
   title   = {Adaptive large-scale mantle convection simulations},
   year    = {2016},
   school  = {University of Leicester},
   url     = {}
+}
+
+@Article{cruz.ramos:general,
+  author  = {Luis M. De La Cruz and Eduardo Ramos},
+  title   = {General Template Units for the Finite Volume Method in Box-Shaped Domains},
+  journal = {{ACM} Transactions on Mathematical Software},
+  year    = {2016},
+  volume  = {43},
+  number  = {1},
+  pages   = {1--32},
+  month   = {aug},
+  doi     = {10.1145/2835175},
+  publisher = {Association for Computing Machinery ({ACM})}
+}
+
+@Article{dalcin.collier.ea:petiga--a-framework-for-high-performance-isogeometric-analysis,
+  author  = {L. Dalcin and N. Collier and P. Vignal and A.M.A. C{\^{o}}rtes and V.M. Calo},
+  title   = {{PetIGA: A framework for high-performance isogeometric analysis}},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2016},
+  volume  = {308},
+  pages   = {151--181},
+  month   = {aug},
+  doi     = {10.1016/j.cma.2016.05.011},
+  note    = {Unconfirmed citation},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{dallmann.arndt.ea:local,
@@ -397,6 +447,14 @@
   doi     = {10.1093/gji/ggw329}
 }
 
+@PhDThesis{dannberg:dynamics-of-mantle-plumes--linking-scales-and-coupling-physics,
+  author  = {Dannberg, J.},
+  school  = {Potsdam University},
+  title   = {{Dynamics of Mantle Plumes: Linking Scales and Coupling Physics}},
+  url     = {https://nbn-resolving.org/urn:nbn:de:kobv:517-opus4-91024},
+  year    = {2016}
+}
+
 @Article{davydov.young.ea:on,
   author  = {D. Davydov and T. D. Young and P. Steinmann},
   title   = {On the adaptive finite element analysis of the Kohn-Sham equations: Methods, algorithms, and implementation},
@@ -408,15 +466,16 @@
   doi     = {}
 }
 
-@Article{hai.bause.ea:finite,
-  author  = {B. S. M. Ebna Hai and M. Bause and P. A. Kuberry},
-  title   = {Finite Element Approximation of the eXtended Fluid-Structure Interaction (eXFSI) Problem},
-  journal = {In proceedings of: the ASME 2016 Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2016-7506, pp. V01AT11A001/1--12, July 10--14, Washington, DC, USA},
+@InProceedings{droba:tangle-free-finite-element-mesh-motion-for-ablation-problems,
+  author  = {Droba, Justin},
+  title   = {{Tangle-Free Finite Element Mesh Motion for Ablation Problems}},
+  booktitle = {46th {AIAA} Thermophysics Conference},
   year    = {2016},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
+  address = {Reston, Virginia},
+  month   = {jun},
+  publisher = {American Institute of Aeronautics and Astronautics},
+  doi     = {10.2514/6.2016-3386},
+  note    = {Unconfirmed citation}
 }
 
 @Article{ellam.zabaras.ea:bayesian,
@@ -430,6 +489,21 @@
   doi     = {}
 }
 
+@Article{ervin.lee.ea:generalized-newtonian-fluid-flow-through-a-porous-medium,
+  author  = {V.J. Ervin and Hyesuk Lee and A.J. Salgado},
+  title   = {{Generalized Newtonian fluid flow through a porous medium}},
+  journal = {Journal of Mathematical Analysis and Applications},
+  year    = {2016},
+  volume  = {433},
+  number  = {1},
+  pages   = {603--621},
+  month   = {jan},
+  doi     = {10.1016/j.jmaa.2015.07.054},
+  note    = {Unconfirmed citation},
+  publisher = {Elsevier {BV}},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0022247X15007003}
+}
+
 @Article{exner.brezina:partition,
   author  = {P. Exner and J. Brezina},
   title   = {Partition of unity methods for approximation of point water sources in porous media},
@@ -439,6 +513,20 @@
   pages   = {21--32},
   url     = {http://www.sciencedirect.com/science/article/pii/S0096300315012862},
   doi     = {}
+}
+
+@Article{feng.hui:force-sensing-using-3d-displacement-measurements-in-linear-elastic-bodies,
+  author  = {Feng, Xinzeng and Hui, Chung-Yuen},
+  title   = {{Force sensing using 3D displacement measurements in linear elastic bodies}},
+  journal = {Computational Mechanics},
+  year    = {2016},
+  volume  = {58},
+  number  = {1},
+  pages   = {91--105},
+  month   = {apr},
+  issn    = {0178-7675},
+  doi     = {10.1007/s00466-016-1283-1},
+  publisher = {Springer Nature}
 }
 
 @Article{freddi.royer-carfagni:phase-field,
@@ -474,17 +562,6 @@
   doi     = {}
 }
 
-@Article{frei:eulerian,
-  author  = {S. Frei},
-  title   = {Eulerian finite element methods for interface problems and fluid-structure interactions},
-  journal = {PhD dissertation, University of Heidelberg, Heidelberg, Germany},
-  year    = {2016},
-  volume  = {},
-  pages   = {},
-  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/21590},
-  doi     = {}
-}
-
 @Article{frei.richter.ea:long-term,
   doi     = {10.1016/j.jcp.2016.06.015},
   url     = {https://doi.org/10.1016/j.jcp.2016.06.015},
@@ -496,6 +573,17 @@
   author  = {S. Frei and T. Richter and T. Wick},
   title   = {Long-term simulation of large deformation, mechano-chemical fluid-structure interactions in {ALE} and fully Eulerian coordinates},
   journal = {Journal of Computational Physics}
+}
+
+@Article{frei:eulerian,
+  author  = {S. Frei},
+  title   = {Eulerian finite element methods for interface problems and fluid-structure interactions},
+  journal = {PhD dissertation, University of Heidelberg, Heidelberg, Germany},
+  year    = {2016},
+  volume  = {},
+  pages   = {},
+  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/21590},
+  doi     = {}
 }
 
 @Article{frohne.heister.ea:efficient,
@@ -530,12 +618,13 @@
   doi     = {10.1007/s00574-016-0142-1}
 }
 
-@PhDThesis{dannberg:dynamics-of-mantle-plumes--linking-scales-and-coupling-physics,
-  author  = {Dannberg, J.},
-  school  = {Potsdam University},
-  title   = {{Dynamics of Mantle Plumes: Linking Scales and Coupling Physics}},
-  url     = {https://nbn-resolving.org/urn:nbn:de:kobv:517-opus4-91024},
-  year    = {2016}
+@Misc{gassmoeller.heien.ea:flexible,
+  title   = {Flexible and scalable particle-in-cell methods for massively parallel computations},
+  author  = {R. Gassmoeller and E. Heien and E. G. Puckett and W. Bangerth},
+  year    = {2016},
+  eprint  = {1612.03369},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
 }
 
 @Article{gassmoller.dannberg.ea:major,
@@ -547,6 +636,30 @@
   pages   = {},
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2015GC006177/full},
   doi     = {}
+}
+
+@Misc{gersbacher:implementation,
+  title   = {Implementation of $hp$-adaptive discontinuous finite element methods in Dune-Fem},
+  author  = {Christoph Gersbacher},
+  year    = {2016},
+  eprint  = {1604.07242},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.MS}
+}
+
+@Article{gholami.malhotra.ea:fft,
+  author  = {Gholami, Amir and Malhotra, Dhairya and Sundar, Hari and Biros, George},
+  title   = {{FFT}, {FMM}, or Multigrid? A comparative Study of State-Of-the-Art Poisson Solvers for Uniform and Nonuniform Grids in the Unit Cube},
+  journal = {SIAM Journal on Scientific Computing},
+  year    = {2016},
+  volume  = {38},
+  number  = {3},
+  pages   = {C280--C306},
+  month   = {jan},
+  issn    = {1064-8275},
+  doi     = {10.1137/15m1010798},
+  note    = {Unconfirmed citation},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @PhDThesis{ghorashi:goal-oriented,
@@ -567,6 +680,30 @@
   doi     = {}
 }
 
+@Article{giuliani.krivodonova:edge,
+  author  = {Giuliani, Andrew and Krivodonova, Lilia},
+  title   = {Edge coloring in unstructured CFD codes},
+  journal = {arxiv.org},
+  year    = {2016},
+  month   = {jan},
+  archiveprefix = {arXiv},
+  arxivid = {1601.07613},
+  eprint  = {http://arxiv.org/abs/1601.07613v2},
+  eprintclass = {cs.DC},
+  eprinttype = {arXiv},
+  keywords = {cs.DC},
+  url     = {http://arxiv.org/abs/1601.07613}
+}
+
+@PhDThesis{guittet:simulation-of-incompressible-viscous-flows-on-distributed-octree-grids,
+  author  = {Guittet, A},
+  title   = {{Simulation of incompressible viscous flows on distributed Octree grids}},
+  school  = {University of California},
+  year    = {2016},
+  note    = {Unconfirmed citation},
+  url     = {https://search.proquest.com/openview/a7b27aaca7f352c4cd8446610eeb79f0/1?pq-origsite=gscholar&cbl=18750&diss=y}
+}
+
 @Article{gupta.langelaar.ea:combined,
   author  = {D. K. Gupta and M. Langelaar and F. van Keulen},
   title   = {Combined mesh and penalization adaptivity based topology optimization},
@@ -578,19 +715,22 @@
   doi     = {}
 }
 
+@Article{hai.bause.ea:finite,
+  author  = {B. S. M. Ebna Hai and M. Bause and P. A. Kuberry},
+  title   = {Finite Element Approximation of the eXtended Fluid-Structure Interaction (eXFSI) Problem},
+  journal = {In proceedings of: the ASME 2016 Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2016-7506, pp. V01AT11A001/1--12, July 10--14, Washington, DC, USA},
+  year    = {2016},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
 @MastersThesis{hamann:linear,
   author  = {T. Hamann},
   title   = {A linear finite element model of the biceps brachii skeletal muscle},
   year    = {2016},
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
-  url     = {}
-}
-
-@PhDThesis{harmon:numerical,
-  author  = {M. Harmon},
-  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
-  year    = {2016},
-  school  = {University of Texas at Austin},
   url     = {}
 }
 
@@ -605,15 +745,12 @@
   doi     = {}
 }
 
-@Article{hartmann.leicht:generation,
-  author  = {R. Hartmann and T. Leicht},
-  title   = {Generation of unstructured curvilinear grids and high-order Discontinuous Galerkin discretization applied to a 3D high-lift configuration},
-  journal = {International Journal on Numerical Methods Fluids},
+@PhDThesis{harmon:numerical,
+  author  = {M. Harmon},
+  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
   year    = {2016},
-  volume  = {82},
-  pages   = {316--333},
-  url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/},
-  doi     = {}
+  school  = {University of Texas at Austin},
+  url     = {}
 }
 
 @Article{harting:reaction-diffusion-ode,
@@ -624,6 +761,17 @@
   volume  = {},
   pages   = {},
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20550/},
+  doi     = {}
+}
+
+@Article{hartmann.leicht:generation,
+  author  = {R. Hartmann and T. Leicht},
+  title   = {Generation of unstructured curvilinear grids and high-order Discontinuous Galerkin discretization applied to a 3D high-lift configuration},
+  journal = {International Journal on Numerical Methods Fluids},
+  year    = {2016},
+  volume  = {82},
+  pages   = {316--333},
+  url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/},
   doi     = {}
 }
 
@@ -649,6 +797,15 @@
   doi     = {}
 }
 
+@MastersThesis{huang:computational,
+  author  = {Tzu-Hsuan Huang},
+  title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
+  school  = {National Taiwan University},
+  year    = {2016},
+  note    = {Unconfirmed citation},
+  url     = {https://hdl.handle.net/11296/2hzk7d}
+}
+
 @Article{jiang.rudraraju.ea:multiphysics,
   doi     = {10.1021/acs.jpcc.6b09775},
   url     = {https://doi.org/10.1021/acs.jpcc.6b09775},
@@ -671,6 +828,28 @@
   url     = {}
 }
 
+@Book{john:finite,
+  title   = {Finite Element Methods for Incompressible Flow Problems},
+  publisher = {Springer International Publishing},
+  year    = {2016},
+  author  = {Volker John},
+  doi     = {10.1007/978-3-319-45750-5},
+  url     = {https://link.springer.com/content/pdf/10.1007/978-3-319-45750-5.pdf}
+}
+
+@InCollection{john:the-time-dependent-navier-stokes-equations--laminar-flows,
+  author  = {John, Volker},
+  title   = {{The Time-Dependent Navier--Stokes Equations: Laminar Flows}},
+  booktitle = {Finite Element Methods for Incompressible Flow Problems},
+  publisher = {Springer International Publishing},
+  year    = {2016},
+  volume  = {51},
+  series  = {Springer Series in Computational Mathematics},
+  pages   = {355--445},
+  doi     = {10.1007/978-3-319-45750-5_7},
+  journal = {Springer}
+}
+
 @MastersThesis{kahler:on,
   author  = {R. Kahler},
   title   = {On Identification of Nonlinear Parameters in PDEs},
@@ -688,6 +867,20 @@
   pages   = {},
   url     = {},
   doi     = {}
+}
+
+@Article{kanschat.lorca:weakly,
+  doi     = {10.1515/cmam-2016-0023},
+  url     = {https://doi.org/10.1515/cmam-2016-0023},
+  year    = {2016},
+  month   = jan,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {16},
+  number  = {4},
+  pages   = {563--577},
+  author  = {Guido Kanschat and Jos{\'{e}} Pablo Lucero Lorca},
+  title   = {A Weakly Penalized Discontinuous Galerkin Method for Radiation in Dense, Scattering Media},
+  journal = {Computational Methods in Applied Mathematics}
 }
 
 @Article{kanschat.mao:multiplicative,
@@ -745,15 +938,30 @@
   doi     = {}
 }
 
-@Article{konzen.sauter.ea:numerical,
-  author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo and P. Zingano},
-  title   = {Numerical simulations with the finite element method for the Burgers' equation on the real line},
-  journal = {arXiv:1605.01109},
+@Article{klinsmann.rosato.ea:modeling-crack-growth-during-li-insertion-in-storage-particles-using-a-fracture-phase-field-approach,
+  author  = {Markus Klinsmann and Daniele Rosato and Marc Kamlah and Robert M. McMeeking},
+  title   = {{Modeling crack growth during Li insertion in storage particles using a fracture phase field approach}},
+  journal = {Journal of the Mechanics and Physics of Solids},
   year    = {2016},
-  volume  = {},
-  pages   = {},
-  url     = {https://arxiv.org/abs/1605.01109},
-  doi     = {}
+  volume  = {92},
+  pages   = {313--344},
+  month   = {jul},
+  doi     = {10.1016/j.jmps.2016.04.004},
+  note    = {Unconfirmed citation},
+  publisher = {Elsevier {BV}}
+}
+
+@Book{klinsmann:effects,
+  title   = {The Effects of Internal Stress and Lithium Transport on Fracture in Storage Materials in Lithium-Ion Batteries},
+  publisher = {KIT Scientific Publishing},
+  year    = {2016},
+  author  = {Klinsmann, Markus},
+  volume  = {54},
+  series  = {Schriftenreihe des Instituts fuer Angewandte Materialien, Karlsruher Institut f\"{u}r Technologie},
+  isbn    = {9783731504559},
+  ean     = {9783731504559},
+  pagetotal = {246},
+  url     = {https://books.google.com/books?hl=en&lr=&id=DaPBCwAAQBAJ&oi=fnd&pg=PA1&ots=OQG-TEOrRd&sig=Rpv8vp1yic72js-9bWMDR3l2lPY}
 }
 
 @Article{konzen.sauter.ea:green,
@@ -767,6 +975,39 @@
   doi     = {}
 }
 
+@Article{konzen.sauter.ea:numerical,
+  author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo and P. Zingano},
+  title   = {Numerical simulations with the finite element method for the Burgers' equation on the real line},
+  journal = {arXiv:1605.01109},
+  year    = {2016},
+  volume  = {},
+  pages   = {},
+  url     = {https://arxiv.org/abs/1605.01109},
+  doi     = {}
+}
+
+@Article{kormann:time-space,
+  doi     = {10.4208/cicp.101214.021015a},
+  url     = {https://doi.org/10.4208/cicp.101214.021015a},
+  year    = {2016},
+  month   = jun,
+  publisher = {Global Science Press},
+  volume  = {20},
+  number  = {1},
+  pages   = {60--85},
+  author  = {Katharina Kormann},
+  title   = {A Time-Space Adaptive Method for the Schr\"{o}dinger Equation},
+  journal = {Communications in Computational Physics}
+}
+
+@MastersThesis{kottapalli:numerical-prediction-of-flow-induced-vibrations-in-nuclear-reactors-through-pressure-fluctuation-modeling,
+  author  = {Shravan Kottapalli},
+  title   = {{Numerical Prediction of Flow Induced Vibrations in Nuclear Reactors through Pressure Fluctuation Modeling}},
+  school  = {Delft University of Technology},
+  year    = {2016},
+  url     = {https://repository.tudelft.nl/islandora/object/uuid:f2c3e758-6c90-4877-8c89-cea243be882c/datastream/OBJ/www.cfd-online.com/Wiki/Reynolds_stress _model_(RSM).pdf}
+}
+
 @Article{kramer.hagemann.ea:parallel,
   author  = {S. C. Kramer and J. Hagemann and L. Kunneke and J. Lebert},
   title   = {Parallel Statistical Multiresolution Estimation for Image Reconstruction},
@@ -776,6 +1017,20 @@
   pages   = {C533--C559},
   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1020332},
   doi     = {10.1137/15M1020332}
+}
+
+@Article{kronbichler.diagne.ea:fast,
+  author  = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
+  title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
+  journal = {The International Journal of High Performance Computing Applications},
+  year    = {2016},
+  volume  = {32},
+  number  = {2},
+  pages   = {266--287},
+  month   = {oct},
+  doi     = {10.1177/1094342016671790},
+  publisher = {{SAGE} Publications},
+  url     = {https://mediatum.ub.tum.de/1272587}
 }
 
 @Article{kronbichler.schoeder.ea:comparison,
@@ -789,12 +1044,37 @@
   doi     = {10.1002/nme.5137}
 }
 
+@Article{kuberry.lee:convergence-of-a-fluid-structure-interaction-problem-decoupled-by-a-neumann-control-over-a-single-time-step,
+  author  = {Paul Kuberry and Hyesuk Lee},
+  title   = {{Convergence of a fluid--structure interaction problem decoupled by a Neumann control over a single time step}},
+  journal = {Journal of Mathematical Analysis and Applications},
+  year    = {2016},
+  volume  = {437},
+  number  = {1},
+  pages   = {645--667},
+  month   = {may},
+  doi     = {10.1016/j.jmaa.2016.01.022},
+  note    = {Unconfirmed citation},
+  publisher = {Elsevier {BV}},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0022247X16000470}
+}
+
 @MastersThesis{kufner:entwurf,
   author  = {M. Kufner},
   title   = {Entwurf und Implementierung eines Perfectly Matched Layer f\"{u}r die lineare Akustik},
   year    = {2016},
   school  = {Technical University of Munich},
   url     = {}
+}
+
+@MastersThesis{kumar:investigation,
+  author  = {Kumar, Pankaj},
+  title   = {{I}nvestigation of density in {B}uoyancy {F}lows using {CFD} code {J}u{F}ire},
+  school  = {Bergische Universit{\"a}t Wuppertal},
+  reportid = {FZJ-2016-05448},
+  pages   = {xv, 63 p.},
+  year    = {2016},
+  url     = {https://juser.fz-juelich.de/record/819869}
 }
 
 @Article{kunisch.pieper.ea:time,
@@ -806,6 +1086,26 @@
   pages   = {381--414},
   url     = {http://www.esaim-m2an.org/articles/m2an/abs/2016/02/m2an141121/m2an141121.html},
   doi     = {}
+}
+
+@InProceedings{lahnert.burstedde.ea:towards,
+  author  = {Michael Lahnert and Carsten Burstedde and Christian Holm and Miriam Mehl and Georg Rempfer and Florian Weik},
+  title   = {Towards Lattice--Boltzmann On Dynamically Adaptive Grids -- Minimally-invasive Grid Exchange In Espresso},
+  booktitle = {Proceedings of the {VII} European Congress on Computational Methods in Applied Sciences and Engineering},
+  year    = {2016},
+  doi     = {10.7712/100016.1982.4659},
+  url     = {https://pdfs.semanticscholar.org/8fc8/2d82beb2997c127248b85ceec8c21bdecfca.pdf}
+}
+
+@InCollection{le-borne:hierarchical,
+  author  = {{Le Borne}, Sabine},
+  title   = {Hierarchical Preconditioners for High-Order {FEM}},
+  booktitle = {Lecture Notes in Computational Science and Engineering},
+  publisher = {Springer International Publishing},
+  year    = {2016},
+  pages   = {559--566},
+  doi     = {10.1007/978-3-319-18827-0_57},
+  url     = {http://link.springer.com/10.1007/978-3-319-18827-0_57}
 }
 
 @Article{lee.lee.ea:locally,
@@ -832,6 +1132,16 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
+@TechReport{lee.mikelic.ea:phase-field*1,
+  author  = {Lee, S and Mikelic, A and Wheeler, MF and Wick, T},
+  title   = {Phase-field modeling of proppant-filled fractures in a poroelastic medium},
+  institution = {The Institute for Computational Engineering and Sciences},
+  year    = {2016},
+  number  = {ICES REPORT 16-03},
+  address = {The University of Texas at Austin},
+  url     = {https://www.ices.utexas.edu/media/reports/2016/1603.pdf}
+}
+
 @Article{lee.reber.ea:investigation,
   doi     = {10.1002/2016gl069979},
   url     = {https://doi.org/10.1002/2016gl069979},
@@ -844,6 +1154,17 @@
   author  = {Sanghyun Lee and Jacqueline E. Reber and Nicholas W. Hayman and Mary F. Wheeler},
   title   = {Investigation of wing crack formation with a combined phase-field and experimental approach},
   journal = {Geophysical Research Letters}
+}
+
+@Article{lee.salgado:stability,
+  author  = {S. Lee and A. Salgado},
+  title   = {Stability analysis of pressure correction schemes for the Navier-Stokes equations with traction boundary conditions},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2016},
+  volume  = {309},
+  pages   = {307--324},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0045782516304923},
+  doi     = {}
 }
 
 @Article{lee.wheeler.ea:pressure,
@@ -863,6 +1184,30 @@
   year    = {2016},
   school  = {Technical University of Munich},
   url     = {}
+}
+
+@Article{leibner.milk.ea:extending-dune--the-dune-xt-modules,
+  author  = {Leibner, Tobias and Milk, Ren{\'{e}} and Schindler, Felix},
+  title   = {{Extending DUNE: The dune-xt modules}},
+  journal = {arxiv.org},
+  year    = {2016},
+  month   = {feb},
+  archiveprefix = {arXiv},
+  arxivid = {1602.08991},
+  eprint  = {1602.08991},
+  url     = {http://arxiv.org/abs/1602.08991}
+}
+
+@Article{lemenager.oneill.ea:numerical-modelling-of-the-sydney-basin-using-temperature-dependent-thermal-conductivity-measurements,
+  author  = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang},
+  title   = {{Numerical Modelling of the Sydney Basin Using Temperature Dependent Thermal Conductivity Measurements}},
+  journal = {{ASEG} Extended Abstracts},
+  year    = {2016},
+  volume  = {1},
+  pages   = {1--7},
+  doi     = {10.1071/aseg2016ab238},
+  publisher = {{CSIRO} Publishing},
+  url     = {http://www.publish.csiro.au/EX/ASEG2016ab238}
 }
 
 @Article{li.hartmann:adjoint-based,
@@ -887,6 +1232,35 @@
   doi     = {10.1103/PhysRevE.93.013121}
 }
 
+@InProceedings{lofstead.jean-baptiste.ea:delta,
+  author  = {Lofstead, Jay and Jean-Baptiste, Gregory and Oldfield, Ron},
+  title   = {Delta: Data Reduction for Integrated Application Workflows and Data Storage},
+  booktitle = {ISC High Performance 2016: High Performance Computing},
+  year    = {2016},
+  editor  = {Taufer, M. and Mohr, B. and Kunkel, J.},
+  volume  = {9945},
+  series  = {Lecture Notes in Computer Science},
+  pages   = {142--152},
+  publisher = {Springer International Publishing},
+  doi     = {10.1007/978-3-319-46079-6_11},
+  isbn    = {978-3-319-46079-6},
+  journal = {Springer}
+}
+
+@Article{madzvamuse.chung:analysis-and-simulations-of-coupled-bulk-surface-reaction-diffusion-systems-on-exponentially-evolving-volumes,
+  author  = {A. Madzvamuse and A. H. Chung},
+  title   = {{Analysis and Simulations of Coupled Bulk-surface Reaction-Diffusion Systems on Exponentially Evolving Volumes}},
+  journal = {Mathematical Modelling of Natural Phenomena},
+  year    = {2016},
+  volume  = {11},
+  number  = {5},
+  pages   = {4--32},
+  doi     = {10.1051/mmnp/201611502},
+  note    = {Unconfirmed citation},
+  editor  = {A. Morozov and M. Ptashnyk and V. Volpert},
+  publisher = {{EDP} Sciences}
+}
+
 @Article{madzvamuse.chung:bulk-surface,
   author  = {A. Madzvamuse and A. H. W. Chung},
   title   = {The bulk-surface finite element method for reaction--diffusion systems on stationary volumes},
@@ -896,6 +1270,20 @@
   pages   = {9--21},
   url     = {http://www.sciencedirect.com/science/article/pii/S0168874X15001377},
   doi     = {}
+}
+
+@Article{maier.bardelloni.ea:linearoperator-a,
+  doi     = {10.1016/j.camwa.2016.04.024},
+  url     = {https://doi.org/10.1016/j.camwa.2016.04.024},
+  year    = {2016},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {72},
+  number  = {1},
+  pages   = {1--24},
+  author  = {Matthias Maier and Mauro Bardelloni and Luca Heltai},
+  title   = {{LinearOperator}---A generic, high-level expression syntax for linear algebra},
+  journal = {Computers {\&} Mathematics with Applications}
 }
 
 @Article{maier.rannacher:duality-based,
@@ -909,6 +1297,19 @@
   doi     = {}
 }
 
+@Article{mandal.dean-ben.ea:visual,
+  author  = {Subhamoy Mandal and Xose Luis Dean-Ben and Daniel Razansky},
+  title   = {Visual Quality Enhancement in Optoacoustic Tomography Using Active Contour Segmentation Priors},
+  journal = {{IEEE} Transactions on Medical Imaging},
+  year    = {2016},
+  volume  = {35},
+  number  = {10},
+  pages   = {2209--2217},
+  month   = {oct},
+  doi     = {10.1109/tmi.2016.2553156},
+  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})}
+}
+
 @Article{marojevic.goklu.ea:atus-pro,
   author  = {\v{Z}. Marojevi\'{c}' and E. G\"{o}kl\"{u} and C. L\"{a}mmerzahl},
   title   = {ATUS-PRO: A FEM-based solver for the time-dependent and stationary Gross-Pitaevskii equation},
@@ -918,6 +1319,52 @@
   pages   = {216--232},
   url     = {},
   doi     = {}
+}
+
+@MastersThesis{maroudas:support-of-pdes-for-multidomain-problems-in-a-solving-environment,
+  author  = {Maroudas, Emmanouil},
+  title   = {{Support of PDEs for multidomain problems in a solving environment}},
+  school  = {University of Thessaly},
+  year    = {2016},
+  url     = {http://ir.lib.uth.gr/bitstream/handle/11615/46361/14595.pdf?sequence=1}
+}
+
+@Article{maurer.wieners:scalable,
+  author  = {Maurer, Daniel and Wieners, Christian},
+  title   = {A scalable parallel factorization of finite element matrices with distributed Schur complements},
+  journal = {Numerical Linear Algebra with Applications},
+  year    = {2016},
+  volume  = {23},
+  number  = {5},
+  pages   = {848--864},
+  month   = {jun},
+  doi     = {10.1002/nla.2057},
+  note    = {Unconfirmed citation},
+  publisher = {Wiley}
+}
+
+@Article{mcrae.bercea.ea:automated,
+  author  = {McRae, A. T. T. and Bercea, G.-T. and Mitchell, L. and Ham, D. A. and Cotter, C. J.},
+  title   = {Automated Generation and Symbolic Manipulation of Tensor Product Finite Elements},
+  journal = {{SIAM} Journal on Scientific Computing},
+  year    = {2016},
+  volume  = {38},
+  number  = {5},
+  pages   = {S25--S47},
+  month   = {jan},
+  doi     = {10.1137/15m1021167},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
+}
+
+@InProceedings{mihankhah.wang:environment,
+  author  = {Ehsan Mihankhah and Danwei Wang},
+  title   = {Environment characterization using Laplace eigenvalues},
+  booktitle = {2016 14th International Conference on Control, Automation, Robotics and Vision (ICARCV)},
+  year    = {2016},
+  pages   = {1--6},
+  month   = {nov},
+  publisher = {{IEEE}},
+  doi     = {10.1109/icarcv.2016.7838769}
 }
 
 @Article{milk.rave.ea:pymor,
@@ -931,6 +1378,19 @@
   doi     = {}
 }
 
+@Article{mirzadeh.guittet.ea:parallel-level-set-methods-on-adaptive-tree-based-grids,
+  author  = {Mohammad Mirzadeh and Arthur Guittet and Carsten Burstedde and Frederic Gibou},
+  title   = {{Parallel level-set methods on adaptive tree-based grids}},
+  journal = {Journal of Computational Physics},
+  year    = {2016},
+  volume  = {322},
+  pages   = {345--364},
+  month   = {oct},
+  doi     = {10.1016/j.jcp.2016.06.017},
+  note    = {Unconfirmed citation},
+  publisher = {Elsevier {BV}}
+}
+
 @Article{mital.wick.ea:discontinuous,
   author  = {P. Mital and T. Wick and M. F. Wheeler and G. Pencheva},
   title   = {Discontinuous and enriched Galerkin methods for phase-field fracture propagation in elasticity},
@@ -940,6 +1400,37 @@
   pages   = {},
   url     = {},
   doi     = {}
+}
+
+@Article{mitchell.muller:high-level-implementation-of-geometric-multigrid-solvers-for-finite-element-problems--applications-in-atmospheric-modelling,
+  author  = {Lawrence Mitchell and Eike Hermann M\"{u}ller},
+  title   = {{High level implementation of geometric multigrid solvers for finite element problems: Applications in atmospheric modelling}},
+  journal = {Journal of Computational Physics},
+  year    = {2016},
+  volume  = {327},
+  pages   = {1--18},
+  month   = {dec},
+  doi     = {10.1016/j.jcp.2016.09.037},
+  note    = {Unconfirmed citation},
+  publisher = {Elsevier {BV}}
+}
+
+@Article{moawad:approximation,
+  author  = {R. F. M. Moawad},
+  title   = {Approximation of The Neutron Diffusion Equation on Hexagonal Geometries Using a h-p Finite Element Method},
+  journal = {PhD dissertation, La Universitat Polit\`{e}cnica de Val\`{e}ncia, Spain},
+  year    = {2016},
+  volume  = {},
+  pages   = {},
+  url     = {https://riunet.upv.es/handle/10251/65353},
+  doi     = {}
+}
+
+@Misc{mohebujjaman:solution,
+  author  = {Muhammad Mohebujjaman},
+  title   = {Solution of incompressible viscous time-dependent Navier-Stokes equations using projection method},
+  year    = {2016},
+  url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/project/Solution-of-incompressible-viscous-time-dependent-Navier-Stokes-equations-using-projection-method/attachment/57ad503e08aef1b475aef153/AS:394116325232643@1470976062899/download/project+_write.pdf?context=ProjectUpdatesLog}
 }
 
 @Article{moinger.forster-zugel.ea:simulation,
@@ -972,17 +1463,6 @@
   volume  = {95},
   pages   = {575--601},
   url     = {http://www.sciencedirect.com/science/article/pii/S0022509615301903},
-  doi     = {}
-}
-
-@Article{moawad:approximation,
-  author  = {R. F. M. Moawad},
-  title   = {Approximation of The Neutron Diffusion Equation on Hexagonal Geometries Using a h-p Finite Element Method},
-  journal = {PhD dissertation, La Universitat Polit\`{e}cnica de Val\`{e}ncia, Spain},
-  year    = {2016},
-  volume  = {},
-  pages   = {},
-  url     = {https://riunet.upv.es/handle/10251/65353},
   doi     = {}
 }
 
@@ -1075,6 +1555,21 @@
   publisher = {Wiley}
 }
 
+@Article{peterson.stogner:a-c1-continuous-finite-element-formulation-for-solving-the-jeffery-hamel-boundary-value-problem,
+  author  = {John W. Peterson and Roy H. Stogner},
+  title   = {{A C$^{1}$-continuous finite element formulation for solving the Jeffery-Hamel boundary value problem}},
+  journal = {arxiv.org},
+  year    = {2016},
+  month   = {dec},
+  archiveprefix = {arXiv},
+  arxivid = {1612.06312},
+  eprint  = {1612.06312},
+  eprintclass = {math.NA},
+  eprinttype = {arXiv},
+  keywords = {math.NA, 34B15},
+  url     = {https://arxiv.org/abs/1612.06312}
+}
+
 @PhDThesis{quezada-de-luna:high-order,
   author  = {M. {Quezada de Luna}},
   title   = {High-order and maximum principle preserving (MPP) techniques for solving conservation laws with applications on multiphase flow},
@@ -1083,12 +1578,51 @@
   url     = {}
 }
 
+@MastersThesis{rahman:posteriori,
+  author  = {Rahman, Mohammad Arifur},
+  title   = {An a posteriori error estimator for the C$^{0}$ Interior Penalty Approximations of Fourth Order Elliptic Boundary Value Problem on Quadrilateral Meshes},
+  school  = {The University of Texas at El Paso},
+  year    = {2016},
+  note    = {Unconfirmed citation},
+  url     = {http://search.proquest.com/openview/a1ba7b7eb39434a7aa45eb9e604a8e22/1?pq-origsite=gscholar&cbl=18750&diss=y}
+}
+
+@Article{rathgeber.ham.ea:firedrake--automating-the-finite-element-method-by-composing-abstractions,
+  author  = {Florian Rathgeber and David A. Ham and Lawrence Mitchell and Michael Lange and Fabio Luporini and Andrew T. T. Mcrae and Gheorghe-Teodor Bercea and Graham R. Markall and Paul H. J. Kelly},
+  title   = {{Firedrake: automating the finite element method by composing abstractions}},
+  journal = {{ACM} Transactions on Mathematical Software},
+  year    = {2016},
+  volume  = {43},
+  number  = {3},
+  pages   = {1--27},
+  month   = {dec},
+  doi     = {10.1145/2998441},
+  publisher = {Association for Computing Machinery ({ACM})},
+  url     = {http://www.doc.ic.ac.uk/~lmitche1/08-06-PASC-firedrake.pdf}
+}
+
+@InProceedings{riedlbauer.steinmann.ea:simulation-of-temperature-distribution-and-mechanical-material-behaviour-in-selective-beam-melting-processes,
+  author  = {Riedlbauer, D and Steinmann, P and Mergheim, J},
+  title   = {{Simulation of temperature distribution and mechanical material behaviour in selective beam melting processes}},
+  booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
+  year    = {2016},
+  url     = {https://www.eccomas2016.org/proceedings/pdf/4477.pdf}
+}
+
 @MastersThesis{roberge:computational,
   author  = {J. R. Roberge},
   title   = {Computational Design of Ceramic Bone Scaffolds Fabricated Via Direct Ink Writing},
   year    = {2016},
   school  = {University of Connecticut, Connecticut},
   url     = {http://digitalcommons.uconn.edu/gs_theses/989/}
+}
+
+@InProceedings{rodriguez-gonzalez.montesi:new,
+  author  = {Rodr\'{i}guez-Gonz\'{a}lez, Juan and Montesi, Laurent},
+  title   = {A new finite element code for the study of strain-localization under strike-slip faults},
+  booktitle = {American Geophysical Union Fall Meeting Abstracts},
+  year    = {2016},
+  url     = {https://agu.confex.com/agu/fm16/meetingapp.cgi/Paper/183591}
 }
 
 @Article{rose:true,
@@ -1102,15 +1636,47 @@
   doi     = {}
 }
 
-@Article{lee.salgado:stability,
-  author  = {S. Lee and A. Salgado},
-  title   = {Stability analysis of pressure correction schemes for the Navier-Stokes equations with traction boundary conditions},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
+@PhDThesis{roszmann:simulation,
+  author  = {Roszmann, Jordan Douglas},
+  title   = {Simulation and growth of cadmium zinc telluride from small seeds by the travelling heater method},
+  school  = {University of Victoria},
   year    = {2016},
-  volume  = {309},
-  pages   = {307--324},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0045782516304923},
-  doi     = {}
+  url     = {http://dspace.library.uvic.ca/handle/1828/7347}
+}
+
+@Article{rudraraju.ven.ea:mechano-chemical,
+  author  = {Shiva Rudraraju and Anton Van der Ven and Krishna Garikipati},
+  title   = {Mechano-chemical spinodal decomposition: a phenomenological theory of phase transformations in multi-component, crystalline solids},
+  journal = {Computational Materials},
+  year    = 2016,
+  volume  = 2,
+  pages   = 16012,
+  url     = {10.1038/npjcompumats.2016.12}
+}
+
+@Article{salinger.bartlett.ea:albany--using-component-based-design-to-develop-a-flexible--generic-multiphysics-analysis-code,
+  author  = {Andrew G. Salinger and Roscoe A. Bartlett and Andrew M. Bradley and Qiushi Chen and Irina P. Demeshko and Xujiao Gao and Glen A. Hansen and Alejandro Mota and Richard P. Muller and Erik Nielsen and Jakob T. Ostien and Roger P. Pawlowski and Mauro Perego and Eric T. Phipps and WaiChing Sun and Irina K. Tezaur},
+  title   = {{Albany: Using component-based design to develop a flexible, generic multiphysics analysis code}},
+  journal = {International Journal for Multiscale Computational Engineering},
+  year    = {2016},
+  volume  = {14},
+  number  = {4},
+  pages   = {415--438},
+  doi     = {10.1615/intjmultcompeng.2016017040},
+  note    = {Unconfirmed citation},
+  publisher = {Begell House}
+}
+
+@InProceedings{salmoiraghi.ballarin.ea:advances,
+  author  = {Salmoiraghi, F and Ballarin, F and Corsi, G and Mola, A and Tezzele, M},
+  title   = {Advances in geometrical parametrization and reduced order models and methods for computational fluid dynamics problems in applied sciences and engineering},
+  booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
+  organization = {Institute of Structural Analysis and Antiseismic Research School of Civil Engineering National Technical University of Athens (NTUA) Greece},
+  year    = {2016},
+  volume  = {1},
+  pages   = {1013--1031},
+  url     = {http://preprints.sissa.it/xmlui/handle/1963/35179},
+  doi     = {10.7712/100016.1867.8680}
 }
 
 @Article{samii.michoski.ea:parallel,
@@ -1122,6 +1688,23 @@
   pages   = {118--139},
   url     = {},
   doi     = {10.1016/j.cma.2016.02.009}
+}
+
+@TechReport{sasidharan.snir:miniamr,
+  author  = {Sasidharan, Aparna and Snir, Marc},
+  title   = {MiniAMR -- A miniapp for Adaptive Mesh Refinement},
+  institution = {University of Illinois at Urbana-Champaign},
+  year    = {2016},
+  url     = {https://www.ideals.illinois.edu/handle/2142/91046}
+}
+
+@PhDThesis{scheffer:charakterisierung,
+  author  = {Scheffer, Tobias},
+  title   = {Charakterisierung des nichtlinear-viskoelastischen Materialverhaltens gef{\"{u}}llter Elastomere},
+  school  = {Universit\"{a}t des Saarlandes},
+  year    = {2016},
+  doi     = {10.22028/D291-23130},
+  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/23186}
 }
 
 @Article{schlogl.leyendecker:dynamic,
@@ -1146,14 +1729,6 @@
   doi     = {}
 }
 
-@PhDThesis{sheldon:hybridizable,
-  author  = {J. Sheldon},
-  title   = {A hybridizable discontinuous Galerkin method for modeling fluid-structure interaction.},
-  year    = {2016},
-  school  = {The Pennsylvania State University},
-  url     = {}
-}
-
 @Article{sheldon.miller.ea:hybridizable,
   author  = {J. P. Sheldon and S. T. Miller and J. S. Pitt},
   title   = {A hybridizable discontinuous Galerkin method for modeling fluid--structure interaction},
@@ -1163,6 +1738,21 @@
   pages   = {},
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303941},
   doi     = {}
+}
+
+@PhDThesis{sheldon:hybridizable,
+  author  = {J. Sheldon},
+  title   = {A hybridizable discontinuous Galerkin method for modeling fluid-structure interaction.},
+  year    = {2016},
+  school  = {The Pennsylvania State University},
+  url     = {}
+}
+
+@MastersThesis{siehr:das-newton-verfahren-zur-berechnung-variationeller-eigenwertprobleme,
+  author  = {Siehr, Philipp},
+  title   = {{Das Newton-Verfahren zur Berechnung variationeller Eigenwertprobleme}},
+  school  = {Universit\"{a}t Heidelberg},
+  year    = {2016}
 }
 
 @Article{soine.hersch.ea:measuring,
@@ -1179,6 +1769,25 @@
   journal = {Interface Focus}
 }
 
+@InProceedings{stegmann.yang:development-of-a-discontinuous-galerkin-time-domain-solver-on-a-staggered-grid-for-pan-spectral-single-scattering-analysis,
+  author  = {P. G. Stegmann and P. Yang},
+  title   = {{Development of a Discontinuous Galerkin Time Domain Solver on a staggered grid for pan-spectral single scattering analysis}},
+  booktitle = {Light, Energy and the Environment},
+  year    = {2016},
+  organization = {Optical Society of America},
+  publisher = {{OSA}},
+  doi     = {10.1364/fts.2016.jw4a.29},
+  note    = {Unconfirmed citation}
+}
+
+@PhDThesis{stegmann:light,
+  author  = {Stegmann, Patrick G\"{u}nther},
+  title   = {Light Scattering by Non-Spherical Particles},
+  school  = {Technische Universit\"{a}t Darmstadt},
+  year    = {2016},
+  url     = {http://tuprints.ulb.tu-darmstadt.de/5257/}
+}
+
 @Article{stoll.pearson.ea:fast,
   author  = {M. Stoll and J. Pearson and P. K. Maini},
   title   = {Fast solvers for optimal control problems from pattern formation},
@@ -1188,6 +1797,14 @@
   pages   = {27--45},
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999115006683},
   doi     = {}
+}
+
+@PhDThesis{tsoeu:electrical,
+  author  = {T{\v{s}}oeu, Mohohlo Samuel},
+  title   = {Electrical Impedance Tomography/Spectroscopy (EITS): a Code Division Multiplexed (CDM) approaches},
+  school  = {University of Cape Town},
+  year    = {2016},
+  url     = {https://open.uct.ac.za/handle/11427/22866}
 }
 
 @Article{turcksin.kronbichler.ea:workstream,
@@ -1201,6 +1818,19 @@
   doi     = {}
 }
 
+@Article{turner.clarno.ea:the-virtual-environment-for-reactor-applications-vera--design-and-architecture,
+  author  = {John A. Turner and Kevin Clarno and Matt Sieger and Roscoe Bartlett and Benjamin Collins and Roger Pawlowski and Rodney Schmidt and Randall Summers},
+  title   = {{The Virtual Environment for Reactor Applications (VERA): Design and architecture}},
+  journal = {Journal of Computational Physics},
+  year    = {2016},
+  volume  = {326},
+  pages   = {544--568},
+  month   = {dec},
+  doi     = {10.1016/j.jcp.2016.09.003},
+  note    = {Unconfirmed citation},
+  publisher = {Elsevier {BV}}
+}
+
 @Article{veske.kyritsakis.ea:atomistic,
   author  = {M. Veske and A. Kyritsakis and F. Djurabekova and R. Aare and K. Eimre and V. Zadin},
   title   = {Atomistic modeling of metal surfaces under high electric fields: Direct coupling of electric fields to the atomistic simulations},
@@ -1212,6 +1842,19 @@
   doi     = {}
 }
 
+@Article{vidal-ferrandiz.fayez.ea:moving,
+  doi     = {10.1016/j.cam.2015.03.040},
+  url     = {https://doi.org/10.1016/j.cam.2015.03.040},
+  year    = {2016},
+  month   = jan,
+  publisher = {Elsevier {BV}},
+  volume  = {291},
+  pages   = {197--208},
+  author  = {A. Vidal-Ferr{\`{a}}ndiz and R. Fayez and D. Ginestar and G. Verd{\'{u}}},
+  title   = {Moving meshes to solve the time-dependent neutron diffusion equation in hexagonal geometry},
+  journal = {Journal of Computational and Applied Mathematics}
+}
+
 @Article{vidal-ferrandiz.gonzalez-pintor.ea:use,
   author  = {A. Vidal-Ferrandiz and S. Gonzalez-Pintor and D. Ginestart and G. Verdu and M. Asadzadeh and C. Demaziere},
   title   = {Use of discontinuity factors in high-order finite element methods},
@@ -1221,6 +1864,18 @@
   pages   = {728--738},
   url     = {http://www.sciencedirect.com/science/article/pii/S0306454915003357},
   doi     = {}
+}
+
+@InProceedings{voll.stollenwerk.ea:computing,
+  doi     = {10.1117/12.2220292},
+  url     = {https://doi.org/10.1117/12.2220292},
+  year    = {2016},
+  month   = mar,
+  publisher = {{SPIE}},
+  author  = {Annika V\"{o}ll and Jochen Stollenwerk and Peter Loosen},
+  editor  = {Friedhelm Dorsch and Stefan Kaierle},
+  title   = {Computing specific intensity distributions for laser material processing by solving an inverse heat conduction problem},
+  booktitle = {High-Power Laser Materials Processing: Lasers, Beam Delivery, Diagnostics, and Applications V}
 }
 
 @Article{voll.stollenwerk.ea:computing*1,
@@ -1243,6 +1898,36 @@
   pages   = {170--192},
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516000062},
   doi     = {}
+}
+
+@Article{wang.rudraraju.ea:three,
+  title   = "A three dimensional field formulation, and isogeometric solutions to point and line defects using Toupin's theory of gradient elasticity at finite strains",
+  journal = "Journal of the Mechanics and Physics of Solids",
+  volume  = "94",
+  pages   = "336--361",
+  year    = "2016",
+  doi     = "10.1016/j.jmps.2016.03.028",
+  author  = "Z. Wang and S. Rudraraju and K. Garikipati"
+}
+
+@Article{white.castelletto.ea:block-partitioned,
+  author  = {J. A. White and N. Castelletto and H. A. Tchelepi},
+  title   = {Block-partitioned solvers for coupled poromechanics: A unified framework},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2016},
+  volume  = {303},
+  pages   = {55--74},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0045782516000104},
+  doi     = {}
+}
+
+@PhDThesis{white:parallel-block-preconditioning-of-the-incompressible-navier-stokes-equations-with-weakly-imposed-boundary-conditions,
+  author  = {White, Raymon},
+  title   = {{Parallel block preconditioning of the incompressible Navier-Stokes equations with weakly imposed boundary conditions}},
+  school  = {University of Manchester},
+  year    = {2016},
+  note    = {Unconfirmed citation},
+  url     = {http://search.proquest.com/openview/283931f019e73788c05df3ebafe35abc/1?pq-origsite=gscholar&cbl=2026366&diss=y}
 }
 
 @Article{wick:coupling,
@@ -1278,509 +1963,6 @@
   doi     = {}
 }
 
-@Article{white.castelletto.ea:block-partitioned,
-  author  = {J. A. White and N. Castelletto and H. A. Tchelepi},
-  title   = {Block-partitioned solvers for coupled poromechanics: A unified framework},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2016},
-  volume  = {303},
-  pages   = {55--74},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0045782516000104},
-  doi     = {}
-}
-
-@PhDThesis{yang:continuous,
-  author  = {Y. Yang},
-  title   = {Continuous finite element approximation of hyperbolic systems},
-  year    = {2016},
-  school  = {Texas A\&M University},
-  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/157976}
-}
-
-@Article{young.vargas.ea:hartree-fock,
-  author  = {T. D. Young and R. Vargas and J.Garza},
-  title   = {A Hartree--Fock study of the confined helium atom: Local and global basis set approaches},
-  journal = {Physics Letters A, Vol. 380},
-  year    = {2016},
-  volume  = {},
-  pages   = {712--717},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0375960115009998},
-  doi     = {}
-}
-
-@Article{zhang.oneill:early,
-  author  = {S. Zhang and C. O'Neill},
-  title   = {The early geodynamic evolution of Mars-type planets},
-  journal = {Icarus, Vol. 265, pp. 187--208},
-  year    = {2016},
-  volume  = {},
-  pages   = {},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0019103515004856},
-  doi     = {}
-}
-
-@Article{zhang.norato.ea:geometry,
-  author  = {S. Zhang and J. A. Norato and A. L. Gain and N. Lyu},
-  title   = {A geometry projection method for the topology optimization of plate structures},
-  journal = {Structural and Multidisciplinary Optimization, issue 5, pp. 1173--1190},
-  year    = {2016},
-  volume  = {54},
-  pages   = {},
-  url     = {https://link.springer.com/article/10.1007/s00158-016-1466-6},
-  doi     = {}
-}
-
-@Article{zheng.mcclarren:moment,
-  author  = {W. Zheng and R. G. McClarren},
-  title   = {Moment closures based on minimizing the residual of the PN angular expansion in radiation transport},
-  journal = {J. Comput. Phys.},
-  year    = {2016},
-  volume  = {314},
-  pages   = {682--699},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116001820},
-  doi     = {}
-}
-
-@Article{zheng.mcclarren:asymptotic,
-  author  = {W. Zheng and R. G. McClarren},
-  title   = {Asymptotic preserving least square PN methods of transport equation},
-  journal = {Proceedings of PHYSOR 2016, Sun Valley, Idaho, May 1-5},
-  year    = {2016},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Misc{arndt.lucero.ea:a-parallel-multigrid-matrix-free-solver-using-schwarz-smoothers,
-  author  = {Arndt, D and Lucero, P and Witte, J and Kanschat, PEG},
-  title   = {{A Parallel Multigrid Matrix-Free Solver using Schwarz Smoothers}},
-  howpublished = {PDE Software Frameworks 2016},
-  year    = {2016},
-  url     = {http://www.mathsim.eu/~darndt/files/PDESoft2016Arndt.pdf}
-}
-
-@Article{assier.poon.ea:spectral-study-of-the-laplace-beltrami-operator-arising-in-the-problem-of-acoustic-wave-scattering-by-a-quarter-plane,
-  author  = {Assier, RC and Poon, C and Peake, N},
-  title   = {{Spectral study of the Laplace--Beltrami operator arising in the problem of acoustic wave scattering by a quarter-plane}},
-  journal = {The Quarterly Journal of Mechanics and Applied Mathematics},
-  year    = {2016},
-  volume  = {69},
-  number  = {3},
-  pages   = {281--317},
-  month   = {aug},
-  doi     = {10.1093/qjmam/hbw008},
-  publisher = {Oxford University Press ({OUP})}
-}
-
-@Article{bonito.pasciak:numerical-approximation-of-fractional-powers-of-regularly-accretive-operators,
-  author  = {Andrea Bonito and Joseph E. Pasciak},
-  title   = {{Numerical approximation of fractional powers of regularly accretive operators}},
-  journal = {{IMA} Journal of Numerical Analysis},
-  year    = {2016},
-  volume  = {37},
-  number  = {3},
-  pages   = {1245--1273},
-  month   = {aug},
-  doi     = {10.1093/imanum/drw042},
-  publisher = {Oxford University Press ({OUP})}
-}
-
-@Manual{chen.ladenheim.ea:the-manchester-thermal-analyzer,
-  title   = {{The Manchester Thermal Analyzer}},
-  author  = {Chen, Yi-Chung and Ladenheim, Scott and Mihajlovi{\'{c}}, Milan and Pavlidis, Vasilis},
-  year    = {2016},
-  url     = {https://pdfs.semanticscholar.org/853e/b3362f9d2670680f21dc7ed280e745fa6a9f.pdf}
-}
-
-@Article{cockburn.demlow:hybridizable-discontinuous-galerkin-and-mixed-finite-element-methods-for-elliptic-problems-on-surfaces,
-  author  = {Bernardo Cockburn and Alan Demlow},
-  title   = {{Hybridizable discontinuous Galerkin and mixed finite element methods for elliptic problems on surfaces}},
-  journal = {Mathematics of Computation},
-  year    = {2016},
-  volume  = {85},
-  number  = {302},
-  pages   = {2609--2638},
-  month   = {mar},
-  doi     = {10.1090/mcom/3093},
-  publisher = {American Mathematical Society ({AMS})}
-}
-
-@Article{cruz.ramos:general,
-  author  = {Luis M. De La Cruz and Eduardo Ramos},
-  title   = {General Template Units for the Finite Volume Method in Box-Shaped Domains},
-  journal = {{ACM} Transactions on Mathematical Software},
-  year    = {2016},
-  volume  = {43},
-  number  = {1},
-  pages   = {1--32},
-  month   = {aug},
-  doi     = {10.1145/2835175},
-  publisher = {Association for Computing Machinery ({ACM})}
-}
-
-@Article{dalcin.collier.ea:petiga--a-framework-for-high-performance-isogeometric-analysis,
-  author  = {L. Dalcin and N. Collier and P. Vignal and A.M.A. C{\^{o}}rtes and V.M. Calo},
-  title   = {{PetIGA: A framework for high-performance isogeometric analysis}},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2016},
-  volume  = {308},
-  pages   = {151--181},
-  month   = {aug},
-  doi     = {10.1016/j.cma.2016.05.011},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}}
-}
-
-@Article{ervin.lee.ea:generalized-newtonian-fluid-flow-through-a-porous-medium,
-  author  = {V.J. Ervin and Hyesuk Lee and A.J. Salgado},
-  title   = {{Generalized Newtonian fluid flow through a porous medium}},
-  journal = {Journal of Mathematical Analysis and Applications},
-  year    = {2016},
-  volume  = {433},
-  number  = {1},
-  pages   = {603--621},
-  month   = {jan},
-  doi     = {10.1016/j.jmaa.2015.07.054},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0022247X15007003}
-}
-
-@Misc{gersbacher:implementation,
-  title   = {Implementation of $hp$-adaptive discontinuous finite element methods in Dune-Fem},
-  author  = {Christoph Gersbacher},
-  year    = {2016},
-  eprint  = {1604.07242},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.MS}
-}
-
-@PhDThesis{guittet:simulation-of-incompressible-viscous-flows-on-distributed-octree-grids,
-  author  = {Guittet, A},
-  title   = {{Simulation of incompressible viscous flows on distributed Octree grids}},
-  school  = {University of California},
-  year    = {2016},
-  note    = {Unconfirmed citation},
-  url     = {https://search.proquest.com/openview/a7b27aaca7f352c4cd8446610eeb79f0/1?pq-origsite=gscholar&cbl=18750&diss=y}
-}
-
-@Book{john:finite,
-  title   = {Finite Element Methods for Incompressible Flow Problems},
-  publisher = {Springer International Publishing},
-  year    = {2016},
-  author  = {Volker John},
-  doi     = {10.1007/978-3-319-45750-5},
-  url     = {https://link.springer.com/content/pdf/10.1007/978-3-319-45750-5.pdf}
-}
-
-@Book{klinsmann:effects,
-  title   = {The Effects of Internal Stress and Lithium Transport on Fracture in Storage Materials in Lithium-Ion Batteries},
-  publisher = {KIT Scientific Publishing},
-  year    = {2016},
-  author  = {Klinsmann, Markus},
-  volume  = {54},
-  series  = {Schriftenreihe des Instituts fuer Angewandte Materialien, Karlsruher Institut f\"{u}r Technologie},
-  isbn    = {9783731504559},
-  ean     = {9783731504559},
-  pagetotal = {246},
-  url     = {https://books.google.com/books?hl=en&lr=&id=DaPBCwAAQBAJ&oi=fnd&pg=PA1&ots=OQG-TEOrRd&sig=Rpv8vp1yic72js-9bWMDR3l2lPY}
-}
-
-@Article{klinsmann.rosato.ea:modeling-crack-growth-during-li-insertion-in-storage-particles-using-a-fracture-phase-field-approach,
-  author  = {Markus Klinsmann and Daniele Rosato and Marc Kamlah and Robert M. McMeeking},
-  title   = {{Modeling crack growth during Li insertion in storage particles using a fracture phase field approach}},
-  journal = {Journal of the Mechanics and Physics of Solids},
-  year    = {2016},
-  volume  = {92},
-  pages   = {313--344},
-  month   = {jul},
-  doi     = {10.1016/j.jmps.2016.04.004},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}}
-}
-
-@MastersThesis{kottapalli:numerical-prediction-of-flow-induced-vibrations-in-nuclear-reactors-through-pressure-fluctuation-modeling,
-  author  = {Shravan Kottapalli},
-  title   = {{Numerical Prediction of Flow Induced Vibrations in Nuclear Reactors through Pressure Fluctuation Modeling}},
-  school  = {Delft University of Technology},
-  year    = {2016},
-  url     = {https://repository.tudelft.nl/islandora/object/uuid:f2c3e758-6c90-4877-8c89-cea243be882c/datastream/OBJ/www.cfd-online.com/Wiki/Reynolds_stress _model_(RSM).pdf}
-}
-
-@Article{kuberry.lee:convergence-of-a-fluid-structure-interaction-problem-decoupled-by-a-neumann-control-over-a-single-time-step,
-  author  = {Paul Kuberry and Hyesuk Lee},
-  title   = {{Convergence of a fluid--structure interaction problem decoupled by a Neumann control over a single time step}},
-  journal = {Journal of Mathematical Analysis and Applications},
-  year    = {2016},
-  volume  = {437},
-  number  = {1},
-  pages   = {645--667},
-  month   = {may},
-  doi     = {10.1016/j.jmaa.2016.01.022},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0022247X16000470}
-}
-
-@InProceedings{lahnert.burstedde.ea:towards,
-  author  = {Michael Lahnert and Carsten Burstedde and Christian Holm and Miriam Mehl and Georg Rempfer and Florian Weik},
-  title   = {Towards Lattice--Boltzmann On Dynamically Adaptive Grids -- Minimally-invasive Grid Exchange In Espresso},
-  booktitle = {Proceedings of the {VII} European Congress on Computational Methods in Applied Sciences and Engineering},
-  year    = {2016},
-  doi     = {10.7712/100016.1982.4659},
-  url     = {https://pdfs.semanticscholar.org/8fc8/2d82beb2997c127248b85ceec8c21bdecfca.pdf}
-}
-
-@InCollection{le-borne:hierarchical,
-  author  = {{Le Borne}, Sabine},
-  title   = {Hierarchical Preconditioners for High-Order {FEM}},
-  booktitle = {Lecture Notes in Computational Science and Engineering},
-  publisher = {Springer International Publishing},
-  year    = {2016},
-  pages   = {559--566},
-  doi     = {10.1007/978-3-319-18827-0_57},
-  url     = {http://link.springer.com/10.1007/978-3-319-18827-0_57}
-}
-
-@TechReport{lee.mikelic.ea:phase-field*1,
-  author  = {Lee, S and Mikelic, A and Wheeler, MF and Wick, T},
-  title   = {Phase-field modeling of proppant-filled fractures in a poroelastic medium},
-  institution = {The Institute for Computational Engineering and Sciences},
-  year    = {2016},
-  number  = {ICES REPORT 16-03},
-  address = {The University of Texas at Austin},
-  url     = {https://www.ices.utexas.edu/media/reports/2016/1603.pdf}
-}
-
-@Article{lemenager.oneill.ea:numerical-modelling-of-the-sydney-basin-using-temperature-dependent-thermal-conductivity-measurements,
-  author  = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang},
-  title   = {{Numerical Modelling of the Sydney Basin Using Temperature Dependent Thermal Conductivity Measurements}},
-  journal = {{ASEG} Extended Abstracts},
-  year    = {2016},
-  volume  = {1},
-  pages   = {1--7},
-  doi     = {10.1071/aseg2016ab238},
-  publisher = {{CSIRO} Publishing},
-  url     = {http://www.publish.csiro.au/EX/ASEG2016ab238}
-}
-
-@Article{madzvamuse.chung:analysis-and-simulations-of-coupled-bulk-surface-reaction-diffusion-systems-on-exponentially-evolving-volumes,
-  author  = {A. Madzvamuse and A. H. Chung},
-  title   = {{Analysis and Simulations of Coupled Bulk-surface Reaction-Diffusion Systems on Exponentially Evolving Volumes}},
-  journal = {Mathematical Modelling of Natural Phenomena},
-  year    = {2016},
-  volume  = {11},
-  number  = {5},
-  pages   = {4--32},
-  doi     = {10.1051/mmnp/201611502},
-  note    = {Unconfirmed citation},
-  editor  = {A. Morozov and M. Ptashnyk and V. Volpert},
-  publisher = {{EDP} Sciences}
-}
-
-@Article{mandal.dean-ben.ea:visual,
-  author  = {Subhamoy Mandal and Xose Luis Dean-Ben and Daniel Razansky},
-  title   = {Visual Quality Enhancement in Optoacoustic Tomography Using Active Contour Segmentation Priors},
-  journal = {{IEEE} Transactions on Medical Imaging},
-  year    = {2016},
-  volume  = {35},
-  number  = {10},
-  pages   = {2209--2217},
-  month   = {oct},
-  doi     = {10.1109/tmi.2016.2553156},
-  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})}
-}
-
-@InProceedings{mihankhah.wang:environment,
-  author  = {Ehsan Mihankhah and Danwei Wang},
-  title   = {Environment characterization using Laplace eigenvalues},
-  booktitle = {2016 14th International Conference on Control, Automation, Robotics and Vision (ICARCV)},
-  year    = {2016},
-  pages   = {1--6},
-  month   = {nov},
-  publisher = {{IEEE}},
-  doi     = {10.1109/icarcv.2016.7838769}
-}
-
-@Article{mirzadeh.guittet.ea:parallel-level-set-methods-on-adaptive-tree-based-grids,
-  author  = {Mohammad Mirzadeh and Arthur Guittet and Carsten Burstedde and Frederic Gibou},
-  title   = {{Parallel level-set methods on adaptive tree-based grids}},
-  journal = {Journal of Computational Physics},
-  year    = {2016},
-  volume  = {322},
-  pages   = {345--364},
-  month   = {oct},
-  doi     = {10.1016/j.jcp.2016.06.017},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}}
-}
-
-@Article{mitchell.muller:high-level-implementation-of-geometric-multigrid-solvers-for-finite-element-problems--applications-in-atmospheric-modelling,
-  author  = {Lawrence Mitchell and Eike Hermann M\"{u}ller},
-  title   = {{High level implementation of geometric multigrid solvers for finite element problems: Applications in atmospheric modelling}},
-  journal = {Journal of Computational Physics},
-  year    = {2016},
-  volume  = {327},
-  pages   = {1--18},
-  month   = {dec},
-  doi     = {10.1016/j.jcp.2016.09.037},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}}
-}
-
-@Article{rathgeber.ham.ea:firedrake--automating-the-finite-element-method-by-composing-abstractions,
-  author  = {Florian Rathgeber and David A. Ham and Lawrence Mitchell and Michael Lange and Fabio Luporini and Andrew T. T. Mcrae and Gheorghe-Teodor Bercea and Graham R. Markall and Paul H. J. Kelly},
-  title   = {{Firedrake: automating the finite element method by composing abstractions}},
-  journal = {{ACM} Transactions on Mathematical Software},
-  year    = {2016},
-  volume  = {43},
-  number  = {3},
-  pages   = {1--27},
-  month   = {dec},
-  doi     = {10.1145/2998441},
-  publisher = {Association for Computing Machinery ({ACM})},
-  url     = {http://www.doc.ic.ac.uk/~lmitche1/08-06-PASC-firedrake.pdf}
-}
-
-@Misc{mohebujjaman:solution,
-  author  = {Muhammad Mohebujjaman},
-  title   = {Solution of incompressible viscous time-dependent Navier-Stokes equations using projection method},
-  year    = {2016},
-  url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/project/Solution-of-incompressible-viscous-time-dependent-Navier-Stokes-equations-using-projection-method/attachment/57ad503e08aef1b475aef153/AS:394116325232643@1470976062899/download/project+_write.pdf?context=ProjectUpdatesLog}
-}
-
-@MastersThesis{rahman:posteriori,
-  author  = {Rahman, Mohammad Arifur},
-  title   = {An a posteriori error estimator for the C$^{0}$ Interior Penalty Approximations of Fourth Order Elliptic Boundary Value Problem on Quadrilateral Meshes},
-  school  = {The University of Texas at El Paso},
-  year    = {2016},
-  note    = {Unconfirmed citation},
-  url     = {http://search.proquest.com/openview/a1ba7b7eb39434a7aa45eb9e604a8e22/1?pq-origsite=gscholar&cbl=18750&diss=y}
-}
-
-@InProceedings{riedlbauer.steinmann.ea:simulation-of-temperature-distribution-and-mechanical-material-behaviour-in-selective-beam-melting-processes,
-  author  = {Riedlbauer, D and Steinmann, P and Mergheim, J},
-  title   = {{Simulation of temperature distribution and mechanical material behaviour in selective beam melting processes}},
-  booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
-  year    = {2016},
-  url     = {https://www.eccomas2016.org/proceedings/pdf/4477.pdf}
-}
-
-@InProceedings{rodriguez-gonzalez.montesi:new,
-  author  = {Rodr\'{i}guez-Gonz\'{a}lez, Juan and Montesi, Laurent},
-  title   = {A new finite element code for the study of strain-localization under strike-slip faults},
-  booktitle = {American Geophysical Union Fall Meeting Abstracts},
-  year    = {2016},
-  url     = {https://agu.confex.com/agu/fm16/meetingapp.cgi/Paper/183591}
-}
-
-@PhDThesis{roszmann:simulation,
-  author  = {Roszmann, Jordan Douglas},
-  title   = {Simulation and growth of cadmium zinc telluride from small seeds by the travelling heater method},
-  school  = {University of Victoria},
-  year    = {2016},
-  url     = {http://dspace.library.uvic.ca/handle/1828/7347}
-}
-
-@Article{salinger.bartlett.ea:albany--using-component-based-design-to-develop-a-flexible--generic-multiphysics-analysis-code,
-  author  = {Andrew G. Salinger and Roscoe A. Bartlett and Andrew M. Bradley and Qiushi Chen and Irina P. Demeshko and Xujiao Gao and Glen A. Hansen and Alejandro Mota and Richard P. Muller and Erik Nielsen and Jakob T. Ostien and Roger P. Pawlowski and Mauro Perego and Eric T. Phipps and WaiChing Sun and Irina K. Tezaur},
-  title   = {{Albany: Using component-based design to develop a flexible, generic multiphysics analysis code}},
-  journal = {International Journal for Multiscale Computational Engineering},
-  year    = {2016},
-  volume  = {14},
-  number  = {4},
-  pages   = {415--438},
-  doi     = {10.1615/intjmultcompeng.2016017040},
-  note    = {Unconfirmed citation},
-  publisher = {Begell House}
-}
-
-@InProceedings{salmoiraghi.ballarin.ea:advances,
-  author  = {Salmoiraghi, F and Ballarin, F and Corsi, G and Mola, A and Tezzele, M},
-  title   = {Advances in geometrical parametrization and reduced order models and methods for computational fluid dynamics problems in applied sciences and engineering},
-  booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
-  organization = {Institute of Structural Analysis and Antiseismic Research School of Civil Engineering National Technical University of Athens (NTUA) Greece},
-  year    = {2016},
-  volume  = {1},
-  pages   = {1013--1031},
-  url     = {http://preprints.sissa.it/xmlui/handle/1963/35179},
-  doi     = {10.7712/100016.1867.8680}
-}
-
-@TechReport{sasidharan.snir:miniamr,
-  author  = {Sasidharan, Aparna and Snir, Marc},
-  title   = {MiniAMR -- A miniapp for Adaptive Mesh Refinement},
-  institution = {University of Illinois at Urbana-Champaign},
-  year    = {2016},
-  url     = {https://www.ideals.illinois.edu/handle/2142/91046}
-}
-
-@PhDThesis{scheffer:charakterisierung,
-  author  = {Scheffer, Tobias},
-  title   = {Charakterisierung des nichtlinear-viskoelastischen Materialverhaltens gef{\"{u}}llter Elastomere},
-  school  = {Universit\"{a}t des Saarlandes},
-  year    = {2016},
-  doi     = {10.22028/D291-23130},
-  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/23186}
-}
-
-@MastersThesis{siehr:das-newton-verfahren-zur-berechnung-variationeller-eigenwertprobleme,
-  author  = {Siehr, Philipp},
-  title   = {{Das Newton-Verfahren zur Berechnung variationeller Eigenwertprobleme}},
-  school  = {Universit\"{a}t Heidelberg},
-  year    = {2016}
-}
-
-@InProceedings{stegmann.yang:development-of-a-discontinuous-galerkin-time-domain-solver-on-a-staggered-grid-for-pan-spectral-single-scattering-analysis,
-  author  = {P. G. Stegmann and P. Yang},
-  title   = {{Development of a Discontinuous Galerkin Time Domain Solver on a staggered grid for pan-spectral single scattering analysis}},
-  booktitle = {Light, Energy and the Environment},
-  year    = {2016},
-  organization = {Optical Society of America},
-  publisher = {{OSA}},
-  doi     = {10.1364/fts.2016.jw4a.29},
-  note    = {Unconfirmed citation}
-}
-
-@PhDThesis{stegmann:light,
-  author  = {Stegmann, Patrick G\"{u}nther},
-  title   = {Light Scattering by Non-Spherical Particles},
-  school  = {Technische Universit\"{a}t Darmstadt},
-  year    = {2016},
-  url     = {http://tuprints.ulb.tu-darmstadt.de/5257/}
-}
-
-@PhDThesis{tsoeu:electrical,
-  author  = {T{\v{s}}oeu, Mohohlo Samuel},
-  title   = {Electrical Impedance Tomography/Spectroscopy (EITS): a Code Division Multiplexed (CDM) approaches},
-  school  = {University of Cape Town},
-  year    = {2016},
-  url     = {https://open.uct.ac.za/handle/11427/22866}
-}
-
-@Article{turner.clarno.ea:the-virtual-environment-for-reactor-applications-vera--design-and-architecture,
-  author  = {John A. Turner and Kevin Clarno and Matt Sieger and Roscoe Bartlett and Benjamin Collins and Roger Pawlowski and Rodney Schmidt and Randall Summers},
-  title   = {{The Virtual Environment for Reactor Applications (VERA): Design and architecture}},
-  journal = {Journal of Computational Physics},
-  year    = {2016},
-  volume  = {326},
-  pages   = {544--568},
-  month   = {dec},
-  doi     = {10.1016/j.jcp.2016.09.003},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}}
-}
-
-@PhDThesis{white:parallel-block-preconditioning-of-the-incompressible-navier-stokes-equations-with-weakly-imposed-boundary-conditions,
-  author  = {White, Raymon},
-  title   = {{Parallel block preconditioning of the incompressible Navier-Stokes equations with weakly imposed boundary conditions}},
-  school  = {University of Manchester},
-  year    = {2016},
-  note    = {Unconfirmed citation},
-  url     = {http://search.proquest.com/openview/283931f019e73788c05df3ebafe35abc/1?pq-origsite=gscholar&cbl=2026366&diss=y}
-}
-
 @TechReport{wilbrandt.bartsch.ea:parmoon,
   author  = {Wilbrandt, U and Bartsch, C and Ahmed, N and Alia, N and Anker, F},
   title   = {ParMooN -- a modernized program package based on mapped finite elements},
@@ -1801,26 +1983,12 @@
   url     = {https://www.researchgate.net/profile/Hao_Li192/publication/312344754_High_Order_Accurate_Curved-element_Implementation_in_OpenFOAM_for_Discontinuous_Galerkin_Method/links/590d26134585159781831faa/High-Order-Accurate-Curved-element-Implementation-in-OpenFOAM-for-Discontinuous-Galerkin-Method.pdf}
 }
 
-@Article{zander.bog.ea:the-multi-level-hp-method-for-three-dimensional-problems--dynamically-changing-high-order-mesh-refinement-with-arbitrary-hanging-nodes,
-  author  = {Nils Zander and Tino Bog and Mohamed Elhaddad and Felix Frischmann and Stefan Kollmannsberger and Ernst Rank},
-  title   = {{The multi-level hp-method for three-dimensional problems: Dynamically changing high-order mesh refinement with arbitrary hanging nodes}},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
+@PhDThesis{yang:continuous,
+  author  = {Y. Yang},
+  title   = {Continuous finite element approximation of hyperbolic systems},
   year    = {2016},
-  volume  = {310},
-  pages   = {252--277},
-  month   = {oct},
-  doi     = {10.1016/j.cma.2016.07.007},
-  note    = {Unconfirmed citation},
-  publisher = {Elsevier {BV}}
-}
-
-@MastersThesis{huang:computational,
-  author  = {Tzu-Hsuan Huang},
-  title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
-  school  = {National Taiwan University},
-  year    = {2016},
-  note    = {Unconfirmed citation},
-  url     = {https://hdl.handle.net/11296/2hzk7d}
+  school  = {Texas A\&M University},
+  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/157976}
 }
 
 @Article{yoon.kang:mass-transfer-enhancement-by-a-single-emulsion-droplet,
@@ -1836,132 +2004,61 @@
   url     = {http://www.worldscientific.com/doi/abs/10.1142/S2010132516500036}
 }
 
-@Article{mcrae.bercea.ea:automated,
-  author  = {McRae, A. T. T. and Bercea, G.-T. and Mitchell, L. and Ham, D. A. and Cotter, C. J.},
-  title   = {Automated Generation and Symbolic Manipulation of Tensor Product Finite Elements},
-  journal = {{SIAM} Journal on Scientific Computing},
+@Article{young.vargas.ea:hartree-fock,
+  author  = {T. D. Young and R. Vargas and J.Garza},
+  title   = {A Hartree--Fock study of the confined helium atom: Local and global basis set approaches},
+  journal = {Physics Letters A, Vol. 380},
   year    = {2016},
-  volume  = {38},
-  number  = {5},
-  pages   = {S25--S47},
-  month   = {jan},
-  doi     = {10.1137/15m1021167},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
+  volume  = {},
+  pages   = {712--717},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0375960115009998},
+  doi     = {}
 }
 
-@Article{maurer.wieners:scalable,
-  author  = {Maurer, Daniel and Wieners, Christian},
-  title   = {A scalable parallel factorization of finite element matrices with distributed Schur complements},
-  journal = {Numerical Linear Algebra with Applications},
+@Article{zander.bog.ea:the-multi-level-hp-method-for-three-dimensional-problems--dynamically-changing-high-order-mesh-refinement-with-arbitrary-hanging-nodes,
+  author  = {Nils Zander and Tino Bog and Mohamed Elhaddad and Felix Frischmann and Stefan Kollmannsberger and Ernst Rank},
+  title   = {{The multi-level hp-method for three-dimensional problems: Dynamically changing high-order mesh refinement with arbitrary hanging nodes}},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
   year    = {2016},
-  volume  = {23},
-  number  = {5},
-  pages   = {848--864},
-  month   = {jun},
-  doi     = {10.1002/nla.2057},
+  volume  = {310},
+  pages   = {252--277},
+  month   = {oct},
+  doi     = {10.1016/j.cma.2016.07.007},
   note    = {Unconfirmed citation},
-  publisher = {Wiley}
+  publisher = {Elsevier {BV}}
 }
 
-@InProceedings{lofstead.jean-baptiste.ea:delta,
-  author  = {Lofstead, Jay and Jean-Baptiste, Gregory and Oldfield, Ron},
-  title   = {Delta: Data Reduction for Integrated Application Workflows and Data Storage},
-  booktitle = {ISC High Performance 2016: High Performance Computing},
+@Article{zhang.norato.ea:geometry,
+  author  = {S. Zhang and J. A. Norato and A. L. Gain and N. Lyu},
+  title   = {A geometry projection method for the topology optimization of plate structures},
+  journal = {Structural and Multidisciplinary Optimization, issue 5, pp. 1173--1190},
   year    = {2016},
-  editor  = {Taufer, M. and Mohr, B. and Kunkel, J.},
-  volume  = {9945},
-  series  = {Lecture Notes in Computer Science},
-  pages   = {142--152},
-  publisher = {Springer International Publishing},
-  doi     = {10.1007/978-3-319-46079-6_11},
-  isbn    = {978-3-319-46079-6},
-  journal = {Springer}
+  volume  = {54},
+  pages   = {},
+  url     = {https://link.springer.com/article/10.1007/s00158-016-1466-6},
+  doi     = {}
 }
 
-@Article{leibner.milk.ea:extending-dune--the-dune-xt-modules,
-  author  = {Leibner, Tobias and Milk, Ren{\'{e}} and Schindler, Felix},
-  title   = {{Extending DUNE: The dune-xt modules}},
-  journal = {arxiv.org},
+@Article{zhang.oneill:early,
+  author  = {S. Zhang and C. O'Neill},
+  title   = {The early geodynamic evolution of Mars-type planets},
+  journal = {Icarus, Vol. 265, pp. 187--208},
   year    = {2016},
-  month   = {feb},
-  archiveprefix = {arXiv},
-  arxivid = {1602.08991},
-  eprint  = {1602.08991},
-  url     = {http://arxiv.org/abs/1602.08991}
+  volume  = {},
+  pages   = {},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0019103515004856},
+  doi     = {}
 }
 
-@Article{giuliani.krivodonova:edge,
-  author  = {Giuliani, Andrew and Krivodonova, Lilia},
-  title   = {Edge coloring in unstructured CFD codes},
-  journal = {arxiv.org},
+@Article{zheng.mcclarren:asymptotic,
+  author  = {W. Zheng and R. G. McClarren},
+  title   = {Asymptotic preserving least square PN methods of transport equation},
+  journal = {Proceedings of PHYSOR 2016, Sun Valley, Idaho, May 1-5},
   year    = {2016},
-  month   = {jan},
-  archiveprefix = {arXiv},
-  arxivid = {1601.07613},
-  eprint  = {http://arxiv.org/abs/1601.07613v2},
-  eprintclass = {cs.DC},
-  eprinttype = {arXiv},
-  keywords = {cs.DC},
-  url     = {http://arxiv.org/abs/1601.07613}
-}
-
-@Article{gholami.malhotra.ea:fft,
-  author  = {Gholami, Amir and Malhotra, Dhairya and Sundar, Hari and Biros, George},
-  title   = {{FFT}, {FMM}, or Multigrid? A comparative Study of State-Of-the-Art Poisson Solvers for Uniform and Nonuniform Grids in the Unit Cube},
-  journal = {SIAM Journal on Scientific Computing},
-  year    = {2016},
-  volume  = {38},
-  number  = {3},
-  pages   = {C280--C306},
-  month   = {jan},
-  issn    = {1064-8275},
-  doi     = {10.1137/15m1010798},
-  note    = {Unconfirmed citation},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
-}
-
-@Article{feng.hui:force-sensing-using-3d-displacement-measurements-in-linear-elastic-bodies,
-  author  = {Feng, Xinzeng and Hui, Chung-Yuen},
-  title   = {{Force sensing using 3D displacement measurements in linear elastic bodies}},
-  journal = {Computational Mechanics},
-  year    = {2016},
-  volume  = {58},
-  number  = {1},
-  pages   = {91--105},
-  month   = {apr},
-  issn    = {0178-7675},
-  doi     = {10.1007/s00466-016-1283-1},
-  publisher = {Springer Nature}
-}
-
-@Article{burstedde.holke:a-tetrahedral-space-filling-curve-for-nonconforming-adaptive-meshes,
-  author  = {Burstedde, Carsten and Holke, Johannes},
-  title   = {{A Tetrahedral Space-Filling Curve for Nonconforming Adaptive Meshes}},
-  journal = {{SIAM} Journal on Scientific Computing},
-  year    = {2016},
-  volume  = {38},
-  number  = {5},
-  pages   = {C471--C503},
-  month   = {jan},
-  issn    = {1064-8275},
-  doi     = {10.1137/15M1040049},
-  note    = {Unconfirmed citation},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
-}
-
-@Article{bauman.stogner:grins--a-multiphysics-framework-based-on-the-libmesh-finite-element-library,
-  author  = {Bauman, Paul T. and Stogner, Roy H.},
-  title   = {{GRINS: A Multiphysics Framework Based on the libMesh Finite Element Library}},
-  journal = {{SIAM} Journal on Scientific Computing},
-  year    = {2016},
-  volume  = {38},
-  number  = {5},
-  pages   = {S78--S100},
-  month   = {jan},
-  issn    = {1064-8275},
-  doi     = {10.1137/15M1026110},
-  note    = {Unconfirmed citation},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
 }
 
 @Article{zheng.mcclarren:effective-non-oscillatory-regularized-l1-finite-elements-for-particle-transport-simulations,
@@ -1979,51 +2076,15 @@
   url     = {https://arxiv.org/abs/1612.05581}
 }
 
-@MastersThesis{maroudas:support-of-pdes-for-multidomain-problems-in-a-solving-environment,
-  author  = {Maroudas, Emmanouil},
-  title   = {{Support of PDEs for multidomain problems in a solving environment}},
-  school  = {University of Thessaly},
+@Article{zheng.mcclarren:moment,
+  author  = {W. Zheng and R. G. McClarren},
+  title   = {Moment closures based on minimizing the residual of the PN angular expansion in radiation transport},
+  journal = {J. Comput. Phys.},
   year    = {2016},
-  url     = {http://ir.lib.uth.gr/bitstream/handle/11615/46361/14595.pdf?sequence=1}
-}
-
-@InProceedings{droba:tangle-free-finite-element-mesh-motion-for-ablation-problems,
-  author  = {Droba, Justin},
-  title   = {{Tangle-Free Finite Element Mesh Motion for Ablation Problems}},
-  booktitle = {46th {AIAA} Thermophysics Conference},
-  year    = {2016},
-  address = {Reston, Virginia},
-  month   = {jun},
-  publisher = {American Institute of Aeronautics and Astronautics},
-  doi     = {10.2514/6.2016-3386},
-  note    = {Unconfirmed citation}
-}
-
-@InCollection{john:the-time-dependent-navier-stokes-equations--laminar-flows,
-  author  = {John, Volker},
-  title   = {{The Time-Dependent Navier--Stokes Equations: Laminar Flows}},
-  booktitle = {Finite Element Methods for Incompressible Flow Problems},
-  publisher = {Springer International Publishing},
-  year    = {2016},
-  volume  = {51},
-  series  = {Springer Series in Computational Mathematics},
-  pages   = {355--445},
-  doi     = {10.1007/978-3-319-45750-5_7},
-  journal = {Springer}
-}
-
-@Article{kronbichler.diagne.ea:fast,
-  author  = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
-  title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
-  journal = {The International Journal of High Performance Computing Applications},
-  year    = {2016},
-  volume  = {32},
-  number  = {2},
-  pages   = {266--287},
-  month   = {oct},
-  doi     = {10.1177/1094342016671790},
-  publisher = {{SAGE} Publications},
-  url     = {https://mediatum.ub.tum.de/1272587}
+  volume  = {314},
+  pages   = {682--699},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116001820},
+  doi     = {}
 }
 
 @PhDThesis{zheng:least-squares,
@@ -2034,57 +2095,6 @@
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/159075}
 }
 
-@Article{peterson.stogner:a-c1-continuous-finite-element-formulation-for-solving-the-jeffery-hamel-boundary-value-problem,
-  author  = {John W. Peterson and Roy H. Stogner},
-  title   = {{A C$^{1}$-continuous finite element formulation for solving the Jeffery-Hamel boundary value problem}},
-  journal = {arxiv.org},
-  year    = {2016},
-  month   = {dec},
-  archiveprefix = {arXiv},
-  arxivid = {1612.06312},
-  eprint  = {1612.06312},
-  eprintclass = {math.NA},
-  eprinttype = {arXiv},
-  keywords = {math.NA, 34B15},
-  url     = {https://arxiv.org/abs/1612.06312}
-}
-
-@MastersThesis{castelli:numerische,
-  author  = {Castelli, G. F.},
-  title   = {Die Numerische Simulation eines Mikroskalenmodells f{\"u}r Li-Ionen-Batterien},
-  school  = {Karlsruhe Institute of Technology (KIT)},
-  year    = {2016}
-}
-
-@Article{wang.rudraraju.ea:three,
-  title   = "A three dimensional field formulation, and isogeometric solutions to point and line defects using Toupin's theory of gradient elasticity at finite strains",
-  journal = "Journal of the Mechanics and Physics of Solids",
-  volume  = "94",
-  pages   = "336--361",
-  year    = "2016",
-  doi     = "10.1016/j.jmps.2016.03.028",
-  author  = "Z. Wang and S. Rudraraju and K. Garikipati"
-}
-
-@Article{rudraraju.ven.ea:mechano-chemical,
-  author  = {Shiva Rudraraju and Anton Van der Ven and Krishna Garikipati},
-  title   = {Mechano-chemical spinodal decomposition: a phenomenological theory of phase transformations in multi-component, crystalline solids},
-  journal = {Computational Materials},
-  year    = 2016,
-  volume  = 2,
-  pages   = 16012,
-  url     = {10.1038/npjcompumats.2016.12}
-}
-
-@Misc{gassmoeller.heien.ea:flexible,
-  title   = {Flexible and scalable particle-in-cell methods for massively parallel computations},
-  author  = {R. Gassmoeller and E. Heien and E. G. Puckett and W. Bangerth},
-  year    = {2016},
-  eprint  = {1612.03369},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
 @MastersThesis{zixuan:computational,
   title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
   author  = {Huang Zixuan},
@@ -2093,16 +2103,6 @@
   school  = {National Taiwan University},
   doi     = {10.6342/NTU201602040},
   url     = {https://www.airitilibrary.com/Publication/alDetailedMesh?DocID=U0001-0508201623573200}
-}
-
-@MastersThesis{kumar:investigation,
-  author  = {Kumar, Pankaj},
-  title   = {{I}nvestigation of density in {B}uoyancy {F}lows using {CFD} code {J}u{F}ire},
-  school  = {Bergische Universit{\"a}t Wuppertal},
-  reportid = {FZJ-2016-05448},
-  pages   = {xv, 63 p.},
-  year    = {2016},
-  url     = {https://juser.fz-juelich.de/record/819869}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1,798 +1,5 @@
 % Encoding: US-ASCII
 
-@PhDThesis{cox:adaptive-large-scale-mantle-convection-simulations,
-  title   = {{Adaptive large-scale mantle convection simulations}},
-  author  = {Cox, S. P.},
-  year    = {2017},
-  school  = {University of Leicester},
-  url     = {https://lra.le.ac.uk/handle/2381/39571}
-}
-
-@Article{ganesan:microstructural-response-of-magnesium-alloys--3d-crystal-plasticity-and-experimental-validation,
-  title   = {{Microstructural Response of Magnesium Alloys: 3D Crystal Plasticity and Experimental Validation}},
-  author  = {Ganesan, S},
-  year    = {2017},
-  school  = {University of Michigan},
-  url     = {http://www-personal.umich.edu/~veeras/papers/sriramthesis.pdf}
-}
-
-@PhDThesis{giuliani:modelling-fluid-structure-interaction-problems-using-boundary-element-method,
-  title   = {{Modelling Fluid Structure Interaction problems using Boundary Element Method}},
-  author  = {Giuliani, N},
-  school  = {Scuola Internazionale Superiore di Studi Avanzati - Trieste},
-  year    = {2017},
-  url     = {https://iris.sissa.it/handle/20.500.11767/57293}
-}
-
-@InProceedings{horak.straub.ea:epicyclic,
-  title   = {Epicyclic oscillations of thick relativistic disks},
-  author  = {J. Hor{\'a}k and O. Straub and E. {\v{S}}r{\'a}mkov{\'a} and K. Goluchov{\'{a}} and G. T{\"{o}}r{\"{o}}k},
-  booktitle = {Proceedings of RAGtime 2015/2016/2017, Opava, Czech Republic},
-  editor  = {Z. Stuchl{\'i}k, G. Tor{\"o}k and V. Karas},
-  pages   = {47--59},
-  year    = {2017},
-  url     = {http://proceedings.physics.cz/images/proc17/hor2.pdf}
-}
-
-@Article{grohs.hiptmair.ea:tensor-product,
-  doi     = {10.5802/smai-jcm.26},
-  url     = {https://doi.org/10.5802/smai-jcm.26},
-  year    = {2017},
-  publisher = {Cellule {MathDoc}/{CEDRAM}},
-  volume  = {3},
-  pages   = {219--248},
-  author  = {Philipp Grohs and Ralf Hiptmair and Simon Pintarelli},
-  title   = {Tensor-Product Discretization for the Spatially Inhomogeneous and Transient Boltzmann Equation in Two Dimensions},
-  journal = {{SMAI} Journal of Computational Mathematics}
-}
-
-@PhDThesis{holmgren:modelling-of-moving-contact-lines-in-two-phase-flows,
-  title   = {{Modelling of Moving Contact Lines in Two-Phase Flows}},
-  author  = {Holmgren, H},
-  year    = {2017},
-  school  = {Uppsala University},
-  url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2:1139929}
-}
-
-@Article{oneill.turner.ea:inception,
-  doi     = {10.1098/rsta.2017.0414},
-  title   = {The inception of plate tectonics: a record of failure},
-  author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
-  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
-  volume  = {376},
-  number  = {2132},
-  pages   = {20170414},
-  year    = {2018},
-  publisher = {The Royal Society Publishing}
-}
-
-@Article{oneill.marchi.ea:impact-driven,
-  doi     = {10.1038/ngeo3029},
-  title   = {Impact-driven subduction on the {H}adean {E}arth},
-  author  = {O'Neill, C. and Marchi, S. and Zhang, S. and Bottke, W.},
-  journal = {Nature Geoscience},
-  volume  = {10},
-  number  = {10},
-  pages   = {793},
-  year    = {2017},
-  publisher = {Nature Publishing Group}
-}
-
-@InProceedings{korous.karban.ea:distributed,
-  title   = {Distributed Implicit Discontinuous Galerkin {MHD} Solver},
-  author  = {Korous, L and Karban, P and Skala, J},
-  booktitle = {Proceedings of the 2017 CompuMag conference},
-  year    = {2017},
-  url     = {http://www.compumag.org/CMAG2017/[PD-A7-13]_492.pdf}
-}
-
-@PhDThesis{joos:microstructural-characterisation--modelling-and-simulation-of-solid-oxide-fuel-cell-cathodes,
-  title   = {{Microstructural Characterisation, Modelling and Simulation of Solid Oxide Fuel Cell Cathodes}},
-  author  = {Joos, J},
-  year    = {2017},
-  school  = {Karlsruhe Institute of Technology},
-  url     = {https://publikationen.bibliothek.kit.edu/1000064791/4189242}
-}
-
-@PhDThesis{kramer:lattice-boltzmann-methoden,
-  author  = {Andreas Kr{\"a}mer},
-  title   = {Lattice-{B}oltzmann-{M}ethoden zur {S}imulation inkompressibler {W}irbelstr{\"o}mungen},
-  year    = {2017},
-  school  = {Universit{\"a}t Siegen},
-  url     = {https://dspace.ub.uni-siegen.de/handle/ubsi/1237}
-}
-
-@PhDThesis{beams:high-order-hybrid-methods-using-greens-functions-and-finite-elements,
-  title   = {{High-order hybrid methods using Green's functions and finite elements}},
-  author  = {Beams, Natalie N},
-  school  = {University of Illinois at Urbana-Champaign},
-  year    = {2017},
-  url     = {https://www.ideals.illinois.edu/bitstream/handle/2142/98387/BEAMS-DISSERTATION-2017.pdf?sequence=1}
-}
-
-@PhDThesis{brand:forces-and-flow-of-contractile-networks,
-  title   = {{Forces and Flow of Contractile Networks}},
-  author  = {Brand, Christoph Alexander},
-  year    = {2017},
-  school  = {Heidelberg University},
-  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20233/1/thesis20151207.pdf},
-  doi     = {10.11588/heidok.00020233}
-}
-
-@Misc{welper:h,
-  title   = {$h$ and $hp$-adaptive Interpolation by Transformed Snapshots for Parametric and Stochastic Hyperbolic PDEs},
-  author  = {G. Welper},
-  year    = {2017},
-  eprint  = {1710.11481},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{wells.banks:using,
-  title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates},
-  author  = {David Wells and Jeffrey Banks},
-  year    = {2017},
-  eprint  = {1711.05922},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{riviere.kanschat:finite,
-  title   = {A finite element method with strong mass conservation for Biot's linear consolidation model},
-  author  = {Beatrice Riviere and Guido Kanschat},
-  year    = {2017},
-  eprint  = {1712.07468},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{marojevic.goklu.ea:life,
-  title   = {Life time of topological coherent modes of a Bose--Einstein condensate in a gravito optical surface trap},
-  author  = {{\v{Z}}elimir Marojevi{\'c} and Ertan G{\"o}kl{\"u} and Hannes Uecker and Claus L{\"a}mmerzahl},
-  year    = {2017},
-  eprint  = {1708.04443},
-  archiveprefix = {arXiv},
-  primaryclass = {quant-ph}
-}
-
-@Misc{maier.margetis.ea:generation,
-  title   = {Generation of surface plasmon-polaritons by edge effects},
-  author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
-  year    = {2017},
-  eprint  = {1702.00848},
-  archiveprefix = {arXiv},
-  primaryclass = {physics.comp-ph}
-}
-
-@Misc{licht.maier:flux,
-  title   = {Flux Reconstruction for Goal-Oriented A Posteriori Error Estimation},
-  author  = {Martin Licht and Matthias Maier},
-  year    = {2017},
-  eprint  = {1707.09659},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@MastersThesis{alzetta:core,
-  author  = {G. Alzetta},
-  title   = {Core building blocks for massively parallel multi-physics applications},
-  school  = {SISSA},
-  year    = {2017},
-  url     = {https://iris.sissa.it/retrieve/handle/20.500.11767/68032/61711/Giovanni%20Alzetta.pdf}
-}
-
-@Misc{joshi.chatterjee:a-posteriori,
-  title   = {A-posteriori diffusion analysis of higher-order numerical schemes for application to propagating linear waves},
-  author  = {S. M. Joshi and A. Chatterjee},
-  year    = {2017},
-  eprint  = {1707.05026},
-  archiveprefix = {arXiv},
-  primaryclass = {physics.comp-ph}
-}
-
-@Misc{galiano.velasco:on,
-  title   = {On a cross-diffusion system arising in image denosing},
-  author  = {Gonzalo Galiano and Juli{\'a}n Velasco},
-  year    = {2017},
-  eprint  = {1703.02487},
-  archiveprefix = {arXiv},
-  primaryclass = {math.AP}
-}
-
-@Misc{emerson:posteriori,
-  title   = {A Posteriori Error Estimators for the Frank-Oseen Model of Liquid Crystals},
-  author  = {D. B. Emerson},
-  year    = {2017},
-  eprint  = {1709.06157},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{charnyi.heister.ea:efficient,
-  title   = {Efficient discretizations for the EMAC formulation of the incompressible Navier-Stokes equations},
-  author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
-  year    = {2017},
-  eprint  = {1712.00857},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{berselli.wells.ea:spatial,
-  title   = {Spatial Filtering for Reduced Order Modeling},
-  author  = {L. C. Berselli and D. Wells and X. Xie and T. Iliescu},
-  year    = {2017},
-  eprint  = {1707.04133},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{bonito.demlow.ea:priori,
-  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace-Beltrami Operator},
-  author  = {Andrea Bonito and Alan Demlow and Justin Owen},
-  year    = {2017},
-  eprint  = {1801.00197},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Article{zheng.mcclarren:accurate,
-  doi     = {10.1016/j.pnucene.2017.06.001},
-  url     = {https://doi.org/10.1016/j.pnucene.2017.06.001},
-  year    = {2017},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {101},
-  pages   = {394--400},
-  author  = {Weixiong Zheng and Ryan G. McClarren},
-  title   = {Accurate least-squares $P_N$ scaling based on problem optical thickness for solving neutron transport problems},
-  journal = {Progress in Nuclear Energy}
-}
-
-@Article{zheng.mcclarren.ea:accurate,
-  doi     = {10.1080/00295639.2017.1407592},
-  url     = {https://doi.org/10.1080/00295639.2017.1407592},
-  year    = {2017},
-  month   = dec,
-  publisher = {Informa {UK} Limited},
-  volume  = {189},
-  number  = {3},
-  pages   = {259--271},
-  author  = {Weixiong Zheng and Ryan G. McClarren and Jim E. Morel},
-  title   = {An Accurate Globally Conservative Subdomain Discontinuous Least-Squares Scheme for Solving Neutron Transport Problems},
-  journal = {Nuclear Science and Engineering}
-}
-
-@InProceedings{zheng.mcclarren:continuous-discontinuous,
-  author  = {W. Zheng and R. G. McClarren},
-  title   = {A Continuous-Discontinuous Hybrid Finite Element Method for $S_N$ Transport},
-  booktitle = {Transactions of the American Nuclear Society},
-  year    = {2017},
-  volume  = {116},
-  pages   = {647--649},
-  url     = {https://www.researchgate.net/publication/317620866_A_Continuous-Discontinuous_Hybrid_Finite_Element_Method_for_SN_Transport}
-}
-
-@Article{zhang.norato:optimal,
-  doi     = {10.1115/1.4036999},
-  url     = {https://doi.org/10.1115/1.4036999},
-  year    = {2017},
-  month   = jun,
-  publisher = {{ASME} International},
-  volume  = {139},
-  number  = {8},
-  author  = {Shanglong Zhang and Juli{\'{a}}n A. Norato},
-  title   = {Optimal Design of Panel Reinforcements With Ribs Made of Plates},
-  journal = {Journal of Mechanical Design}
-}
-
-@Article{zhang.gain.ea:stress-based,
-  doi     = {10.1016/j.cma.2017.06.025},
-  url     = {https://doi.org/10.1016/j.cma.2017.06.025},
-  year    = {2017},
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = {325},
-  pages   = {1--21},
-  author  = {Shanglong Zhang and Arun L. Gain and Juli{\'{a}}n A. Norato},
-  title   = {Stress-based topology optimization with discrete geometric components},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{yu.cheng.ea:residual-based,
-  doi     = {10.1016/j.compfluid.2017.08.016},
-  url     = {https://doi.org/10.1016/j.compfluid.2017.08.016},
-  year    = {2017},
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = {156},
-  pages   = {470--484},
-  author  = {Shengjiao Yu and Jian Cheng and Huiqiang Yue and Tiegang Liu},
-  title   = {A residual-based h-adaptive reconstructed discontinuous Galerkin method for the compressible Euler equations on unstructured grids},
-  journal = {Computers {\&} Fluids}
-}
-
-@PhDThesis{wilmers:multiphysically,
-  doi     = {10.15480/882.1438},
-  url     = {https://tubdok.tub.tuhh.de/handle/11420/1441},
-  author  = {Wilmers, Jana},
-  keywords = {600: Technik, 600},
-  language = {en},
-  title   = {Multiphysically coupled modelling of polymer-based materials},
-  publisher = {TUHH Universit\"{a}tsbibliothek},
-  year    = {2017}
-}
-
-@Article{garikipati:perspectives,
-  doi     = {10.1016/j.jmps.2016.11.013},
-  url     = {https://doi.org/10.1016/j.jmps.2016.11.013},
-  year    = {2017},
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = {99},
-  pages   = {192--210},
-  author  = {Krishna Garikipati},
-  title   = {Perspectives on the mathematics of biological patterning and morphogenesis},
-  journal = {Journal of the Mechanics and Physics of Solids}
-}
-
-@Article{seydel.schuster:identifying,
-  doi     = {10.1088/1361-6420/aa8d91},
-  url     = {https://doi.org/10.1088/1361-6420/aa8d91},
-  year    = {2017},
-  month   = nov,
-  publisher = {{IOP} Publishing},
-  volume  = {33},
-  number  = {12},
-  pages   = {124004},
-  author  = {Julia Seydel and Thomas Schuster},
-  title   = {Identifying the stored energy of a hyperelastic structure by using an attenuated Landweber method},
-  journal = {Inverse Problems}
-}
-
-@InProceedings{santos.azeredo-coutinho:continuous,
-  doi     = {10.20906/cps/cilamce2017-0712},
-  url     = {https://doi.org/10.20906/cps/cilamce2017-0712},
-  year    = {2017},
-  publisher = {{ABMEC} Brazilian Association of Computational Methods in Engineering},
-  author  = {T{\'{u}}lio Ligneul Santos and Alvaro Luiz Gayoso de Azeredo Coutinho},
-  title   = {A continuous finite element approach to the well-balanced shallow water equations},
-  booktitle = {Proceedings of the {XXXVIII} Iberian Latin American Congress on Computational Methods in Engineering}
-}
-
-@InCollection{russ.pacini:empirically-derived,
-  doi     = {10.1007/978-3-319-54735-0_8},
-  url     = {https://doi.org/10.1007/978-3-319-54735-0_8},
-  year    = {2017},
-  publisher = {Springer International Publishing},
-  pages   = {71--82},
-  author  = {Jonathan B. Russ and Benjamin R. Pacini},
-  title   = {Empirically-Derived, Constitutive Damping Model for Cellular Silicone},
-  booktitle = {Shock {\&} Vibration, Aircraft/Aerospace, Energy Harvesting, Acoustics {\&} Optics, Volume 9}
-}
-
-@Article{roland.tjardes.ea:personalized,
-  doi     = {10.1002/pamm.201710078},
-  url     = {https://doi.org/10.1002/pamm.201710078},
-  year    = {2017},
-  month   = dec,
-  publisher = {Wiley},
-  volume  = {17},
-  number  = {1},
-  pages   = {217--218},
-  author  = {Michael Roland and Thorsten Tjardes and Bertil Bouillon and Stefan Diebels},
-  title   = {Personalized simulation of a bone-implant-system during a step forward},
-  journal = {{PAMM}}
-}
-
-@Article{pratik-rai:adjoint-based,
-  doi     = {10.13140/RG.2.2.23244.10884},
-  url     = {http://rgdoi.net/10.13140/RG.2.2.23244.10884},
-  author  = {{Pratik Rai}},
-  title   = {Adjoint-based error estimation and mesh adaptivity for stationary fluid-structure interaction},
-  publisher = {Unpublished},
-  year    = {2017}
-}
-
-@Article{porcelli.simoncini.ea:preconditioning,
-  doi     = {10.1016/j.camwa.2017.04.033},
-  url     = {https://doi.org/10.1016/j.camwa.2017.04.033},
-  year    = {2017},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {74},
-  number  = {5},
-  pages   = {1059--1075},
-  author  = {Margherita Porcelli and Valeria Simoncini and Martin Stoll},
-  title   = {Preconditioning {PDE}-constrained optimization with L1-sparsity and control constraints},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{na.sun.ea:effects,
-  doi     = {10.1002/2016jb013374},
-  url     = {https://doi.org/10.1002/2016jb013374},
-  year    = {2017},
-  month   = aug,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {122},
-  number  = {8},
-  pages   = {6202--6230},
-  author  = {SeonHong Na and WaiChing Sun and Mathew D. Ingraham and Hongkyu Yoon},
-  title   = {Effects of spatial heterogeneity and material anisotropy on the fracture pattern and macroscopic effective toughness of Mancos Shale in Brazilian tests},
-  journal = {Journal of Geophysical Research: Solid Earth}
-}
-
-@Article{mehnert.pelteret.ea:numerical,
-  doi     = {10.1177/1081286517729867},
-  url     = {https://doi.org/10.1177/1081286517729867},
-  year    = {2017},
-  month   = sep,
-  publisher = {{SAGE} Publications},
-  volume  = {22},
-  number  = {11},
-  pages   = {2196--2213},
-  author  = {Markus Mehnert and Jean-Paul Pelteret and Paul Steinmann},
-  title   = {Numerical modelling of nonlinear thermo-electro-elasticity},
-  journal = {Mathematics and Mechanics of Solids}
-}
-
-@Article{maier.nemilentsau.ea:ultracompact,
-  doi     = {10.1021/acsphotonics.7b01094},
-  url     = {https://doi.org/10.1021/acsphotonics.7b01094},
-  year    = {2017},
-  month   = dec,
-  publisher = {American Chemical Society ({ACS})},
-  volume  = {5},
-  number  = {2},
-  pages   = {544--551},
-  author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
-  title   = {Ultracompact Amplitude Modulator by Coupling Hyperbolic Polaritons over a Graphene-Covered Gap},
-  journal = {{ACS} Photonics}
-}
-
-@Article{lovelace.demos.ea:numerically,
-  doi     = {10.1088/1361-6382/aa9ccc},
-  url     = {https://doi.org/10.1088/1361-6382/aa9ccc},
-  year    = {2017},
-  month   = dec,
-  publisher = {{IOP} Publishing},
-  volume  = {35},
-  number  = {2},
-  pages   = {025017},
-  author  = {Geoffrey Lovelace and Nicholas Demos and Haroon Khan},
-  title   = {Numerically modeling Brownian thermal noise in amorphous and crystalline thin coatings},
-  journal = {Classical and Quantum Gravity}
-}
-
-@Article{liu.foo.ea:3d,
-  doi     = {10.1016/j.camss.2017.07.005},
-  url     = {https://doi.org/10.1016/j.camss.2017.07.005},
-  year    = {2017},
-  month   = aug,
-  publisher = {Springer Nature},
-  volume  = {30},
-  number  = {4},
-  pages   = {374--389},
-  author  = {Jun Liu and Choon Chiang Foo and Zhi-Qian Zhang},
-  title   = {A 3D multi-field element for simulating the electromechanical coupling behavior of dielectric elastomers},
-  journal = {Acta Mechanica Solida Sinica}
-}
-
-@Article{liu.liang:prevalence,
-  doi     = {10.1126/sciadv.1701872},
-  url     = {https://doi.org/10.1126/sciadv.1701872},
-  year    = {2017},
-  month   = nov,
-  publisher = {American Association for the Advancement of Science ({AAAS})},
-  volume  = {3},
-  number  = {11},
-  pages   = {e1701872},
-  author  = {Boda Liu and Yan Liang},
-  title   = {The prevalence of kilometer-scale heterogeneity in the source region of {MORB} upper mantle},
-  journal = {Science Advances}
-}
-
-@InProceedings{li.ren.ea:practical,
-  doi     = {10.1109/cit.2017.22},
-  url     = {https://doi.org/10.1109/cit.2017.22},
-  year    = {2017},
-  month   = aug,
-  publisher = {{IEEE}},
-  author  = {Hao Li and Xiaoguang Ren and Yufei Lin and Yuhua Tang and Shuai Ye},
-  title   = {Practical Performance Models for High-Order {CFD} Simulation},
-  booktitle = {2017 {IEEE} International Conference on Computer and Information Technology ({CIT})}
-}
-
-@Article{kynch.ledger:resolving,
-  doi     = {10.1016/j.compstruc.2016.05.021},
-  url     = {https://doi.org/10.1016/j.compstruc.2016.05.021},
-  year    = {2017},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {181},
-  pages   = {41--54},
-  author  = {R.M. Kynch and P.D. Ledger},
-  title   = {Resolving the sign conflict problem for hp-hexahedral N{\'{e}}d{\'{e}}lec elements with application to eddy current problems},
-  journal = {Computers {\&} Structures}
-}
-
-@Article{kramer.kullmer.ea:semi-lagrangian,
-  doi     = {10.1103/physreve.95.023305},
-  url     = {https://doi.org/10.1103/physreve.95.023305},
-  year    = {2017},
-  month   = feb,
-  publisher = {American Physical Society ({APS})},
-  volume  = {95},
-  number  = {2},
-  author  = {Andreas Kr\"{a}mer and Knut K\"{u}llmer and Dirk Reith and Wolfgang Joppich and Holger Foysi},
-  title   = {Semi-Lagrangian off-lattice Boltzmann method for weakly compressible flows},
-  journal = {Physical Review E}
-}
-
-@Article{almeida-konzen.azevedo.ea:numerical,
-  doi     = {10.5540/tema.2017.018.02.0287},
-  url     = {https://doi.org/10.5540/tema.2017.018.02.0287},
-  year    = {2017},
-  month   = aug,
-  publisher = {Brazilian Society for Computational and Applied Mathematics ({SBMAC})},
-  volume  = {18},
-  number  = {2},
-  pages   = {0287},
-  author  = {Pedro Henrique de Almeida Konzen and F S Azevedo and E Sauter and P R A Zingano},
-  title   = {Numerical Simulations with the Galerkin Least Squares Finite Element Method for the Burgers' Equation on the Real Line},
-  journal = {{TEMA} (S{\~{a}}o Carlos)}
-}
-
-@Article{karban.dolezel:fully,
-  doi     = {10.1007/s00202-017-0629-9},
-  url     = {https://doi.org/10.1007/s00202-017-0629-9},
-  year    = {2017},
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {99},
-  number  = {4},
-  pages   = {1255--1261},
-  author  = {Pavel Karban and Ivo Dole{\v{z}}el},
-  title   = {Fully adaptive higher-order finite element analysis of fast transient phenomena on overhead lines},
-  journal = {Electrical Engineering}
-}
-
-@Article{brisard:reconstructing,
-  doi     = {10.1002/nme.5263},
-  url     = {https://doi.org/10.1002/nme.5263},
-  year    = {2016},
-  month   = may,
-  publisher = {Wiley},
-  volume  = {109},
-  number  = {4},
-  pages   = {459--486},
-  author  = {S{\'{e}}bastien Brisard},
-  title   = {Reconstructing displacements from the solution to the periodic Lippmann-Schwinger equation discretized on a uniform grid},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{hwang.fish.ea:software,
-  doi     = {10.1002/2016ea000225},
-  url     = {https://doi.org/10.1002/2016ea000225},
-  year    = {2017},
-  month   = nov,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {4},
-  number  = {11},
-  pages   = {670--680},
-  author  = {Lorraine Hwang and Allison Fish and Laura Soito and MacKenzie Smith and Louise H. Kellogg},
-  title   = {Software and the Scientist: Coding and Citation Practices in Geodynamics},
-  journal = {Earth and Space Science}
-}
-
-@InCollection{hinze.kunkel.ea:model,
-  doi     = {10.1007/978-3-319-07236-4_1},
-  url     = {https://doi.org/10.1007/978-3-319-07236-4_1},
-  year    = {2017},
-  publisher = {Springer International Publishing},
-  pages   = {1--37},
-  author  = {Michael Hinze and Martin Kunkel and Ulrich Matthes and Morten Vierling},
-  title   = {Model Order Reduction of Integrated Circuits in Electrical Networks},
-  booktitle = {Mathematics in Industry}
-}
-
-@Article{guermond.popov.ea:invariant,
-  doi     = {10.1137/16m1063034},
-  url     = {https://doi.org/10.1137/16m1063034},
-  year    = {2017},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {39},
-  number  = {2},
-  pages   = {A385--A414},
-  author  = {Jean-Luc Guermond and Bojan Popov and Laura Saavedra and Yong Yang},
-  title   = {Invariant Domains Preserving Arbitrary Lagrangian Eulerian Approximation of Hyperbolic Systems with Continuous Finite Elements},
-  journal = {{SIAM} Journal on Scientific Computing}
-}
-
-@Article{ghorashi.lahmer.ea:stochastic,
-  doi     = {10.1016/j.enggeo.2016.07.012},
-  url     = {https://doi.org/10.1016/j.enggeo.2016.07.012},
-  year    = {2017},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {225},
-  pages   = {103--113},
-  author  = {S.Sh. Ghorashi and T. Lahmer and A.S. Bagherzadeh and G. Zi and T. Rabczuk},
-  title   = {A stochastic computational method based on goal-oriented error estimation for heterogeneous geological materials},
-  journal = {Engineering Geology}
-}
-
-@Article{fu.ermakov.ea:interior,
-  doi     = {10.1016/j.epsl.2017.07.053},
-  url     = {https://doi.org/10.1016/j.epsl.2017.07.053},
-  year    = {2017},
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = {476},
-  pages   = {153--164},
-  author  = {Roger R. Fu and Anton I. Ermakov and Simone Marchi and Julie C. Castillo-Rogez and Carol A. Raymond and Bradford H. Hager and Maria T. Zuber and Scott D. King and Michael T. Bland and Maria Cristina De Sanctis and Frank Preusker and Ryan S. Park and Christopher T. Russell},
-  title   = {The interior structure of Ceres as revealed by surface topography},
-  journal = {Earth and Planetary Science Letters}
-}
-
-@Article{endtmayer.wick:partition-of-unity,
-  doi     = {10.1515/cmam-2017-0001},
-  url     = {https://doi.org/10.1515/cmam-2017-0001},
-  year    = {2017},
-  month   = jan,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {17},
-  number  = {4},
-  author  = {Bernhard Endtmayer and Thomas Wick},
-  title   = {A Partition-of-Unity Dual-Weighted Residual Approach for Multi-Objective Goal Functional Error Estimation Applied to Elliptic Problems},
-  journal = {Computational Methods in Applied Mathematics}
-}
-
-@Article{thieulot:analytical,
-  doi     = {10.5194/se-8-1181-2017},
-  url     = {https://doi.org/10.5194/se-8-1181-2017},
-  year    = {2017},
-  month   = nov,
-  publisher = {Copernicus {GmbH}},
-  volume  = {8},
-  number  = {6},
-  pages   = {1181--1191},
-  author  = {Cedric Thieulot},
-  title   = {Analytical solution for viscous incompressible Stokes flow in a spherical shell},
-  journal = {Solid Earth}
-}
-
-@Article{dhillon.milinkovitch.ea:bifurcation,
-  doi     = {10.1007/s11538-017-0255-8},
-  url     = {https://doi.org/10.1007/s11538-017-0255-8},
-  year    = {2017},
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {79},
-  number  = {4},
-  pages   = {788--827},
-  author  = {Daljit Singh J. Dhillon and Michel C. Milinkovitch and Matthias Zwicker},
-  title   = {Bifurcation Analysis of Reaction Diffusion Systems on Arbitrary Surfaces},
-  journal = {Bulletin of Mathematical Biology}
-}
-
-@Article{harmon.gamba.ea:numerical,
-  doi     = {10.1016/j.jcp.2016.08.026},
-  url     = {https://doi.org/10.1016/j.jcp.2016.08.026},
-  year    = {2016},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {327},
-  pages   = {140--167},
-  author  = {Michael Harmon and Irene M. Gamba and Kui Ren},
-  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical ({PEC}) solar cells},
-  journal = {Journal of Computational Physics}
-}
-
-@Article{cajuhi.sanavia.ea:phase-field,
-  doi     = {10.1007/s00466-017-1459-3},
-  url     = {https://doi.org/10.1007/s00466-017-1459-3},
-  year    = {2017},
-  month   = aug,
-  publisher = {Springer Nature},
-  volume  = {61},
-  number  = {3},
-  pages   = {299--318},
-  author  = {T. Cajuhi and L. Sanavia and L. De Lorenzis},
-  title   = {Phase-field modeling of fracture in variably saturated porous media},
-  journal = {Computational Mechanics}
-}
-
-@InProceedings{narayanan.madduri:parallel,
-  doi     = {10.1109/ipdpsw.2017.160},
-  url     = {https://doi.org/10.1109/ipdpsw.2017.160},
-  year    = {2017},
-  month   = may,
-  publisher = {{IEEE}},
-  author  = {Ramachandran Kodanganallur Narayanan and Kamesh Madduri},
-  title   = {Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation},
-  booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})}
-}
-
-@Article{burger.kenettinkara.ea:approximate,
-  doi     = {10.1016/j.camwa.2017.06.019},
-  url     = {https://doi.org/10.1016/j.camwa.2017.06.019},
-  year    = {2017},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {74},
-  number  = {6},
-  pages   = {1288--1310},
-  author  = {Raimund B\"{u}rger and Sudarshan Kumar Kenettinkara and David Zor{\'{i}}o},
-  title   = {Approximate Lax-Wendroff discontinuous Galerkin methods for hyperbolic conservation laws},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{avila.meister.ea:adaptive,
-  doi     = {10.1016/j.apnum.2017.06.013},
-  url     = {https://doi.org/10.1016/j.apnum.2017.06.013},
-  year    = {2017},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {121},
-  pages   = {149--169},
-  author  = {A.I. {\'{A}}vila and A. Meister and M. Steigemann},
-  title   = {An adaptive Galerkin method for the time-dependent complex Schr\"{o}dinger equation},
-  journal = {Applied Numerical Mathematics}
-}
-
-@InProceedings{aristotelous.papanicolaou:numerical,
-  doi     = {10.1063/1.5007418},
-  url     = {https://doi.org/10.1063/1.5007418},
-  year    = {2017},
-  booktitle = {AIP Conference Proceedings, volume 1895},
-  author  = {A. C. Aristotelous and N. C. Papanicolaou},
-  title   = {A numerical study of biofilm growth in a microgravity environment}
-}
-
-@Article{aizinger.kosik.ea:anisotropic,
-  doi     = {10.1002/fld.4360},
-  url     = {https://doi.org/10.1002/fld.4360},
-  year    = {2017},
-  month   = jan,
-  publisher = {Wiley},
-  volume  = {84},
-  number  = {9},
-  pages   = {543--565},
-  author  = {Vadym Aizinger and Adam Kos{\'{i}}k and Dmitri Kuzmin and Balthasar Reuter},
-  title   = {Anisotropic slope limiting for discontinuous Galerkin methods},
-  journal = {International Journal for Numerical Methods in Fluids}
-}
-
-@Article{mohebujjaman.rebholz:efficient,
-  doi     = {10.1515/cmam-2016-0033},
-  url     = {https://doi.org/10.1515/cmam-2016-0033},
-  year    = {2017},
-  month   = jan,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {17},
-  number  = {1},
-  author  = {Muhammad Mohebujjaman and Leo G. Rebholz},
-  title   = {An Efficient Algorithm for Computation of {MHD} Flow Ensembles},
-  journal = {Computational Methods in Applied Mathematics}
-}
-
-@TechReport{mohebujjaman:high-order,
-  author  = {Mohebujjaman, M.},
-  year    = {2017},
-  title   = {High-order efficient algorithms for computation of {MHD} flow ensemble},
-  institution = {Virginia Tech},
-  url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/publication/327449710_HIGH_ORDER_EFFICIENT_ALGORITHM_FOR_COMPUTATION_OF_MHD_FLOW_ENSEMBLE/links/5b903a08a6fdcce8a4c3548d/HIGH-ORDER-EFFICIENT-ALGORITHM-FOR-COMPUTATION-OF-MHD-FLOW-ENSEMBLE.pdf}
-}
-
-@MastersThesis{strom:preconditioned,
-  author  = {A. Str\"{o}m},
-  title   = {Preconditioned iterative methods for PDE-constrained optimization problems with pointwise state constraints},
-  year    = {2017},
-  school  = {Uppsala University, Sweden},
-  url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A1081649&dswid=292}
-}
-
 @Article{adler.emerson.ea:combining,
   author  = {J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan},
   title   = {Combining Deflation and Nested Iteration for Computing Multiple Solutions of Nonlinear Variational Problems},
@@ -815,6 +22,20 @@
   doi     = {}
 }
 
+@Article{aizinger.kosik.ea:anisotropic,
+  doi     = {10.1002/fld.4360},
+  url     = {https://doi.org/10.1002/fld.4360},
+  year    = {2017},
+  month   = jan,
+  publisher = {Wiley},
+  volume  = {84},
+  number  = {9},
+  pages   = {543--565},
+  author  = {Vadym Aizinger and Adam Kos{\'{i}}k and Dmitri Kuzmin and Balthasar Reuter},
+  title   = {Anisotropic slope limiting for discontinuous Galerkin methods},
+  journal = {International Journal for Numerical Methods in Fluids}
+}
+
 @Article{almani.lee.ea:multirate,
   author  = {T. Almani and S. Lee and M. F. Wheeler and T. Wick},
   title   = {Multirate coupling for flow and geomechanics applied to hydraulic fracturing using an adaptive phase-field technique},
@@ -824,6 +45,28 @@
   pages   = {},
   url     = {},
   doi     = {}
+}
+
+@Article{almeida-konzen.azevedo.ea:numerical,
+  doi     = {10.5540/tema.2017.018.02.0287},
+  url     = {https://doi.org/10.5540/tema.2017.018.02.0287},
+  year    = {2017},
+  month   = aug,
+  publisher = {Brazilian Society for Computational and Applied Mathematics ({SBMAC})},
+  volume  = {18},
+  number  = {2},
+  pages   = {0287},
+  author  = {Pedro Henrique de Almeida Konzen and F S Azevedo and E Sauter and P R A Zingano},
+  title   = {Numerical Simulations with the Galerkin Least Squares Finite Element Method for the Burgers' Equation on the Real Line},
+  journal = {{TEMA} (S{\~{a}}o Carlos)}
+}
+
+@MastersThesis{alzetta:core,
+  author  = {G. Alzetta},
+  title   = {Core building blocks for massively parallel multi-physics applications},
+  school  = {SISSA},
+  year    = {2017},
+  url     = {https://iris.sissa.it/retrieve/handle/20.500.11767/68032/61711/Giovanni%20Alzetta.pdf}
 }
 
 @Article{araujo.engstrom:on,
@@ -854,20 +97,6 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{ballani.kressner.ea:multilevel,
-  doi     = {10.1007/s40072-017-0092-7},
-  url     = {https://doi.org/10.1007/s40072-017-0092-7},
-  year    = {2017},
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {5},
-  number  = {3},
-  pages   = {400--427},
-  author  = {Jonas Ballani and Daniel Kressner and Michael D. Peters},
-  title   = {Multilevel tensor approximation of {PDEs} with random data},
-  journal = {Stochastics and Partial Differential Equations: Analysis and Computations}
-}
-
 @Article{arbogast.hesse.ea:mixed*1,
   author  = {T. Arbogast and M. A. Hesse and A. L. Taicher},
   title   = {Mixed Methods for Two-Phase Darcy--Stokes Mixtures of Partially Melted Materials with Regions of Zero Porosity},
@@ -877,6 +106,15 @@
   pages   = {B375-B402},
   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1091095},
   doi     = {}
+}
+
+@InProceedings{aristotelous.papanicolaou:numerical,
+  doi     = {10.1063/1.5007418},
+  url     = {https://doi.org/10.1063/1.5007418},
+  year    = {2017},
+  booktitle = {AIP Conference Proceedings, volume 1895},
+  author  = {A. C. Aristotelous and N. C. Papanicolaou},
+  title   = {A numerical study of biofilm growth in a microgravity environment}
 }
 
 @Article{arndt.bangerth.ea:deal-ii,
@@ -901,6 +139,19 @@
   doi     = {10.1126/sciadv.1700457}
 }
 
+@Article{avila.meister.ea:adaptive,
+  doi     = {10.1016/j.apnum.2017.06.013},
+  url     = {https://doi.org/10.1016/j.apnum.2017.06.013},
+  year    = {2017},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {121},
+  pages   = {149--169},
+  author  = {A.I. {\'{A}}vila and A. Meister and M. Steigemann},
+  title   = {An adaptive Galerkin method for the time-dependent complex Schr\"{o}dinger equation},
+  journal = {Applied Numerical Mathematics}
+}
+
 @Article{axelsson.farouq.ea:preconditioner,
   author  = {O. Axelsson and S. Farouq and M. Neytcheva},
   title   = {A preconditioner for optimal control problems, constrained by Stokes equation with a time-harmonic control},
@@ -923,6 +174,20 @@
   doi     = {}
 }
 
+@Article{ballani.kressner.ea:multilevel,
+  doi     = {10.1007/s40072-017-0092-7},
+  url     = {https://doi.org/10.1007/s40072-017-0092-7},
+  year    = {2017},
+  month   = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {5},
+  number  = {3},
+  pages   = {400--427},
+  author  = {Jonas Ballani and Daniel Kressner and Michael D. Peters},
+  title   = {Multilevel tensor approximation of {PDEs} with random data},
+  journal = {Stochastics and Partial Differential Equations: Analysis and Computations}
+}
+
 @Article{basak.levitas:interfacial,
   author  = {A. Basak and V. I. Levitas},
   title   = {Interfacial stresses within boundary between martensitic variants: Analytical and numerical finite strain solutions for three phase field models},
@@ -931,17 +196,6 @@
   volume  = {139},
   pages   = {174--187},
   url     = {},
-  doi     = {}
-}
-
-@Article{bause.radu.ea:space-time,
-  author  = {M. Bause and F. A. Radu and U. K\"{o}cher},
-  title   = {Space-time finite element approximation of the Biot poroelasticity system with iterative coupling},
-  journal = {Comput. Meth. Appl. Mech. Engrg.},
-  year    = {2017},
-  volume  = {320},
-  pages   = {745--768},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0045782516316164?via%3Dihub},
   doi     = {}
 }
 
@@ -956,6 +210,45 @@
   doi     = {10.1007/s00211-017-0894-6}
 }
 
+@Article{bause.radu.ea:space-time,
+  author  = {M. Bause and F. A. Radu and U. K\"{o}cher},
+  title   = {Space-time finite element approximation of the Biot poroelasticity system with iterative coupling},
+  journal = {Comput. Meth. Appl. Mech. Engrg.},
+  year    = {2017},
+  volume  = {320},
+  pages   = {745--768},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0045782516316164?via%3Dihub},
+  doi     = {}
+}
+
+@PhDThesis{beams:high-order-hybrid-methods-using-greens-functions-and-finite-elements,
+  title   = {{High-order hybrid methods using Green's functions and finite elements}},
+  author  = {Beams, Natalie N},
+  school  = {University of Illinois at Urbana-Champaign},
+  year    = {2017},
+  url     = {https://www.ideals.illinois.edu/bitstream/handle/2142/98387/BEAMS-DISSERTATION-2017.pdf?sequence=1}
+}
+
+@Article{becerra.akbarzadeh-sharbaf.ea:solving,
+  author  = {D. M. Fernandez Becerra and A. Akbarzadeh-Sharbaf and D. Giannacopoulos},
+  title   = {Solving Finite-Element Time-Domain Problems with GaBP},
+  journal = {IEEE Transactions on Magnetics PP(99):1-1},
+  year    = {2017},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Misc{berselli.wells.ea:spatial,
+  title   = {Spatial Filtering for Reduced Order Modeling},
+  author  = {L. C. Berselli and D. Wells and X. Xie and T. Iliescu},
+  year    = {2017},
+  eprint  = {1707.04133},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
 @Article{biermann.blum.ea:modelling,
   author  = {D. Biermann and H. Blum and I. Iovkov and A. Rademacher and K. Rosin and F.-T. Suttmeier},
   title   = {Modelling, Simulation and Compensation of Thermomechanically Induced Deviations in Deep-Hole Drilling with Minimum Quantity Lubrication},
@@ -965,6 +258,16 @@
   pages   = {181--218},
   url     = {https://doi.org/10.1007/978-3-319-57120-1_10},
   doi     = {10.1007/978-3-319-57120-1_10}
+}
+
+@MastersThesis{boltersdorf:ausarbeitung,
+  author  = {Boltersdorf, Jana},
+  title   = {{A}usarbeitung und {V}ergleich verschiedener {G}itterverfeinerungsstrategien hinsichtlich der parallelen {P}erformance eines {B}randsimulationsprogramms mit adaptiver {G}itterverfeinerung},
+  school  = {Fachhochschule Aachen},
+  reportid = {FZJ-2018-00798},
+  pages   = {63 p.},
+  year    = {2017},
+  url     = {https://juser.fz-juelich.de/record/842585}
 }
 
 @Article{bonetti.cavaterra.ea:nonlinear,
@@ -989,6 +292,24 @@
   doi     = {}
 }
 
+@Misc{bonito.demlow.ea:priori,
+  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace-Beltrami Operator},
+  author  = {Andrea Bonito and Alan Demlow and Justin Owen},
+  year    = {2017},
+  eprint  = {1801.00197},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@PhDThesis{brand:forces-and-flow-of-contractile-networks,
+  title   = {{Forces and Flow of Contractile Networks}},
+  author  = {Brand, Christoph Alexander},
+  year    = {2017},
+  school  = {Heidelberg University},
+  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20233/1/thesis20151207.pdf},
+  doi     = {10.11588/heidok.00020233}
+}
+
 @MastersThesis{brauer:reduced-order,
   author  = {P. Br\"{a}uer},
   title   = {Reduced-Order modeling for transient thermoelasticity with moving sources using global-local bases},
@@ -1006,6 +327,20 @@
   pages   = {},
   url     = {},
   doi     = {10.1002/2017GC006875}
+}
+
+@Article{brisard:reconstructing,
+  doi     = {10.1002/nme.5263},
+  url     = {https://doi.org/10.1002/nme.5263},
+  year    = {2016},
+  month   = may,
+  publisher = {Wiley},
+  volume  = {109},
+  number  = {4},
+  pages   = {459--486},
+  author  = {S{\'{e}}bastien Brisard},
+  title   = {Reconstructing displacements from the solution to the periodic Lippmann-Schwinger equation discretized on a uniform grid},
+  journal = {International Journal for Numerical Methods in Engineering}
 }
 
 @Article{brisard:reconstructing*1,
@@ -1030,6 +365,34 @@
   doi     = {}
 }
 
+@Article{burger.kenettinkara.ea:approximate,
+  doi     = {10.1016/j.camwa.2017.06.019},
+  url     = {https://doi.org/10.1016/j.camwa.2017.06.019},
+  year    = {2017},
+  month   = sep,
+  publisher = {Elsevier {BV}},
+  volume  = {74},
+  number  = {6},
+  pages   = {1288--1310},
+  author  = {Raimund B\"{u}rger and Sudarshan Kumar Kenettinkara and David Zor{\'{i}}o},
+  title   = {Approximate Lax-Wendroff discontinuous Galerkin methods for hyperbolic conservation laws},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
+@Article{cajuhi.sanavia.ea:phase-field,
+  doi     = {10.1007/s00466-017-1459-3},
+  url     = {https://doi.org/10.1007/s00466-017-1459-3},
+  year    = {2017},
+  month   = aug,
+  publisher = {Springer Nature},
+  volume  = {61},
+  number  = {3},
+  pages   = {299--318},
+  author  = {T. Cajuhi and L. Sanavia and L. De Lorenzis},
+  title   = {Phase-field modeling of fracture in variably saturated porous media},
+  journal = {Computational Mechanics}
+}
+
 @Article{carraro.goll:goal-oriented,
   author  = {T. Carraro and C. Goll},
   title   = {A Goal-Oriented Error Estimator for a Class of Homogenization Problems},
@@ -1052,6 +415,28 @@
   doi     = {}
 }
 
+@Article{chandrashekar.zenk:well-balanced,
+  author  = {Praveen Chandrashekar and Markus Zenk},
+  title   = {Well-Balanced Nodal Discontinuous Galerkin Method for Euler Equations with Gravity},
+  journal = {Journal of Scientific Computing},
+  year    = {2017},
+  volume  = {71},
+  number  = {3},
+  pages   = {1062--1093},
+  month   = {jan},
+  doi     = {10.1007/s10915-016-0339-x},
+  publisher = {Springer Nature}
+}
+
+@Misc{charnyi.heister.ea:efficient,
+  title   = {Efficient discretizations for the EMAC formulation of the incompressible Navier-Stokes equations},
+  author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
+  year    = {2017},
+  eprint  = {1712.00857},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
 @Article{charnyi.heister.ea:on,
   author  = {S. Charnyi and T. Heister and M. A. Olshanskii and L. G. Rebholz},
   title   = {On conservation laws of Navier-Stokes Galerkin discretizations},
@@ -1069,6 +454,14 @@
   year    = {2017},
   school  = {Texas A\&M University},
   url     = {}
+}
+
+@PhDThesis{cox:adaptive-large-scale-mantle-convection-simulations,
+  title   = {{Adaptive large-scale mantle convection simulations}},
+  author  = {Cox, S. P.},
+  year    = {2017},
+  school  = {University of Leicester},
+  url     = {https://lra.le.ac.uk/handle/2381/39571}
 }
 
 @Article{dannberg.eilon.ea:importance,
@@ -1120,14 +513,6 @@
   journal = {Communications in Computational Physics}
 }
 
-@PhDThesis{villiers:patient-specific,
-  author  = {A. M. De Villiers},
-  title   = {A patient-specific FSI model for vascular access in haemodialysis},
-  year    = {2017},
-  school  = {University of Cape Town},
-  url     = {http://hdl.handle.net/11427/24441}
-}
-
 @Article{dewitt.solomon.ea:misfit-driven,
   author  = {S. DeWitt and E. L. S. Solomon and A. R. Natarajan and V. Araulio-Peters and S. Rudrajaru and L. K. Aegesen and B. Puchala and E. A. Marquis and A. van der Ven and K. Thornton and J. E. Allison},
   title   = {Misfit-driven {\ss}''' precipitate composition and morphology in Mg-Nd alloys},
@@ -1136,6 +521,20 @@
   volume  = {136},
   pages   = {378--389},
   doi     = {10.1016/j.actamat.2017.06.053}
+}
+
+@Article{dhillon.milinkovitch.ea:bifurcation,
+  doi     = {10.1007/s11538-017-0255-8},
+  url     = {https://doi.org/10.1007/s11538-017-0255-8},
+  year    = {2017},
+  month   = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {79},
+  number  = {4},
+  pages   = {788--827},
+  author  = {Daljit Singh J. Dhillon and Michel C. Milinkovitch and Matthias Zwicker},
+  title   = {Bifurcation Analysis of Reaction Diffusion Systems on Arbitrary Surfaces},
+  journal = {Bulletin of Mathematical Biology}
 }
 
 @Article{diehl:review,
@@ -1158,34 +557,26 @@
   url     = {}
 }
 
-@PhDThesis{hai:finite,
-  author  = {B. S. M. Ebna Hai},
-  title   = {Finite Element Approximation of Ultrasonic Wave Propagation under Fluid-Structure Interaction for Structural Health Monitoring Systems},
+@Misc{emerson:posteriori,
+  title   = {A Posteriori Error Estimators for the Frank-Oseen Model of Liquid Crystals},
+  author  = {D. B. Emerson},
   year    = {2017},
-  school  = {Helmut Schmidt University-University of the Federal Armed Forces Hambur, Germany},
-  url     = {}
+  eprint  = {1709.06157},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
 }
 
-@Article{hai.bause:mathematical,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Mathematical Modelling and Numerical Simulation of the On-line Structural Health Monitoring System},
-  journal = {In proceedings of: the 11 th International Workshop on Structural Health Monitoring, Structural Health Monitoring 2017, Sept 12--14, Stanford University, CA, USA. In: F-K. Chang and F. Kopsaftopoulos (Ed.), ``Structural Health Monitoring 2017: Real-Time Material State Awareness and Data-Driven Safety Assurance.''},
+@Article{endtmayer.wick:partition-of-unity,
+  doi     = {10.1515/cmam-2017-0001},
+  url     = {https://doi.org/10.1515/cmam-2017-0001},
   year    = {2017},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{hai.bause:finite,
-  author  = {B. S. M. Ebna Hai and M. Bause},
-  title   = {Finite Element Approximation of Fluid-Structure Interaction (FSI) Problem with Coupled Wave Propagation},
-  journal = {In proceedings of: the 88 th GAMM Annual Meeting of the International Association of Applied Mathematics and Mechanics, March 6--10, Weimar, Germany. In: PAMM - Proceedings in Applied Mathematics and Mechanics},
-  year    = {2017},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
+  month   = jan,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {17},
+  number  = {4},
+  author  = {Bernhard Endtmayer and Thomas Wick},
+  title   = {A Partition-of-Unity Dual-Weighted Residual Approach for Multi-Objective Goal Functional Error Estimation Applied to Elliptic Problems},
+  journal = {Computational Methods in Applied Mathematics}
 }
 
 @Article{ervin.lee.ea:nonlinear,
@@ -1210,17 +601,6 @@
   doi     = {}
 }
 
-@Article{becerra.akbarzadeh-sharbaf.ea:solving,
-  author  = {D. M. Fernandez Becerra and A. Akbarzadeh-Sharbaf and D. Giannacopoulos},
-  title   = {Solving Finite-Element Time-Domain Problems with GaBP},
-  journal = {IEEE Transactions on Magnetics PP(99):1-1},
-  year    = {2017},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
 @Article{freddi.iurlano:numerical,
   author  = {F. Freddi and F. Iurlano},
   title   = {Numerical insight of a variational smeared approach to cohesive fracture},
@@ -1232,6 +612,19 @@
   doi     = {}
 }
 
+@Article{fu.ermakov.ea:interior,
+  doi     = {10.1016/j.epsl.2017.07.053},
+  url     = {https://doi.org/10.1016/j.epsl.2017.07.053},
+  year    = {2017},
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = {476},
+  pages   = {153--164},
+  author  = {Roger R. Fu and Anton I. Ermakov and Simone Marchi and Julie C. Castillo-Rogez and Carol A. Raymond and Bradford H. Hager and Maria T. Zuber and Scott D. King and Michael T. Bland and Maria Cristina De Sanctis and Frank Preusker and Ryan S. Park and Christopher T. Russell},
+  title   = {The interior structure of Ceres as revealed by surface topography},
+  journal = {Earth and Planetary Science Letters}
+}
+
 @MastersThesis{fuchs:hermite-artige,
   author  = {A. Fuchs},
   title   = {Hermite-artige Basisfunktionen f\"{u}r diskontinuierliche Galerkin-Verfahren hoher Ordnung},
@@ -1239,6 +632,15 @@
   school  = {Technical University of Munich},
   note    = {Bachelor's thesis},
   url     = {}
+}
+
+@Misc{galiano.velasco:on,
+  title   = {On a cross-diffusion system arising in image denosing},
+  author  = {Gonzalo Galiano and Juli{\'a}n Velasco},
+  year    = {2017},
+  eprint  = {1703.02487},
+  archiveprefix = {arXiv},
+  primaryclass = {math.AP}
 }
 
 @PhDThesis{gallego-valencia:on,
@@ -1249,12 +651,54 @@
   url     = {https://www.researchgate.net/profile/Juan_Gallego-Valencia/publication/317093976_On_Runge-Kutta_discontinuous_Galerkin_methods_for_compressible_Euler_equations_and_the_ideal_magneto-hydrodynamical_model/links/592978060f7e9b9979a686c2/On-Runge-Kutta-discontinuous-Galerkin-methods-for-compressible-Euler-equations-and-the-ideal-magneto-hydrodynamical-model.pdf}
 }
 
+@PhDThesis{gallego-valencia:on-runge-kutta-discontinuous-galerkin-methods-for-compressible-euler-equations-and-the-ideal-magneto-hydrodynamical-model,
+  title   = {{On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamical model}},
+  author  = {J. P. {Gallego Valencia}},
+  year    = {2017},
+  school  = {University of W{\"u}rzburg},
+  url     = {https://www.researchgate.net/profile/Juan_Gallego-Valencia/publication/317093976_On_Runge-Kutta_discontinuous_Galerkin_methods_for_compressible_Euler_equations_and_the_ideal_magneto-hydrodynamical_model/links/592978060f7e9b9979a686c2/On-Runge-Kutta-discontinuous-Galerkin-methods-for-compressible-Euler-equations-and-the-ideal-magneto-hydrodynamical-model.pdf}
+}
+
+@Article{ganesan:microstructural-response-of-magnesium-alloys--3d-crystal-plasticity-and-experimental-validation,
+  title   = {{Microstructural Response of Magnesium Alloys: 3D Crystal Plasticity and Experimental Validation}},
+  author  = {Ganesan, S},
+  year    = {2017},
+  school  = {University of Michigan},
+  url     = {http://www-personal.umich.edu/~veeras/papers/sriramthesis.pdf}
+}
+
+@Article{garikipati:perspectives,
+  doi     = {10.1016/j.jmps.2016.11.013},
+  url     = {https://doi.org/10.1016/j.jmps.2016.11.013},
+  year    = {2017},
+  month   = feb,
+  publisher = {Elsevier {BV}},
+  volume  = {99},
+  pages   = {192--210},
+  author  = {Krishna Garikipati},
+  title   = {Perspectives on the mathematics of biological patterning and morphogenesis},
+  journal = {Journal of the Mechanics and Physics of Solids}
+}
+
 @PhDThesis{ghesmati:residual,
   author  = {A. Ghesmati},
   title   = {Residual and goal-oriented h- and hp-adaptive finite element; application for elliptic and saddle point problems},
   year    = {2017},
   school  = {Texas A\&M University},
   url     = {}
+}
+
+@Article{ghorashi.lahmer.ea:stochastic,
+  doi     = {10.1016/j.enggeo.2016.07.012},
+  url     = {https://doi.org/10.1016/j.enggeo.2016.07.012},
+  year    = {2017},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {225},
+  pages   = {103--113},
+  author  = {S.Sh. Ghorashi and T. Lahmer and A.S. Bagherzadeh and G. Zi and T. Rabczuk},
+  title   = {A stochastic computational method based on goal-oriented error estimation for heterogeneous geological materials},
+  journal = {Engineering Geology}
 }
 
 @Article{ghorashi.rabczuk:goal-oriented,
@@ -1266,6 +710,14 @@
   pages   = {3--19},
   url     = {https://link.springer.com/article/10.1007/s10704-016-0113-y},
   doi     = {}
+}
+
+@PhDThesis{giuliani:modelling-fluid-structure-interaction-problems-using-boundary-element-method,
+  title   = {{Modelling Fluid Structure Interaction problems using Boundary Element Method}},
+  author  = {Giuliani, N},
+  school  = {Scuola Internazionale Superiore di Studi Avanzati - Trieste},
+  year    = {2017},
+  url     = {https://iris.sissa.it/handle/20.500.11767/57293}
 }
 
 @Article{glerum.thieulot.ea:implementing,
@@ -1299,6 +751,40 @@
   doi     = {}
 }
 
+@Article{goll.wick.ea:dopelib,
+  doi     = {10.11588/ANS.2017.2.11815},
+  url     = {http://journals.ub.uni-heidelberg.de/index.php/ans/article/view/11815},
+  author  = {Goll, Christian and Wick, Thomas and Wollner, Winnifried},
+  keywords = {goal oriented interface design; numerical solution of optimization problems and partial differential equations},
+  language = {en},
+  title   = {{DOpElib}: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving {PDEs} and Optimization Problems with {PDEs}},
+  journal = {Archive of Numerical Software},
+  volume  = {Vol 5},
+  pages   = {No 2 (2017)},
+  publisher = {Archive of Numerical Software},
+  year    = {2017}
+}
+
+@Article{grohs.hiptmair.ea:tensor-product,
+  doi     = {10.5802/smai-jcm.26},
+  url     = {https://doi.org/10.5802/smai-jcm.26},
+  year    = {2017},
+  publisher = {Cellule {MathDoc}/{CEDRAM}},
+  volume  = {3},
+  pages   = {219--248},
+  author  = {Philipp Grohs and Ralf Hiptmair and Simon Pintarelli},
+  title   = {Tensor-Product Discretization for the Spatially Inhomogeneous and Transient Boltzmann Equation in Two Dimensions},
+  journal = {{SMAI} Journal of Computational Mathematics}
+}
+
+@PhDThesis{grove:discretizations,
+  title   = {Discretizations \& Efficient Linear Solvers for Problems Related to Fluid Flow},
+  author  = {Ryan R. Grove},
+  school  = {Clemson University},
+  year    = {2017},
+  url     = {https://tigerprints.clemson.edu/all_dissertations/1985/}
+}
+
 @Article{guermond.luna.ea:conservative,
   author  = {J.-L. Guermond and M. Quesada de Luna and T. Thompson},
   title   = {An conservative anti-diffusion technique for the level set method},
@@ -1308,6 +794,20 @@
   pages   = {448--468},
   url     = {http://www.sciencedirect.com/science/article/pii/S037704271730081X},
   doi     = {}
+}
+
+@Article{guermond.popov.ea:invariant,
+  doi     = {10.1137/16m1063034},
+  url     = {https://doi.org/10.1137/16m1063034},
+  year    = {2017},
+  month   = jan,
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {39},
+  number  = {2},
+  pages   = {A385--A414},
+  author  = {Jean-Luc Guermond and Bojan Popov and Laura Saavedra and Yong Yang},
+  title   = {Invariant Domains Preserving Arbitrary Lagrangian Eulerian Approximation of Hyperbolic Systems with Continuous Finite Elements},
+  journal = {{SIAM} Journal on Scientific Computing}
 }
 
 @Article{gupta.veen.ea:bounds,
@@ -1320,6 +820,36 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5455/full},
   doi     = {},
   note    = {In press}
+}
+
+@Article{hai.bause:finite,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Finite Element Approximation of Fluid-Structure Interaction (FSI) Problem with Coupled Wave Propagation},
+  journal = {In proceedings of: the 88 th GAMM Annual Meeting of the International Association of Applied Mathematics and Mechanics, March 6--10, Weimar, Germany. In: PAMM - Proceedings in Applied Mathematics and Mechanics},
+  year    = {2017},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{hai.bause:mathematical,
+  author  = {B. S. M. Ebna Hai and M. Bause},
+  title   = {Mathematical Modelling and Numerical Simulation of the On-line Structural Health Monitoring System},
+  journal = {In proceedings of: the 11 th International Workshop on Structural Health Monitoring, Structural Health Monitoring 2017, Sept 12--14, Stanford University, CA, USA. In: F-K. Chang and F. Kopsaftopoulos (Ed.), ``Structural Health Monitoring 2017: Real-Time Material State Awareness and Data-Driven Safety Assurance.''},
+  year    = {2017},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@PhDThesis{hai:finite,
+  author  = {B. S. M. Ebna Hai},
+  title   = {Finite Element Approximation of Ultrasonic Wave Propagation under Fluid-Structure Interaction for Structural Health Monitoring Systems},
+  year    = {2017},
+  school  = {Helmut Schmidt University-University of the Federal Armed Forces Hambur, Germany},
+  url     = {}
 }
 
 @MastersThesis{haider:numerical,
@@ -1337,6 +867,19 @@
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
   note    = {Project thesis},
   url     = {}
+}
+
+@Article{harmon.gamba.ea:numerical,
+  doi     = {10.1016/j.jcp.2016.08.026},
+  url     = {https://doi.org/10.1016/j.jcp.2016.08.026},
+  year    = {2016},
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {327},
+  pages   = {140--167},
+  author  = {Michael Harmon and Irene M. Gamba and Kui Ren},
+  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical ({PEC}) solar cells},
+  journal = {Journal of Computational Physics}
 }
 
 @Article{he.puckett.ea:discontinuous,
@@ -1361,6 +904,49 @@
   doi     = {10.1093/gji/ggx195}
 }
 
+@InCollection{hinze.kunkel.ea:model,
+  doi     = {10.1007/978-3-319-07236-4_1},
+  url     = {https://doi.org/10.1007/978-3-319-07236-4_1},
+  year    = {2017},
+  publisher = {Springer International Publishing},
+  pages   = {1--37},
+  author  = {Michael Hinze and Martin Kunkel and Ulrich Matthes and Morten Vierling},
+  title   = {Model Order Reduction of Integrated Circuits in Electrical Networks},
+  booktitle = {Mathematics in Industry}
+}
+
+@PhDThesis{holmgren:modelling-of-moving-contact-lines-in-two-phase-flows,
+  title   = {{Modelling of Moving Contact Lines in Two-Phase Flows}},
+  author  = {Holmgren, H},
+  year    = {2017},
+  school  = {Uppsala University},
+  url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2:1139929}
+}
+
+@InProceedings{horak.straub.ea:epicyclic,
+  title   = {Epicyclic oscillations of thick relativistic disks},
+  author  = {J. Hor{\'a}k and O. Straub and E. {\v{S}}r{\'a}mkov{\'a} and K. Goluchov{\'{a}} and G. T{\"{o}}r{\"{o}}k},
+  booktitle = {Proceedings of RAGtime 2015/2016/2017, Opava, Czech Republic},
+  editor  = {Z. Stuchl{\'i}k, G. Tor{\"o}k and V. Karas},
+  pages   = {47--59},
+  year    = {2017},
+  url     = {http://proceedings.physics.cz/images/proc17/hor2.pdf}
+}
+
+@Article{hwang.fish.ea:software,
+  doi     = {10.1002/2016ea000225},
+  url     = {https://doi.org/10.1002/2016ea000225},
+  year    = {2017},
+  month   = nov,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {4},
+  number  = {11},
+  pages   = {670--680},
+  author  = {Lorraine Hwang and Allison Fish and Laura Soito and MacKenzie Smith and Louise H. Kellogg},
+  title   = {Software and the Scientist: Coding and Citation Practices in Geodynamics},
+  journal = {Earth and Space Science}
+}
+
 @Article{jansen.sohrabi.ea:hulk,
   author  = {G. Jansen and R. Sohrabi and S. A. Miller},
   title   = {HULK -- Simple and fast generation of structured hexahedral meshes for improved subsurface simulations},
@@ -1383,6 +969,31 @@
   doi     = {}
 }
 
+@PhDThesis{joos:microstructural-characterisation--modelling-and-simulation-of-solid-oxide-fuel-cell-cathodes,
+  title   = {{Microstructural Characterisation, Modelling and Simulation of Solid Oxide Fuel Cell Cathodes}},
+  author  = {Joos, J},
+  year    = {2017},
+  school  = {Karlsruhe Institute of Technology},
+  url     = {https://publikationen.bibliothek.kit.edu/1000064791/4189242}
+}
+
+@Misc{joshi.chatterjee:a-posteriori,
+  title   = {A-posteriori diffusion analysis of higher-order numerical schemes for application to propagating linear waves},
+  author  = {S. M. Joshi and A. Chatterjee},
+  year    = {2017},
+  eprint  = {1707.05026},
+  archiveprefix = {arXiv},
+  primaryclass = {physics.comp-ph}
+}
+
+@MastersThesis{kan:finite,
+  author  = {Kan, Duygu},
+  title   = {Finite element solution for 2-D and 3-D acoustic scattering problem},
+  school  = {\.{I}stanbul Teknik \"{U}niversitesi},
+  year    = {2017},
+  url     = {https://acikbilim.yok.gov.tr/handle/20.500.12812/128565}
+}
+
 @Article{kanschat.lazarov.ea:geometric,
   author  = {G. Kanschat and R. Lazarov and Y. Mao},
   title   = {Geometric Multigrid for Darcy and Brinkman models of flows in highly heterogeneous porous media: A numerical study},
@@ -1392,6 +1003,20 @@
   pages   = {174--185},
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302333},
   doi     = {}
+}
+
+@Article{karban.dolezel:fully,
+  doi     = {10.1007/s00202-017-0629-9},
+  url     = {https://doi.org/10.1007/s00202-017-0629-9},
+  year    = {2017},
+  month   = aug,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {99},
+  number  = {4},
+  pages   = {1255--1261},
+  author  = {Pavel Karban and Ivo Dole{\v{z}}el},
+  title   = {Fully adaptive higher-order finite element analysis of fast transient phenomena on overhead lines},
+  journal = {Electrical Engineering}
 }
 
 @Article{karrecha.abbassi.ea:self-consistent,
@@ -1417,6 +1042,45 @@
   author  = {Justin A. Kauffman and Jason P. Sheldon and Scott T. Miller},
   title   = {Overset meshing coupled with hybridizable discontinuous Galerkin finite elements},
   journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@InProceedings{kodanganallur-narayanan:parallel-particle-in-cell-performance-optimization--a-case-study-of-electrospray-simulation,
+  author  = {{Kodanganallur Narayanan}, Ramachandran},
+  title   = {{Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation}},
+  booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})},
+  year    = {2017},
+  month   = {may},
+  publisher = {{IEEE}},
+  doi     = {10.1109/ipdpsw.2017.160}
+}
+
+@InProceedings{korous.karban.ea:distributed,
+  title   = {Distributed Implicit Discontinuous Galerkin {MHD} Solver},
+  author  = {Korous, L and Karban, P and Skala, J},
+  booktitle = {Proceedings of the 2017 CompuMag conference},
+  year    = {2017},
+  url     = {http://www.compumag.org/CMAG2017/[PD-A7-13]_492.pdf}
+}
+
+@Article{kramer.kullmer.ea:semi-lagrangian,
+  doi     = {10.1103/physreve.95.023305},
+  url     = {https://doi.org/10.1103/physreve.95.023305},
+  year    = {2017},
+  month   = feb,
+  publisher = {American Physical Society ({APS})},
+  volume  = {95},
+  number  = {2},
+  author  = {Andreas Kr\"{a}mer and Knut K\"{u}llmer and Dirk Reith and Wolfgang Joppich and Holger Foysi},
+  title   = {Semi-Lagrangian off-lattice Boltzmann method for weakly compressible flows},
+  journal = {Physical Review E}
+}
+
+@PhDThesis{kramer:lattice-boltzmann-methoden,
+  author  = {Andreas Kr{\"a}mer},
+  title   = {Lattice-{B}oltzmann-{M}ethoden zur {S}imulation inkompressibler {W}irbelstr{\"o}mungen},
+  year    = {2017},
+  school  = {Universit{\"a}t Siegen},
+  url     = {https://dspace.ub.uni-siegen.de/handle/ubsi/1237}
 }
 
 @Article{krank.fehn.ea:high-order,
@@ -1452,15 +1116,17 @@
   doi     = {}
 }
 
-@Article{lee.wheeler:adaptive,
-  author  = {S. Lee and M. F. Wheeler},
-  title   = {Adaptive enriched Galerkin methods for miscible displacement problems with entropy residual stabilization},
-  journal = {Journal of Computational Physics},
+@Article{kynch.ledger:resolving,
+  doi     = {10.1016/j.compstruc.2016.05.021},
+  url     = {https://doi.org/10.1016/j.compstruc.2016.05.021},
   year    = {2017},
-  volume  = {331},
-  pages   = {19--37},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116305952},
-  doi     = {}
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {181},
+  pages   = {41--54},
+  author  = {R.M. Kynch and P.D. Ledger},
+  title   = {Resolving the sign conflict problem for hp-hexahedral N{\'{e}}d{\'{e}}lec elements with application to eddy current problems},
+  journal = {Computers {\&} Structures}
 }
 
 @Article{lee.wheeler.ea:initialization,
@@ -1474,6 +1140,30 @@
   doi     = {10.1016/j.mechrescom.2016.04.002}
 }
 
+@Article{lee.wheeler.ea:iterative,
+  author  = {S. Lee and M. F. Wheeler and T. Wick},
+  title   = {Iterative coupling of flow, geomechanics and adaptive phase-field fracture including level-set crack width approaches},
+  journal = {Journal of Computational and Applied Mathematics},
+  year    = {2017},
+  volume  = {314},
+  pages   = {40--60},
+  month   = {apr},
+  doi     = {10.1016/j.cam.2016.10.022},
+  publisher = {Elsevier {BV}},
+  url     = {https://pdfs.semanticscholar.org/02aa/832e109562d3201aaab220f0b6e3a4ddddbb.pdf}
+}
+
+@Article{lee.wheeler:adaptive,
+  author  = {S. Lee and M. F. Wheeler},
+  title   = {Adaptive enriched Galerkin methods for miscible displacement problems with entropy residual stabilization},
+  journal = {Journal of Computational Physics},
+  year    = {2017},
+  volume  = {331},
+  pages   = {19--37},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116305952},
+  doi     = {}
+}
+
 @Article{li.gurnis.ea:towards,
   author  = {D. Li and M. Gurnis and G. Stadler},
   title   = {Towards adjoint-based inversion of time-dependent mantle convection with nonlinear viscosity},
@@ -1485,6 +1175,26 @@
   doi     = {}
 }
 
+@InProceedings{li.ren.ea:practical,
+  doi     = {10.1109/cit.2017.22},
+  url     = {https://doi.org/10.1109/cit.2017.22},
+  year    = {2017},
+  month   = aug,
+  publisher = {{IEEE}},
+  author  = {Hao Li and Xiaoguang Ren and Yufei Lin and Yuhua Tang and Shuai Ye},
+  title   = {Practical Performance Models for High-Order {CFD} Simulation},
+  booktitle = {2017 {IEEE} International Conference on Computer and Information Technology ({CIT})}
+}
+
+@Misc{licht.maier:flux,
+  title   = {Flux Reconstruction for Goal-Oriented A Posteriori Error Estimation},
+  author  = {Martin Licht and Matthias Maier},
+  year    = {2017},
+  eprint  = {1707.09659},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
 @MastersThesis{lin:high,
   author  = {S. Lin},
   title   = {High Performance Techniques Applied in Partial Differential Equations Library},
@@ -1492,6 +1202,43 @@
   school  = {St. Johns University},
   note    = {Honors thesis},
   url     = {}
+}
+
+@Article{liu.foo.ea:3d,
+  doi     = {10.1016/j.camss.2017.07.005},
+  url     = {https://doi.org/10.1016/j.camss.2017.07.005},
+  year    = {2017},
+  month   = aug,
+  publisher = {Springer Nature},
+  volume  = {30},
+  number  = {4},
+  pages   = {374--389},
+  author  = {Jun Liu and Choon Chiang Foo and Zhi-Qian Zhang},
+  title   = {A 3D multi-field element for simulating the electromechanical coupling behavior of dielectric elastomers},
+  journal = {Acta Mechanica Solida Sinica}
+}
+
+@Article{liu.liang:prevalence,
+  doi     = {10.1126/sciadv.1701872},
+  url     = {https://doi.org/10.1126/sciadv.1701872},
+  year    = {2017},
+  month   = nov,
+  publisher = {American Association for the Advancement of Science ({AAAS})},
+  volume  = {3},
+  number  = {11},
+  pages   = {e1701872},
+  author  = {Boda Liu and Yan Liang},
+  title   = {The prevalence of kilometer-scale heterogeneity in the source region of {MORB} upper mantle},
+  journal = {Science Advances}
+}
+
+@TechReport{ljungkvist.kronbichler:multigrid-for-matrix-free-finite-element-computations-on-graphics-processors,
+  title   = {{Multigrid for matrix-free finite element computations on graphics processors}},
+  author  = {Ljungkvist, K and Kronbichler, M},
+  institution = {Uppsala University},
+  number  = {2017-006},
+  year    = {2017},
+  url     = {https://pdfs.semanticscholar.org/924a/734d1e402f8b562e18c28a681baeaf10e34a.pdf}
 }
 
 @PhDThesis{ljungkvist:finite,
@@ -1518,6 +1265,29 @@
   address = {San Diego, CA, USA}
 }
 
+@Article{lovelace.demos.ea:numerically,
+  doi     = {10.1088/1361-6382/aa9ccc},
+  url     = {https://doi.org/10.1088/1361-6382/aa9ccc},
+  year    = {2017},
+  month   = dec,
+  publisher = {{IOP} Publishing},
+  volume  = {35},
+  number  = {2},
+  pages   = {025017},
+  author  = {Geoffrey Lovelace and Nicholas Demos and Haroon Khan},
+  title   = {Numerically modeling Brownian thermal noise in amorphous and crystalline thin coatings},
+  journal = {Classical and Quantum Gravity}
+}
+
+@InProceedings{luo.zhao:numerical-simulation-of-temperature-fields-in-powder-bed-fusion-process-by-using-hybrid-heat-source-model,
+  title   = {{Numerical simulation of temperature fields in powder bed fusion process by using hybrid heat source model}},
+  author  = {Luo, Z and Zhao, YF},
+  journal = {sffsymposium.engr.utexas.edu},
+  year    = {2017},
+  booktitle = {Proceedings of the 28th Annual International Solid Freeform Fabrication Symposium: An Additive Manufacturing conference},
+  url     = {https://sffsymposium.engr.utexas.edu/sites/default/files/2017/Manuscripts/NumericalSimulationofTemperatureFieldsinPowd.pdf}
+}
+
 @Article{maier.margetis.ea:dipole,
   author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
   title   = {Dipole excitation of surface plasmon on a conducting sheet: Finite element approximation and validation},
@@ -1528,6 +1298,38 @@
   month   = {jun},
   doi     = {10.1016/j.jcp.2017.03.014},
   publisher = {Elsevier {BV}}
+}
+
+@Misc{maier.margetis.ea:generation,
+  title   = {Generation of surface plasmon-polaritons by edge effects},
+  author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
+  year    = {2017},
+  eprint  = {1702.00848},
+  archiveprefix = {arXiv},
+  primaryclass = {physics.comp-ph}
+}
+
+@Article{maier.nemilentsau.ea:ultracompact,
+  doi     = {10.1021/acsphotonics.7b01094},
+  url     = {https://doi.org/10.1021/acsphotonics.7b01094},
+  year    = {2017},
+  month   = dec,
+  publisher = {American Chemical Society ({ACS})},
+  volume  = {5},
+  number  = {2},
+  pages   = {544--551},
+  author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
+  title   = {Ultracompact Amplitude Modulator by Coupling Hyperbolic Polaritons over a Graphene-Covered Gap},
+  journal = {{ACS} Photonics}
+}
+
+@Misc{marojevic.goklu.ea:life,
+  title   = {Life time of topological coherent modes of a Bose--Einstein condensate in a gravito optical surface trap},
+  author  = {{\v{Z}}elimir Marojevi{\'c} and Ertan G{\"o}kl{\"u} and Hannes Uecker and Claus L{\"a}mmerzahl},
+  year    = {2017},
+  eprint  = {1708.04443},
+  archiveprefix = {arXiv},
+  primaryclass = {quant-ph}
 }
 
 @Article{mcgovern.kollet.ea:novel,
@@ -1544,12 +1346,63 @@
   journal = {Computational Geosciences}
 }
 
+@Article{mehnert.pelteret.ea:numerical,
+  doi     = {10.1177/1081286517729867},
+  url     = {https://doi.org/10.1177/1081286517729867},
+  year    = {2017},
+  month   = sep,
+  publisher = {{SAGE} Publications},
+  volume  = {22},
+  number  = {11},
+  pages   = {2196--2213},
+  author  = {Markus Mehnert and Jean-Paul Pelteret and Paul Steinmann},
+  title   = {Numerical modelling of nonlinear thermo-electro-elasticity},
+  journal = {Mathematics and Mechanics of Solids}
+}
+
 @MastersThesis{mentler:high,
   author  = {M. Mentler},
   title   = {High performance implementation of one-field elasticity using the deal.II Finite Element library},
   year    = {2017},
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
   url     = {}
+}
+
+@Article{mohebujjaman.rebholz:efficient,
+  doi     = {10.1515/cmam-2016-0033},
+  url     = {https://doi.org/10.1515/cmam-2016-0033},
+  year    = {2017},
+  month   = jan,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {17},
+  number  = {1},
+  author  = {Muhammad Mohebujjaman and Leo G. Rebholz},
+  title   = {An Efficient Algorithm for Computation of {MHD} Flow Ensembles},
+  journal = {Computational Methods in Applied Mathematics}
+}
+
+@TechReport{mohebujjaman:c-parallel-implementation-of-incompressible-viscous-time-dependent-nse-simulation-using-projection-method-in-dealii,
+  title   = {{C++ parallel implementation of incompressible viscous time-dependent NSE simulation using projection method in Dealii}},
+  author  = {Mohebujjaman, M},
+  institution = {Virginia Tech},
+  year    = {2017},
+  url     = {http://mmohebu.people.clemson.edu/PDFDocuments/project_HPC_Projection_Method_NSE.pdf}
+}
+
+@PhDThesis{mohebujjaman:efficient,
+  title   = {Efficient Numerical Methods for Magnetohydrodynamic Flow},
+  author  = {Muhammad Mohebujjaman},
+  school  = {Clemson University},
+  year    = {2017},
+  url     = {https://tigerprints.clemson.edu/all_dissertations/2027/}
+}
+
+@TechReport{mohebujjaman:high-order,
+  author  = {Mohebujjaman, M.},
+  year    = {2017},
+  title   = {High-order efficient algorithms for computation of {MHD} flow ensemble},
+  institution = {Virginia Tech},
+  url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/publication/327449710_HIGH_ORDER_EFFICIENT_ALGORITHM_FOR_COMPUTATION_OF_MHD_FLOW_ENSEMBLE/links/5b903a08a6fdcce8a4c3548d/HIGH-ORDER-EFFICIENT-ALGORITHM-FOR-COMPUTATION-OF-MHD-FLOW-ENSEMBLE.pdf}
 }
 
 @Article{mola.heitai.ea:wet,
@@ -1563,6 +1416,28 @@
   doi     = {}
 }
 
+@PhDThesis{monavari:continuum,
+  title   = {Continuum Dislocation Kinematics},
+  author  = {Mehran Monavari},
+  school  = {Friedrich-Alexander-Universit{\"a}t Erlangen-N{\"u}rnberg},
+  year    = {2017},
+  url     = {https://opus4.kobv.de/opus4-fau/frontdoor/deliver/index/docId/8685/file/MehranMonavariDissertation.pdf}
+}
+
+@Article{na.sun.ea:effects,
+  doi     = {10.1002/2016jb013374},
+  url     = {https://doi.org/10.1002/2016jb013374},
+  year    = {2017},
+  month   = aug,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {122},
+  number  = {8},
+  pages   = {6202--6230},
+  author  = {SeonHong Na and WaiChing Sun and Mathew D. Ingraham and Hongkyu Yoon},
+  title   = {Effects of spatial heterogeneity and material anisotropy on the fracture pattern and macroscopic effective toughness of Mancos Shale in Brazilian tests},
+  journal = {Journal of Geophysical Research: Solid Earth}
+}
+
 @Article{na.sun:computational,
   author  = {S. H. Na and W.C. Sun},
   title   = {Computational thermo-hydro-mechanics for multiphase freezing and thawing porous media in the finite deformation range},
@@ -1572,6 +1447,17 @@
   pages   = {667--700},
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516311240},
   doi     = {}
+}
+
+@InProceedings{narayanan.madduri:parallel,
+  doi     = {10.1109/ipdpsw.2017.160},
+  url     = {https://doi.org/10.1109/ipdpsw.2017.160},
+  year    = {2017},
+  month   = may,
+  publisher = {{IEEE}},
+  author  = {Ramachandran Kodanganallur Narayanan and Kamesh Madduri},
+  title   = {Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation},
+  booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})}
 }
 
 @Article{odster.wheeler.ea:postprocessing,
@@ -1585,6 +1471,52 @@
   doi     = {}
 }
 
+@Article{oneill.marchi.ea:impact-driven,
+  doi     = {10.1038/ngeo3029},
+  title   = {Impact-driven subduction on the {H}adean {E}arth},
+  author  = {O'Neill, C. and Marchi, S. and Zhang, S. and Bottke, W.},
+  journal = {Nature Geoscience},
+  volume  = {10},
+  number  = {10},
+  pages   = {793},
+  year    = {2017},
+  publisher = {Nature Publishing Group}
+}
+
+@Article{oneill.turner.ea:inception,
+  doi     = {10.1098/rsta.2017.0414},
+  title   = {The inception of plate tectonics: a record of failure},
+  author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
+  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+  volume  = {376},
+  number  = {2132},
+  pages   = {20170414},
+  year    = {2018},
+  publisher = {The Royal Society Publishing}
+}
+
+@PhDThesis{patty:an-energy-formulation-of-surface-tension-or-willmore-force-for-two-phase-flow,
+  title   = {{An Energy Formulation of Surface Tension or Willmore Force For Two-Phase Flow}},
+  author  = {Patty, S.},
+  school  = {Texas A\&M University},
+  year    = {2017},
+  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/165987}
+}
+
+@Article{porcelli.simoncini.ea:preconditioning,
+  doi     = {10.1016/j.camwa.2017.04.033},
+  url     = {https://doi.org/10.1016/j.camwa.2017.04.033},
+  year    = {2017},
+  month   = sep,
+  publisher = {Elsevier {BV}},
+  volume  = {74},
+  number  = {5},
+  pages   = {1059--1075},
+  author  = {Margherita Porcelli and Valeria Simoncini and Martin Stoll},
+  title   = {Preconditioning {PDE}-constrained optimization with L1-sparsity and control constraints},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
 @Article{poy.bunel.ea:role,
   author  = {G. Poy and F. Bunel and P. Oswald},
   title   = {Role of anchoring energy on the texture of cholesteric droplets: Finite-element simulations and experiments},
@@ -1596,12 +1528,36 @@
   doi     = {}
 }
 
+@Article{pratik-rai:adjoint-based,
+  doi     = {10.13140/RG.2.2.23244.10884},
+  url     = {http://rgdoi.net/10.13140/RG.2.2.23244.10884},
+  author  = {{Pratik Rai}},
+  title   = {Adjoint-based error estimation and mesh adaptivity for stationary fluid-structure interaction},
+  publisher = {Unpublished},
+  year    = {2017}
+}
+
 @PhDThesis{quinelato:mixed,
   author  = {T. O. Quinelato},
   title   = {Mixed Hybrid Finite Element Methods in Elasticity and Poroelasticity},
   year    = {2017},
   school  = {Laborat\'{o}rio Nacional de Computa\c{c}\~{a}o Cient\'{i}fica, Brazil},
   url     = {}
+}
+
+@PhDThesis{ramirez:time-dependent,
+  title   = {Time-dependent {S}tokes-{D}arcy Flow with Deposition},
+  author  = {Javier Ruiz Ramirez},
+  school  = {Clemson University},
+  year    = {2017},
+  url     = {https://tigerprints.clemson.edu/all_dissertations/1968/}
+}
+
+@MastersThesis{rave:kopplung,
+  author  = {Rave, Kevin},
+  title   = {Kopplung von {OpenFOAM} und {deal.II} {G}leichungsl{\"o}sern mit {preCICE} zur {S}imulation multiphysikalischer {P}robleme},
+  school  = {Universit{\"a}t Siegen},
+  year    = {2017}
 }
 
 @Article{riedlbauer.scharowski.ea:macroscopic,
@@ -1626,15 +1582,27 @@
   doi     = {}
 }
 
-@Article{rose.buffett:scaling,
-  author  = {I. Rose and B. Buffett},
-  title   = {Scaling rates of true polar wander in convecting planets and moons},
-  journal = {Physics of the Earth and Planetary Interiors},
+@Misc{riviere.kanschat:finite,
+  title   = {A finite element method with strong mass conservation for Biot's linear consolidation model},
+  author  = {Beatrice Riviere and Guido Kanschat},
   year    = {2017},
-  volume  = {273},
-  pages   = {1--10},
-  url     = {https://doi.org/10.1016/j.pepi.2017.10.003},
-  doi     = {}
+  eprint  = {1712.07468},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{roland.tjardes.ea:personalized,
+  doi     = {10.1002/pamm.201710078},
+  url     = {https://doi.org/10.1002/pamm.201710078},
+  year    = {2017},
+  month   = dec,
+  publisher = {Wiley},
+  volume  = {17},
+  number  = {1},
+  pages   = {217--218},
+  author  = {Michael Roland and Thorsten Tjardes and Bertil Bouillon and Stefan Diebels},
+  title   = {Personalized simulation of a bone-implant-system during a step forward},
+  journal = {{PAMM}}
 }
 
 @Article{rose.buffett.ea:stability,
@@ -1646,6 +1614,46 @@
   pages   = {90--100},
   url     = {http://dx.doi.org/10.1016/j.pepi.2016.11.007},
   doi     = {}
+}
+
+@Article{rose.buffett:scaling,
+  author  = {I. Rose and B. Buffett},
+  title   = {Scaling rates of true polar wander in convecting planets and moons},
+  journal = {Physics of the Earth and Planetary Interiors},
+  year    = {2017},
+  volume  = {273},
+  pages   = {1--10},
+  url     = {https://doi.org/10.1016/j.pepi.2017.10.003},
+  doi     = {}
+}
+
+@InCollection{russ.pacini:empirically-derived,
+  doi     = {10.1007/978-3-319-54735-0_8},
+  url     = {https://doi.org/10.1007/978-3-319-54735-0_8},
+  year    = {2017},
+  publisher = {Springer International Publishing},
+  pages   = {71--82},
+  author  = {Jonathan B. Russ and Benjamin R. Pacini},
+  title   = {Empirically-Derived, Constitutive Damping Model for Cellular Silicone},
+  booktitle = {Shock {\&} Vibration, Aircraft/Aerospace, Energy Harvesting, Acoustics {\&} Optics, Volume 9}
+}
+
+@PhDThesis{sabawi:adaptive-discontinuous-galerkin-methods-for-interface-problems,
+  title   = {{Adaptive discontinuous Galerkin methods for interface problems}},
+  author  = {Sabawi, YA},
+  year    = {2017},
+  school  = {University of Leicester},
+  url     = {http://hdl.handle.net/2381/39386}
+}
+
+@InProceedings{santos.azeredo-coutinho:continuous,
+  doi     = {10.20906/cps/cilamce2017-0712},
+  url     = {https://doi.org/10.20906/cps/cilamce2017-0712},
+  year    = {2017},
+  publisher = {{ABMEC} Brazilian Association of Computational Methods in Engineering},
+  author  = {T{\'{u}}lio Ligneul Santos and Alvaro Luiz Gayoso de Azeredo Coutinho},
+  title   = {A continuous finite element approach to the well-balanced shallow water equations},
+  booktitle = {Proceedings of the {XXXVIII} Iberian Latin American Congress on Computational Methods in Engineering}
 }
 
 @Article{schoeder.kronbichler.ea:photoacoustic,
@@ -1670,6 +1678,20 @@
   doi     = {}
 }
 
+@Article{seydel.schuster:identifying,
+  doi     = {10.1088/1361-6420/aa8d91},
+  url     = {https://doi.org/10.1088/1361-6420/aa8d91},
+  year    = {2017},
+  month   = nov,
+  publisher = {{IOP} Publishing},
+  volume  = {33},
+  number  = {12},
+  pages   = {124004},
+  author  = {Julia Seydel and Thomas Schuster},
+  title   = {Identifying the stored energy of a hyperelastic structure by using an attenuated Landweber method},
+  journal = {Inverse Problems}
+}
+
 @Article{seydel.schuster:identifying*1,
   author  = {J. Seydel and T. Schuster},
   title   = {Identifying the stored energy of a hyperelastic structure by using an attenuated Landweber method},
@@ -1681,6 +1703,49 @@
   doi     = {}
 }
 
+@PhDThesis{seydel:identifikation-der-verzerrungsenergiedichte-hyperelastischer-materialien-aus-zeitabhangigen-randmessungen,
+  title   = {{Identifikation der Verzerrungsenergiedichte hyperelastischer Materialien aus zeitabh{\"{a}}ngigen Randmessungen}},
+  author  = {Seydel, J.},
+  year    = {2017},
+  school  = {Universit{\"a}t des Saarlandes},
+  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/26795},
+  doi     = {10.22028/D291-26782}
+}
+
+@PhDThesis{shakir:multilevel-schwarz-methods-for-incompressible-flow-problems,
+  title   = {{Multilevel Schwarz Methods for Incompressible Flow Problems}},
+  author  = {Shakir, N.},
+  year    = {2017},
+  school  = {Heidelberg University},
+  doi     = {10.11588/heidok.00023210},
+  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/23210}
+}
+
+@TechReport{song.west.ea:munition-penetration-depth-prediction,
+  title   = {{Munition Penetration Depth Prediction}},
+  author  = {Song, A. S. and West, B. A. and Taylor, O. D. S. and O'Connor, D. T.},
+  year    = {2017},
+  url     = {http://www.dtic.mil/get-tr-doc/pdf?AD=AD1039187},
+  institution = {US Army Corps of Engineers},
+  number  = {SERDP SEED Project MR 2629}
+}
+
+@MastersThesis{strom:preconditioned,
+  author  = {A. Str\"{o}m},
+  title   = {Preconditioned iterative methods for PDE-constrained optimization problems with pointwise state constraints},
+  year    = {2017},
+  school  = {Uppsala University, Sweden},
+  url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A1081649&dswid=292}
+}
+
+@PhDThesis{sutton:virtual-element-methods,
+  title   = {{Virtual Element Methods}},
+  author  = {Sutton, O. J.},
+  year    = {2017},
+  school  = {University of Leicester},
+  url     = {https://lra.le.ac.uk/handle/2381/39955}
+}
+
 @Article{takeyama.saitoh.ea:variable,
   author  = {K. Takeyama and T. R. Saitoh and J. Makino},
   title   = {Variable inertia method: A novel numerical method for mantle convection simulation},
@@ -1690,6 +1755,28 @@
   pages   = {82--103},
   url     = {http://www.sciencedirect.com/science/article/pii/S138410761630046X},
   doi     = {}
+}
+
+@PhDThesis{teichert:mathematical-framework-and-numerical-methods-for-the-modeling-of-mechanochemistry-in-multi-phase-materials,
+  title   = {{Mathematical Framework and Numerical Methods for the Modeling of Mechanochemistry in Multi-Phase Materials}},
+  author  = {Teichert, Gregory},
+  url     = {http://hdl.handle.net/2027.42/138690},
+  year    = {2017},
+  school  = {University of Michigan}
+}
+
+@Article{thieulot:analytical,
+  doi     = {10.5194/se-8-1181-2017},
+  url     = {https://doi.org/10.5194/se-8-1181-2017},
+  year    = {2017},
+  month   = nov,
+  publisher = {Copernicus {GmbH}},
+  volume  = {8},
+  number  = {6},
+  pages   = {1181--1191},
+  author  = {Cedric Thieulot},
+  title   = {Analytical solution for viscous incompressible Stokes flow in a spherical shell},
+  journal = {Solid Earth}
 }
 
 @Article{toulopoulos.wick:numerical,
@@ -1730,6 +1817,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716301157}
 }
 
+@PhDThesis{villiers:patient-specific,
+  author  = {A. M. De Villiers},
+  title   = {A patient-specific FSI model for vascular access in haemodialysis},
+  year    = {2017},
+  school  = {University of Cape Town},
+  url     = {http://hdl.handle.net/11427/24441}
+}
+
 @Article{wang.siegel.ea:intercalation,
   author  = {Z. Wang and J. B. Siegel and K. Garikipati},
   title   = {Intercalation driven porosity effects in coupled continuum models for the electrical, chemical, thermal and mechanical response of battery electrode materials},
@@ -1739,6 +1834,36 @@
   pages   = {},
   url     = {},
   doi     = {}
+}
+
+@Misc{wells.banks:using,
+  title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates},
+  author  = {David Wells and Jeffrey Banks},
+  year    = {2017},
+  eprint  = {1711.05922},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Misc{welper:h,
+  title   = {$h$ and $hp$-adaptive Interpolation by Transformed Snapshots for Parametric and Stochastic Hyperbolic PDEs},
+  author  = {G. Welper},
+  year    = {2017},
+  eprint  = {1710.11481},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@InCollection{wick:coupling,
+  doi     = {10.1515/9783110494259-009},
+  url     = {https://doi.org/10.1515/9783110494259-009},
+  year    = {2017},
+  month   = nov,
+  publisher = {De Gruyter},
+  pages   = {329--366},
+  author  = {Thomas Wick},
+  title   = {Coupling fluid-structure interaction with phase-field fracture: Algorithmic details},
+  booktitle = {Fluid-Structure Interaction}
 }
 
 @Article{wick:error-oriented,
@@ -1768,18 +1893,6 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@InCollection{wick:coupling,
-  doi     = {10.1515/9783110494259-009},
-  url     = {https://doi.org/10.1515/9783110494259-009},
-  year    = {2017},
-  month   = nov,
-  publisher = {De Gruyter},
-  pages   = {329--366},
-  author  = {Thomas Wick},
-  title   = {Coupling fluid-structure interaction with phase-field fracture: Algorithmic details},
-  booktitle = {Fluid-Structure Interaction}
-}
-
 @Article{wilmers.mcbride.ea:interface,
   author  = {J. Wilmers and A. McBride and S. Bargmann},
   title   = {Interface elasticity effects in polymer-filled nanoporous metals},
@@ -1791,183 +1904,15 @@
   doi     = {}
 }
 
-@Article{zhou.putz.ea:mixed,
-  author  = {J. Zhou and A. Putz and M. Secanell},
-  title   = {A Mixed Wettability Pore Size Distribution Based Mathematical Model for Analyzing Two-Phase Flow in Porous Electrodes I. Mathematical Model},
-  journal = {Journal of The Electrochemical Society, issue 6, F530-F539},
-  year    = {2017},
-  volume  = {164},
-  pages   = {},
-  url     = {http://jes.ecsdl.org/content/164/6/F530.short},
-  doi     = {}
-}
-
-@InProceedings{kodanganallur-narayanan:parallel-particle-in-cell-performance-optimization--a-case-study-of-electrospray-simulation,
-  author  = {{Kodanganallur Narayanan}, Ramachandran},
-  title   = {{Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation}},
-  booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})},
-  year    = {2017},
-  month   = {may},
-  publisher = {{IEEE}},
-  doi     = {10.1109/ipdpsw.2017.160}
-}
-
-@Article{lee.wheeler.ea:iterative,
-  author  = {S. Lee and M. F. Wheeler and T. Wick},
-  title   = {Iterative coupling of flow, geomechanics and adaptive phase-field fracture including level-set crack width approaches},
-  journal = {Journal of Computational and Applied Mathematics},
-  year    = {2017},
-  volume  = {314},
-  pages   = {40--60},
-  month   = {apr},
-  doi     = {10.1016/j.cam.2016.10.022},
-  publisher = {Elsevier {BV}},
-  url     = {https://pdfs.semanticscholar.org/02aa/832e109562d3201aaab220f0b6e3a4ddddbb.pdf}
-}
-
-@Article{chandrashekar.zenk:well-balanced,
-  author  = {Praveen Chandrashekar and Markus Zenk},
-  title   = {Well-Balanced Nodal Discontinuous Galerkin Method for Euler Equations with Gravity},
-  journal = {Journal of Scientific Computing},
-  year    = {2017},
-  volume  = {71},
-  number  = {3},
-  pages   = {1062--1093},
-  month   = {jan},
-  doi     = {10.1007/s10915-016-0339-x},
-  publisher = {Springer Nature}
-}
-
-@PhDThesis{ramirez:time-dependent,
-  title   = {Time-dependent {S}tokes-{D}arcy Flow with Deposition},
-  author  = {Javier Ruiz Ramirez},
-  school  = {Clemson University},
-  year    = {2017},
-  url     = {https://tigerprints.clemson.edu/all_dissertations/1968/}
-}
-
-@PhDThesis{mohebujjaman:efficient,
-  title   = {Efficient Numerical Methods for Magnetohydrodynamic Flow},
-  author  = {Muhammad Mohebujjaman},
-  school  = {Clemson University},
-  year    = {2017},
-  url     = {https://tigerprints.clemson.edu/all_dissertations/2027/}
-}
-
-@PhDThesis{grove:discretizations,
-  title   = {Discretizations \& Efficient Linear Solvers for Problems Related to Fluid Flow},
-  author  = {Ryan R. Grove},
-  school  = {Clemson University},
-  year    = {2017},
-  url     = {https://tigerprints.clemson.edu/all_dissertations/1985/}
-}
-
-@MastersThesis{rave:kopplung,
-  author  = {Rave, Kevin},
-  title   = {Kopplung von {OpenFOAM} und {deal.II} {G}leichungsl{\"o}sern mit {preCICE} zur {S}imulation multiphysikalischer {P}robleme},
-  school  = {Universit{\"a}t Siegen},
+@PhDThesis{wilmers:multiphysically,
+  doi     = {10.15480/882.1438},
+  url     = {https://tubdok.tub.tuhh.de/handle/11420/1441},
+  author  = {Wilmers, Jana},
+  keywords = {600: Technik, 600},
+  language = {en},
+  title   = {Multiphysically coupled modelling of polymer-based materials},
+  publisher = {TUHH Universit\"{a}tsbibliothek},
   year    = {2017}
-}
-
-@TechReport{ljungkvist.kronbichler:multigrid-for-matrix-free-finite-element-computations-on-graphics-processors,
-  title   = {{Multigrid for matrix-free finite element computations on graphics processors}},
-  author  = {Ljungkvist, K and Kronbichler, M},
-  institution = {Uppsala University},
-  number  = {2017-006},
-  year    = {2017},
-  url     = {https://pdfs.semanticscholar.org/924a/734d1e402f8b562e18c28a681baeaf10e34a.pdf}
-}
-
-@InProceedings{luo.zhao:numerical-simulation-of-temperature-fields-in-powder-bed-fusion-process-by-using-hybrid-heat-source-model,
-  title   = {{Numerical simulation of temperature fields in powder bed fusion process by using hybrid heat source model}},
-  author  = {Luo, Z and Zhao, YF},
-  journal = {sffsymposium.engr.utexas.edu},
-  year    = {2017},
-  booktitle = {Proceedings of the 28th Annual International Solid Freeform Fabrication Symposium: An Additive Manufacturing conference},
-  url     = {https://sffsymposium.engr.utexas.edu/sites/default/files/2017/Manuscripts/NumericalSimulationofTemperatureFieldsinPowd.pdf}
-}
-
-@TechReport{mohebujjaman:c-parallel-implementation-of-incompressible-viscous-time-dependent-nse-simulation-using-projection-method-in-dealii,
-  title   = {{C++ parallel implementation of incompressible viscous time-dependent NSE simulation using projection method in Dealii}},
-  author  = {Mohebujjaman, M},
-  institution = {Virginia Tech},
-  year    = {2017},
-  url     = {http://mmohebu.people.clemson.edu/PDFDocuments/project_HPC_Projection_Method_NSE.pdf}
-}
-
-@PhDThesis{patty:an-energy-formulation-of-surface-tension-or-willmore-force-for-two-phase-flow,
-  title   = {{An Energy Formulation of Surface Tension or Willmore Force For Two-Phase Flow}},
-  author  = {Patty, S.},
-  school  = {Texas A\&M University},
-  year    = {2017},
-  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/165987}
-}
-
-@PhDThesis{sabawi:adaptive-discontinuous-galerkin-methods-for-interface-problems,
-  title   = {{Adaptive discontinuous Galerkin methods for interface problems}},
-  author  = {Sabawi, YA},
-  year    = {2017},
-  school  = {University of Leicester},
-  url     = {http://hdl.handle.net/2381/39386}
-}
-
-@PhDThesis{seydel:identifikation-der-verzerrungsenergiedichte-hyperelastischer-materialien-aus-zeitabhangigen-randmessungen,
-  title   = {{Identifikation der Verzerrungsenergiedichte hyperelastischer Materialien aus zeitabh{\"{a}}ngigen Randmessungen}},
-  author  = {Seydel, J.},
-  year    = {2017},
-  school  = {Universit{\"a}t des Saarlandes},
-  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/26795},
-  doi     = {10.22028/D291-26782}
-}
-
-@PhDThesis{shakir:multilevel-schwarz-methods-for-incompressible-flow-problems,
-  title   = {{Multilevel Schwarz Methods for Incompressible Flow Problems}},
-  author  = {Shakir, N.},
-  year    = {2017},
-  school  = {Heidelberg University},
-  doi     = {10.11588/heidok.00023210},
-  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/23210}
-}
-
-@TechReport{song.west.ea:munition-penetration-depth-prediction,
-  title   = {{Munition Penetration Depth Prediction}},
-  author  = {Song, A. S. and West, B. A. and Taylor, O. D. S. and O'Connor, D. T.},
-  year    = {2017},
-  url     = {http://www.dtic.mil/get-tr-doc/pdf?AD=AD1039187},
-  institution = {US Army Corps of Engineers},
-  number  = {SERDP SEED Project MR 2629}
-}
-
-@PhDThesis{sutton:virtual-element-methods,
-  title   = {{Virtual Element Methods}},
-  author  = {Sutton, O. J.},
-  year    = {2017},
-  school  = {University of Leicester},
-  url     = {https://lra.le.ac.uk/handle/2381/39955}
-}
-
-@PhDThesis{teichert:mathematical-framework-and-numerical-methods-for-the-modeling-of-mechanochemistry-in-multi-phase-materials,
-  title   = {{Mathematical Framework and Numerical Methods for the Modeling of Mechanochemistry in Multi-Phase Materials}},
-  author  = {Teichert, Gregory},
-  url     = {http://hdl.handle.net/2027.42/138690},
-  year    = {2017},
-  school  = {University of Michigan}
-}
-
-@PhDThesis{gallego-valencia:on-runge-kutta-discontinuous-galerkin-methods-for-compressible-euler-equations-and-the-ideal-magneto-hydrodynamical-model,
-  title   = {{On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamical model}},
-  author  = {J. P. {Gallego Valencia}},
-  year    = {2017},
-  school  = {University of W{\"u}rzburg},
-  url     = {https://www.researchgate.net/profile/Juan_Gallego-Valencia/publication/317093976_On_Runge-Kutta_discontinuous_Galerkin_methods_for_compressible_Euler_equations_and_the_ideal_magneto-hydrodynamical_model/links/592978060f7e9b9979a686c2/On-Runge-Kutta-discontinuous-Galerkin-methods-for-compressible-Euler-equations-and-the-ideal-magneto-hydrodynamical-model.pdf}
-}
-
-@PhDThesis{monavari:continuum,
-  title   = {Continuum Dislocation Kinematics},
-  author  = {Mehran Monavari},
-  school  = {Friedrich-Alexander-Universit{\"a}t Erlangen-N{\"u}rnberg},
-  year    = {2017},
-  url     = {https://opus4.kobv.de/opus4-fau/frontdoor/deliver/index/docId/8685/file/MehranMonavariDissertation.pdf}
 }
 
 @TechReport{yoon:multiscale,
@@ -1978,36 +1923,91 @@
   url     = {http://prod.sandia.gov/techlib/access-control.cgi/2017/1710273.pdf}
 }
 
-@MastersThesis{boltersdorf:ausarbeitung,
-  author  = {Boltersdorf, Jana},
-  title   = {{A}usarbeitung und {V}ergleich verschiedener {G}itterverfeinerungsstrategien hinsichtlich der parallelen {P}erformance eines {B}randsimulationsprogramms mit adaptiver {G}itterverfeinerung},
-  school  = {Fachhochschule Aachen},
-  reportid = {FZJ-2018-00798},
-  pages   = {63 p.},
+@Article{yu.cheng.ea:residual-based,
+  doi     = {10.1016/j.compfluid.2017.08.016},
+  url     = {https://doi.org/10.1016/j.compfluid.2017.08.016},
   year    = {2017},
-  url     = {https://juser.fz-juelich.de/record/842585}
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = {156},
+  pages   = {470--484},
+  author  = {Shengjiao Yu and Jian Cheng and Huiqiang Yue and Tiegang Liu},
+  title   = {A residual-based h-adaptive reconstructed discontinuous Galerkin method for the compressible Euler equations on unstructured grids},
+  journal = {Computers {\&} Fluids}
 }
 
-@MastersThesis{kan:finite,
-  author  = {Kan, Duygu},
-  title   = {Finite element solution for 2-D and 3-D acoustic scattering problem},
-  school  = {\.{I}stanbul Teknik \"{U}niversitesi},
+@Article{zhang.gain.ea:stress-based,
+  doi     = {10.1016/j.cma.2017.06.025},
+  url     = {https://doi.org/10.1016/j.cma.2017.06.025},
   year    = {2017},
-  url     = {https://acikbilim.yok.gov.tr/handle/20.500.12812/128565}
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = {325},
+  pages   = {1--21},
+  author  = {Shanglong Zhang and Arun L. Gain and Juli{\'{a}}n A. Norato},
+  title   = {Stress-based topology optimization with discrete geometric components},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{goll.wick.ea:dopelib,
-  doi     = {10.11588/ANS.2017.2.11815},
-  url     = {http://journals.ub.uni-heidelberg.de/index.php/ans/article/view/11815},
-  author  = {Goll, Christian and Wick, Thomas and Wollner, Winnifried},
-  keywords = {goal oriented interface design; numerical solution of optimization problems and partial differential equations},
-  language = {en},
-  title   = {{DOpElib}: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving {PDEs} and Optimization Problems with {PDEs}},
-  journal = {Archive of Numerical Software},
-  volume  = {Vol 5},
-  pages   = {No 2 (2017)},
-  publisher = {Archive of Numerical Software},
-  year    = {2017}
+@Article{zhang.norato:optimal,
+  doi     = {10.1115/1.4036999},
+  url     = {https://doi.org/10.1115/1.4036999},
+  year    = {2017},
+  month   = jun,
+  publisher = {{ASME} International},
+  volume  = {139},
+  number  = {8},
+  author  = {Shanglong Zhang and Juli{\'{a}}n A. Norato},
+  title   = {Optimal Design of Panel Reinforcements With Ribs Made of Plates},
+  journal = {Journal of Mechanical Design}
+}
+
+@Article{zheng.mcclarren.ea:accurate,
+  doi     = {10.1080/00295639.2017.1407592},
+  url     = {https://doi.org/10.1080/00295639.2017.1407592},
+  year    = {2017},
+  month   = dec,
+  publisher = {Informa {UK} Limited},
+  volume  = {189},
+  number  = {3},
+  pages   = {259--271},
+  author  = {Weixiong Zheng and Ryan G. McClarren and Jim E. Morel},
+  title   = {An Accurate Globally Conservative Subdomain Discontinuous Least-Squares Scheme for Solving Neutron Transport Problems},
+  journal = {Nuclear Science and Engineering}
+}
+
+@Article{zheng.mcclarren:accurate,
+  doi     = {10.1016/j.pnucene.2017.06.001},
+  url     = {https://doi.org/10.1016/j.pnucene.2017.06.001},
+  year    = {2017},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {101},
+  pages   = {394--400},
+  author  = {Weixiong Zheng and Ryan G. McClarren},
+  title   = {Accurate least-squares $P_N$ scaling based on problem optical thickness for solving neutron transport problems},
+  journal = {Progress in Nuclear Energy}
+}
+
+@InProceedings{zheng.mcclarren:continuous-discontinuous,
+  author  = {W. Zheng and R. G. McClarren},
+  title   = {A Continuous-Discontinuous Hybrid Finite Element Method for $S_N$ Transport},
+  booktitle = {Transactions of the American Nuclear Society},
+  year    = {2017},
+  volume  = {116},
+  pages   = {647--649},
+  url     = {https://www.researchgate.net/publication/317620866_A_Continuous-Discontinuous_Hybrid_Finite_Element_Method_for_SN_Transport}
+}
+
+@Article{zhou.putz.ea:mixed,
+  author  = {J. Zhou and A. Putz and M. Secanell},
+  title   = {A Mixed Wettability Pore Size Distribution Based Mathematical Model for Analyzing Two-Phase Flow in Porous Electrodes I. Mathematical Model},
+  journal = {Journal of The Electrochemical Society, issue 6, F530-F539},
+  year    = {2017},
+  volume  = {164},
+  pages   = {},
+  url     = {http://jes.ecsdl.org/content/164/6/F530.short},
+  doi     = {}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1,17 +1,456 @@
 % Encoding: US-ASCII
 
-@Article{jodlbauer.langer.ea:parallel,
-  doi     = {10.1002/nme.5970},
-  url     = {https://doi.org/10.1002/nme.5970},
+@Article{aagesen.adams.ea:prisms,
+  author  = {L. K. Aagesen and J. F. Adams and J. E. Allison and W. B. Andrews and V. Araullo-Peters and T. Berman and Z. Chen and S. Daly and S. Das and S. DeWitt and S. Ganesan and K. Garikipati and V. Gavini and A. Githens and M. Hedstrom and Z. Huang and H. V. Jagadish and J. W. Jones and J. Luce and E. A. Marquis and A. Misra and D. Montiel and P. Motamarri and A. D. Murphy and A. R. Natarajan and S. Panwar and B. Puchala and L. Qi and S. Rudraraju and K. Sagiyama and E. L. S. Solomon and V. Sundararaghavan and G. Tarcea and G. H. Teichert and J. C. Thomas and K. Thornton and A. Van der Ven and Z. Wang and T. Weymouth and C. Yang},
+  title   = {{PRISMS}: {A}n Integrated, Open-Source Framework for Accelerating Predictive Structural Materials Science},
+  journal = {The Journal of The Minderals, Metals \& Materials Society (JOM)},
+  year    = 2018,
+  volume  = 70,
+  pages   = {2298--2314},
+  doi     = {10.1007/s11837-018-3079-6}
+}
+
+@PhDThesis{aggul:high,
+  author  = {Aggul, Mustafa},
+  title   = {High Accuracy Methods and Regularization Techniques for Fluid Flows and Fluid-Fluid interactions},
+  url     = {https://digitalcommons.mtu.edu/etdr/642/},
+  publisher = {Michigan Tech},
+  year    = {2018}
+}
+
+@Article{alhazmi:exploring,
+  doi     = {10.14569/ijacsa.2019.0100372},
+  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
+  year    = {2019},
+  publisher = {The Science and Information Organization},
+  volume  = {10},
+  number  = {3},
+  author  = {Muflih Alhazmi},
+  title   = {Exploring Mechanisms for Pattern Formation through Coupled Bulk-Surface {PDEs} in Case of Non-linear Reactions},
+  journal = {International Journal of Advanced Computer Science and Applications}
+}
+
+@PhDThesis{alhazmi:exploring-mechanisms-for-pattern-formation-through-coupled-bulk-surface-pdes,
+  author  = {Alhazmi, M.},
+  title   = {{Exploring mechanisms for pattern formation through coupled bulk-surface PDEs}},
+  year    = {2018},
+  url     = {http://sro.sussex.ac.uk/id/eprint/78232/},
+  school  = {University of Sussex}
+}
+
+@Article{alzetta.arndt.ea:deal-ii,
+  title   = {The \texttt{deal.II} Library, Version 9.0},
+  author  = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
+  journal = {Journal of Numerical Mathematics},
+  year    = {2018},
+  volume  = {26},
+  number  = {4},
+  pages   = {173--183},
+  doi     = {10.1515/jnma-2018-0054}
+}
+
+@Article{araujo-cabarcas.engstrom.ea:efficient,
+  author  = {J. C. Araujo-Cabarcas and C. Engstr\"{o}m and E. Jarlebring},
+  title   = {Efficient resonance computations for Helmholtz problems based on a Dirichlet-to-Neumann map},
+  journal = {Journal of Computational and Applied Mathematics},
+  year    = {2018},
+  volume  = {330},
+  pages   = {177--192},
+  url     = {},
+  doi     = {}
+}
+
+@Misc{arbogast.tao:direct,
+  title   = {Direct Serendipity and Mixed Finite Elements on Convex Quadrilaterals},
+  author  = {Todd Arbogast and Zhen Tao},
+  year    = {2018},
+  eprint  = {1809.02192},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{arndt.kanschat:a-c1-mapping-based-on-finite-elements-on-quadrilateral-and-hexahedral-meshes,
+  author  = {Arndt, Daniel and Kanschat, Guido},
+  title   = {{A C1-mapping based on finite elements on quadrilateral and hexahedral meshes}},
+  journal = {arxiv: 1810.02473},
+  year    = {2018},
+  month   = {oct},
+  url     = {https://arxiv.org/abs/1810.02473}
+}
+
+@Misc{arndt.kanschat:c1-mapping,
+  title   = {A C1-mapping based on finite elements on quadrilateral and hexahedral meshes},
+  author  = {Daniel Arndt and Guido Kanschat},
+  year    = {2018},
+  eprint  = {1810.02473},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{axelsson.neytcheva.ea:efficient,
+  doi     = {10.1515/jnma-2017-0047},
+  url     = {https://doi.org/10.1515/jnma-2017-0047},
+  year    = {2018},
+  month   = dec,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {26},
+  number  = {4},
+  pages   = {185--207},
+  author  = {Owe Axelsson and Maya Neytcheva and Anders Str\"{o}m},
+  title   = {An efficient preconditioning method for state box-constrained optimal control problems},
+  journal = {Journal of Numerical Mathematics}
+}
+
+@InCollection{babaei.levitas:phase,
+  doi     = {10.1007/978-3-319-76968-4_26},
+  url     = {https://doi.org/10.1007/978-3-319-76968-4_26},
+  year    = {2018},
+  publisher = {Springer International Publishing},
+  pages   = {167--170},
+  author  = {H. Babaei and V. I. Levitas},
+  title   = {Phase Field Study of Lattice Instability and Nanostructure Evolution in Silicon During Phase Transformation Under Complex Loading},
+  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
+}
+
+@Article{babaei.levitas:phase-field,
+  doi     = {10.1016/j.ijplas.2018.04.006},
+  url     = {https://doi.org/10.1016/j.ijplas.2018.04.006},
+  year    = {2018},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {107},
+  pages   = {223--245},
+  author  = {Hamed Babaei and Valery I. Levitas},
+  title   = {Phase-field approach for stress- and temperature-induced phase transformations that satisfies lattice instability conditions. Part 2. simulations of phase transformations Si I$\leftrightarrow$ Si {II}},
+  journal = {International Journal of Plasticity}
+}
+
+@Misc{badia.martin.ea:fempar,
+  title   = {FEMPAR: An object-oriented parallel finite element framework},
+  author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
+  year    = {2017},
+  eprint  = {1708.01773},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.CE}
+}
+
+@Article{badnava.msekh.ea:h-adaptive,
+  title   = {An h-adaptive thermo-mechanical phase field model for fracture},
+  journal = {Finite Elements in Analysis and Design},
+  volume  = {138},
+  pages   = {31 - 47},
+  year    = {2018},
+  issn    = {0168-874X},
+  doi     = {https://doi.org/10.1016/j.finel.2017.09.003},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0168874X17303347},
+  author  = {Hojjat Badnava and Mohammed A. Msekh and Elahe Etemadi and Timon Rabczuk}
+}
+
+@InCollection{basak.levitas:nanoscale,
+  doi     = {10.1007/978-3-319-76968-4_25},
+  url     = {https://doi.org/10.1007/978-3-319-76968-4_25},
+  year    = {2018},
+  publisher = {Springer International Publishing},
+  pages   = {161--165},
+  author  = {Anup Basak and Valery I. Levitas},
+  title   = {Nanoscale Phase Field Modeling and Simulations of Martensitic Phase Transformations and Twinning at Finite Strains},
+  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
+}
+
+@Article{basak.levitas:nanoscale*1,
+  doi     = {10.1016/j.jmps.2018.01.014},
+  url     = {https://doi.org/10.1016/j.jmps.2018.01.014},
+  year    = {2018},
+  month   = apr,
+  publisher = {Elsevier {BV}},
+  volume  = {113},
+  pages   = {162--196},
+  author  = {Anup Basak and Valery I. Levitas},
+  title   = {Nanoscale multiphase phase field approach for stress- and temperature-induced martensitic phase transformations with interfacial stresses at finite strains},
+  journal = {Journal of the Mechanics and Physics of Solids}
+}
+
+@Article{basak.levitas:phase,
+  author  = {A. Basak and V. I. Levitas},
+  title   = {Phase field study of surface-induced melting and solidification from a nanovoid: Effect of dimensionless width of void surface and void size},
+  journal = {Applied Physics Letters, article 201602},
+  year    = {2018},
+  volume  = {112},
+  pages   = {},
+  url     = {https://doi.org/10.1063/1.5029911},
+  doi     = {}
+}
+
+@Article{bause.kocher.ea:post-processed,
+  author  = {M. Bause and U. K\"{o}cher and F. A. Radu and F. Schieweck},
+  title   = {Post-processed Galerkin approximation of improved order for wave equations},
+  journal = {},
+  note    = {Submitted},
+  year    = {2018},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{beams.klockner.ea:high-order,
+  doi     = {10.1016/j.jcp.2018.08.032},
+  url     = {https://doi.org/10.1016/j.jcp.2018.08.032},
+  year    = {2018},
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {375},
+  pages   = {1295--1313},
+  author  = {Natalie N. Beams and Andreas Kl\"{o}ckner and Luke N. Olson},
+  title   = {High-order finite element--integral equation coupling on embedded meshes},
+  journal = {Journal of Computational Physics}
+}
+
+@InBook{boffi.gastaldi.ea:distributed,
+  author  = {Boffi, Daniele and Gastaldi, Lucia and Heltai, Luca},
+  editor  = {Boffi, Daniele and Pavarino, Luca F. and Rozza, Gianluigi and Scacchi, Simone and Vergara, Christian},
+  title   = {A Distributed Lagrange Formulation of the Finite Element Immersed Boundary Method for Fluids Interacting with Compressible Solids},
+  booktitle = {Mathematical and Numerical Modeling of the Cardiovascular System and Applications},
+  year    = {2018},
+  publisher = {Springer International Publishing},
+  address = {Cham},
+  pages   = {1--21},
+  doi     = {10.1007/978-3-319-96649-6}
+}
+
+@Article{bonito.borthagaray.ea:numerical,
+  title   = {Numerical methods for fractional diffusion},
+  volume  = {19},
+  issn    = {1433-0369},
+  url     = {http://dx.doi.org/10.1007/s00791-018-0289-y},
+  doi     = {10.1007/s00791-018-0289-y},
+  number  = {5-6},
+  journal = {Computing and Visualization in Science},
+  publisher = {Springer Science and Business Media LLC},
+  author  = {Bonito, Andrea and Borthagaray, Juan Pablo and Nochetto, Ricardo H. and Ot{\'a}rola, Enrique and Salgado, Abner J.},
+  year    = {2018},
+  month   = {Mar},
+  pages   = {19--46}
+}
+
+@Article{bonito.demlow.ea:priori,
+  doi     = {10.1137/17m1163311},
+  url     = {https://doi.org/10.1137/17m1163311},
+  year    = {2018},
+  month   = jan,
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {56},
+  number  = {5},
+  pages   = {2963--2988},
+  author  = {Andrea Bonito and Alan Demlow and Justin Owen},
+  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace--Beltrami Operator},
+  journal = {{SIAM} Journal on Numerical Analysis}
+}
+
+@Misc{bonito.girault.ea:finite,
+  title   = {Finite Element Approximation of a Strain-Limiting Elastic Model},
+  author  = {Andrea Bonito and Vivette Girault and Endre Suli},
+  year    = {2018},
+  eprint  = {1805.04006},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Misc{bonito.lei.ea:finite,
+  title   = {Finite element approximation of an obstacle problem for a class of integro-differential operators},
+  author  = {Andrea Bonito and Wenyu Lei and Abner J. Salgado},
+  year    = {2018},
+  eprint  = {1808.01576},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{borregales.radu.ea:robust,
+  author  = {Manuel Borregales and Florin Adrian Radu and Kundan Kumar and Jan Martin Nordbotten},
+  title   = {Robust iterative schemes for non-linear poromechanics},
+  journal = {Computational Geosciences},
+  year    = {2018},
+  volume  = {22},
+  number  = {4},
+  pages   = {1021-1038},
+  doi     = {10.1007/s10596-018-9736-6},
+  url     = {http://hdl.handle.net/1956/22101}
+}
+
+@Article{brauss.meir:on,
+  author  = {K. D. Brauss and A. J. Meir},
+  title   = {On a parallel, 3-dimensional, finite element solver for viscous, resistive, stationary magnetohydrodynamics equations: {V}elocity-current formulation},
+  journal = {Applied Numerical Mathematics},
+  year    = {2018},
+  volume  = {},
+  pages   = {},
+  url     = {https://doi.org/10.1016/j.apnum.2018.01.014},
+  doi     = {},
+  note    = {In press}
+}
+
+@Article{brauss.meir:on*1,
+  doi     = {10.1016/j.apnum.2018.01.014},
+  url     = {https://doi.org/10.1016/j.apnum.2018.01.014},
+  year    = {2018},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {133},
+  pages   = {130--143},
+  author  = {K.D. Brauss and A.J. Meir},
+  title   = {On a parallel, 3-dimensional, finite element solver for viscous, resistive, stationary magnetohydrodynamics equations: Velocity--current formulation},
+  journal = {Applied Numerical Mathematics}
+}
+
+@Article{bredow.steinberger:variable,
+  doi     = {10.1002/2017gl075822},
+  url     = {https://doi.org/10.1002/2017gl075822},
+  year    = {2018},
+  month   = jan,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {45},
+  number  = {1},
+  pages   = {126--136},
+  author  = {Eva Bredow and Bernhard Steinberger},
+  title   = {Variable Melt Production Rate of the {K}erguelen {HotSpot} Due To Long-Term Plume-Ridge Interaction},
+  journal = {Geophysical Research Letters}
+}
+
+@Article{bruchhauser.schwegler.ea:dual,
+  title   = {Dual weighted residual based error control for nonstationary convection-dominated equations: potential or ballast?},
+  author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
+  journal = {arXiv:1812.06810},
+  year    = 2018,
+  url     = {https://arxiv.org/abs/1812.06810}
+}
+
+@Misc{bruchhauser.schwegler.ea:numerical,
+  title   = {Numerical study of goal-oriented error control for stabilized finite element methods},
+  author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
+  year    = {2018},
+  eprint  = {1803.10643},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{bruna-rosso.demir.ea:global,
+  author  = {Claire Bruna-Rosso and Ali G\"{o}khan Demir and Maurizio Vedani and Barbara Previtali},
+  title   = {Global sensitivity analyses of a selective laser melting finite element model: influential parameters identification},
+  journal = {The International Journal of Advanced Manufacturing Technology},
+  year    = {2018},
+  volume  = {99},
+  number  = {1-4},
+  pages   = {833--843},
+  month   = {aug},
+  doi     = {10.1007/s00170-018-2531-7},
+  publisher = {Springer Nature America, Inc}
+}
+
+@Article{bruna-rosso.demir.ea:selective,
+  author  = {Claire Bruna-Rosso and Ali G\"{o}khan Demir and Barbara Previtali},
+  title   = {Selective laser melting finite element modeling: Validation with high-speed imaging and lack of fusion defects prediction},
+  journal = {Materials {\&} Design},
+  year    = {2018},
+  volume  = {156},
+  pages   = {143--153},
+  month   = {oct},
+  doi     = {10.1016/j.matdes.2018.06.037},
+  publisher = {Elsevier {BV}}
+}
+
+@Article{bryant.sun:mixed-mode,
+  author  = {Eric C. Bryant and WaiChing Sun},
+  title   = {A mixed-mode phase field fracture model in anisotropic rocks with consistent kinematics},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2018},
+  volume  = {342},
+  pages   = {561--584},
+  month   = dec,
+  doi     = {10.1016/j.cma.2018.08.008},
+  publisher = {Elsevier {BV}}
+}
+
+@Article{bunger.richter.ea:deterministic,
+  doi     = {10.1088/1757-899x/304/1/012004},
+  url     = {https://doi.org/10.1088/1757-899x/304/1/012004},
+  year    = {2018},
+  month   = jan,
+  publisher = {{IOP} Publishing},
+  volume  = {304},
+  pages   = {012004},
+  author  = {J B\"{u}nger and S Richter and M Torrilhon},
+  title   = {A deterministic model of electron transport for electron probe microanalysis},
+  journal = {{IOP} Conference Series: Materials Science and Engineering}
+}
+
+@Misc{burstedde:parallel,
+  title   = {Parallel tree algorithms for AMR and non-standard data access},
+  author  = {Carsten Burstedde},
+  year    = {2018},
+  eprint  = {1803.08432},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.DC}
+}
+
+@Article{bzowski.rauch.ea:application,
+  title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
+  journal = {Procedia Manufacturing},
+  volume  = {15},
+  pages   = {1847--1855},
+  year    = {2018},
+  note    = {Proceedings of the 17th International Conference on Metal Forming METAL FORMING 2018 September 16 -- 19, 2018, Loisir Hotel Toyohashi, Toyohashi, Japan},
+  doi     = {https://doi.org/10.1016/j.promfg.2018.07.205},
+  url     = {http://www.sciencedirect.com/science/article/pii/S2351978918308977},
+  author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk}
+}
+
+@MastersThesis{c--a--h--blom:state-of-the-art-numerical-subduction-modelling-with-aspect--thermo-mechanically-coupled-viscoplastic-compressible-rheology--free-surface--phase-changes--latent-heat-and-open-sidewalls,
+  author  = {{C. A. H. Blom}},
+  school  = {Utrecht University},
+  title   = {{State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls}},
+  url     = {https://dspace.library.uu.nl/handle/1874/348133},
+  year    = {2016}
+}
+
+@Article{caen.schutz.ea:high-throughput,
+  doi     = {10.1038/s41378-018-0033-2},
+  url     = {https://doi.org/10.1038/s41378-018-0033-2},
   year    = {2018},
   month   = oct,
-  publisher = {Wiley},
-  volume  = {117},
-  number  = {6},
-  pages   = {623--643},
-  author  = {D. Jodlbauer and U. Langer and T. Wick},
-  title   = {Parallel block-preconditioned monolithic solvers for fluid-structure interaction problems},
-  journal = {International Journal for Numerical Methods in Engineering}
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {4},
+  number  = {1},
+  author  = {Ouriel Caen and Simon Sch\"{u}tz and M. S. Suryateja Jammalamadaka and J{\'{e}}r{\'{e}}my Vrignon and Philippe Nizard and Tobias M. Schneider and Jean-Christophe Baret and Val{\'{e}}rie Taly},
+  title   = {High-throughput multiplexed fluorescence-activated droplet sorting},
+  journal = {Microsystems {\&} Nanoengineering}
+}
+
+@Article{cangiani.georgoulis.ea:adaptive,
+  doi     = {10.1090/mcom/3322},
+  url     = {https://doi.org/10.1090/mcom/3322},
+  year    = {2018},
+  month   = feb,
+  publisher = {American Mathematical Society ({AMS})},
+  volume  = {87},
+  number  = {314},
+  pages   = {2675--2707},
+  author  = {Andrea Cangiani and Emmanuil H. Georgoulis and Younis A. Sabawi},
+  title   = {Adaptive discontinuous Galerkin methods for elliptic interface problems},
+  journal = {Mathematics of Computation}
+}
+
+@Article{cangiani.georgoulis.ea:revealing,
+  doi     = {10.1098/rspa.2017.0608},
+  url     = {https://doi.org/10.1098/rspa.2017.0608},
+  year    = {2018},
+  month   = may,
+  publisher = {The Royal Society},
+  volume  = {474},
+  number  = {2213},
+  pages   = {20170608},
+  author  = {A. Cangiani and E. H. Georgoulis and A. Yu. Morozov and O. J. Sutton},
+  title   = {Revealing new dynamical patterns in a reaction-diffusion model with cyclic competition via a novel computational framework},
+  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
 }
 
 @Article{carraro.dorsam.ea:adaptive,
@@ -41,232 +480,74 @@
   journal = {Nonlinear Analysis: Real World Applications}
 }
 
-@Article{veske.kyritsakis.ea:dynamic,
-  doi     = {10.1016/j.jcp.2018.04.031},
-  url     = {https://doi.org/10.1016/j.jcp.2018.04.031},
+@Misc{carraro.wetterauer.ea:level-set,
+  title   = {A level-set approach for a multi-scale cancer invasion model},
+  author  = {Thomas Carraro and Sven E. Wetterauer and Ana Victoria Ponce Bobadilla and Dumitru Trucu},
   year    = {2018},
-  month   = aug,
+  eprint  = {1805.07485},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{carreno.vidal-ferrandiz.ea:block,
+  doi     = {10.1016/j.anucene.2018.08.010},
+  url     = {https://doi.org/10.1016/j.anucene.2018.08.010},
+  year    = {2018},
+  month   = nov,
   publisher = {Elsevier {BV}},
-  volume  = {367},
-  pages   = {279--294},
-  author  = {Mihkel Veske and Andreas Kyritsakis and Kristjan Eimre and Vahur Zadin and Alvo Aabloo and Flyura Djurabekova},
-  title   = {Dynamic coupling of a finite element solver to large-scale atomistic simulations},
-  journal = {Journal of Computational Physics}
+  volume  = {121},
+  pages   = {513--524},
+  author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
+  title   = {Block hybrid multilevel method to compute the dominant $\lambda$-modes of the neutron diffusion equation},
+  journal = {Annals of Nuclear Energy}
 }
 
-@Article{bzowski.rauch.ea:application,
-  title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
-  journal = {Procedia Manufacturing},
-  volume  = {15},
-  pages   = {1847--1855},
+@InCollection{carreno.vidal-ferrandiz.ea:solution,
+  doi     = {10.1007/978-3-319-93701-4_67},
+  url     = {https://doi.org/10.1007/978-3-319-93701-4_67},
   year    = {2018},
-  note    = {Proceedings of the 17th International Conference on Metal Forming METAL FORMING 2018 September 16 -- 19, 2018, Loisir Hotel Toyohashi, Toyohashi, Japan},
-  doi     = {https://doi.org/10.1016/j.promfg.2018.07.205},
-  url     = {http://www.sciencedirect.com/science/article/pii/S2351978918308977},
-  author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk}
+  publisher = {Springer International Publishing},
+  pages   = {846--855},
+  author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
+  title   = {The Solution of the Lambda Modes Problem Using Block Iterative Eigensolvers},
+  booktitle = {Lecture Notes in Computer Science}
 }
 
-@Article{bonito.borthagaray.ea:numerical,
-  title   = {Numerical methods for fractional diffusion},
-  volume  = {19},
-  issn    = {1433-0369},
-  url     = {http://dx.doi.org/10.1007/s00791-018-0289-y},
-  doi     = {10.1007/s00791-018-0289-y},
-  number  = {5-6},
-  journal = {Computing and Visualization in Science},
-  publisher = {Springer Science and Business Media LLC},
-  author  = {Bonito, Andrea and Borthagaray, Juan Pablo and Nochetto, Ricardo H. and Ot{\'a}rola, Enrique and Salgado, Abner J.},
+@InProceedings{castelletto.ferronato.ea:fully-implicit,
+  doi     = {10.3997/2214-4609.201802132},
+  url     = {https://doi.org/10.3997/2214-4609.201802132},
   year    = {2018},
-  month   = {Mar},
-  pages   = {19--46}
+  month   = sep,
+  publisher = {{EAGE} Publications {BV}},
+  author  = {N. Castelletto and M. Ferronato and A. Franceschini and R.R. Settgast and J.A. White},
+  title   = {Fully-Implicit Solvers For Coupled Poromechanics Of Fractured Reservoirs},
+  booktitle = {{ECMOR} {XVI} - 16th European Conference on the Mathematics of Oil Recovery}
 }
 
-@Article{dorschner.chikatamarla.ea:fluid-structure,
-  doi     = {10.1103/physreve.97.023305},
-  url     = {https://doi.org/10.1103/physreve.97.023305},
+@InProceedings{chandrashekar.gallego-valencia.ea:a-runge-kutta-discontinuous-galerkin-scheme-for-the-ideal-magnetohydrodynamical-model,
+  author  = {Chandrashekar, Praveen and Gallego-Valencia, Juan Pablo and Klingenberg, Christian},
+  title   = {{A Runge-Kutta Discontinuous Galerkin Scheme for the Ideal Magnetohydrodynamical Model}},
+  booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
   year    = {2018},
-  month   = feb,
-  publisher = {American Physical Society ({APS})},
-  volume  = {97},
-  number  = {2},
-  author  = {B. Dorschner and S. S. Chikatamarla and I. V. Karlin},
-  title   = {Fluid-structure interaction with the entropic lattice Boltzmann method},
-  journal = {Physical Review E}
+  volume  = {236},
+  series  = {Springer Proceedings in Mathematics \& Statistics},
+  pages   = {335--344},
+  publisher = {Springer International Publishing},
+  doi     = {10.1007/978-3-319-91545-6_27},
+  journal = {Springer},
+  url     = {https://www.researchgate.net/profile/Christian_Klingenberg/publication/325949144_A_Runge-Kutta_Discontinuous_Galerkin_Scheme_for_the_Ideal_Magnetohydrodynamical_Model/links/5b640dafa6fdcc45b30cab8c/A-Runge-Kutta-Discontinuous-Galerkin-Scheme-for-the-Ideal-Magnetohydrodynamical-Model.pdf?origin=publication_detail}
 }
 
-@Article{alzetta.arndt.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.0},
-  author  = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
-  journal = {Journal of Numerical Mathematics},
+@Article{chandrashekar:global,
+  author  = {Praveen Chandrashekar},
+  title   = {A global divergence conforming {DG} method for hyperbolic conservation laws with divergence constraint},
+  journal = {Journal of Scientific Computing},
   year    = {2018},
-  volume  = {26},
-  number  = {4},
-  pages   = {173--183},
-  doi     = {10.1515/jnma-2018-0054}
-}
-
-@Article{araujo-cabarcas.engstrom.ea:efficient,
-  author  = {J. C. Araujo-Cabarcas and C. Engstr\"{o}m and E. Jarlebring},
-  title   = {Efficient resonance computations for Helmholtz problems based on a Dirichlet-to-Neumann map},
-  journal = {Journal of Computational and Applied Mathematics},
-  year    = {2018},
-  volume  = {330},
-  pages   = {177--192},
-  url     = {},
-  doi     = {}
-}
-
-@Article{basak.levitas:phase,
-  author  = {A. Basak and V. I. Levitas},
-  title   = {Phase field study of surface-induced melting and solidification from a nanovoid: Effect of dimensionless width of void surface and void size},
-  journal = {Applied Physics Letters, article 201602},
-  year    = {2018},
-  volume  = {112},
-  pages   = {},
-  url     = {https://doi.org/10.1063/1.5029911},
-  doi     = {}
-}
-
-@Article{bause.kocher.ea:post-processed,
-  author  = {M. Bause and U. K\"{o}cher and F. A. Radu and F. Schieweck},
-  title   = {Post-processed Galerkin approximation of improved order for wave equations},
-  journal = {},
-  note    = {Submitted},
-  year    = {2018},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
-}
-
-@Article{bonito.demlow.ea:priori,
-  doi     = {10.1137/17m1163311},
-  url     = {https://doi.org/10.1137/17m1163311},
-  year    = {2018},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {56},
-  number  = {5},
-  pages   = {2963--2988},
-  author  = {Andrea Bonito and Alan Demlow and Justin Owen},
-  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace--Beltrami Operator},
-  journal = {{SIAM} Journal on Numerical Analysis}
-}
-
-@Article{dannberg.gassmoller:chemical,
-  author  = {Dannberg, Juliane and Gassm{\"{o}}ller, Rene},
-  journal = {Proceedings of the National Academy of Sciences},
-  number  = {17},
-  pages   = {4351--4356},
-  publisher = {National Acad Sciences},
-  title   = {Chemical trends in ocean islands explained by plume-slab interaction},
-  volume  = {115},
-  year    = {2018},
-  doi     = {10.1073/pnas.1714125115}
-}
-
-@MastersThesis{ellowitz:dynamics-of-magma-recharge-and-mixing-at-mount-hood-volcano--oregon--insights-from-enclave-bearing-lavas,
-  author  = {Ellowitz, Molly},
-  doi     = {10.15760/etd.6429},
-  school  = {Portland State University},
-  title   = {{Dynamics of Magma Recharge and Mixing at Mount Hood Volcano, Oregon -- Insights from Enclave-bearing Lavas}},
-  type    = {Master Thesis},
-  url     = {https://archives.pdx.edu/ds/psu/26513},
-  year    = {2018}
-}
-
-@Article{puckett.turcotte.ea:new,
-  doi     = {10.1016/j.pepi.2017.10.004},
-  url     = {https://doi.org/10.1016/j.pepi.2017.10.004},
-  year    = {2018},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {276},
-  pages   = {10--35},
-  author  = {Elbridge Gerry Puckett and Donald L. Turcotte and Ying He and Harsha Lokavarapu and Jonathan M. Robey and Louise H. Kellogg},
-  title   = {New numerical approaches for modeling thermochemical convection in a compositionally stratified fluid},
-  journal = {Physics of the Earth and Planetary Interiors}
-}
-
-@Article{brauss.meir:on,
-  author  = {K. D. Brauss and A. J. Meir},
-  title   = {On a parallel, 3-dimensional, finite element solver for viscous, resistive, stationary magnetohydrodynamics equations: {V}elocity-current formulation},
-  journal = {Applied Numerical Mathematics},
-  year    = {2018},
-  volume  = {},
-  pages   = {},
-  url     = {https://doi.org/10.1016/j.apnum.2018.01.014},
-  doi     = {},
-  note    = {In press}
-}
-
-@Article{axelsson.neytcheva.ea:efficient,
-  doi     = {10.1515/jnma-2017-0047},
-  url     = {https://doi.org/10.1515/jnma-2017-0047},
-  year    = {2018},
-  month   = dec,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {26},
-  number  = {4},
-  pages   = {185--207},
-  author  = {Owe Axelsson and Maya Neytcheva and Anders Str\"{o}m},
-  title   = {An efficient preconditioning method for state box-constrained optimal control problems},
-  journal = {Journal of Numerical Mathematics}
-}
-
-@Article{bredow.steinberger:variable,
-  doi     = {10.1002/2017gl075822},
-  url     = {https://doi.org/10.1002/2017gl075822},
-  year    = {2018},
-  month   = jan,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {45},
-  number  = {1},
-  pages   = {126--136},
-  author  = {Eva Bredow and Bernhard Steinberger},
-  title   = {Variable Melt Production Rate of the {K}erguelen {HotSpot} Due To Long-Term Plume-Ridge Interaction},
-  journal = {Geophysical Research Letters}
-}
-
-@Article{lee.mikelic.ea:phase-field,
-  doi     = {10.1137/17m1145239},
-  url     = {https://doi.org/10.1137/17m1145239},
-  year    = {2018},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {16},
-  number  = {4},
-  pages   = {1542--1580},
-  author  = {Sanghyun Lee and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
-  title   = {Phase-Field Modeling of Two Phase Fluid Filled Fractures in a Poroelastic Medium},
-  journal = {Multiscale Modeling {\&} Simulation}
-}
-
-@Article{lee.min.ea:optimal,
-  doi     = {10.1007/s10596-018-9728-6},
-  url     = {https://doi.org/10.1007/s10596-018-9728-6},
-  year    = {2018},
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {22},
-  number  = {3},
-  pages   = {833--849},
-  author  = {Sanghyun Lee and Baehyun Min and Mary F. Wheeler},
-  title   = {Optimal design of hydraulic fracturing in porous media using the phase field fracture model coupled with genetic algorithm},
-  journal = {Computational Geosciences}
-}
-
-@Article{lee.wheeler:enriched,
-  doi     = {10.1016/j.jcp.2018.03.031},
-  url     = {https://doi.org/10.1016/j.jcp.2018.03.031},
-  year    = {2018},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {367},
-  pages   = {65--86},
-  author  = {Sanghyun Lee and Mary F. Wheeler},
-  title   = {Enriched Galerkin methods for two-phase flow in porous media with capillary pressure},
-  journal = {Journal of Computational Physics}
+  pages   = {1--24},
+  month   = {sep},
+  doi     = {10.1007/s10915-018-0841-4},
+  publisher = {Springer Nature America, Inc},
+  url     = {https://rdcu.be/725Z}
 }
 
 @Article{chang.fabien.ea:comparative,
@@ -281,6 +562,155 @@
   author  = {Justin Chang and Maurice S. Fabien and Matthew G. Knepley and Richard T. Mills},
   title   = {Comparative Study of Finite Element Methods Using the Time-Accuracy-Size({TAS}) Spectrum Analysis},
   journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@Article{charnyi.heister.ea:efficient,
+  author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
+  title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier-Stokes equations},
+  journal = {Applied Numerical Mathematics},
+  year    = {2018},
+  doi     = {10.1016/j.apnum.2018.11.013},
+  url     = {https://arxiv.org/abs/1712.00857},
+  note    = {in press}
+}
+
+@PhDThesis{charnyi:emac,
+  title   = {The {EMAC} scheme for Navier-Stokes simulations, and application to flow past bluff bodies},
+  author  = {Sergey Charnyi},
+  school  = {Clemson University},
+  year    = {2018},
+  url     = {https://tigerprints.clemson.edu/all_dissertations/2243/}
+}
+
+@Article{cheng.yue.ea:analysis,
+  doi     = {10.1016/j.jcp.2018.02.031},
+  url     = {https://doi.org/10.1016/j.jcp.2018.02.031},
+  year    = {2018},
+  month   = jun,
+  publisher = {Elsevier {BV}},
+  volume  = {362},
+  pages   = {305--326},
+  author  = {Jian Cheng and Huiqiang Yue and Shengjiao Yu and Tiegang Liu},
+  title   = {Analysis and development of adjoint-based h-adaptive direct discontinuous Galerkin method for the compressible Navier--Stokes equations},
+  journal = {Journal of Computational Physics}
+}
+
+@Article{cheng:direct,
+  doi     = {10.4208/aamm.oa-2017-0060},
+  url     = {https://doi.org/10.4208/aamm.oa-2017-0060},
+  year    = {2018},
+  month   = jun,
+  publisher = {Global Science Press},
+  volume  = {10},
+  number  = {1},
+  pages   = {1--21},
+  author  = {Jian Cheng},
+  title   = {A Direct Discontinuous Galerkin Method with Interface Correction for the Compressible Navier-Stokes Equations on Unstructured Grids},
+  journal = {Advances in Applied Mathematics and Mechanics}
+}
+
+@InCollection{choo.lee:enriched,
+  doi     = {10.1007/978-3-319-97112-4_69},
+  url     = {https://doi.org/10.1007/978-3-319-97112-4_69},
+  year    = {2018},
+  publisher = {Springer International Publishing},
+  pages   = {312--315},
+  author  = {Jinhyun Choo and Sanghyun Lee},
+  title   = {Enriched Galerkin Finite Element Method for Locally Mass Conservative Simulation of Coupled Hydromechanical Problems},
+  booktitle = {Springer Series in Geomechanics and Geoengineering}
+}
+
+@Article{choo.lee:enriched*1,
+  doi     = {10.1016/j.cma.2018.06.022},
+  url     = {https://doi.org/10.1016/j.cma.2018.06.022},
+  year    = {2018},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {341},
+  pages   = {311--332},
+  author  = {Jinhyun Choo and Sanghyun Lee},
+  title   = {Enriched Galerkin finite elements for coupled poromechanics with local mass conservation},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{choo.sun:coupled,
+  doi     = {10.1016/j.cma.2017.10.009},
+  url     = {https://doi.org/10.1016/j.cma.2017.10.009},
+  year    = {2018},
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {330},
+  pages   = {1--32},
+  author  = {Jinhyun Choo and Waiching Sun},
+  title   = {Coupled phase-field and plasticity modeling of geological materials: From brittle fracture to ductile flow},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{choo.sun:cracking,
+  doi     = {10.1016/j.cma.2018.01.044},
+  url     = {https://doi.org/10.1016/j.cma.2018.01.044},
+  year    = {2018},
+  month   = jun,
+  publisher = {Elsevier {BV}},
+  volume  = {335},
+  pages   = {347--379},
+  author  = {Jinhyun Choo and WaiChing Sun},
+  title   = {Cracking and damage from crystallization in pores: Coupled chemo-hydro-mechanics and phase-field modeling},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{choo:large,
+  doi     = {10.1002/nme.5915},
+  url     = {https://doi.org/10.1002/nme.5915},
+  year    = {2018},
+  month   = aug,
+  publisher = {Wiley},
+  volume  = {116},
+  number  = {1},
+  pages   = {66--90},
+  author  = {Jinhyun Choo},
+  title   = {Large deformation poromechanics with local mass conservation: An enriched Galerkin finite element framework},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@MastersThesis{cinatl:finite,
+  title   = {Finite Element Discretizations for Linear Elasticity},
+  author  = {Emma Cinatl},
+  school  = {Clemson University},
+  year    = {2018},
+  url     = {https://tigerprints.clemson.edu/all_theses/2977/}
+}
+
+@InCollection{dang.do.ea:fractured,
+  doi     = {10.1007/978-981-13-2306-5_15},
+  url     = {https://doi.org/10.1007/978-981-13-2306-5_15},
+  year    = {2018},
+  month   = sep,
+  publisher = {Springer Singapore},
+  pages   = {123--129},
+  author  = {Hong-Lam Dang and Duc-Phi Do and Dashnor Hoxha},
+  title   = {Fractured Reservoirs Modeling by Embedded Fracture Continuum Approach: Field-Scale Applications},
+  booktitle = {Lecture Notes in Civil Engineering}
+}
+
+@PhDThesis{dang:hydro-mechanical,
+  author  = {Hong Lam Dang},
+  title   = {A hydro-mechanical modeling of double porosity and double permeability fractured reservoirs},
+  school  = {Universit\'{e} D'Orl\'{e}ans},
+  year    = {2018},
+  url     = {ftp://ftp.univ-orleans.fr/theses/honglam-dang_3747.pdf}
+}
+
+@Article{dannberg.gassmoller:chemical,
+  author  = {Dannberg, Juliane and Gassm{\"{o}}ller, Rene},
+  journal = {Proceedings of the National Academy of Sciences},
+  number  = {17},
+  pages   = {4351--4356},
+  publisher = {National Acad Sciences},
+  title   = {Chemical trends in ocean islands explained by plume-slab interaction},
+  volume  = {115},
+  year    = {2018},
+  doi     = {10.1073/pnas.1714125115}
 }
 
 @Article{davydov.heister.ea:matrix-free,
@@ -306,15 +736,30 @@
   doi     = {}
 }
 
-@Article{ilio.dorschner.ea:simulation,
-  author  = {G. Di Ilio and B. Dorschner and G. Bella and S. Succi and I. V. Karlin},
-  title   = {Simulation of turbulent flows with the entropic multi-relaxation time lattice Boltzmann method on body-fitted meshes},
-  journal = {Journal of Fluid Mechanics},
+@InProceedings{deolmi.dahmen.ea:effective-boundary-conditions-for-turbulent-compressible-flows-over-a-riblet-surface,
+  author  = {Deolmi, G. and Dahmen, W. and M{\"{u}}ller, S. and Albers, M. and Meysonnat, P. S. and Schr{\"{o}}der, W.},
+  title   = {{Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface}},
+  booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
   year    = {2018},
-  volume  = {849},
-  pages   = {35--56},
-  url     = {https://www.researchgate.net/publication/325069808_Simulation_of_turbulent_flows_with_the_entropic_multi-relaxation_time_lattice_Boltzmann_method_on_body-fitted_meshes},
-  doi     = {10.1017/jfm.2018.413}
+  volume  = {236},
+  series  = {Springer Proceedings in Mathematics \& Statistics},
+  pages   = {473--485},
+  publisher = {Springer International Publishing},
+  doi     = {10.1007/978-3-319-91545-6_36},
+  journal = {Springer}
+}
+
+@Article{deolmi.muller:two-step,
+  doi     = {10.1016/j.matcom.2018.02.008},
+  url     = {https://doi.org/10.1016/j.matcom.2018.02.008},
+  year    = {2018},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {150},
+  pages   = {49--65},
+  author  = {G. Deolmi and S. M\"{u}ller},
+  title   = {A two-step model order reduction method to simulate a compressible flow over an extended rough surface},
+  journal = {Mathematics and Computers in Simulation}
 }
 
 @MastersThesis{dommaraju:partition,
@@ -323,6 +768,124 @@
   year    = {2018},
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
   url     = {}
+}
+
+@Article{dorschner.chikatamarla.ea:fluid-structure,
+  doi     = {10.1103/physreve.97.023305},
+  url     = {https://doi.org/10.1103/physreve.97.023305},
+  year    = {2018},
+  month   = feb,
+  publisher = {American Physical Society ({APS})},
+  volume  = {97},
+  number  = {2},
+  author  = {B. Dorschner and S. S. Chikatamarla and I. V. Karlin},
+  title   = {Fluid-structure interaction with the entropic lattice Boltzmann method},
+  journal = {Physical Review E}
+}
+
+@PhDThesis{dorschner:entropic,
+  doi     = {10.3929/ETHZ-B-000278644},
+  url     = {http://hdl.handle.net/20.500.11850/278644},
+  author  = {Dorschner, Benedikt},
+  title   = {Entropic Lattice Boltzmann Method for Complex Flows},
+  school  = {ETH Zurich},
+  year    = {2018}
+}
+
+@Article{duijn.mikelic.ea:monolithic,
+  doi     = {10.1177/1081286518801050},
+  url     = {https://doi.org/10.1177/1081286518801050},
+  year    = {2018},
+  month   = oct,
+  publisher = {{SAGE} Publications},
+  volume  = {24},
+  number  = {5},
+  pages   = {1530--1555},
+  author  = {CJ van Duijn and Andro Mikeli{\'{c}} and Thomas Wick},
+  title   = {A monolithic phase-field model of a fluid-driven fracture in a nonlinear poroelastic medium},
+  journal = {Mathematics and Mechanics of Solids}
+}
+
+@Article{dunkelberger.metaferia.ea:theoretical,
+  doi     = {10.1021/acs.jpcb.8b07638},
+  url     = {https://doi.org/10.1021/acs.jpcb.8b07638},
+  year    = {2018},
+  month   = sep,
+  publisher = {American Chemical Society ({ACS})},
+  volume  = {122},
+  number  = {49},
+  pages   = {11579--11590},
+  author  = {Emily B. Dunkelberger and Belhu Metaferia and Troy Cellmer and Eric R. Henry},
+  title   = {Theoretical Simulation of Red Cell Sickling Upon Deoxygenation Based on the Physical Chemistry of Sickle Hemoglobin Fiber Formation},
+  journal = {The Journal of Physical Chemistry B}
+}
+
+@Article{ellam:bayesian,
+  doi     = {10.25560/70367},
+  url     = {http://spiral.imperial.ac.uk/handle/10044/1/70367},
+  author  = {Ellam, Louis},
+  title   = {Bayesian approaches to modelling physical and socio-economic systems},
+  publisher = {Imperial College London},
+  year    = {2018},
+  copyright = {Creative Commons Attribution NonCommercial Licence}
+}
+
+@MastersThesis{ellowitz:dynamics-of-magma-recharge-and-mixing-at-mount-hood-volcano--oregon--insights-from-enclave-bearing-lavas,
+  author  = {Ellowitz, Molly},
+  doi     = {10.15760/etd.6429},
+  school  = {Portland State University},
+  title   = {{Dynamics of Magma Recharge and Mixing at Mount Hood Volcano, Oregon -- Insights from Enclave-bearing Lavas}},
+  type    = {Master Thesis},
+  url     = {https://archives.pdx.edu/ds/psu/26513},
+  year    = {2018}
+}
+
+@Article{emerson.farrell.ea:computing,
+  doi     = {10.1080/02678292.2017.1365385},
+  url     = {https://doi.org/10.1080/02678292.2017.1365385},
+  year    = {2017},
+  month   = aug,
+  publisher = {Informa {UK} Limited},
+  volume  = {45},
+  number  = {3},
+  pages   = {341--350},
+  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
+  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
+  journal = {Liquid Crystals}
+}
+
+@Misc{emerson:error,
+  title   = {Error Estimators and Marking Strategies for Electrically Coupled Liquid Crystal Systems},
+  author  = {D. B. Emerson},
+  year    = {2018},
+  eprint  = {1806.06248},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{endtmayer.langer.ea:multiple,
+  doi     = {10.1002/pamm.201800048},
+  url     = {https://doi.org/10.1002/pamm.201800048},
+  year    = {2018},
+  month   = dec,
+  publisher = {Wiley},
+  volume  = {18},
+  number  = {1},
+  author  = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
+  title   = {Multiple goal-oriented error estimates applied to 3d non-linear problems},
+  journal = {{PAMM}}
+}
+
+@InCollection{evgrafov:discontinuous,
+  doi     = {10.1007/978-3-319-97773-7_24},
+  url     = {https://doi.org/10.1007/978-3-319-97773-7_24},
+  year    = {2018},
+  month   = sep,
+  publisher = {Springer International Publishing},
+  pages   = {260--271},
+  author  = {Anton Evgrafov},
+  title   = {Discontinuous Petrov-Galerkin Methods for Topology Optimization},
+  booktitle = {{EngOpt} 2018 Proceedings of the 6th International Conference on Engineering Optimization}
 }
 
 @Article{failer.wick:adaptive,
@@ -334,6 +897,19 @@
   pages   = {448--477},
   url     = {https://www.sciencedirect.com/science/article/pii/S0021999118302377},
   doi     = {}
+}
+
+@Article{failer.wick:adaptive*1,
+  doi     = {10.1016/j.jcp.2018.04.021},
+  url     = {https://doi.org/10.1016/j.jcp.2018.04.021},
+  year    = {2018},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {366},
+  pages   = {448--477},
+  author  = {Lukas Failer and Thomas Wick},
+  title   = {Adaptive time-step control for nonlinear fluid--structure interaction},
+  journal = {Journal of Computational Physics}
 }
 
 @Article{fehn.wall.ea:efficiency,
@@ -361,6 +937,86 @@
   doi     = {10.1016/j.jcp.2018.06.037}
 }
 
+@PhDThesis{ferrandiz:development,
+  doi     = {10.4995/thesis/10251/98522},
+  url     = {https://doi.org/10.4995/thesis/10251/98522},
+  year    = {2018},
+  publisher = {Universitat Politecnica de Valencia},
+  author  = {Antoni Vidal Ferr{\`{a}}ndiz},
+  title   = {Development of a finite element method for neutron transport equation approximations}
+}
+
+@Article{freddi.sacco.ea:enriched,
+  author  = {Freddi, F. and Sacco, E. and Serpieri, R.},
+  title   = {An enriched damage-frictional cohesive-zone model incorporating stress multi-axiality},
+  journal = {Meccanica},
+  year    = {2018},
+  volume  = {53},
+  number  = {3},
+  pages   = {573-592}
+}
+
+@Misc{frei.richter.ea:on,
+  title   = {On the implementation of a locally modified finite element method for interface problems in deal.II},
+  author  = {Stefan Frei and Thomas Richter and Thomas Wick},
+  year    = {2018},
+  eprint  = {1806.00999},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{freund.kim.ea:field,
+  doi     = {10.1016/j.jnnfm.2018.03.013},
+  url     = {https://doi.org/10.1016/j.jnnfm.2018.03.013},
+  year    = {2018},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {257},
+  pages   = {71--82},
+  author  = {J.B. Freund and J. Kim and R.H. Ewoldt},
+  title   = {Field sensitivity of flow predictions to rheological parameters},
+  journal = {Journal of Non-Newtonian Fluid Mechanics}
+}
+
+@Article{galiano.velasco:on,
+  doi     = {10.1016/j.camwa.2018.05.035},
+  url     = {https://doi.org/10.1016/j.camwa.2018.05.035},
+  year    = {2018},
+  month   = sep,
+  publisher = {Elsevier {BV}},
+  volume  = {76},
+  number  = {5},
+  pages   = {984--996},
+  author  = {Gonzalo Galiano and Juli{\'{a}}n Velasco},
+  title   = {On a cross-diffusion system arising in image denoising},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
+@InCollection{gantner.herrmann.ea:multilevel,
+  doi     = {10.1007/978-3-319-72456-0_18},
+  url     = {https://doi.org/10.1007/978-3-319-72456-0_18},
+  year    = {2018},
+  publisher = {Springer International Publishing},
+  pages   = {373--405},
+  author  = {Robert N. Gantner and Lukas Herrmann and Christoph Schwab},
+  title   = {Multilevel {QMC} with Product Weights for Affine-Parametric, Elliptic {PDEs}},
+  booktitle = {Contemporary Computational Mathematics - A Celebration of the 80th Birthday of Ian Sloan}
+}
+
+@Article{gassmoller.lokavarapu.ea:flexible,
+  doi     = {10.1029/2018gc007508},
+  url     = {https://doi.org/10.1029/2018gc007508},
+  year    = {2018},
+  month   = sep,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {19},
+  number  = {9},
+  pages   = {3596--3604},
+  author  = {Rene Gassm\"{o}ller and Harsha Lokavarapu and Eric Heien and Elbridge Gerry Puckett and Wolfgang Bangerth},
+  title   = {Flexible and Scalable Particle-in-Cell Methods With Adaptive Mesh Refinement for Geodynamic Computations},
+  journal = {Geochemistry, Geophysics, Geosystems}
+}
+
 @Article{ge.holmgren.ea:effective,
   doi     = {10.1103/physrevfluids.3.054201},
   url     = {https://doi.org/10.1103/physrevfluids.3.054201},
@@ -374,6 +1030,55 @@
   journal = {Physical Review Fluids}
 }
 
+@PhDThesis{ghesmati:residual-and-goal-oriented-h-and-hp-adaptive-finite-element--application-for-elliptic-and-saddle-point-problems,
+  author  = {Ghesmati, Arezou},
+  title   = {{Residual and Goal-Oriented h-and hp-adaptive Finite Element; Application for Elliptic and Saddle Point Problems}},
+  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/173289},
+  publisher = {Texas A\&M University},
+  year    = {2018}
+}
+
+@Article{giuliani.heltai.ea:predicting,
+  doi     = {10.1089/soro.2017.0099},
+  url     = {https://doi.org/10.1089/soro.2017.0099},
+  year    = {2018},
+  month   = aug,
+  publisher = {Mary Ann Liebert Inc},
+  volume  = {5},
+  number  = {4},
+  pages   = {410--424},
+  author  = {Nicola Giuliani and Luca Heltai and Antonio DeSimone},
+  title   = {Predicting and Optimizing Microswimmer Performance from the Hydrodynamics of Its Components: The Relevance of Interactions},
+  journal = {Soft Robotics}
+}
+
+@Article{giuliani.mola.ea:-bem,
+  doi     = {10.1016/j.advengsoft.2018.03.008},
+  url     = {https://doi.org/10.1016/j.advengsoft.2018.03.008},
+  year    = {2018},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {121},
+  pages   = {39--58},
+  author  = {Nicola Giuliani and Andrea Mola and Luca Heltai},
+  title   = {$\pi$-{BEM}: A flexible parallel implementation for adaptive, geometry aware, and high order boundary element methods},
+  journal = {Advances in Engineering Software}
+}
+
+@Article{glerum.thieulot.ea:nonlinear,
+  doi     = {10.5194/se-9-267-2018},
+  url     = {https://doi.org/10.5194/se-9-267-2018},
+  year    = {2018},
+  month   = mar,
+  publisher = {Copernicus {GmbH}},
+  volume  = {9},
+  number  = {2},
+  pages   = {267--294},
+  author  = {Anne Glerum and Cedric Thieulot and Menno Fraters and Constantijn Blom and Wim Spakman},
+  title   = {Nonlinear viscoplasticity in {ASPECT}: benchmarking and applications to subduction},
+  journal = {Solid Earth}
+}
+
 @Article{goll.wick.ea:dopelib,
   author  = {C. Goll and T. Wick and W. Wollner},
   title   = {DOpElib: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving PDEs and Optimization Problems with PDEs},
@@ -383,6 +1088,100 @@
   pages   = {1--14},
   url     = {},
   doi     = {}
+}
+
+@Article{gong.chen.ea:fast,
+  title   = {Fast simulations of a large number of crystals growth in centimeter-scale during alloy solidification via nonlinearly preconditioned quantitative phase-field formula},
+  author  = {Tong Zhao Gong and Yun Chen and Yan Fei Cao and Xiu Hong Kang and Dian Zhong Li},
+  doi     = {10.1016/j.commatsci.2018.02.003},
+  url     = {https://doi.org/10.1016/j.commatsci.2018.02.003},
+  year    = {2018},
+  month   = may,
+  publisher = {Elsevier {BV}},
+  volume  = {147},
+  pages   = {338--352},
+  journal = {Computational Materials Science}
+}
+
+@Article{gonzalez-valverde.garcia-aznar:mechanical,
+  doi     = {10.1016/j.cma.2018.03.036},
+  url     = {https://doi.org/10.1016/j.cma.2018.03.036},
+  year    = {2018},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {337},
+  pages   = {246--262},
+  author  = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
+  title   = {Mechanical modeling of collective cell migration: An agent-based and continuum material approach},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@PhDThesis{greene:a-bayesian-approach-to-spike-sorting-of-neural-data-via-source-localization,
+  author  = {Greene, P},
+  title   = {{A Bayesian Approach to Spike Sorting of Neural Data via Source Localization}},
+  url     = {https://repository.arizona.edu/handle/10150/628404},
+  publisher = {University of Arizona},
+  year    = {2018}
+}
+
+@Article{guermond.nazarov.ea:second-order,
+  doi     = {10.1137/17m1149961},
+  url     = {https://doi.org/10.1137/17m1149961},
+  year    = {2018},
+  month   = jan,
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {40},
+  number  = {5},
+  pages   = {A3211--A3239},
+  author  = {Jean-Luc Guermond and Murtazo Nazarov and Bojan Popov and Ignacio Tomas},
+  title   = {Second-Order Invariant Domain Preserving Approximation of the Euler Equations Using Convex Limiting},
+  journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@TechReport{gulevich.gulevich:user-guide-for-mitmojco-1-2-microscopic-tunneling-model-for-josephson-contacts-mitmojco-1-2,
+  author  = {Gulevich, Dmitry R and Gulevich, Dmitry R},
+  title   = {{User Guide for MiTMoJCo 1.2 (Microscopic Tunneling Model for Josephson Contacts) MiTMoJCo 1.2}},
+  url     = {https://github.com/drgulevich/mitmojco},
+  year    = {2018}
+}
+
+@Article{gulevich.koshelets.ea:bridging,
+  author  = {D. R. Gulevich and V. P. Koshelets and F. V. Kusmartsev},
+  title   = {Bridging the Terahertz gap for chaotic sources with superconducting junctions},
+  journal = {arXiv:1709.04052},
+  year    = {2018},
+  volume  = {},
+  pages   = {},
+  url     = {https://arxiv.org/abs/1709.04052},
+  doi     = {}
+}
+
+@Misc{gulevich:mitmojco,
+  title   = {MiTMoJCo: Microscopic Tunneling Model for Josephson Contacts},
+  author  = {Dmitry R. Gulevich},
+  year    = {2018},
+  eprint  = {1809.04706},
+  archiveprefix = {arXiv},
+  primaryclass = {cond-mat.supr-con}
+}
+
+@TechReport{gulevich:mitmojco-1-2,
+  author  = {Gulevich, D. R.},
+  title   = {{MiTMoJCo 1.2}},
+  year    = {2018},
+  url     = {https://www.researchgate.net/profile/D_Gulevich/publication/318380494_User_Guide_for_MiTMoJCo_12_Microscopic_Tunneling_Model_for_Josephson_Contacts/links/5ba4005d92851ca9ed1a09b1/User-Guide-for-MiTMoJCo-12-Microscopic-Tunneling-Model-for-Josephson-Contacts.pdf}
+}
+
+@InCollection{gulpak.wernsing.ea:compensation,
+  doi     = {10.1007/978-3-319-57120-1_12},
+  url     = {https://doi.org/10.1007/978-3-319-57120-1_12},
+  year    = {2017},
+  month   = sep,
+  publisher = {Springer International Publishing},
+  pages   = {251--288},
+  author  = {M. Gulpak and H. Wernsing and J. S\"{o}lter and C. B\"{u}skens},
+  title   = {Compensation Strategies for Thermal Effects in Dry Milling},
+  booktitle = {Lecture Notes in Production Engineering}
 }
 
 @Article{guo.song.ea:pressure,
@@ -430,15 +1229,237 @@
   year    = {2018}
 }
 
-@Article{odster.kvamsdal.ea:simple,
-  author  = {L. Hov Ods\ae{}ter and T. Kvamsdal and M. G Larson},
-  title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
-  journal = {arXiv:1803.03423},
+@Article{gupta.langelaar.ea:qr-patterns,
+  doi     = {10.1007/s00158-018-2048-6},
+  url     = {https://doi.org/10.1007/s00158-018-2048-6},
   year    = {2018},
-  volume  = {},
+  month   = aug,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {58},
+  number  = {4},
+  pages   = {1335--1350},
+  author  = {Deepak K. Gupta and Matthijs Langelaar and Fred van Keulen},
+  title   = {{QR}-patterns: artefacts in multiresolution topology optimization},
+  journal = {Structural and Multidisciplinary Optimization}
+}
+
+@Article{ha.choo.ea:liquid,
+  doi     = {10.1007/s00603-018-1542-x},
+  url     = {https://doi.org/10.1007/s00603-018-1542-x},
+  year    = {2018},
+  month   = jul,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {51},
+  number  = {11},
+  pages   = {3407--3420},
+  author  = {Seong Jun Ha and Jinhyun Choo and Tae Sup Yun},
+  title   = {Liquid {CO}2 Fracturing: Effect of Fluid Permeation on the Breakdown Pressure and Cracking Behavior},
+  journal = {Rock Mechanics and Rock Engineering}
+}
+
+@InProceedings{hai.bause:mathematical-modelling-of-structural-health-monitoring-systems--coupling-fluid-structure-interaction-with-wave-propagation-,
+  author  = {Hai, BSME and Bause, M},
+  title   = {{Mathematical Modelling of Structural Health Monitoring Systems: Coupling Fluid-Structure Interaction with Wave Propagation.}},
+  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/filePaper/p1848.pdf},
+  year    = {2018}
+}
+
+@InProceedings{hai.bause:numerical,
+  doi     = {10.1115/imece2018-87448},
+  url     = {https://doi.org/10.1115/imece2018-87448},
+  year    = {2018},
+  month   = nov,
+  publisher = {American Society of Mechanical Engineers},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Numerical Modeling and Approximation of the Coupling Lamb Wave Propagation With Fluid-Structure Interaction Problem},
+  booktitle = {Volume 9: Mechanics of Solids, Structures, and Fluids}
+}
+
+@Article{heister.wick:parallel,
+  title   = {Parallel solution, adaptivity, computational convergence, and open-source code of 2d and 3d pressurized phase-field fracture problems},
+  author  = {Timo Heister and Thomas Wick},
+  journal = {Proc. Appl. Math. Mech.},
+  year    = {2018},
+  number  = {1},
+  pages   = {e201800353},
+  volume  = {18},
+  doi     = {10.1002/pamm.201800353}
+}
+
+@TechReport{hochbruck.kohler:on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-methods-on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-problems,
+  author  = {Hochbruck, Marlis and K{\"{o}}hler, Jonas},
+  title   = {{On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type methods On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type problems}},
+  url     = {https://www.waves.kit.edu/downloads/CRC1173_Preprint_2017-34.pdf},
+  year    = {2018}
+}
+
+@PhDThesis{huang:hybrid-analog-digital-co-processing-for-scientific-computation,
+  author  = {Huang, Y.},
+  title   = {{Hybrid Analog-Digital Co-Processing for Scientific Computation}},
+  url     = {https://academiccommons.columbia.edu/doi/10.7916/D8V711TR},
+  publisher = {Columbia University},
+  year    = {2018}
+}
+
+@Article{ilio.dorschner.ea:simulation,
+  author  = {G. Di Ilio and B. Dorschner and G. Bella and S. Succi and I. V. Karlin},
+  title   = {Simulation of turbulent flows with the entropic multi-relaxation time lattice Boltzmann method on body-fitted meshes},
+  journal = {Journal of Fluid Mechanics},
+  year    = {2018},
+  volume  = {849},
+  pages   = {35--56},
+  url     = {https://www.researchgate.net/publication/325069808_Simulation_of_turbulent_flows_with_the_entropic_multi-relaxation_time_lattice_Boltzmann_method_on_body-fitted_meshes},
+  doi     = {10.1017/jfm.2018.413}
+}
+
+@Article{ilio.dorschner.ea:simulation*1,
+  doi     = {10.1017/jfm.2018.413},
+  url     = {https://doi.org/10.1017/jfm.2018.413},
+  year    = {2018},
+  month   = jun,
+  publisher = {Cambridge University Press ({CUP})},
+  volume  = {849},
+  pages   = {35--56},
+  author  = {G. Di Ilio and B. Dorschner and G. Bella and S. Succi and I. V. Karlin},
+  title   = {Simulation of turbulent flows with the entropic multirelaxation time lattice Boltzmann method on body-fitted meshes},
+  journal = {Journal of Fluid Mechanics}
+}
+
+@Article{jadamba.khan.ea:elliptic,
+  url     = {http://www.ybook.co.jp/online2/oppafa/vol3/p309.html},
+  year    = {2018},
+  month   = {Jan},
+  volume  = {3},
+  number  = {2},
+  author  = {Jadamba, B and Khan, A. A. and Kahler, R. and Sama, M.},
+  title   = {Elliptic Inverse Problems of Identifying Nonlinear Parameters},
+  journal = {Pure and Applied Functional Analysis}
+}
+
+@PhDThesis{jansen:modeling-heat-and-fluid-flow-in-discrete-fracture-networks,
+  author  = {Jansen, G.},
+  title   = {{Modeling heat and fluid flow in discrete fracture networks}},
+  url     = {https://doc.rero.ch/record/328092},
+  publisher = {Universit\'{e} de Neuch\^{a}tel},
+  year    = {2018}
+}
+
+@Article{jithin-jith:acousto-elastic,
+  doi     = {10.13140/RG.2.2.30755.14885},
+  url     = {http://rgdoi.net/10.13140/RG.2.2.30755.14885},
+  author  = {{Jithin Jith}},
+  language = {en},
+  title   = {Acousto-Elastic Interactions in High-Pressure Centrifugal Compressors},
+  publisher = {Unpublished},
+  year    = {2018}
+}
+
+@Article{jodlbauer.langer.ea:parallel,
+  doi     = {10.1002/nme.5970},
+  url     = {https://doi.org/10.1002/nme.5970},
+  year    = {2018},
+  month   = oct,
+  publisher = {Wiley},
+  volume  = {117},
+  number  = {6},
+  pages   = {623--643},
+  author  = {D. Jodlbauer and U. Langer and T. Wick},
+  title   = {Parallel block-preconditioned monolithic solvers for fluid-structure interaction problems},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@Article{k-gupta.keulen.ea:design,
+  author  = {K. Gupta, Deepak and Keulen, Fred and Langelaar, Matthijs},
+  year    = {2018},
+  month   = {11},
   pages   = {},
-  url     = {},
+  title   = {Design and analysis adaptivity in multi-resolution topology optimization},
+  journal = {arXiv:1811.09821},
+  volume  = {},
+  url     = {https://arxiv.org/abs/1811.09821},
   doi     = {}
+}
+
+@Article{kanschat.riviere:finite,
+  doi     = {10.1007/s10915-018-0843-2},
+  url     = {https://doi.org/10.1007/s10915-018-0843-2},
+  year    = {2018},
+  month   = oct,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {77},
+  number  = {3},
+  pages   = {1762--1779},
+  author  = {Guido Kanschat and Beatrice Riviere},
+  title   = {A Finite Element Method with Strong Mass Conservation for Biot's Linear Consolidation Model},
+  journal = {Journal of Scientific Computing}
+}
+
+@Article{karban.kropik.ea:bayes,
+  doi     = {10.1016/j.amc.2017.07.043},
+  url     = {https://doi.org/10.1016/j.amc.2017.07.043},
+  year    = {2018},
+  month   = feb,
+  publisher = {Elsevier {BV}},
+  volume  = {319},
+  pages   = {681--692},
+  author  = {Pavel Karban and Petr Krop{\'{i}}k and V{\'{a}}clav Kotlan and Ivo Dole{\v{z}}el},
+  title   = {Bayes approach to solving T.E.A.M. benchmark problems 22 and 25 and its comparison with other optimization techniques},
+  journal = {Applied Mathematics and Computation}
+}
+
+@PhDThesis{kauffman:overset,
+  author  = {Kauffman, Justin},
+  title   = {An Overset Mesh Framework for the Hybridizable Discontinuous Galerkin Finite Element Method},
+  school  = {Pennsylvania State University},
+  year    = {2018},
+  month   = {1}
+}
+
+@Article{kaufl.grayver.ea:topographic,
+  title   = {Topographic distortions of magnetotelluric transfer functions: a high-resolution 3-D modelling study using real elevation data},
+  author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Kuvshinov, Alexey V},
+  journal = {Geophysical Journal International},
+  volume  = {215},
+  number  = {3},
+  pages   = {1943--1961},
+  year    = {2018},
+  publisher = {Oxford University Press},
+  doi     = {10.1093/gji/ggy375}
+}
+
+@Article{kazemi.vaziri.ea:topology,
+  doi     = {10.1115/1.4040624},
+  url     = {https://doi.org/10.1115/1.4040624},
+  year    = {2018},
+  month   = sep,
+  publisher = {{ASME} International},
+  volume  = {140},
+  number  = {11},
+  author  = {Hesaneh Kazemi and Ashkan Vaziri and Juli{\'{a}}n A. Norato},
+  title   = {Topology Optimization of Structures Made of Discrete Geometric Components With Different Materials},
+  journal = {Journal of Mechanical Design}
+}
+
+@Article{kerganer.mergheim.ea:modeling,
+  doi     = {10.1016/j.camwa.2018.05.016},
+  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
+  year    = {2019},
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = {78},
+  number  = {7},
+  pages   = {2338--2350},
+  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
+  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
+@PhDThesis{khattatov:efficient,
+  author  = {Eldar Khattatov},
+  title   = {Efficient discretization techniques and domain decomposition methods for poroelasticity},
+  school  = {University of Pittsburgh},
+  year    = {2018},
+  url     = {http://d-scholarship.pitt.edu/34001/1/thesis_khattatov.pdf}
 }
 
 @Misc{kocher.bause:mixed,
@@ -448,6 +1469,14 @@
   eprint  = {1805.00771},
   archiveprefix = {arXiv},
   primaryclass = {math.NA}
+}
+
+@InProceedings{koepf.soldner.ea:3d,
+  author  = {Koepf, Johannes and Soldner, Dominic and Gotterbarm, Martin and Markl, Matthias and Mergheim, Julia and K{\"o}rner, Carolin},
+  year    = {2018},
+  month   = {May},
+  title   = {3D Grainstructure simulation in powder bed additive manufacturing},
+  booktitle = {NAFEMS Konferenz 2018}
 }
 
 @Article{krank.kronbichler.ea:direct,
@@ -475,16 +1504,30 @@
   doi     = {10.1002/fld.4409}
 }
 
-@Article{oneill.zhang:lateral,
-  doi     = {10.1029/2018JB015698},
-  title   = {Lateral Mixing Processes in the {H}adean},
-  author  = {O'Neill, C. J. and Zhang, S.},
-  journal = {Journal of Geophysical Research: Solid Earth},
-  volume  = {123},
-  number  = {8},
-  pages   = {7074--7089},
+@InProceedings{kronbichler.allalen:efficient,
+  doi     = {10.1007/978-3-319-99654-7_7},
+  url     = {https://doi.org/10.1007/978-3-319-99654-7_7},
   year    = {2018},
-  publisher = {Wiley Online Library}
+  publisher = {Springer International Publishing},
+  pages   = {89--110},
+  author  = {Martin Kronbichler and Momme Allalen},
+  title   = {Efficient High-Order Discontinuous Galerkin Finite Elements with Matrix-Free Implementations},
+  booktitle = {Advances and New Trends in Environmental Informatics},
+  editor  = {Bungartz, Hans-Joachim and Kranzlm\"uller, Dieter and Weinberg, Volker and Weism\"uller, Jens and Wohlgemuth, Volker},
+  series  = {Progress in {IS}}
+}
+
+@Article{kronbichler.diagne.ea:fast,
+  author  = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
+  title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
+  journal = {The International Journal of High Performance Computing Applications},
+  volume  = {32},
+  number  = {2},
+  pages   = {266-287},
+  year    = {2018},
+  doi     = {10.1177/1094342016671790},
+  url     = {https://doi.org/10.1177/1094342016671790},
+  eprint  = { https://doi.org/10.1177/1094342016671790 }
 }
 
 @InProceedings{kronbichler.krank.ea:new,
@@ -500,6 +1543,184 @@
   doi     = {10.1007/978-3-319-64519-3_42}
 }
 
+@Article{kronbichler.wall:performance,
+  author  = {Kronbichler, Martin and Wall, Wolfgang A.},
+  title   = {A Performance Comparison of Continuous and Discontinuous Galerkin Methods with Fast Multigrid Solvers},
+  journal = {SIAM Journal on Scientific Computing},
+  volume  = {40},
+  number  = {5},
+  pages   = {A3423--A3448},
+  year    = {2018},
+  doi     = {10.1137/16M110455X},
+  url     = { https://doi.org/10.1137/16M110455X}
+}
+
+@Article{ladenheim.chen.ea:mta,
+  author  = {Scott Ladenheim and Yi-Chung Chen and Milan D. Mihajlovi{\'c} and Vasilis F. Pavlidis},
+  title   = {The {MTA}: {A}n Advanced and Versatile Thermal Simulator for Integrated Systems},
+  journal = {IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems},
+  year    = {2018},
+  volume  = {37},
+  number  = {12},
+  pages   = {3123--3136},
+  month   = {January},
+  doi     = {10.1109/TCAD.2018.2789729}
+}
+
+@Article{lambe.czekanski:density,
+  doi     = {10.1002/nme.5843},
+  year    = {2018},
+  month   = jun,
+  publisher = {Wiley},
+  volume  = {115},
+  number  = {10},
+  pages   = {1266--1286},
+  author  = {Andrew B. Lambe and Aleksander Czekanski},
+  title   = {A density field parametrization for topology optimization using {B}ernstein elements},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@Article{lambe.czekanski:topology,
+  doi     = {10.1002/nme.5617},
+  url     = {https://doi.org/10.1002/nme.5617},
+  year    = {2017},
+  month   = aug,
+  publisher = {Wiley},
+  volume  = {113},
+  number  = {3},
+  pages   = {357--373},
+  author  = {Andrew B. Lambe and Aleksander Czekanski},
+  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@Article{lee.mikelic.ea:phase-field,
+  doi     = {10.1137/17m1145239},
+  url     = {https://doi.org/10.1137/17m1145239},
+  year    = {2018},
+  month   = jan,
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {16},
+  number  = {4},
+  pages   = {1542--1580},
+  author  = {Sanghyun Lee and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
+  title   = {Phase-Field Modeling of Two Phase Fluid Filled Fractures in a Poroelastic Medium},
+  journal = {Multiscale Modeling {\&} Simulation}
+}
+
+@Article{lee.min.ea:optimal,
+  doi     = {10.1007/s10596-018-9728-6},
+  url     = {https://doi.org/10.1007/s10596-018-9728-6},
+  year    = {2018},
+  month   = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {22},
+  number  = {3},
+  pages   = {833--849},
+  author  = {Sanghyun Lee and Baehyun Min and Mary F. Wheeler},
+  title   = {Optimal design of hydraulic fracturing in porous media using the phase field fracture model coupled with genetic algorithm},
+  journal = {Computational Geosciences}
+}
+
+@Article{lee.wheeler:enriched,
+  doi     = {10.1016/j.jcp.2018.03.031},
+  url     = {https://doi.org/10.1016/j.jcp.2018.03.031},
+  year    = {2018},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {367},
+  pages   = {65--86},
+  author  = {Sanghyun Lee and Mary F. Wheeler},
+  title   = {Enriched Galerkin methods for two-phase flow in porous media with capillary pressure},
+  journal = {Journal of Computational Physics}
+}
+
+@Article{lemenager.oneill.ea:effect,
+  doi     = {10.1186/s40517-018-0092-5},
+  url     = {https://doi.org/10.1186/s40517-018-0092-5},
+  year    = {2018},
+  month   = may,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {6},
+  number  = {1},
+  author  = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang and Morgan Evans},
+  title   = {The effect of temperature-dependent thermal conductivity on the geothermal structure of the Sydney Basin},
+  journal = {Geothermal Energy}
+}
+
+@MastersThesis{lin:stabilized,
+  author  = {Sen Lin},
+  title   = {Stabilized finite element methods and applications},
+  school  = {Penn State University},
+  year    = 2018,
+  url     = {https://etda.libraries.psu.edu/files/final_submissions/17393}
+}
+
+@Article{liu.reina:dynamic,
+  doi     = {10.1007/s00466-018-1662-x},
+  url     = {https://doi.org/10.1007/s00466-018-1662-x},
+  year    = {2018},
+  month   = dec,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {64},
+  number  = {1},
+  pages   = {147--161},
+  author  = {Chenchen Liu and Celia Reina},
+  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
+  journal = {Computational Mechanics}
+}
+
+@Article{liu.yin:unconditionally,
+  author  = {H. Liu and P. Yin},
+  title   = {Unconditionally energy stable DG schemes for the Swift-Hohenberg equation},
+  journal = {Journal of Scientific Computing},
+  year    = 2018,
+  note    = {submitted}
+}
+
+@PhDThesis{lucero-lorca:multilevel-schwarz-methods-for-multigroup-radiation-transport-problems,
+  author  = {Jose Pablo {Lucero Lorca}},
+  title   = {{Multilevel Schwarz methods for multigroup radiation transport problems}},
+  year    = {2018},
+  school  = {Heidelberg University},
+  url     = {https://archiv.ub.uni-heidelberg.de/volltextserver/25216/},
+  doi     = {10.11588/heidok.00025216}
+}
+
+@Article{ludvigsson.steffen.ea:high-order,
+  author  = {Ludvigsson, Gustav and Steffen, Kyle R. and Sticko, Simon and Wang, Siyang and Xia, Qing and Epshteyn, Yekaterina and Kreiss, Gunilla},
+  title   = {High-Order Numerical Methods for 2D Parabolic Problems in Single and Composite Domains},
+  journal = {Journal of Scientific Computing},
+  year    = {2018},
+  month   = {Aug},
+  volume  = {76},
+  number  = {2},
+  pages   = {812--847},
+  issn    = {1573-7691},
+  doi     = {10.1007/s10915-017-0637-y},
+  url     = {https://doi.org/10.1007/s10915-017-0637-y}
+}
+
+@InProceedings{luo.zhao:finite,
+  doi     = {10.1115/detc2018-85701},
+  url     = {https://doi.org/10.1115/detc2018-85701},
+  year    = {2018},
+  month   = aug,
+  publisher = {American Society of Mechanical Engineers},
+  author  = {Zhibo Luo and Yaoyao Fiona Zhao},
+  title   = {Finite Element Thermal Analysis of Melt Pool in Selective Laser Melting Process},
+  booktitle = {38th Computers and Information in Engineering Conference, Volume 1A}
+}
+
+@Misc{maday.marcati:regularity,
+  title   = {Regularity and $hp$ discontinuous {G}alerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
+  author  = {Yvon Maday and Carlo Marcati},
+  year    = {2018},
+  eprint  = {1810.09010},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
 @Article{maier.margetis.ea:generation,
   author  = {M. Maier and D. Margetis and M. Luskin},
   title   = {Generation of surface plasmon-polaritons by edge effects},
@@ -509,6 +1730,26 @@
   pages   = {77--97},
   url     = {http://www.intlpress.com/site/pub/pages/journals/items/cms/content/vols/0016/0001/a004/},
   doi     = {}
+}
+
+@Misc{maier.mattheakis.ea:homogenization,
+  title   = {Homogenization of plasmonic crystals: Seeking the epsilon-near-zero effect},
+  author  = {Matthias Maier and Marios Mattheakis and Efthimios Kaxiras and Mitchell Luskin and Dionisios Margetis},
+  year    = {2018},
+  eprint  = {1809.08276},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{maier.nemilentsau.ea:ultracompact,
+  author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
+  doi     = {10.1021/acsphotonics.7b01094},
+  journal = {ACS Photonics},
+  number  = {2},
+  pages   = {544--551},
+  title   = {Ultracompact amplitude modulator by coupling hyperbolic polaritons over a graphene-covered gap},
+  volume  = {5},
+  year    = {2018}
 }
 
 @Article{maier.rannacher:duality-based,
@@ -525,6 +1766,160 @@
   journal = {Multiscale Modeling {\&} Simulation}
 }
 
+@PhDThesis{marcati:discontinuous,
+  author  = {Carlo Marcati},
+  title   = {Discontinuous hp finite element methods for elliptic eigenvalue problems with singular potentials: with applications to quantum chemistry},
+  school  = {Sorbonne University, Paris},
+  year    = {2018},
+  url     = {https://tel.archives-ouvertes.fr/tel-02072774/}
+}
+
+@PhDThesis{massoudi:numerical-algorithms-for-the-linear-quadratic-optimal-control-of-well-posed-linear-systems,
+  author  = {Massoudi, A},
+  title   = {{Numerical Algorithms for the Linear-Quadratic Optimal Control of Well-Posed Linear Systems}},
+  publisher = {Universit\"{a}t Hamburg},
+  url     = {https://ediss.sub.uni-hamburg.de/volltexte/2018/9055/},
+  year    = {2018}
+}
+
+@InProceedings{mehnert.hossain.ea:a-thermo-electro-viscoelastic-material-model-for-the-simulation-of-vhb-4905,
+  author  = {Mehnert, M and Hossain, M and Steinmann, P},
+  journal = {congress.cimne.com},
+  title   = {{A THERMO-ELECTRO-VISCOELASTIC MATERIAL MODEL FOR THE SIMULATION OF VHB 4905}},
+  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a839.pdf},
+  year    = {2018}
+}
+
+@Article{mehnert.hossain.ea:numerical,
+  doi     = {10.1016/j.ijnonlinmec.2018.08.016},
+  url     = {https://doi.org/10.1016/j.ijnonlinmec.2018.08.016},
+  year    = {2018},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {106},
+  pages   = {13--24},
+  author  = {Markus Mehnert and Mokarram Hossain and Paul Steinmann},
+  title   = {Numerical modeling of thermo-electro-viscoelasticity with field-dependent material parameters},
+  journal = {International Journal of Non-Linear Mechanics}
+}
+
+@TechReport{mohebujjaman:high,
+  year    = {2018},
+  author  = {Mohebujjaman, Muhammad},
+  institution = {Virginia Tech University},
+  title   = {High order efficient algorithm for computation of {MHD} flow ensemble},
+  url     = {https://mohebujjaman.github.io/Second_order_ensembleMHD_Mohebujjaman.pdf}
+}
+
+@Misc{mohebujjaman:second,
+  title   = {Second order ensemble simulation for {MHD} flow in Els{\"a}sser variable with noisy input data},
+  author  = {Muhammad Mohebujjaman},
+  year    = {2018},
+  eprint  = {1803.06980},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@MastersThesis{munch:efficient,
+  author  = {M\"unch, Peter},
+  title   = {An efficient hybrid multigrid solver for high-order discontinuous Galerkin methods},
+  school  = {Technical University of Munich},
+  year    = {2018},
+  month   = {oct},
+  url     = {https://mediatum.ub.tum.de/node?id=1514962}
+}
+
+@Article{murphy.venkataraman.ea:parameter,
+  doi     = {10.1142/s1793524518500535},
+  url     = {https://doi.org/10.1142/s1793524518500535},
+  year    = {2018},
+  month   = may,
+  publisher = {World Scientific Pub Co Pte Lt},
+  volume  = {11},
+  number  = {04},
+  pages   = {1850053},
+  author  = {Laura Murphy and Chandrasekhar Venkataraman and Anotida Madzvamuse},
+  title   = {Parameter identification through mode isolation for reaction-diffusion systems on arbitrary geometries},
+  journal = {International Journal of Biomathematics}
+}
+
+@Article{na.sun:computational,
+  author  = {SeonHong Na and WaiChing Sun},
+  title   = {Computational thermomechanics of crystalline rock, Part I: A combined multi-phase-field/crystal plasticity approach for single crystal simulations},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2018},
+  volume  = {338},
+  pages   = {657--691},
+  month   = {aug},
+  doi     = {10.1016/j.cma.2017.12.022},
+  publisher = {Elsevier {BV}}
+}
+
+@PhDThesis{na:multiscale-thermo-hydro-mechanical-chemical-coupling-effects-for-fluid-infiltrating-crystalline-solids-and-geomaterials--theory--implementation--and-validation,
+  author  = {Na, S. H.},
+  title   = {{Multiscale thermo-hydro-mechanical-chemical coupling effects for fluid-infiltrating crystalline solids and geomaterials: theory, implementation, and validation}},
+  url     = {https://academiccommons.columbia.edu/doi/10.7916/D8P85VM9},
+  publisher = {Columbia University},
+  year    = {2018}
+}
+
+@Article{neitzel.wick.ea:optimal,
+  author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
+  title   = {An Optimal Control Problem Governed by a Regularized Phase-field Fracture Propagation Model. {P}art {I}{I} {T}he Regularization Limit},
+  journal = {SIAM Journal on Control and Optimization},
+  volume  = {55},
+  number  = {4},
+  pages   = {18},
+  year    = {2018},
+  doi     = {10.1137/16M1062375}
+}
+
+@Article{neitzel.wollner:priori,
+  doi     = {10.1007/s00211-017-0906-6},
+  url     = {https://doi.org/10.1007/s00211-017-0906-6},
+  year    = {2018},
+  month   = jul,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {138},
+  number  = {2},
+  pages   = {273--299},
+  author  = {I. Neitzel and W. Wollner},
+  title   = {A priori $L^2$ -discretization error estimates for the state in elliptic optimization problems with pointwise inequality state constraints},
+  journal = {Numerische Mathematik}
+}
+
+@Article{odster.kvamsdal.ea:simple,
+  author  = {L. Hov Ods\ae{}ter and T. Kvamsdal and M. G Larson},
+  title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
+  journal = {arXiv:1803.03423},
+  year    = {2018},
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
+}
+
+@Article{oneill.zhang:lateral,
+  doi     = {10.1029/2018JB015698},
+  title   = {Lateral Mixing Processes in the {H}adean},
+  author  = {O'Neill, C. J. and Zhang, S.},
+  journal = {Journal of Geophysical Research: Solid Earth},
+  volume  = {123},
+  number  = {8},
+  pages   = {7074--7089},
+  year    = {2018},
+  publisher = {Wiley Online Library}
+}
+
+@Misc{pearson.porcelli.ea:interior,
+  title   = {Interior Point Methods and Preconditioning for PDE-Constrained Optimization Problems Involving Sparsity Terms},
+  author  = {John W. Pearson and Margherita Porcelli and Martin Stoll},
+  year    = {2018},
+  eprint  = {1806.05896},
+  archiveprefix = {arXiv},
+  primaryclass = {math.OC}
+}
+
 @Article{pelteret.walter.ea:application,
   author  = {Jean-Paul Pelteret and Bastian Walter and Paul Steinmann},
   title   = {Application of metaheuristic algorithms to the identification of nonlinear magneto-viscoelastic constitutive parameters},
@@ -537,12 +1932,189 @@
   publisher = {Elsevier {BV}}
 }
 
+@Article{puckett.turcotte.ea:new,
+  doi     = {10.1016/j.pepi.2017.10.004},
+  url     = {https://doi.org/10.1016/j.pepi.2017.10.004},
+  year    = {2018},
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {276},
+  pages   = {10--35},
+  author  = {Elbridge Gerry Puckett and Donald L. Turcotte and Ying He and Harsha Lokavarapu and Jonathan M. Robey and Louise H. Kellogg},
+  title   = {New numerical approaches for modeling thermochemical convection in a compositionally stratified fluid},
+  journal = {Physics of the Earth and Planetary Interiors}
+}
+
+@Article{qiao.bai.ea:blended,
+  doi     = {10.1051/jnwpu/20183610057},
+  url     = {https://doi.org/10.1051/jnwpu/20183610057},
+  year    = {2018},
+  month   = feb,
+  publisher = {{EDP} Sciences},
+  volume  = {36},
+  number  = {1},
+  pages   = {57--65},
+  author  = {Lei Qiao and Junqiang Bai and Yasong Qiu and Jun Hua and Jiakuan Xu},
+  title   = {A Blended Continuation Method for Solving Steady Inviscid Flow},
+  journal = {Xibei Gongye Daxue Xuebao/Journal of Northwestern Polytechnical University}
+}
+
+@Article{roberge.norato:computational,
+  author  = {Jeffrey Roberge and Juli{\'{a}}n Norato},
+  title   = {Computational design of curvilinear bone scaffolds fabricated via direct ink writing},
+  doi     = {10.1016/j.cad.2017.09.003},
+  url     = {https://doi.org/10.1016/j.cad.2017.09.003},
+  year    = {2018},
+  volume  = {95},
+  pages   = {1--13},
+  journal = {Computer-Aided Design}
+}
+
+@Article{rom.muller:effective,
+  doi     = {10.1016/j.triboint.2018.04.011},
+  url     = {https://doi.org/10.1016/j.triboint.2018.04.011},
+  year    = {2018},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {124},
+  pages   = {247--258},
+  author  = {Michael Rom and Siegfried M\"{u}ller},
+  title   = {An effective Navier-Stokes model for the simulation of textured surface lubrication},
+  journal = {Tribology International}
+}
+
+@Article{ross.ryan.ea:size,
+  doi     = {10.1093/icb/icy021},
+  url     = {https://doi.org/10.1093/icb/icy021},
+  year    = {2018},
+  month   = may,
+  publisher = {Oxford University Press ({OUP})},
+  volume  = {58},
+  number  = {2},
+  pages   = {232--250},
+  author  = {Stephanie A Ross and David S Ryan and Sebastian Dominguez and Nilima Nigam and James M Wakeling},
+  title   = {Size, History-Dependent, Activation and Three-Dimensional Effects on the Work and Power Produced During Cyclic Muscle Contractions},
+  journal = {Integrative and Comparative Biology}
+}
+
 @PhDThesis{sabawi:discontinuous,
   author  = {M. Sabawi},
   title   = {Discontinuous Galerkin timestepping for nonlinear parabolic problems},
   year    = {2018},
   school  = {University of Leicester},
   url     = {}
+}
+
+@PhDThesis{sabawi:discontinuous*1,
+  author  = {Sabawi, Mohammad},
+  title   = {Discontinuous Galerkin timestepping for nonlinear parabolic problems },
+  url     = {https://www.researchgate.net/publication/327546550},
+  publisher = {University of Leicester},
+  year    = {2018}
+}
+
+@Article{sabharwal.gostick.ea:virtual,
+  doi     = {10.1149/2.0921807jes},
+  url     = {https://doi.org/10.1149/2.0921807jes},
+  year    = {2018},
+  publisher = {The Electrochemical Society},
+  volume  = {165},
+  number  = {7},
+  pages   = {F553--F563},
+  author  = {Mayank Sabharwal and Jeff T. Gostick and Marc Secanell},
+  title   = {Virtual Liquid Water Intrusion in Fuel Cell Gas Diffusion Media},
+  journal = {Journal of The Electrochemical Society}
+}
+
+@PhDThesis{sacco:3d,
+  author  = {Filippo Guido Davide Sacco},
+  title   = {A 3D adaptive boundary element method for potential flow with nonlinear Kutta condition},
+  school  = {Politecnico di Milano},
+  year    = {2018},
+  month   = {4},
+  url     = {https://www.politesi.polimi.it/handle/10589/140106}
+}
+
+@Article{safin.minkoff.ea:preconditioned,
+  author  = {Safin, Artur and Minkoff, Susan E. and Zweck, John},
+  title   = {A preconditioned finite element solution of the coupled pressure-temperature equations used to model trace gas sensors},
+  journal = {SIAM Journal on Scientific Computing},
+  volume  = {40},
+  number  = {5},
+  pages   = {B1470--B1493},
+  year    = {2018},
+  doi     = {10.1137/17M1145823},
+  url     = {https://doi.org/10.1137/17M1145823}
+}
+
+@PhDThesis{safin:modeling,
+  author  = {Safin, Artur},
+  title   = {Modeling Trace Gas Sensors with the Coupled Pressure-Temperature Equations},
+  school  = {The University of Texas at Dallas},
+  year    = {2018},
+  month   = {12},
+  url     = {https://hdl.handle.net/10735.1/6420}
+}
+
+@Article{salvadori.damioli.ea:modeling,
+  author  = {A. Salvadori and V. Damioli and C. Ravelli and S. Mitola},
+  title   = {Modeling and Simulation of {VEGF} Receptors Recruitment in Angiogenesis},
+  journal = {Mathematical Problems in Engineering},
+  year    = {2018},
+  volume  = {2018},
+  pages   = {1--10},
+  month   = {aug},
+  doi     = {10.1155/2018/4705472},
+  publisher = {Hindawi Limited}
+}
+
+@Article{samrock.grayver.ea:magnetotelluric,
+  title   = {Magnetotelluric image of transcrustal magmatic system beneath the {Tulu Moye} geothermal prospect in the {Ethiopian Rift}},
+  author  = {Samrock, Friedemann and Grayver, Alexander V and Eysteinsson, Hjalmar and Saar, Martin O},
+  journal = {Geophysical Research Letters},
+  volume  = {45},
+  number  = {23},
+  pages   = {12847--12855},
+  year    = {2018},
+  publisher = {Wiley Online Library},
+  doi     = {10.1029/2018GL080333}
+}
+
+@Article{sarna.torrilhon:entropy,
+  doi     = {10.1016/j.jcp.2018.04.050},
+  year    = {2018},
+  month   = sep,
+  publisher = {Elsevier {BV}},
+  volume  = {369},
+  pages   = {16--44},
+  author  = {Neeraj Sarna and Manuel Torrilhon},
+  title   = {Entropy stable {H}ermite approximation of the linearised {B}oltzmann equation for inflow and outflow boundaries},
+  journal = {Journal of Computational Physics}
+}
+
+@Article{sartori.giuliani.ea:deal2lkit,
+  author  = {Sartori, Alberto and Giuliani, Nicola and Bardelloni, Mauro and Heltai, Luca},
+  doi     = {10.1016/j.softx.2018.09.004},
+  issn    = {23527110},
+  journal = {SoftwareX},
+  pages   = {318--327},
+  title   = {deal2lkit: A toolkit library for high performance programming in deal.II},
+  url     = {https://linkinghub.elsevier.com/retrieve/pii/S2352711018302048},
+  volume  = {7},
+  year    = {2018}
+}
+
+@Article{sartori.giuliani.ea:deal2lkit*1,
+  doi     = {10.1016/j.softx.2018.09.004},
+  url     = {https://doi.org/10.1016/j.softx.2018.09.004},
+  year    = {2018},
+  month   = jan,
+  publisher = {Elsevier {BV}},
+  volume  = {7},
+  pages   = {318--327},
+  author  = {Alberto Sartori and Nicola Giuliani and Mauro Bardelloni and Luca Heltai},
+  title   = {deal2lkit: A toolkit library for high performance programming in deal.{II}},
+  journal = {{SoftwareX}}
 }
 
 @Article{scacchi.brader:local,
@@ -554,6 +2126,23 @@
   pages   = {378--387},
   url     = {https://doi.org/10.1080/00268976.2017.1393117},
   doi     = {10.1080/00268976.2017.1393117}
+}
+
+@Article{schneider.hu.ea:decoupling,
+  title   = {Decoupling Simulation Accuracy from Mesh Quality},
+  url     = {http://par.nsf.gov/biblio/10080686},
+  journal = {ACM Transactions on Graphics},
+  author  = {Schneider, Teseo and Hu, Yixin and Dumas, Jeremie and Gao, Xifeng and Panozzo, Daniele and Zorin, Denis},
+  year    = {2018},
+  month   = {Dec}
+}
+
+@MastersThesis{schneider:simulation,
+  author  = {Schneider, David},
+  title   = {Simulation von Fluid-Struktur-Interaktion mit der Kopplungsbibliothek preCICE},
+  school  = {Universit{\"a}t Siegen},
+  year    = {2018},
+  note    = {Bachelorarbeit}
 }
 
 @Article{schoeder.kormann.ea:efficient,
@@ -592,66 +2181,109 @@
   doi     = {10.1098/rspa.2018.0369}
 }
 
-@Article{giuliani.mola.ea:-bem,
-  doi     = {10.1016/j.advengsoft.2018.03.008},
-  url     = {https://doi.org/10.1016/j.advengsoft.2018.03.008},
+@InCollection{schuster.schopfer:damage,
+  doi     = {10.1007/978-3-319-49715-0_16},
+  url     = {https://doi.org/10.1007/978-3-319-49715-0_16},
+  year    = {2017},
+  month   = aug,
+  publisher = {Springer International Publishing},
+  pages   = {373--397},
+  author  = {T. Schuster and F. Sch\"{o}pfer},
+  title   = {Damage Identification by Dynamic Load Monitoring},
+  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites}
+}
+
+@Article{schutz:3d,
+  title   = {3D Boundary Element Simulation of Droplet Dynamics in Microchannels: How Droplets Squeeze Through Constrictions and Move in Electric Fields},
+  author  = {Sch\"{u}tz, Simon Sebastian},
+  publisher = {EPFL},
+  address = {Lausanne},
+  pages   = {156},
   year    = {2018},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {121},
-  pages   = {39--58},
-  author  = {Nicola Giuliani and Andrea Mola and Luca Heltai},
-  title   = {$\pi$-{BEM}: A flexible parallel implementation for adaptive, geometry aware, and high order boundary element methods},
-  journal = {Advances in Engineering Software}
+  url     = {http://infoscience.epfl.ch/record/255307},
+  doi     = {10.5075/epfl-thesis-8621}
 }
 
-@Article{sabharwal.gostick.ea:virtual,
-  doi     = {10.1149/2.0921807jes},
-  url     = {https://doi.org/10.1149/2.0921807jes},
+@MastersThesis{schuurmans:numerical-modelling-of-overriding-plate-deformation-and-slab-rollback-in-the-western-mediterranean,
+  author  = {Schuurmans, L. F. J.},
+  title   = {{Numerical modelling of overriding plate deformation and slab rollback in the Western Mediterranean}},
+  school  = {Utrecht University},
   year    = {2018},
-  publisher = {The Electrochemical Society},
-  volume  = {165},
-  number  = {7},
-  pages   = {F553--F563},
-  author  = {Mayank Sabharwal and Jeff T. Gostick and Marc Secanell},
-  title   = {Virtual Liquid Water Intrusion in Fuel Cell Gas Diffusion Media},
-  journal = {Journal of The Electrochemical Society}
+  url     = {https://dspace.library.uu.nl/handle/1874/366408}
 }
 
-@Article{dunkelberger.metaferia.ea:theoretical,
-  doi     = {10.1021/acs.jpcb.8b07638},
-  url     = {https://doi.org/10.1021/acs.jpcb.8b07638},
+@PhDThesis{shannon:hybridized-discontinuous-galerkin-methods-for-magnetohydrodynamics,
+  author  = {Shannon, S. J.},
+  title   = {{Hybridized discontinuous Galerkin methods for magnetohydrodynamics}},
+  url     = {https://repositories.lib.utexas.edu/handle/2152/75763},
+  publisher = {University of Texas},
+  year    = {2018}
+}
+
+@Article{sharma.kanschat:contraction,
+  doi     = {10.1515/jnma-2016-1132},
+  url     = {https://doi.org/10.1515/jnma-2016-1132},
   year    = {2018},
-  month   = sep,
-  publisher = {American Chemical Society ({ACS})},
-  volume  = {122},
-  number  = {49},
-  pages   = {11579--11590},
-  author  = {Emily B. Dunkelberger and Belhu Metaferia and Troy Cellmer and Eric R. Henry},
-  title   = {Theoretical Simulation of Red Cell Sickling Upon Deoxygenation Based on the Physical Chemistry of Sickle Hemoglobin Fiber Formation},
-  journal = {The Journal of Physical Chemistry B}
+  month   = dec,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {26},
+  number  = {4},
+  pages   = {209--232},
+  author  = {Natasha Sharma and Guido Kanschat},
+  title   = {A contraction property of an adaptive divergence-conforming discontinuous Galerkin method for the Stokes problem},
+  journal = {Journal of Numerical Mathematics}
 }
 
-@MastersThesis{lin:stabilized,
-  author  = {Sen Lin},
-  title   = {Stabilized finite element methods and applications},
-  school  = {Penn State University},
-  year    = 2018,
-  url     = {https://etda.libraries.psu.edu/files/final_submissions/17393}
+@Article{sheldon.miller.ea:improved,
+  title   = {An Improved Formulation for Hybridizable Discontinuous Galerkin Fluid-Structure Interaction Modeling with Reduced Computational Expense},
+  author  = {Sheldon, Jason P. and Miller, Scott T. and Pitt, Jonathan S.},
+  doi     = {10.4208/cicp.OA-2017-0114},
+  journal = {Communications in Computational Physics},
+  issn    = {1815-2406},
+  number  = 5,
+  volume  = 24,
+  year    = {2018},
+  month   = {6}
 }
 
-@Article{ross.ryan.ea:size,
-  doi     = {10.1093/icb/icy021},
-  url     = {https://doi.org/10.1093/icb/icy021},
+@PhDThesis{shovkun:coupled-chemo-mechanical-processes-in-reservoir-geomechanics,
+  author  = {Shovkun, I},
+  title   = {{Coupled chemo-mechanical processes in reservoir geomechanics}},
+  url     = {https://repositories.lib.utexas.edu/handle/2152/72439},
+  publisher = {University of Texas at Austin},
+  year    = {2018}
+}
+
+@InProceedings{smolyanov.karban:optimal,
+  doi     = {10.1109/elektro.2018.8398325},
+  url     = {https://doi.org/10.1109/elektro.2018.8398325},
   year    = {2018},
   month   = may,
-  publisher = {Oxford University Press ({OUP})},
-  volume  = {58},
-  number  = {2},
-  pages   = {232--250},
-  author  = {Stephanie A Ross and David S Ryan and Sebastian Dominguez and Nilima Nigam and James M Wakeling},
-  title   = {Size, History-Dependent, Activation and Three-Dimensional Effects on the Work and Power Produced During Cyclic Muscle Contractions},
-  journal = {Integrative and Comparative Biology}
+  publisher = {{IEEE}},
+  author  = {Ivan A. Smolyanov and Pavel Karban},
+  title   = {Optimal design of {MHD} pump},
+  booktitle = {2018 {ELEKTRO}}
+}
+
+@Article{steinberger.bredow.ea:widespread-volcanism-in-the-greenland-north-atlantic-region-explained-by-the-iceland-plume,
+  author  = {B. Steinberger and E. Bredow and S. Lebedev and A. Schaeffer and T. H. Torsvik},
+  title   = {{Widespread volcanism in the Greenland-North Atlantic region explained by the Iceland plume}},
+  journal = {Nature Geoscience},
+  year    = 2018,
+  month   = {November},
+  doi     = {10.1038/s41561-018-0251-0}
+}
+
+@PhDThesis{sticko:high,
+  author  = {Sticko, Simon},
+  title   = {High Order Cut Finite Element Methods for Wave Equations},
+  school  = {Uppsala University},
+  series  = {Digital Comprehensive Summaries of Uppsala Dissertations from the Faculty of Science and Technology},
+  issn    = {1651-6214},
+  number  = {1656},
+  isbn    = {978-91-513-0300-0},
+  year    = {2018},
+  url     = {http://urn.kb.se/resolve?urn=urn%3Anbn%3Ase%3Auu%3Adiva-347439}
 }
 
 @Article{tezzele.salmoiraghi.ea:dimension,
@@ -667,257 +2299,43 @@
   journal = {Advanced Modeling and Simulation in Engineering Sciences}
 }
 
-@Article{wells.banks:using,
-  author  = {D. Wells and J. W. Banks},
-  title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates.},
-  journal = {arXiv:1711.05922},
+@Article{truster:deip,
+  doi     = {10.1016/j.softx.2018.05.002},
+  url     = {https://doi.org/10.1016/j.softx.2018.05.002},
   year    = {2018},
-  volume  = {},
-  pages   = {},
-  url     = {},
-  doi     = {}
+  month   = jan,
+  publisher = {Elsevier {BV}},
+  volume  = {7},
+  pages   = {162--170},
+  author  = {Timothy J. Truster},
+  title   = {{DEIP}, discontinuous element insertion Program---Mesh generation for interfacial finite element modeling},
+  journal = {{SoftwareX}}
 }
 
-@Article{wick:numerical,
-  author  = {T. Wick},
-  title   = {Numerical Methods for Partial Differential Equations},
-  journal = {Lecture notes, Institute of Applied Mathematics, Leibniz Universit\"{a}t Hannover, Germany},
+@Article{verner.garikipati:computational,
+  doi     = {10.1016/j.eml.2017.11.003},
+  url     = {https://doi.org/10.1016/j.eml.2017.11.003},
   year    = {2018},
-  volume  = {},
-  pages   = {},
-  url     = {https://www.ifam.uni-hannover.de/1562.html},
-  doi     = {}
-}
-
-@Article{zhang.li:formation,
-  author  = {N. Zhang and Z.-X. Li},
-  title   = {Formation of mantle ``lone plumes'' in the global downwelling zone -- A case for subduction-controlled plume generation beneath the South China Sea},
-  journal = {Tectonophysics},
-  year    = {2018},
-  volume  = {723},
-  pages   = {1--13},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0040195117305000},
-  doi     = {10.1016/j.tecto.2017.11.038}
-}
-
-@Article{zhou.shukla.ea:analysis,
-  author  = {J. J. Zhou and S. Shukla and A. Putz and M. Secanell},
-  title   = {Analysis of the role of the microporous layer in improving polymer electrolyte fuel cell performance},
-  journal = {Electrochimica Acta},
-  year    = {2018},
-  volume  = {268},
-  pages   = {366--382},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0013468618304043?via%3Dihub},
-  doi     = {10.1016/j.electacta.2018.02.100}
-}
-
-@Article{weier.wick:dual-weighted,
-  author  = {Steffen Wei{\ss}er and Thomas Wick},
-  title   = {The Dual-Weighted Residual Estimator Realized on Polygonal Meshes},
-  journal = {Computational Methods in Applied Mathematics},
-  year    = {2018},
+  month   = jan,
+  publisher = {Elsevier {BV}},
   volume  = {18},
-  number  = {4},
-  pages   = {753--776},
-  month   = {oct},
-  doi     = {10.1515/cmam-2017-0046},
-  publisher = {Walter de Gruyter {GmbH}},
-  url     = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf}
+  pages   = {58--69},
+  author  = {S. N. Verner and K. Garikipati},
+  title   = {A computational study of the mechanisms of growth-driven folding patterns on shells, with application to the developing brain},
+  journal = {Extreme Mechanics Letters}
 }
 
-@InProceedings{deolmi.dahmen.ea:effective-boundary-conditions-for-turbulent-compressible-flows-over-a-riblet-surface,
-  author  = {Deolmi, G. and Dahmen, W. and M{\"{u}}ller, S. and Albers, M. and Meysonnat, P. S. and Schr{\"{o}}der, W.},
-  title   = {{Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface}},
-  booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
-  year    = {2018},
-  volume  = {236},
-  series  = {Springer Proceedings in Mathematics \& Statistics},
-  pages   = {473--485},
-  publisher = {Springer International Publishing},
-  doi     = {10.1007/978-3-319-91545-6_36},
-  journal = {Springer}
-}
-
-@Article{deolmi.muller:two-step,
-  doi     = {10.1016/j.matcom.2018.02.008},
-  url     = {https://doi.org/10.1016/j.matcom.2018.02.008},
+@Article{veske.kyritsakis.ea:dynamic,
+  doi     = {10.1016/j.jcp.2018.04.031},
+  url     = {https://doi.org/10.1016/j.jcp.2018.04.031},
   year    = {2018},
   month   = aug,
   publisher = {Elsevier {BV}},
-  volume  = {150},
-  pages   = {49--65},
-  author  = {G. Deolmi and S. M\"{u}ller},
-  title   = {A two-step model order reduction method to simulate a compressible flow over an extended rough surface},
-  journal = {Mathematics and Computers in Simulation}
-}
-
-@InProceedings{chandrashekar.gallego-valencia.ea:a-runge-kutta-discontinuous-galerkin-scheme-for-the-ideal-magnetohydrodynamical-model,
-  author  = {Chandrashekar, Praveen and Gallego-Valencia, Juan Pablo and Klingenberg, Christian},
-  title   = {{A Runge-Kutta Discontinuous Galerkin Scheme for the Ideal Magnetohydrodynamical Model}},
-  booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
-  year    = {2018},
-  volume  = {236},
-  series  = {Springer Proceedings in Mathematics \& Statistics},
-  pages   = {335--344},
-  publisher = {Springer International Publishing},
-  doi     = {10.1007/978-3-319-91545-6_27},
-  journal = {Springer},
-  url     = {https://www.researchgate.net/profile/Christian_Klingenberg/publication/325949144_A_Runge-Kutta_Discontinuous_Galerkin_Scheme_for_the_Ideal_Magnetohydrodynamical_Model/links/5b640dafa6fdcc45b30cab8c/A-Runge-Kutta-Discontinuous-Galerkin-Scheme-for-the-Ideal-Magnetohydrodynamical-Model.pdf?origin=publication_detail}
-}
-
-@Article{duijn.mikelic.ea:monolithic,
-  doi     = {10.1177/1081286518801050},
-  url     = {https://doi.org/10.1177/1081286518801050},
-  year    = {2018},
-  month   = oct,
-  publisher = {{SAGE} Publications},
-  volume  = {24},
-  number  = {5},
-  pages   = {1530--1555},
-  author  = {CJ van Duijn and Andro Mikeli{\'{c}} and Thomas Wick},
-  title   = {A monolithic phase-field model of a fluid-driven fracture in a nonlinear poroelastic medium},
-  journal = {Mathematics and Mechanics of Solids}
-}
-
-@Article{bruna-rosso.demir.ea:selective,
-  author  = {Claire Bruna-Rosso and Ali G\"{o}khan Demir and Barbara Previtali},
-  title   = {Selective laser melting finite element modeling: Validation with high-speed imaging and lack of fusion defects prediction},
-  journal = {Materials {\&} Design},
-  year    = {2018},
-  volume  = {156},
-  pages   = {143--153},
-  month   = {oct},
-  doi     = {10.1016/j.matdes.2018.06.037},
-  publisher = {Elsevier {BV}}
-}
-
-@Article{bruna-rosso.demir.ea:global,
-  author  = {Claire Bruna-Rosso and Ali G\"{o}khan Demir and Maurizio Vedani and Barbara Previtali},
-  title   = {Global sensitivity analyses of a selective laser melting finite element model: influential parameters identification},
-  journal = {The International Journal of Advanced Manufacturing Technology},
-  year    = {2018},
-  volume  = {99},
-  number  = {1-4},
-  pages   = {833--843},
-  month   = {aug},
-  doi     = {10.1007/s00170-018-2531-7},
-  publisher = {Springer Nature America, Inc}
-}
-
-@Article{salvadori.damioli.ea:modeling,
-  author  = {A. Salvadori and V. Damioli and C. Ravelli and S. Mitola},
-  title   = {Modeling and Simulation of {VEGF} Receptors Recruitment in Angiogenesis},
-  journal = {Mathematical Problems in Engineering},
-  year    = {2018},
-  volume  = {2018},
-  pages   = {1--10},
-  month   = {aug},
-  doi     = {10.1155/2018/4705472},
-  publisher = {Hindawi Limited}
-}
-
-@Article{choo.sun:coupled,
-  doi     = {10.1016/j.cma.2017.10.009},
-  url     = {https://doi.org/10.1016/j.cma.2017.10.009},
-  year    = {2018},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {330},
-  pages   = {1--32},
-  author  = {Jinhyun Choo and Waiching Sun},
-  title   = {Coupled phase-field and plasticity modeling of geological materials: From brittle fracture to ductile flow},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{choo.sun:cracking,
-  doi     = {10.1016/j.cma.2018.01.044},
-  url     = {https://doi.org/10.1016/j.cma.2018.01.044},
-  year    = {2018},
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = {335},
-  pages   = {347--379},
-  author  = {Jinhyun Choo and WaiChing Sun},
-  title   = {Cracking and damage from crystallization in pores: Coupled chemo-hydro-mechanics and phase-field modeling},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{choo:large,
-  doi     = {10.1002/nme.5915},
-  url     = {https://doi.org/10.1002/nme.5915},
-  year    = {2018},
-  month   = aug,
-  publisher = {Wiley},
-  volume  = {116},
-  number  = {1},
-  pages   = {66--90},
-  author  = {Jinhyun Choo},
-  title   = {Large deformation poromechanics with local mass conservation: An enriched Galerkin finite element framework},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@InCollection{choo.lee:enriched,
-  doi     = {10.1007/978-3-319-97112-4_69},
-  url     = {https://doi.org/10.1007/978-3-319-97112-4_69},
-  year    = {2018},
-  publisher = {Springer International Publishing},
-  pages   = {312--315},
-  author  = {Jinhyun Choo and Sanghyun Lee},
-  title   = {Enriched Galerkin Finite Element Method for Locally Mass Conservative Simulation of Coupled Hydromechanical Problems},
-  booktitle = {Springer Series in Geomechanics and Geoengineering}
-}
-
-@Article{choo.lee:enriched*1,
-  doi     = {10.1016/j.cma.2018.06.022},
-  url     = {https://doi.org/10.1016/j.cma.2018.06.022},
-  year    = {2018},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {341},
-  pages   = {311--332},
-  author  = {Jinhyun Choo and Sanghyun Lee},
-  title   = {Enriched Galerkin finite elements for coupled poromechanics with local mass conservation},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@PhDThesis{dang:hydro-mechanical,
-  author  = {Hong Lam Dang},
-  title   = {A hydro-mechanical modeling of double porosity and double permeability fractured reservoirs},
-  school  = {Universit\'{e} D'Orl\'{e}ans},
-  year    = {2018},
-  url     = {ftp://ftp.univ-orleans.fr/theses/honglam-dang_3747.pdf}
-}
-
-@Article{chandrashekar:global,
-  author  = {Praveen Chandrashekar},
-  title   = {A global divergence conforming {DG} method for hyperbolic conservation laws with divergence constraint},
-  journal = {Journal of Scientific Computing},
-  year    = {2018},
-  pages   = {1--24},
-  month   = {sep},
-  doi     = {10.1007/s10915-018-0841-4},
-  publisher = {Springer Nature America, Inc},
-  url     = {https://rdcu.be/725Z}
-}
-
-@PhDThesis{xiao:efficient,
-  title   = {Efficient and Accurate Splitting Methods for Flow Problems},
-  author  = {Mengying Xiao},
-  school  = {Clemson University},
-  year    = {2018},
-  url     = {https://tigerprints.clemson.edu/all_dissertations/2174/}
-}
-
-@Article{ladenheim.chen.ea:mta,
-  author  = {Scott Ladenheim and Yi-Chung Chen and Milan D. Mihajlovi{\'c} and Vasilis F. Pavlidis},
-  title   = {The {MTA}: {A}n Advanced and Versatile Thermal Simulator for Integrated Systems},
-  journal = {IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems},
-  year    = {2018},
-  volume  = {37},
-  number  = {12},
-  pages   = {3123--3136},
-  month   = {January},
-  doi     = {10.1109/TCAD.2018.2789729}
+  volume  = {367},
+  pages   = {279--294},
+  author  = {Mihkel Veske and Andreas Kyritsakis and Kristjan Eimre and Vahur Zadin and Alvo Aabloo and Flyura Djurabekova},
+  title   = {Dynamic coupling of a finite element solver to large-scale atomistic simulations},
+  journal = {Journal of Computational Physics}
 }
 
 @Article{villiers.mcbride.ea:a-validated-patient-specific-fsi-model-for-vascular-access-in-haemodialysis,
@@ -935,895 +2353,13 @@
   year    = {2018}
 }
 
-@Article{steinberger.bredow.ea:widespread-volcanism-in-the-greenland-north-atlantic-region-explained-by-the-iceland-plume,
-  author  = {B. Steinberger and E. Bredow and S. Lebedev and A. Schaeffer and T. H. Torsvik},
-  title   = {{Widespread volcanism in the Greenland-North Atlantic region explained by the Iceland plume}},
-  journal = {Nature Geoscience},
-  year    = 2018,
-  month   = {November},
-  doi     = {10.1038/s41561-018-0251-0}
-}
-
-@Article{gulevich.koshelets.ea:bridging,
-  author  = {D. R. Gulevich and V. P. Koshelets and F. V. Kusmartsev},
-  title   = {Bridging the Terahertz gap for chaotic sources with superconducting junctions},
-  journal = {arXiv:1709.04052},
-  year    = {2018},
-  volume  = {},
-  pages   = {},
-  url     = {https://arxiv.org/abs/1709.04052},
-  doi     = {}
-}
-
-@PhDThesis{charnyi:emac,
-  title   = {The {EMAC} scheme for Navier-Stokes simulations, and application to flow past bluff bodies},
-  author  = {Sergey Charnyi},
-  school  = {Clemson University},
-  year    = {2018},
-  url     = {https://tigerprints.clemson.edu/all_dissertations/2243/}
-}
-
-@PhDThesis{zhao:numerical,
-  title   = {A numerical method for the Navier Stokes equations in {Velocity-Vorticity} form},
-  author  = {Liang Zhao},
-  school  = {Clemson University},
-  year    = {2018},
-  url     = {https://tigerprints.clemson.edu/all_dissertations/2288/}
-}
-
-@MastersThesis{cinatl:finite,
-  title   = {Finite Element Discretizations for Linear Elasticity},
-  author  = {Emma Cinatl},
-  school  = {Clemson University},
-  year    = {2018},
-  url     = {https://tigerprints.clemson.edu/all_theses/2977/}
-}
-
-@Article{charnyi.heister.ea:efficient,
-  author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
-  title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier-Stokes equations},
-  journal = {Applied Numerical Mathematics},
-  year    = {2018},
-  doi     = {10.1016/j.apnum.2018.11.013},
-  url     = {https://arxiv.org/abs/1712.00857},
-  note    = {in press}
-}
-
-@Article{heister.wick:parallel,
-  title   = {Parallel solution, adaptivity, computational convergence, and open-source code of 2d and 3d pressurized phase-field fracture problems},
-  author  = {Timo Heister and Thomas Wick},
-  journal = {Proc. Appl. Math. Mech.},
-  year    = {2018},
-  number  = {1},
-  pages   = {e201800353},
-  volume  = {18},
-  doi     = {10.1002/pamm.201800353}
-}
-
-@Article{liu.yin:unconditionally,
-  author  = {H. Liu and P. Yin},
-  title   = {Unconditionally energy stable DG schemes for the Swift-Hohenberg equation},
-  journal = {Journal of Scientific Computing},
-  year    = 2018,
-  note    = {submitted}
-}
-
-@Article{na.sun:computational,
-  author  = {SeonHong Na and WaiChing Sun},
-  title   = {Computational thermomechanics of crystalline rock, Part I: A combined multi-phase-field/crystal plasticity approach for single crystal simulations},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2018},
-  volume  = {338},
-  pages   = {657--691},
-  month   = {aug},
-  doi     = {10.1016/j.cma.2017.12.022},
-  publisher = {Elsevier {BV}}
-}
-
-@Article{bryant.sun:mixed-mode,
-  author  = {Eric C. Bryant and WaiChing Sun},
-  title   = {A mixed-mode phase field fracture model in anisotropic rocks with consistent kinematics},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2018},
-  volume  = {342},
-  pages   = {561--584},
-  month   = dec,
-  doi     = {10.1016/j.cma.2018.08.008},
-  publisher = {Elsevier {BV}}
-}
-
-@Article{k-gupta.keulen.ea:design,
-  author  = {K. Gupta, Deepak and Keulen, Fred and Langelaar, Matthijs},
-  year    = {2018},
-  month   = {11},
-  pages   = {},
-  title   = {Design and analysis adaptivity in multi-resolution topology optimization},
-  journal = {arXiv:1811.09821},
-  volume  = {},
-  url     = {https://arxiv.org/abs/1811.09821},
-  doi     = {}
-}
-
-@Article{aagesen.adams.ea:prisms,
-  author  = {L. K. Aagesen and J. F. Adams and J. E. Allison and W. B. Andrews and V. Araullo-Peters and T. Berman and Z. Chen and S. Daly and S. Das and S. DeWitt and S. Ganesan and K. Garikipati and V. Gavini and A. Githens and M. Hedstrom and Z. Huang and H. V. Jagadish and J. W. Jones and J. Luce and E. A. Marquis and A. Misra and D. Montiel and P. Motamarri and A. D. Murphy and A. R. Natarajan and S. Panwar and B. Puchala and L. Qi and S. Rudraraju and K. Sagiyama and E. L. S. Solomon and V. Sundararaghavan and G. Tarcea and G. H. Teichert and J. C. Thomas and K. Thornton and A. Van der Ven and Z. Wang and T. Weymouth and C. Yang},
-  title   = {{PRISMS}: {A}n Integrated, Open-Source Framework for Accelerating Predictive Structural Materials Science},
-  journal = {The Journal of The Minderals, Metals \& Materials Society (JOM)},
-  year    = 2018,
-  volume  = 70,
-  pages   = {2298--2314},
-  doi     = {10.1007/s11837-018-3079-6}
-}
-
-@Article{sartori.giuliani.ea:deal2lkit,
-  author  = {Sartori, Alberto and Giuliani, Nicola and Bardelloni, Mauro and Heltai, Luca},
-  doi     = {10.1016/j.softx.2018.09.004},
-  issn    = {23527110},
-  journal = {SoftwareX},
-  pages   = {318--327},
-  title   = {deal2lkit: A toolkit library for high performance programming in deal.II},
-  url     = {https://linkinghub.elsevier.com/retrieve/pii/S2352711018302048},
-  volume  = {7},
-  year    = {2018}
-}
-
-@Article{samrock.grayver.ea:magnetotelluric,
-  title   = {Magnetotelluric image of transcrustal magmatic system beneath the {Tulu Moye} geothermal prospect in the {Ethiopian Rift}},
-  author  = {Samrock, Friedemann and Grayver, Alexander V and Eysteinsson, Hjalmar and Saar, Martin O},
-  journal = {Geophysical Research Letters},
-  volume  = {45},
-  number  = {23},
-  pages   = {12847--12855},
-  year    = {2018},
-  publisher = {Wiley Online Library},
-  doi     = {10.1029/2018GL080333}
-}
-
-@Article{kaufl.grayver.ea:topographic,
-  title   = {Topographic distortions of magnetotelluric transfer functions: a high-resolution 3-D modelling study using real elevation data},
-  author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Kuvshinov, Alexey V},
-  journal = {Geophysical Journal International},
-  volume  = {215},
-  number  = {3},
-  pages   = {1943--1961},
-  year    = {2018},
-  publisher = {Oxford University Press},
-  doi     = {10.1093/gji/ggy375}
-}
-
-@Article{ludvigsson.steffen.ea:high-order,
-  author  = {Ludvigsson, Gustav and Steffen, Kyle R. and Sticko, Simon and Wang, Siyang and Xia, Qing and Epshteyn, Yekaterina and Kreiss, Gunilla},
-  title   = {High-Order Numerical Methods for 2D Parabolic Problems in Single and Composite Domains},
-  journal = {Journal of Scientific Computing},
-  year    = {2018},
-  month   = {Aug},
-  volume  = {76},
-  number  = {2},
-  pages   = {812--847},
-  issn    = {1573-7691},
-  doi     = {10.1007/s10915-017-0637-y},
-  url     = {https://doi.org/10.1007/s10915-017-0637-y}
-}
-
-@PhDThesis{sticko:high,
-  author  = {Sticko, Simon},
-  title   = {High Order Cut Finite Element Methods for Wave Equations},
-  school  = {Uppsala University},
-  series  = {Digital Comprehensive Summaries of Uppsala Dissertations from the Faculty of Science and Technology},
-  issn    = {1651-6214},
-  number  = {1656},
-  isbn    = {978-91-513-0300-0},
-  year    = {2018},
-  url     = {http://urn.kb.se/resolve?urn=urn%3Anbn%3Ase%3Auu%3Adiva-347439}
-}
-
-@Article{freddi.sacco.ea:enriched,
-  author  = {Freddi, F. and Sacco, E. and Serpieri, R.},
-  title   = {An enriched damage-frictional cohesive-zone model incorporating stress multi-axiality},
-  journal = {Meccanica},
-  year    = {2018},
-  volume  = {53},
-  number  = {3},
-  pages   = {573-592}
-}
-
-@MastersThesis{schneider:simulation,
-  author  = {Schneider, David},
-  title   = {Simulation von Fluid-Struktur-Interaktion mit der Kopplungsbibliothek preCICE},
-  school  = {Universit{\"a}t Siegen},
-  year    = {2018},
-  note    = {Bachelorarbeit}
-}
-
-@Article{lambe.czekanski:density,
-  doi     = {10.1002/nme.5843},
-  year    = {2018},
-  month   = jun,
-  publisher = {Wiley},
-  volume  = {115},
-  number  = {10},
-  pages   = {1266--1286},
-  author  = {Andrew B. Lambe and Aleksander Czekanski},
-  title   = {A density field parametrization for topology optimization using {B}ernstein elements},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{sarna.torrilhon:entropy,
-  doi     = {10.1016/j.jcp.2018.04.050},
-  year    = {2018},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {369},
-  pages   = {16--44},
-  author  = {Neeraj Sarna and Manuel Torrilhon},
-  title   = {Entropy stable {H}ermite approximation of the linearised {B}oltzmann equation for inflow and outflow boundaries},
-  journal = {Journal of Computational Physics}
-}
-
-@Article{safin.minkoff.ea:preconditioned,
-  author  = {Safin, Artur and Minkoff, Susan E. and Zweck, John},
-  title   = {A preconditioned finite element solution of the coupled pressure-temperature equations used to model trace gas sensors},
-  journal = {SIAM Journal on Scientific Computing},
-  volume  = {40},
-  number  = {5},
-  pages   = {B1470--B1493},
-  year    = {2018},
-  doi     = {10.1137/17M1145823},
-  url     = {https://doi.org/10.1137/17M1145823}
-}
-
-@PhDThesis{safin:modeling,
-  author  = {Safin, Artur},
-  title   = {Modeling Trace Gas Sensors with the Coupled Pressure-Temperature Equations},
-  school  = {The University of Texas at Dallas},
-  year    = {2018},
-  month   = {12},
-  url     = {https://hdl.handle.net/10735.1/6420}
-}
-
-@Article{neitzel.wick.ea:optimal,
-  author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
-  title   = {An Optimal Control Problem Governed by a Regularized Phase-field Fracture Propagation Model. {P}art {I}{I} {T}he Regularization Limit},
-  journal = {SIAM Journal on Control and Optimization},
-  volume  = {55},
-  number  = {4},
-  pages   = {18},
-  year    = {2018},
-  doi     = {10.1137/16M1062375}
-}
-
-@Article{schutz:3d,
-  title   = {3D Boundary Element Simulation of Droplet Dynamics in Microchannels: How Droplets Squeeze Through Constrictions and Move in Electric Fields},
-  author  = {Sch\"{u}tz, Simon Sebastian},
-  publisher = {EPFL},
-  address = {Lausanne},
-  pages   = {156},
-  year    = {2018},
-  url     = {http://infoscience.epfl.ch/record/255307},
-  doi     = {10.5075/epfl-thesis-8621}
-}
-
-@PhDThesis{sacco:3d,
-  author  = {Filippo Guido Davide Sacco},
-  title   = {A 3D adaptive boundary element method for potential flow with nonlinear Kutta condition},
-  school  = {Politecnico di Milano},
-  year    = {2018},
-  month   = {4},
-  url     = {https://www.politesi.polimi.it/handle/10589/140106}
-}
-
-@Article{arndt.kanschat:a-c1-mapping-based-on-finite-elements-on-quadrilateral-and-hexahedral-meshes,
-  author  = {Arndt, Daniel and Kanschat, Guido},
-  title   = {{A C1-mapping based on finite elements on quadrilateral and hexahedral meshes}},
-  journal = {arxiv: 1810.02473},
-  year    = {2018},
-  month   = {oct},
-  url     = {https://arxiv.org/abs/1810.02473}
-}
-
-@InBook{boffi.gastaldi.ea:distributed,
-  author  = {Boffi, Daniele and Gastaldi, Lucia and Heltai, Luca},
-  editor  = {Boffi, Daniele and Pavarino, Luca F. and Rozza, Gianluigi and Scacchi, Simone and Vergara, Christian},
-  title   = {A Distributed Lagrange Formulation of the Finite Element Immersed Boundary Method for Fluids Interacting with Compressible Solids},
-  booktitle = {Mathematical and Numerical Modeling of the Cardiovascular System and Applications},
-  year    = {2018},
-  publisher = {Springer International Publishing},
-  address = {Cham},
-  pages   = {1--21},
-  doi     = {10.1007/978-3-319-96649-6}
-}
-
-@Article{kronbichler.diagne.ea:fast,
-  author  = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
-  title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
-  journal = {The International Journal of High Performance Computing Applications},
-  volume  = {32},
-  number  = {2},
-  pages   = {266-287},
-  year    = {2018},
-  doi     = {10.1177/1094342016671790},
-  url     = {https://doi.org/10.1177/1094342016671790},
-  eprint  = { https://doi.org/10.1177/1094342016671790 }
-}
-
-@Article{kronbichler.wall:performance,
-  author  = {Kronbichler, Martin and Wall, Wolfgang A.},
-  title   = {A Performance Comparison of Continuous and Discontinuous Galerkin Methods with Fast Multigrid Solvers},
-  journal = {SIAM Journal on Scientific Computing},
-  volume  = {40},
-  number  = {5},
-  pages   = {A3423--A3448},
-  year    = {2018},
-  doi     = {10.1137/16M110455X},
-  url     = { https://doi.org/10.1137/16M110455X}
-}
-
-@Article{badnava.msekh.ea:h-adaptive,
-  title   = {An h-adaptive thermo-mechanical phase field model for fracture},
-  journal = {Finite Elements in Analysis and Design},
-  volume  = {138},
-  pages   = {31 - 47},
-  year    = {2018},
-  issn    = {0168-874X},
-  doi     = {https://doi.org/10.1016/j.finel.2017.09.003},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0168874X17303347},
-  author  = {Hojjat Badnava and Mohammed A. Msekh and Elahe Etemadi and Timon Rabczuk}
-}
-
-@Article{sheldon.miller.ea:improved,
-  title   = {An Improved Formulation for Hybridizable Discontinuous Galerkin Fluid-Structure Interaction Modeling with Reduced Computational Expense},
-  author  = {Sheldon, Jason P. and Miller, Scott T. and Pitt, Jonathan S.},
-  doi     = {10.4208/cicp.OA-2017-0114},
-  journal = {Communications in Computational Physics},
-  issn    = {1815-2406},
-  number  = 5,
-  volume  = 24,
-  year    = {2018},
-  month   = {6}
-}
-
-@PhDThesis{kauffman:overset,
-  author  = {Kauffman, Justin},
-  title   = {An Overset Mesh Framework for the Hybridizable Discontinuous Galerkin Finite Element Method},
-  school  = {Pennsylvania State University},
-  year    = {2018},
-  month   = {1}
-}
-
-@PhDThesis{khattatov:efficient,
-  author  = {Eldar Khattatov},
-  title   = {Efficient discretization techniques and domain decomposition methods for poroelasticity},
-  school  = {University of Pittsburgh},
-  year    = {2018},
-  url     = {http://d-scholarship.pitt.edu/34001/1/thesis_khattatov.pdf}
-}
-
-@Article{bruchhauser.schwegler.ea:dual,
-  title   = {Dual weighted residual based error control for nonstationary convection-dominated equations: potential or ballast?},
-  author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
-  journal = {arXiv:1812.06810},
-  year    = 2018,
-  url     = {https://arxiv.org/abs/1812.06810}
-}
-
-@PhDThesis{marcati:discontinuous,
-  author  = {Carlo Marcati},
-  title   = {Discontinuous hp finite element methods for elliptic eigenvalue problems with singular potentials: with applications to quantum chemistry},
-  school  = {Sorbonne University, Paris},
-  year    = {2018},
-  url     = {https://tel.archives-ouvertes.fr/tel-02072774/}
-}
-
-@Article{guermond.nazarov.ea:second-order,
-  doi     = {10.1137/17m1149961},
-  url     = {https://doi.org/10.1137/17m1149961},
-  year    = {2018},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {40},
-  number  = {5},
-  pages   = {A3211--A3239},
-  author  = {Jean-Luc Guermond and Murtazo Nazarov and Bojan Popov and Ignacio Tomas},
-  title   = {Second-Order Invariant Domain Preserving Approximation of the Euler Equations Using Convex Limiting},
-  journal = {{SIAM} Journal on Scientific Computing}
-}
-
-@Article{giuliani.heltai.ea:predicting,
-  doi     = {10.1089/soro.2017.0099},
-  url     = {https://doi.org/10.1089/soro.2017.0099},
-  year    = {2018},
-  month   = aug,
-  publisher = {Mary Ann Liebert Inc},
-  volume  = {5},
-  number  = {4},
-  pages   = {410--424},
-  author  = {Nicola Giuliani and Luca Heltai and Antonio DeSimone},
-  title   = {Predicting and Optimizing Microswimmer Performance from the Hydrodynamics of Its Components: The Relevance of Interactions},
-  journal = {Soft Robotics}
-}
-
-@Article{zhao.tan:postvoiding,
-  doi     = {10.1109/tvlsi.2018.2861358},
-  url     = {https://doi.org/10.1109/tvlsi.2018.2861358},
+@MastersThesis{vundla:numerical,
+  author  = {Vundla, Nkosilathi},
+  title   = {Numerical modelling of the Oldroyd-B fluid},
+  url     = {http://hdl.handle.net/11427/30996},
   year    = {2018},
   month   = nov,
-  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})},
-  volume  = {26},
-  number  = {11},
-  pages   = {2483--2493},
-  author  = {Hengyang Zhao and Sheldon X.-D. Tan},
-  title   = {Postvoiding {FEM} Analysis for Electromigration Failure Characterization},
-  journal = {{IEEE} Transactions on Very Large Scale Integration ({VLSI}) Systems}
-}
-
-@Article{murphy.venkataraman.ea:parameter,
-  doi     = {10.1142/s1793524518500535},
-  url     = {https://doi.org/10.1142/s1793524518500535},
-  year    = {2018},
-  month   = may,
-  publisher = {World Scientific Pub Co Pte Lt},
-  volume  = {11},
-  number  = {04},
-  pages   = {1850053},
-  author  = {Laura Murphy and Chandrasekhar Venkataraman and Anotida Madzvamuse},
-  title   = {Parameter identification through mode isolation for reaction-diffusion systems on arbitrary geometries},
-  journal = {International Journal of Biomathematics}
-}
-
-@InProceedings{smolyanov.karban:optimal,
-  doi     = {10.1109/elektro.2018.8398325},
-  url     = {https://doi.org/10.1109/elektro.2018.8398325},
-  year    = {2018},
-  month   = may,
-  publisher = {{IEEE}},
-  author  = {Ivan A. Smolyanov and Pavel Karban},
-  title   = {Optimal design of {MHD} pump},
-  booktitle = {2018 {ELEKTRO}}
-}
-
-@Article{galiano.velasco:on,
-  doi     = {10.1016/j.camwa.2018.05.035},
-  url     = {https://doi.org/10.1016/j.camwa.2018.05.035},
-  year    = {2018},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {76},
-  number  = {5},
-  pages   = {984--996},
-  author  = {Gonzalo Galiano and Juli{\'{a}}n Velasco},
-  title   = {On a cross-diffusion system arising in image denoising},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{mehnert.hossain.ea:numerical,
-  doi     = {10.1016/j.ijnonlinmec.2018.08.016},
-  url     = {https://doi.org/10.1016/j.ijnonlinmec.2018.08.016},
-  year    = {2018},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {106},
-  pages   = {13--24},
-  author  = {Markus Mehnert and Mokarram Hossain and Paul Steinmann},
-  title   = {Numerical modeling of thermo-electro-viscoelasticity with field-dependent material parameters},
-  journal = {International Journal of Non-Linear Mechanics}
-}
-
-@Misc{mohebujjaman:second,
-  title   = {Second order ensemble simulation for {MHD} flow in Els{\"a}sser variable with noisy input data},
-  author  = {Muhammad Mohebujjaman},
-  year    = {2018},
-  eprint  = {1803.06980},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{maday.marcati:regularity,
-  title   = {Regularity and $hp$ discontinuous {G}alerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
-  author  = {Yvon Maday and Carlo Marcati},
-  year    = {2018},
-  eprint  = {1810.09010},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Article{roberge.norato:computational,
-  author  = {Jeffrey Roberge and Juli{\'{a}}n Norato},
-  title   = {Computational design of curvilinear bone scaffolds fabricated via direct ink writing},
-  doi     = {10.1016/j.cad.2017.09.003},
-  url     = {https://doi.org/10.1016/j.cad.2017.09.003},
-  year    = {2018},
-  volume  = {95},
-  pages   = {1--13},
-  journal = {Computer-Aided Design}
-}
-
-@Article{gong.chen.ea:fast,
-  title   = {Fast simulations of a large number of crystals growth in centimeter-scale during alloy solidification via nonlinearly preconditioned quantitative phase-field formula},
-  author  = {Tong Zhao Gong and Yun Chen and Yan Fei Cao and Xiu Hong Kang and Dian Zhong Li},
-  doi     = {10.1016/j.commatsci.2018.02.003},
-  url     = {https://doi.org/10.1016/j.commatsci.2018.02.003},
-  year    = {2018},
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = {147},
-  pages   = {338--352},
-  journal = {Computational Materials Science}
-}
-
-@Misc{frei.richter.ea:on,
-  title   = {On the implementation of a locally modified finite element method for interface problems in deal.II},
-  author  = {Stefan Frei and Thomas Richter and Thomas Wick},
-  year    = {2018},
-  eprint  = {1806.00999},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{bruchhauser.schwegler.ea:numerical,
-  title   = {Numerical study of goal-oriented error control for stabilized finite element methods},
-  author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
-  year    = {2018},
-  eprint  = {1803.10643},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Article{verner.garikipati:computational,
-  doi     = {10.1016/j.eml.2017.11.003},
-  url     = {https://doi.org/10.1016/j.eml.2017.11.003},
-  year    = {2018},
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = {18},
-  pages   = {58--69},
-  author  = {S. N. Verner and K. Garikipati},
-  title   = {A computational study of the mechanisms of growth-driven folding patterns on shells, with application to the developing brain},
-  journal = {Extreme Mechanics Letters}
-}
-
-@PhDThesis{alhazmi:exploring-mechanisms-for-pattern-formation-through-coupled-bulk-surface-pdes,
-  author  = {Alhazmi, M.},
-  title   = {{Exploring mechanisms for pattern formation through coupled bulk-surface PDEs}},
-  year    = {2018},
-  url     = {http://sro.sussex.ac.uk/id/eprint/78232/},
-  school  = {University of Sussex}
-}
-
-@PhDThesis{zhao:fem-based-multiphysics-analysis-of-electromigration-voiding-process-in-nanometer-integrated-circuits,
-  author  = {Zhao, H.},
-  title   = {{FEM Based Multiphysics Analysis of Electromigration Voiding Process in Nanometer Integrated Circuits}},
-  year    = {2018},
-  url     = {https://cloudfront.escholarship.org/dist/prd/content/qt41f4p23x/qt41f4p23x.pdf},
-  school  = {University of California, Davis}
-}
-
-@TechReport{gulevich:mitmojco-1-2,
-  author  = {Gulevich, D. R.},
-  title   = {{MiTMoJCo 1.2}},
-  year    = {2018},
-  url     = {https://www.researchgate.net/profile/D_Gulevich/publication/318380494_User_Guide_for_MiTMoJCo_12_Microscopic_Tunneling_Model_for_Josephson_Contacts/links/5ba4005d92851ca9ed1a09b1/User-Guide-for-MiTMoJCo-12-Microscopic-Tunneling-Model-for-Josephson-Contacts.pdf}
-}
-
-@MastersThesis{schuurmans:numerical-modelling-of-overriding-plate-deformation-and-slab-rollback-in-the-western-mediterranean,
-  author  = {Schuurmans, L. F. J.},
-  title   = {{Numerical modelling of overriding plate deformation and slab rollback in the Western Mediterranean}},
-  school  = {Utrecht University},
-  year    = {2018},
-  url     = {https://dspace.library.uu.nl/handle/1874/366408}
-}
-
-@InProceedings{kronbichler.allalen:efficient,
-  doi     = {10.1007/978-3-319-99654-7_7},
-  url     = {https://doi.org/10.1007/978-3-319-99654-7_7},
-  year    = {2018},
-  publisher = {Springer International Publishing},
-  pages   = {89--110},
-  author  = {Martin Kronbichler and Momme Allalen},
-  title   = {Efficient High-Order Discontinuous Galerkin Finite Elements with Matrix-Free Implementations},
-  booktitle = {Advances and New Trends in Environmental Informatics},
-  editor  = {Bungartz, Hans-Joachim and Kranzlm\"uller, Dieter and Weinberg, Volker and Weism\"uller, Jens and Wohlgemuth, Volker},
-  series  = {Progress in {IS}}
-}
-
-@Article{gassmoller.lokavarapu.ea:flexible,
-  doi     = {10.1029/2018gc007508},
-  url     = {https://doi.org/10.1029/2018gc007508},
-  year    = {2018},
-  month   = sep,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {19},
-  number  = {9},
-  pages   = {3596--3604},
-  author  = {Rene Gassm\"{o}ller and Harsha Lokavarapu and Eric Heien and Elbridge Gerry Puckett and Wolfgang Bangerth},
-  title   = {Flexible and Scalable Particle-in-Cell Methods With Adaptive Mesh Refinement for Geodynamic Computations},
-  journal = {Geochemistry, Geophysics, Geosystems}
-}
-
-@InCollection{gantner.herrmann.ea:multilevel,
-  doi     = {10.1007/978-3-319-72456-0_18},
-  url     = {https://doi.org/10.1007/978-3-319-72456-0_18},
-  year    = {2018},
-  publisher = {Springer International Publishing},
-  pages   = {373--405},
-  author  = {Robert N. Gantner and Lukas Herrmann and Christoph Schwab},
-  title   = {Multilevel {QMC} with Product Weights for Affine-Parametric, Elliptic {PDEs}},
-  booktitle = {Contemporary Computational Mathematics - A Celebration of the 80th Birthday of Ian Sloan}
-}
-
-@MastersThesis{c--a--h--blom:state-of-the-art-numerical-subduction-modelling-with-aspect--thermo-mechanically-coupled-viscoplastic-compressible-rheology--free-surface--phase-changes--latent-heat-and-open-sidewalls,
-  author  = {{C. A. H. Blom}},
-  school  = {Utrecht University},
-  title   = {{State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls}},
-  url     = {https://dspace.library.uu.nl/handle/1874/348133},
-  year    = {2016}
-}
-
-@Article{glerum.thieulot.ea:nonlinear,
-  doi     = {10.5194/se-9-267-2018},
-  url     = {https://doi.org/10.5194/se-9-267-2018},
-  year    = {2018},
-  month   = mar,
-  publisher = {Copernicus {GmbH}},
-  volume  = {9},
-  number  = {2},
-  pages   = {267--294},
-  author  = {Anne Glerum and Cedric Thieulot and Menno Fraters and Constantijn Blom and Wim Spakman},
-  title   = {Nonlinear viscoplasticity in {ASPECT}: benchmarking and applications to subduction},
-  journal = {Solid Earth}
-}
-
-@PhDThesis{lucero-lorca:multilevel-schwarz-methods-for-multigroup-radiation-transport-problems,
-  author  = {Jose Pablo {Lucero Lorca}},
-  title   = {{Multilevel Schwarz methods for multigroup radiation transport problems}},
-  year    = {2018},
-  school  = {Heidelberg University},
-  url     = {https://archiv.ub.uni-heidelberg.de/volltextserver/25216/},
-  doi     = {10.11588/heidok.00025216}
-}
-
-@Article{kerganer.mergheim.ea:modeling,
-  doi     = {10.1016/j.camwa.2018.05.016},
-  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
-  year    = {2019},
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = {78},
-  number  = {7},
-  pages   = {2338--2350},
-  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
-  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{freund.kim.ea:field,
-  doi     = {10.1016/j.jnnfm.2018.03.013},
-  url     = {https://doi.org/10.1016/j.jnnfm.2018.03.013},
-  year    = {2018},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {257},
-  pages   = {71--82},
-  author  = {J.B. Freund and J. Kim and R.H. Ewoldt},
-  title   = {Field sensitivity of flow predictions to rheological parameters},
-  journal = {Journal of Non-Newtonian Fluid Mechanics}
-}
-
-@Article{gonzalez-valverde.garcia-aznar:mechanical,
-  doi     = {10.1016/j.cma.2018.03.036},
-  url     = {https://doi.org/10.1016/j.cma.2018.03.036},
-  year    = {2018},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {337},
-  pages   = {246--262},
-  author  = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
-  title   = {Mechanical modeling of collective cell migration: An agent-based and continuum material approach},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Misc{gulevich:mitmojco,
-  title   = {MiTMoJCo: Microscopic Tunneling Model for Josephson Contacts},
-  author  = {Dmitry R. Gulevich},
-  year    = {2018},
-  eprint  = {1809.04706},
-  archiveprefix = {arXiv},
-  primaryclass = {cond-mat.supr-con}
-}
-
-@Misc{maier.mattheakis.ea:homogenization,
-  title   = {Homogenization of plasmonic crystals: Seeking the epsilon-near-zero effect},
-  author  = {Matthias Maier and Marios Mattheakis and Efthimios Kaxiras and Mitchell Luskin and Dionisios Margetis},
-  year    = {2018},
-  eprint  = {1809.08276},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Article{wick:zielorientierte-numerik-fur-multiphysiksimulationen,
-  author  = {T. Wick},
-  title   = {{Zielorientierte Numerik f{\"u}r Multiphysiksimulationen}},
-  journal = {GAMM-Rundbrief},
-  year    = 2018,
-  volume  = 2,
-  pages   = {4--10}
-}
-
-@Article{endtmayer.langer.ea:multiple,
-  doi     = {10.1002/pamm.201800048},
-  url     = {https://doi.org/10.1002/pamm.201800048},
-  year    = {2018},
-  month   = dec,
-  publisher = {Wiley},
-  volume  = {18},
-  number  = {1},
-  author  = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
-  title   = {Multiple goal-oriented error estimates applied to 3d non-linear problems},
-  journal = {{PAMM}}
-}
-
-@Misc{bonito.lei.ea:finite,
-  title   = {Finite element approximation of an obstacle problem for a class of integro-differential operators},
-  author  = {Andrea Bonito and Wenyu Lei and Abner J. Salgado},
-  year    = {2018},
-  eprint  = {1808.01576},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{bonito.girault.ea:finite,
-  title   = {Finite Element Approximation of a Strain-Limiting Elastic Model},
-  author  = {Andrea Bonito and Vivette Girault and Endre Suli},
-  year    = {2018},
-  eprint  = {1805.04006},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@MastersThesis{munch:efficient,
-  author  = {M\"unch, Peter},
-  title   = {An efficient hybrid multigrid solver for high-order discontinuous Galerkin methods},
-  school  = {Technical University of Munich},
-  year    = {2018},
-  month   = {oct},
-  url     = {https://mediatum.ub.tum.de/node?id=1514962}
-}
-
-@Article{borregales.radu.ea:robust,
-  author  = {Manuel Borregales and Florin Adrian Radu and Kundan Kumar and Jan Martin Nordbotten},
-  title   = {Robust iterative schemes for non-linear poromechanics},
-  journal = {Computational Geosciences},
-  year    = {2018},
-  volume  = {22},
-  number  = {4},
-  pages   = {1021-1038},
-  doi     = {10.1007/s10596-018-9736-6},
-  url     = {http://hdl.handle.net/1956/22101}
-}
-
-@Misc{pearson.porcelli.ea:interior,
-  title   = {Interior Point Methods and Preconditioning for PDE-Constrained Optimization Problems Involving Sparsity Terms},
-  author  = {John W. Pearson and Margherita Porcelli and Martin Stoll},
-  year    = {2018},
-  eprint  = {1806.05896},
-  archiveprefix = {arXiv},
-  primaryclass = {math.OC}
-}
-
-@Misc{carraro.wetterauer.ea:level-set,
-  title   = {A level-set approach for a multi-scale cancer invasion model},
-  author  = {Thomas Carraro and Sven E. Wetterauer and Ana Victoria Ponce Bobadilla and Dumitru Trucu},
-  year    = {2018},
-  eprint  = {1805.07485},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{arndt.kanschat:c1-mapping,
-  title   = {A C1-mapping based on finite elements on quadrilateral and hexahedral meshes},
-  author  = {Daniel Arndt and Guido Kanschat},
-  year    = {2018},
-  eprint  = {1810.02473},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{burstedde:parallel,
-  title   = {Parallel tree algorithms for AMR and non-standard data access},
-  author  = {Carsten Burstedde},
-  year    = {2018},
-  eprint  = {1803.08432},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.DC}
-}
-
-@Misc{arbogast.tao:direct,
-  title   = {Direct Serendipity and Mixed Finite Elements on Convex Quadrilaterals},
-  author  = {Todd Arbogast and Zhen Tao},
-  year    = {2018},
-  eprint  = {1809.02192},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{emerson:error,
-  title   = {Error Estimators and Marking Strategies for Electrically Coupled Liquid Crystal Systems},
-  author  = {D. B. Emerson},
-  year    = {2018},
-  eprint  = {1806.06248},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{zhang.guo.ea:runge-kutta,
-  title   = {Runge-Kutta symmetric interior penalty discontinuous Galerkin methods for modified Buckley-Leverett equations},
-  author  = {Hong Zhang and Yunrui Guo and Weibin Li and Paul Andries Zegeling},
-  year    = {2018},
-  eprint  = {1801.07182},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{badia.martin.ea:fempar,
-  title   = {FEMPAR: An object-oriented parallel finite element framework},
-  author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
-  year    = {2017},
-  eprint  = {1708.01773},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.CE}
-}
-
-@Article{emerson.farrell.ea:computing,
-  doi     = {10.1080/02678292.2017.1365385},
-  url     = {https://doi.org/10.1080/02678292.2017.1365385},
-  year    = {2017},
-  month   = aug,
-  publisher = {Informa {UK} Limited},
-  volume  = {45},
-  number  = {3},
-  pages   = {341--350},
-  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
-  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
-  journal = {Liquid Crystals}
-}
-
-@Article{lambe.czekanski:topology,
-  doi     = {10.1002/nme.5617},
-  url     = {https://doi.org/10.1002/nme.5617},
-  year    = {2017},
-  month   = aug,
-  publisher = {Wiley},
-  volume  = {113},
-  number  = {3},
-  pages   = {357--373},
-  author  = {Andrew B. Lambe and Aleksander Czekanski},
-  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{ha.choo.ea:liquid,
-  doi     = {10.1007/s00603-018-1542-x},
-  url     = {https://doi.org/10.1007/s00603-018-1542-x},
-  year    = {2018},
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {51},
-  number  = {11},
-  pages   = {3407--3420},
-  author  = {Seong Jun Ha and Jinhyun Choo and Tae Sup Yun},
-  title   = {Liquid {CO}2 Fracturing: Effect of Fluid Permeation on the Breakdown Pressure and Cracking Behavior},
-  journal = {Rock Mechanics and Rock Engineering}
-}
-
-@Article{ilio.dorschner.ea:simulation*1,
-  doi     = {10.1017/jfm.2018.413},
-  url     = {https://doi.org/10.1017/jfm.2018.413},
-  year    = {2018},
-  month   = jun,
-  publisher = {Cambridge University Press ({CUP})},
-  volume  = {849},
-  pages   = {35--56},
-  author  = {G. Di Ilio and B. Dorschner and G. Bella and S. Succi and I. V. Karlin},
-  title   = {Simulation of turbulent flows with the entropic multirelaxation time lattice Boltzmann method on body-fitted meshes},
-  journal = {Journal of Fluid Mechanics}
+  school  = {University of Cape Town}
 }
 
 @Article{wang.garikipati:multi-physics,
@@ -1852,55 +2388,6 @@
   journal = {Journal of Fluid Mechanics}
 }
 
-@Article{jithin-jith:acousto-elastic,
-  doi     = {10.13140/RG.2.2.30755.14885},
-  url     = {http://rgdoi.net/10.13140/RG.2.2.30755.14885},
-  author  = {{Jithin Jith}},
-  language = {en},
-  title   = {Acousto-Elastic Interactions in High-Pressure Centrifugal Compressors},
-  publisher = {Unpublished},
-  year    = {2018}
-}
-
-@InCollection{evgrafov:discontinuous,
-  doi     = {10.1007/978-3-319-97773-7_24},
-  url     = {https://doi.org/10.1007/978-3-319-97773-7_24},
-  year    = {2018},
-  month   = sep,
-  publisher = {Springer International Publishing},
-  pages   = {260--271},
-  author  = {Anton Evgrafov},
-  title   = {Discontinuous Petrov-Galerkin Methods for Topology Optimization},
-  booktitle = {{EngOpt} 2018 Proceedings of the 6th International Conference on Engineering Optimization}
-}
-
-@Article{cheng:direct,
-  doi     = {10.4208/aamm.oa-2017-0060},
-  url     = {https://doi.org/10.4208/aamm.oa-2017-0060},
-  year    = {2018},
-  month   = jun,
-  publisher = {Global Science Press},
-  volume  = {10},
-  number  = {1},
-  pages   = {1--21},
-  author  = {Jian Cheng},
-  title   = {A Direct Discontinuous Galerkin Method with Interface Correction for the Compressible Navier-Stokes Equations on Unstructured Grids},
-  journal = {Advances in Applied Mathematics and Mechanics}
-}
-
-@Article{cheng.yue.ea:analysis,
-  doi     = {10.1016/j.jcp.2018.02.031},
-  url     = {https://doi.org/10.1016/j.jcp.2018.02.031},
-  year    = {2018},
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = {362},
-  pages   = {305--326},
-  author  = {Jian Cheng and Huiqiang Yue and Shengjiao Yu and Tiegang Liu},
-  title   = {Analysis and development of adjoint-based h-adaptive direct discontinuous Galerkin method for the compressible Navier--Stokes equations},
-  journal = {Journal of Computational Physics}
-}
-
 @Article{wei.wang.ea:study,
   doi     = {10.3390/en11020329},
   url     = {https://doi.org/10.3390/en11020329},
@@ -1915,126 +2402,57 @@
   journal = {Energies}
 }
 
-@Article{lemenager.oneill.ea:effect,
-  doi     = {10.1186/s40517-018-0092-5},
-  url     = {https://doi.org/10.1186/s40517-018-0092-5},
+@Article{weier.wick:dual-weighted,
+  author  = {Steffen Wei{\ss}er and Thomas Wick},
+  title   = {The Dual-Weighted Residual Estimator Realized on Polygonal Meshes},
+  journal = {Computational Methods in Applied Mathematics},
   year    = {2018},
-  month   = may,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {6},
-  number  = {1},
-  author  = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang and Morgan Evans},
-  title   = {The effect of temperature-dependent thermal conductivity on the geothermal structure of the Sydney Basin},
-  journal = {Geothermal Energy}
+  volume  = {18},
+  number  = {4},
+  pages   = {753--776},
+  month   = {oct},
+  doi     = {10.1515/cmam-2017-0046},
+  publisher = {Walter de Gruyter {GmbH}},
+  url     = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf}
 }
 
-@Article{kanschat.riviere:finite,
-  doi     = {10.1007/s10915-018-0843-2},
-  url     = {https://doi.org/10.1007/s10915-018-0843-2},
+@Article{wells.banks:using,
+  author  = {D. Wells and J. W. Banks},
+  title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates.},
+  journal = {arXiv:1711.05922},
   year    = {2018},
-  month   = oct,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {77},
-  number  = {3},
-  pages   = {1762--1779},
-  author  = {Guido Kanschat and Beatrice Riviere},
-  title   = {A Finite Element Method with Strong Mass Conservation for Biot's Linear Consolidation Model},
-  journal = {Journal of Scientific Computing}
+  volume  = {},
+  pages   = {},
+  url     = {},
+  doi     = {}
 }
 
-@Article{bunger.richter.ea:deterministic,
-  doi     = {10.1088/1757-899x/304/1/012004},
-  url     = {https://doi.org/10.1088/1757-899x/304/1/012004},
-  year    = {2018},
-  month   = jan,
-  publisher = {{IOP} Publishing},
-  volume  = {304},
-  pages   = {012004},
-  author  = {J B\"{u}nger and S Richter and M Torrilhon},
-  title   = {A deterministic model of electron transport for electron probe microanalysis},
-  journal = {{IOP} Conference Series: Materials Science and Engineering}
+@InProceedings{wichrowski:multigrid-method-for-stokes-problem-with-discontinuous-viscosity,
+  author  = {Wichrowski, M l},
+  journal = {congress.cimne.com},
+  title   = {{Multigrid method for Stokes problem with discontinuous viscosity}},
+  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a2092.pdf},
+  year    = {2018}
 }
 
-@InCollection{basak.levitas:nanoscale,
-  doi     = {10.1007/978-3-319-76968-4_25},
-  url     = {https://doi.org/10.1007/978-3-319-76968-4_25},
+@Article{wick:numerical,
+  author  = {T. Wick},
+  title   = {Numerical Methods for Partial Differential Equations},
+  journal = {Lecture notes, Institute of Applied Mathematics, Leibniz Universit\"{a}t Hannover, Germany},
   year    = {2018},
-  publisher = {Springer International Publishing},
-  pages   = {161--165},
-  author  = {Anup Basak and Valery I. Levitas},
-  title   = {Nanoscale Phase Field Modeling and Simulations of Martensitic Phase Transformations and Twinning at Finite Strains},
-  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
+  volume  = {},
+  pages   = {},
+  url     = {https://www.ifam.uni-hannover.de/1562.html},
+  doi     = {}
 }
 
-@InCollection{babaei.levitas:phase,
-  doi     = {10.1007/978-3-319-76968-4_26},
-  url     = {https://doi.org/10.1007/978-3-319-76968-4_26},
-  year    = {2018},
-  publisher = {Springer International Publishing},
-  pages   = {167--170},
-  author  = {H. Babaei and V. I. Levitas},
-  title   = {Phase Field Study of Lattice Instability and Nanostructure Evolution in Silicon During Phase Transformation Under Complex Loading},
-  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
-}
-
-@InProceedings{castelletto.ferronato.ea:fully-implicit,
-  doi     = {10.3997/2214-4609.201802132},
-  url     = {https://doi.org/10.3997/2214-4609.201802132},
-  year    = {2018},
-  month   = sep,
-  publisher = {{EAGE} Publications {BV}},
-  author  = {N. Castelletto and M. Ferronato and A. Franceschini and R.R. Settgast and J.A. White},
-  title   = {Fully-Implicit Solvers For Coupled Poromechanics Of Fractured Reservoirs},
-  booktitle = {{ECMOR} {XVI} - 16th European Conference on the Mathematics of Oil Recovery}
-}
-
-@Article{rom.muller:effective,
-  doi     = {10.1016/j.triboint.2018.04.011},
-  url     = {https://doi.org/10.1016/j.triboint.2018.04.011},
-  year    = {2018},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {124},
-  pages   = {247--258},
-  author  = {Michael Rom and Siegfried M\"{u}ller},
-  title   = {An effective Navier-Stokes model for the simulation of textured surface lubrication},
-  journal = {Tribology International}
-}
-
-@Article{babaei.levitas:phase-field,
-  doi     = {10.1016/j.ijplas.2018.04.006},
-  url     = {https://doi.org/10.1016/j.ijplas.2018.04.006},
-  year    = {2018},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {107},
-  pages   = {223--245},
-  author  = {Hamed Babaei and Valery I. Levitas},
-  title   = {Phase-field approach for stress- and temperature-induced phase transformations that satisfies lattice instability conditions. Part 2. simulations of phase transformations Si I$\leftrightarrow$ Si {II}},
-  journal = {International Journal of Plasticity}
-}
-
-@Article{ellam:bayesian,
-  doi     = {10.25560/70367},
-  url     = {http://spiral.imperial.ac.uk/handle/10044/1/70367},
-  author  = {Ellam, Louis},
-  title   = {Bayesian approaches to modelling physical and socio-economic systems},
-  publisher = {Imperial College London},
-  year    = {2018},
-  copyright = {Creative Commons Attribution NonCommercial Licence}
-}
-
-@Article{truster:deip,
-  doi     = {10.1016/j.softx.2018.05.002},
-  url     = {https://doi.org/10.1016/j.softx.2018.05.002},
-  year    = {2018},
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = {7},
-  pages   = {162--170},
-  author  = {Timothy J. Truster},
-  title   = {{DEIP}, discontinuous element insertion Program---Mesh generation for interfacial finite element modeling},
-  journal = {{SoftwareX}}
+@Article{wick:zielorientierte-numerik-fur-multiphysiksimulationen,
+  author  = {T. Wick},
+  title   = {{Zielorientierte Numerik f{\"u}r Multiphysiksimulationen}},
+  journal = {GAMM-Rundbrief},
+  year    = 2018,
+  volume  = 2,
+  pages   = {4--10}
 }
 
 @Article{wilmers.bargmann:functionalisation,
@@ -2050,142 +2468,12 @@
   journal = {Extreme Mechanics Letters}
 }
 
-@Article{gupta.langelaar.ea:qr-patterns,
-  doi     = {10.1007/s00158-018-2048-6},
-  url     = {https://doi.org/10.1007/s00158-018-2048-6},
+@PhDThesis{xiao:efficient,
+  title   = {Efficient and Accurate Splitting Methods for Flow Problems},
+  author  = {Mengying Xiao},
+  school  = {Clemson University},
   year    = {2018},
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {58},
-  number  = {4},
-  pages   = {1335--1350},
-  author  = {Deepak K. Gupta and Matthijs Langelaar and Fred van Keulen},
-  title   = {{QR}-patterns: artefacts in multiresolution topology optimization},
-  journal = {Structural and Multidisciplinary Optimization}
-}
-
-@Article{sharma.kanschat:contraction,
-  doi     = {10.1515/jnma-2016-1132},
-  url     = {https://doi.org/10.1515/jnma-2016-1132},
-  year    = {2018},
-  month   = dec,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {26},
-  number  = {4},
-  pages   = {209--232},
-  author  = {Natasha Sharma and Guido Kanschat},
-  title   = {A contraction property of an adaptive divergence-conforming discontinuous Galerkin method for the Stokes problem},
-  journal = {Journal of Numerical Mathematics}
-}
-
-@Article{beams.klockner.ea:high-order,
-  doi     = {10.1016/j.jcp.2018.08.032},
-  url     = {https://doi.org/10.1016/j.jcp.2018.08.032},
-  year    = {2018},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {375},
-  pages   = {1295--1313},
-  author  = {Natalie N. Beams and Andreas Kl\"{o}ckner and Luke N. Olson},
-  title   = {High-order finite element--integral equation coupling on embedded meshes},
-  journal = {Journal of Computational Physics}
-}
-
-@Article{basak.levitas:nanoscale*1,
-  doi     = {10.1016/j.jmps.2018.01.014},
-  url     = {https://doi.org/10.1016/j.jmps.2018.01.014},
-  year    = {2018},
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = {113},
-  pages   = {162--196},
-  author  = {Anup Basak and Valery I. Levitas},
-  title   = {Nanoscale multiphase phase field approach for stress- and temperature-induced martensitic phase transformations with interfacial stresses at finite strains},
-  journal = {Journal of the Mechanics and Physics of Solids}
-}
-
-@Article{neitzel.wollner:priori,
-  doi     = {10.1007/s00211-017-0906-6},
-  url     = {https://doi.org/10.1007/s00211-017-0906-6},
-  year    = {2018},
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {138},
-  number  = {2},
-  pages   = {273--299},
-  author  = {I. Neitzel and W. Wollner},
-  title   = {A priori $L^2$ -discretization error estimates for the state in elliptic optimization problems with pointwise inequality state constraints},
-  journal = {Numerische Mathematik}
-}
-
-@Article{failer.wick:adaptive*1,
-  doi     = {10.1016/j.jcp.2018.04.021},
-  url     = {https://doi.org/10.1016/j.jcp.2018.04.021},
-  year    = {2018},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {366},
-  pages   = {448--477},
-  author  = {Lukas Failer and Thomas Wick},
-  title   = {Adaptive time-step control for nonlinear fluid--structure interaction},
-  journal = {Journal of Computational Physics}
-}
-
-@PhDThesis{shovkun:coupled-chemo-mechanical-processes-in-reservoir-geomechanics,
-  author  = {Shovkun, I},
-  title   = {{Coupled chemo-mechanical processes in reservoir geomechanics}},
-  url     = {https://repositories.lib.utexas.edu/handle/2152/72439},
-  publisher = {University of Texas at Austin},
-  year    = {2018}
-}
-
-@Article{schneider.hu.ea:decoupling,
-  title   = {Decoupling Simulation Accuracy from Mesh Quality},
-  url     = {http://par.nsf.gov/biblio/10080686},
-  journal = {ACM Transactions on Graphics},
-  author  = {Schneider, Teseo and Hu, Yixin and Dumas, Jeremie and Gao, Xifeng and Panozzo, Daniele and Zorin, Denis},
-  year    = {2018},
-  month   = {Dec}
-}
-
-@PhDThesis{sabawi:discontinuous*1,
-  author  = {Sabawi, Mohammad},
-  title   = {Discontinuous Galerkin timestepping for nonlinear parabolic problems },
-  url     = {https://www.researchgate.net/publication/327546550},
-  publisher = {University of Leicester},
-  year    = {2018}
-}
-
-@InProceedings{koepf.soldner.ea:3d,
-  author  = {Koepf, Johannes and Soldner, Dominic and Gotterbarm, Martin and Markl, Matthias and Mergheim, Julia and K{\"o}rner, Carolin},
-  year    = {2018},
-  month   = {May},
-  title   = {3D Grainstructure simulation in powder bed additive manufacturing},
-  booktitle = {NAFEMS Konferenz 2018}
-}
-
-@PhDThesis{aggul:high,
-  author  = {Aggul, Mustafa},
-  title   = {High Accuracy Methods and Regularization Techniques for Fluid Flows and Fluid-Fluid interactions},
-  url     = {https://digitalcommons.mtu.edu/etdr/642/},
-  publisher = {Michigan Tech},
-  year    = {2018}
-}
-
-@PhDThesis{greene:a-bayesian-approach-to-spike-sorting-of-neural-data-via-source-localization,
-  author  = {Greene, P},
-  title   = {{A Bayesian Approach to Spike Sorting of Neural Data via Source Localization}},
-  url     = {https://repository.arizona.edu/handle/10150/628404},
-  publisher = {University of Arizona},
-  year    = {2018}
-}
-
-@PhDThesis{ghesmati:residual-and-goal-oriented-h-and-hp-adaptive-finite-element--application-for-elliptic-and-saddle-point-problems,
-  author  = {Ghesmati, Arezou},
-  title   = {{Residual and Goal-Oriented h-and hp-adaptive Finite Element; Application for Elliptic and Saddle Point Problems}},
-  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/173289},
-  publisher = {Texas A\&M University},
-  year    = {2018}
+  url     = {https://tigerprints.clemson.edu/all_dissertations/2174/}
 }
 
 @PhDThesis{zareei:transformation-based-wave-control,
@@ -2194,245 +2482,6 @@
   url     = {https://escholarship.org/uc/item/21d6c40m},
   publisher = {University of California, Berkeley},
   year    = {2018}
-}
-
-@PhDThesis{na:multiscale-thermo-hydro-mechanical-chemical-coupling-effects-for-fluid-infiltrating-crystalline-solids-and-geomaterials--theory--implementation--and-validation,
-  author  = {Na, S. H.},
-  title   = {{Multiscale thermo-hydro-mechanical-chemical coupling effects for fluid-infiltrating crystalline solids and geomaterials: theory, implementation, and validation}},
-  url     = {https://academiccommons.columbia.edu/doi/10.7916/D8P85VM9},
-  publisher = {Columbia University},
-  year    = {2018}
-}
-
-@PhDThesis{shannon:hybridized-discontinuous-galerkin-methods-for-magnetohydrodynamics,
-  author  = {Shannon, S. J.},
-  title   = {{Hybridized discontinuous Galerkin methods for magnetohydrodynamics}},
-  url     = {https://repositories.lib.utexas.edu/handle/2152/75763},
-  publisher = {University of Texas},
-  year    = {2018}
-}
-
-@PhDThesis{huang:hybrid-analog-digital-co-processing-for-scientific-computation,
-  author  = {Huang, Y.},
-  title   = {{Hybrid Analog-Digital Co-Processing for Scientific Computation}},
-  url     = {https://academiccommons.columbia.edu/doi/10.7916/D8V711TR},
-  publisher = {Columbia University},
-  year    = {2018}
-}
-
-@PhDThesis{jansen:modeling-heat-and-fluid-flow-in-discrete-fracture-networks,
-  author  = {Jansen, G.},
-  title   = {{Modeling heat and fluid flow in discrete fracture networks}},
-  url     = {https://doc.rero.ch/record/328092},
-  publisher = {Universit\'{e} de Neuch\^{a}tel},
-  year    = {2018}
-}
-
-@Article{jadamba.khan.ea:elliptic,
-  url     = {http://www.ybook.co.jp/online2/oppafa/vol3/p309.html},
-  year    = {2018},
-  month   = {Jan},
-  volume  = {3},
-  number  = {2},
-  author  = {Jadamba, B and Khan, A. A. and Kahler, R. and Sama, M.},
-  title   = {Elliptic Inverse Problems of Identifying Nonlinear Parameters},
-  journal = {Pure and Applied Functional Analysis}
-}
-
-@PhDThesis{dorschner:entropic,
-  doi     = {10.3929/ETHZ-B-000278644},
-  url     = {http://hdl.handle.net/20.500.11850/278644},
-  author  = {Dorschner, Benedikt},
-  title   = {Entropic Lattice Boltzmann Method for Complex Flows},
-  school  = {ETH Zurich},
-  year    = {2018}
-}
-
-@Article{sartori.giuliani.ea:deal2lkit*1,
-  doi     = {10.1016/j.softx.2018.09.004},
-  url     = {https://doi.org/10.1016/j.softx.2018.09.004},
-  year    = {2018},
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = {7},
-  pages   = {318--327},
-  author  = {Alberto Sartori and Nicola Giuliani and Mauro Bardelloni and Luca Heltai},
-  title   = {deal2lkit: A toolkit library for high performance programming in deal.{II}},
-  journal = {{SoftwareX}}
-}
-
-@InProceedings{luo.zhao:finite,
-  doi     = {10.1115/detc2018-85701},
-  url     = {https://doi.org/10.1115/detc2018-85701},
-  year    = {2018},
-  month   = aug,
-  publisher = {American Society of Mechanical Engineers},
-  author  = {Zhibo Luo and Yaoyao Fiona Zhao},
-  title   = {Finite Element Thermal Analysis of Melt Pool in Selective Laser Melting Process},
-  booktitle = {38th Computers and Information in Engineering Conference, Volume 1A}
-}
-
-@PhDThesis{ferrandiz:development,
-  doi     = {10.4995/thesis/10251/98522},
-  url     = {https://doi.org/10.4995/thesis/10251/98522},
-  year    = {2018},
-  publisher = {Universitat Politecnica de Valencia},
-  author  = {Antoni Vidal Ferr{\`{a}}ndiz},
-  title   = {Development of a finite element method for neutron transport equation approximations}
-}
-
-@Article{caen.schutz.ea:high-throughput,
-  doi     = {10.1038/s41378-018-0033-2},
-  url     = {https://doi.org/10.1038/s41378-018-0033-2},
-  year    = {2018},
-  month   = oct,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {4},
-  number  = {1},
-  author  = {Ouriel Caen and Simon Sch\"{u}tz and M. S. Suryateja Jammalamadaka and J{\'{e}}r{\'{e}}my Vrignon and Philippe Nizard and Tobias M. Schneider and Jean-Christophe Baret and Val{\'{e}}rie Taly},
-  title   = {High-throughput multiplexed fluorescence-activated droplet sorting},
-  journal = {Microsystems {\&} Nanoengineering}
-}
-
-@Article{alhazmi:exploring,
-  doi     = {10.14569/ijacsa.2019.0100372},
-  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
-  year    = {2019},
-  publisher = {The Science and Information Organization},
-  volume  = {10},
-  number  = {3},
-  author  = {Muflih Alhazmi},
-  title   = {Exploring Mechanisms for Pattern Formation through Coupled Bulk-Surface {PDEs} in Case of Non-linear Reactions},
-  journal = {International Journal of Advanced Computer Science and Applications}
-}
-
-@PhDThesis{massoudi:numerical-algorithms-for-the-linear-quadratic-optimal-control-of-well-posed-linear-systems,
-  author  = {Massoudi, A},
-  title   = {{Numerical Algorithms for the Linear-Quadratic Optimal Control of Well-Posed Linear Systems}},
-  publisher = {Universit\"{a}t Hamburg},
-  url     = {https://ediss.sub.uni-hamburg.de/volltexte/2018/9055/},
-  year    = {2018}
-}
-
-@TechReport{gulevich.gulevich:user-guide-for-mitmojco-1-2-microscopic-tunneling-model-for-josephson-contacts-mitmojco-1-2,
-  author  = {Gulevich, Dmitry R and Gulevich, Dmitry R},
-  title   = {{User Guide for MiTMoJCo 1.2 (Microscopic Tunneling Model for Josephson Contacts) MiTMoJCo 1.2}},
-  url     = {https://github.com/drgulevich/mitmojco},
-  year    = {2018}
-}
-
-@InCollection{dang.do.ea:fractured,
-  doi     = {10.1007/978-981-13-2306-5_15},
-  url     = {https://doi.org/10.1007/978-981-13-2306-5_15},
-  year    = {2018},
-  month   = sep,
-  publisher = {Springer Singapore},
-  pages   = {123--129},
-  author  = {Hong-Lam Dang and Duc-Phi Do and Dashnor Hoxha},
-  title   = {Fractured Reservoirs Modeling by Embedded Fracture Continuum Approach: Field-Scale Applications},
-  booktitle = {Lecture Notes in Civil Engineering}
-}
-
-@InCollection{schuster.schopfer:damage,
-  doi     = {10.1007/978-3-319-49715-0_16},
-  url     = {https://doi.org/10.1007/978-3-319-49715-0_16},
-  year    = {2017},
-  month   = aug,
-  publisher = {Springer International Publishing},
-  pages   = {373--397},
-  author  = {T. Schuster and F. Sch\"{o}pfer},
-  title   = {Damage Identification by Dynamic Load Monitoring},
-  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites}
-}
-
-@InCollection{gulpak.wernsing.ea:compensation,
-  doi     = {10.1007/978-3-319-57120-1_12},
-  url     = {https://doi.org/10.1007/978-3-319-57120-1_12},
-  year    = {2017},
-  month   = sep,
-  publisher = {Springer International Publishing},
-  pages   = {251--288},
-  author  = {M. Gulpak and H. Wernsing and J. S\"{o}lter and C. B\"{u}skens},
-  title   = {Compensation Strategies for Thermal Effects in Dry Milling},
-  booktitle = {Lecture Notes in Production Engineering}
-}
-
-@Article{cangiani.georgoulis.ea:adaptive,
-  doi     = {10.1090/mcom/3322},
-  url     = {https://doi.org/10.1090/mcom/3322},
-  year    = {2018},
-  month   = feb,
-  publisher = {American Mathematical Society ({AMS})},
-  volume  = {87},
-  number  = {314},
-  pages   = {2675--2707},
-  author  = {Andrea Cangiani and Emmanuil H. Georgoulis and Younis A. Sabawi},
-  title   = {Adaptive discontinuous Galerkin methods for elliptic interface problems},
-  journal = {Mathematics of Computation}
-}
-
-@Article{cangiani.georgoulis.ea:revealing,
-  doi     = {10.1098/rspa.2017.0608},
-  url     = {https://doi.org/10.1098/rspa.2017.0608},
-  year    = {2018},
-  month   = may,
-  publisher = {The Royal Society},
-  volume  = {474},
-  number  = {2213},
-  pages   = {20170608},
-  author  = {A. Cangiani and E. H. Georgoulis and A. Yu. Morozov and O. J. Sutton},
-  title   = {Revealing new dynamical patterns in a reaction-diffusion model with cyclic competition via a novel computational framework},
-  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
-}
-
-@Article{karban.kropik.ea:bayes,
-  doi     = {10.1016/j.amc.2017.07.043},
-  url     = {https://doi.org/10.1016/j.amc.2017.07.043},
-  year    = {2018},
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = {319},
-  pages   = {681--692},
-  author  = {Pavel Karban and Petr Krop{\'{i}}k and V{\'{a}}clav Kotlan and Ivo Dole{\v{z}}el},
-  title   = {Bayes approach to solving T.E.A.M. benchmark problems 22 and 25 and its comparison with other optimization techniques},
-  journal = {Applied Mathematics and Computation}
-}
-
-@Article{brauss.meir:on*1,
-  doi     = {10.1016/j.apnum.2018.01.014},
-  url     = {https://doi.org/10.1016/j.apnum.2018.01.014},
-  year    = {2018},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {133},
-  pages   = {130--143},
-  author  = {K.D. Brauss and A.J. Meir},
-  title   = {On a parallel, 3-dimensional, finite element solver for viscous, resistive, stationary magnetohydrodynamics equations: Velocity--current formulation},
-  journal = {Applied Numerical Mathematics}
-}
-
-@Article{kazemi.vaziri.ea:topology,
-  doi     = {10.1115/1.4040624},
-  url     = {https://doi.org/10.1115/1.4040624},
-  year    = {2018},
-  month   = sep,
-  publisher = {{ASME} International},
-  volume  = {140},
-  number  = {11},
-  author  = {Hesaneh Kazemi and Ashkan Vaziri and Juli{\'{a}}n A. Norato},
-  title   = {Topology Optimization of Structures Made of Discrete Geometric Components With Different Materials},
-  journal = {Journal of Mechanical Design}
-}
-
-@InProceedings{zhang.norato:finding,
-  doi     = {10.1115/detc2018-86116},
-  url     = {https://doi.org/10.1115/detc2018-86116},
-  year    = {2018},
-  month   = aug,
-  publisher = {American Society of Mechanical Engineers},
-  author  = {Shanglong Zhang and Juli{\'{a}}n A. Norato},
-  title   = {Finding Better Local Optima in Topology Optimization via Tunneling},
-  booktitle = {Volume 2B: 44th Design Automation Conference}
 }
 
 @Article{zhang.gain.ea:geometry,
@@ -2449,6 +2498,37 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
+@Misc{zhang.guo.ea:runge-kutta,
+  title   = {Runge-Kutta symmetric interior penalty discontinuous Galerkin methods for modified Buckley-Leverett equations},
+  author  = {Hong Zhang and Yunrui Guo and Weibin Li and Paul Andries Zegeling},
+  year    = {2018},
+  eprint  = {1801.07182},
+  archiveprefix = {arXiv},
+  primaryclass = {math.NA}
+}
+
+@Article{zhang.li:formation,
+  author  = {N. Zhang and Z.-X. Li},
+  title   = {Formation of mantle ``lone plumes'' in the global downwelling zone -- A case for subduction-controlled plume generation beneath the South China Sea},
+  journal = {Tectonophysics},
+  year    = {2018},
+  volume  = {723},
+  pages   = {1--13},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0040195117305000},
+  doi     = {10.1016/j.tecto.2017.11.038}
+}
+
+@InProceedings{zhang.norato:finding,
+  doi     = {10.1115/detc2018-86116},
+  url     = {https://doi.org/10.1115/detc2018-86116},
+  year    = {2018},
+  month   = aug,
+  publisher = {American Society of Mechanical Engineers},
+  author  = {Shanglong Zhang and Juli{\'{a}}n A. Norato},
+  title   = {Finding Better Local Optima in Topology Optimization via Tunneling},
+  booktitle = {Volume 2B: 44th Design Automation Conference}
+}
+
 @Article{zhang.zegeling:simulation,
   doi     = {10.1016/j.amc.2018.06.017},
   url     = {https://doi.org/10.1016/j.amc.2018.06.017},
@@ -2462,125 +2542,45 @@
   journal = {Applied Mathematics and Computation}
 }
 
-@Article{qiao.bai.ea:blended,
-  doi     = {10.1051/jnwpu/20183610057},
-  url     = {https://doi.org/10.1051/jnwpu/20183610057},
-  year    = {2018},
-  month   = feb,
-  publisher = {{EDP} Sciences},
-  volume  = {36},
-  number  = {1},
-  pages   = {57--65},
-  author  = {Lei Qiao and Junqiang Bai and Yasong Qiu and Jun Hua and Jiakuan Xu},
-  title   = {A Blended Continuation Method for Solving Steady Inviscid Flow},
-  journal = {Xibei Gongye Daxue Xuebao/Journal of Northwestern Polytechnical University}
-}
-
-@Article{carreno.vidal-ferrandiz.ea:block,
-  doi     = {10.1016/j.anucene.2018.08.010},
-  url     = {https://doi.org/10.1016/j.anucene.2018.08.010},
+@Article{zhao.tan:postvoiding,
+  doi     = {10.1109/tvlsi.2018.2861358},
+  url     = {https://doi.org/10.1109/tvlsi.2018.2861358},
   year    = {2018},
   month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {121},
-  pages   = {513--524},
-  author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
-  title   = {Block hybrid multilevel method to compute the dominant $\lambda$-modes of the neutron diffusion equation},
-  journal = {Annals of Nuclear Energy}
+  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})},
+  volume  = {26},
+  number  = {11},
+  pages   = {2483--2493},
+  author  = {Hengyang Zhao and Sheldon X.-D. Tan},
+  title   = {Postvoiding {FEM} Analysis for Electromigration Failure Characterization},
+  journal = {{IEEE} Transactions on Very Large Scale Integration ({VLSI}) Systems}
 }
 
-@InCollection{carreno.vidal-ferrandiz.ea:solution,
-  doi     = {10.1007/978-3-319-93701-4_67},
-  url     = {https://doi.org/10.1007/978-3-319-93701-4_67},
+@PhDThesis{zhao:fem-based-multiphysics-analysis-of-electromigration-voiding-process-in-nanometer-integrated-circuits,
+  author  = {Zhao, H.},
+  title   = {{FEM Based Multiphysics Analysis of Electromigration Voiding Process in Nanometer Integrated Circuits}},
   year    = {2018},
-  publisher = {Springer International Publishing},
-  pages   = {846--855},
-  author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
-  title   = {The Solution of the Lambda Modes Problem Using Block Iterative Eigensolvers},
-  booktitle = {Lecture Notes in Computer Science}
+  url     = {https://cloudfront.escholarship.org/dist/prd/content/qt41f4p23x/qt41f4p23x.pdf},
+  school  = {University of California, Davis}
 }
 
-@InProceedings{hai.bause:numerical,
-  doi     = {10.1115/imece2018-87448},
-  url     = {https://doi.org/10.1115/imece2018-87448},
+@PhDThesis{zhao:numerical,
+  title   = {A numerical method for the Navier Stokes equations in {Velocity-Vorticity} form},
+  author  = {Liang Zhao},
+  school  = {Clemson University},
   year    = {2018},
-  month   = nov,
-  publisher = {American Society of Mechanical Engineers},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Numerical Modeling and Approximation of the Coupling Lamb Wave Propagation With Fluid-Structure Interaction Problem},
-  booktitle = {Volume 9: Mechanics of Solids, Structures, and Fluids}
+  url     = {https://tigerprints.clemson.edu/all_dissertations/2288/}
 }
 
-@InProceedings{wichrowski:multigrid-method-for-stokes-problem-with-discontinuous-viscosity,
-  author  = {Wichrowski, M l},
-  journal = {congress.cimne.com},
-  title   = {{Multigrid method for Stokes problem with discontinuous viscosity}},
-  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a2092.pdf},
-  year    = {2018}
-}
-
-@InProceedings{mehnert.hossain.ea:a-thermo-electro-viscoelastic-material-model-for-the-simulation-of-vhb-4905,
-  author  = {Mehnert, M and Hossain, M and Steinmann, P},
-  journal = {congress.cimne.com},
-  title   = {{A THERMO-ELECTRO-VISCOELASTIC MATERIAL MODEL FOR THE SIMULATION OF VHB 4905}},
-  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a839.pdf},
-  year    = {2018}
-}
-
-@InProceedings{hai.bause:mathematical-modelling-of-structural-health-monitoring-systems--coupling-fluid-structure-interaction-with-wave-propagation-,
-  author  = {Hai, BSME and Bause, M},
-  title   = {{Mathematical Modelling of Structural Health Monitoring Systems: Coupling Fluid-Structure Interaction with Wave Propagation.}},
-  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/filePaper/p1848.pdf},
-  year    = {2018}
-}
-
-@TechReport{hochbruck.kohler:on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-methods-on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-problems,
-  author  = {Hochbruck, Marlis and K{\"{o}}hler, Jonas},
-  title   = {{On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type methods On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type problems}},
-  url     = {https://www.waves.kit.edu/downloads/CRC1173_Preprint_2017-34.pdf},
-  year    = {2018}
-}
-
-@TechReport{mohebujjaman:high,
+@Article{zhou.shukla.ea:analysis,
+  author  = {J. J. Zhou and S. Shukla and A. Putz and M. Secanell},
+  title   = {Analysis of the role of the microporous layer in improving polymer electrolyte fuel cell performance},
+  journal = {Electrochimica Acta},
   year    = {2018},
-  author  = {Mohebujjaman, Muhammad},
-  institution = {Virginia Tech University},
-  title   = {High order efficient algorithm for computation of {MHD} flow ensemble},
-  url     = {https://mohebujjaman.github.io/Second_order_ensembleMHD_Mohebujjaman.pdf}
-}
-
-@Article{liu.reina:dynamic,
-  doi     = {10.1007/s00466-018-1662-x},
-  url     = {https://doi.org/10.1007/s00466-018-1662-x},
-  year    = {2018},
-  month   = dec,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {64},
-  number  = {1},
-  pages   = {147--161},
-  author  = {Chenchen Liu and Celia Reina},
-  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
-  journal = {Computational Mechanics}
-}
-
-@MastersThesis{vundla:numerical,
-  author  = {Vundla, Nkosilathi},
-  title   = {Numerical modelling of the Oldroyd-B fluid},
-  url     = {http://hdl.handle.net/11427/30996},
-  year    = {2018},
-  month   = nov,
-  school  = {University of Cape Town}
-}
-
-@Article{maier.nemilentsau.ea:ultracompact,
-  author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
-  doi     = {10.1021/acsphotonics.7b01094},
-  journal = {ACS Photonics},
-  number  = {2},
-  pages   = {544--551},
-  title   = {Ultracompact amplitude modulator by coupling hyperbolic polaritons over a graphene-covered gap},
-  volume  = {5},
-  year    = {2018}
+  volume  = {268},
+  pages   = {366--382},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0013468618304043?via%3Dihub},
+  doi     = {10.1016/j.electacta.2018.02.100}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -1,77 +1,724 @@
 % Encoding: US-ASCII
 
-@Article{heron.pysklywec.ea:deformation,
-  doi     = {10.1130/g45690.1},
+@Article{adler.he.ea:vector-potential,
+  doi     = {10.1016/j.camwa.2018.09.051},
   year    = {2019},
-  month   = dec,
-  publisher = {Geological Society of America},
-  volume  = {47},
+  month   = jan,
+  publisher = {Elsevier {BV}},
+  volume  = {77},
   number  = {2},
-  pages   = {147--150},
-  author  = {P. J. Heron and R. N. Pysklywec and R. Stephenson and J. van Hunen},
-  title   = {Deformation driven by deep and distant structures: Influence of a mantle lithosphere suture in the Ouachita orogeny, southeastern United States},
-  journal = {Geology}
+  pages   = {476--493},
+  author  = {James H. Adler and Yunhui He and Xiaozhe Hu and Scott P. MacLachlan},
+  title   = {Vector-potential finite-element formulations for two-dimensional resistive magnetohydrodynamics},
+  journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{perry-houts.karlstrom:anisotropic-viscosity-and-time-evolving-lithospheric-instabilities-due-to-aligned-igneous-intrusions,
-  author  = {Perry-Houts, Jonathan and Karlstrom, Leif},
-  journal = {Geophysical Journal International},
-  number  = {2},
-  pages   = {794--802},
-  publisher = {Oxford University Press},
-  title   = {{Anisotropic viscosity and time-evolving lithospheric instabilities due to aligned igneous intrusions}},
-  volume  = {216},
+@PhDThesis{africa:scalable,
+  author  = {Pasquale Claudio Africa},
+  title   = {Scalable adaptive simulation of organic thin-film transistors},
+  school  = {Politecnico di Milano},
   year    = {2019},
-  doi     = {10.1093/gji/ggy466}
+  month   = feb,
+  url     = {http://hdl.handle.net/10589/144819}
 }
 
-@InCollection{guermond.popov.ea:arbitrary,
-  doi     = {10.1007/978-3-319-78325-3_14},
+@Article{aggul.kaya.ea:two,
+  doi     = {10.1016/j.amc.2018.12.074},
   year    = {2019},
-  publisher = {Springer International Publishing},
-  pages   = {251--272},
-  author  = {Jean-Luc Guermond and Bojan Popov and Laura Saavedra and Yong Yang},
-  title   = {Arbitrary Lagrangian-Eulerian Finite Element Method Preserving Convex Invariants of Hyperbolic Systems},
-  booktitle = {Computational Methods in Applied Sciences}
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = {358},
+  pages   = {25--36},
+  author  = {Mustafa Aggul and Songul Kaya and Alexander E. Labovsky},
+  title   = {Two approaches to creating a turbulence model with increased temporal accuracy},
+  journal = {Applied Mathematics and Computation}
 }
 
-@Article{lin.xu.ea:mantle,
-  title   = {Mantle upwelling beneath the South China Sea and links to surrounding subduction systems},
-  author  = {Lin, Jian and Xu, Yigang and Sun, Zhen and Zhou, Zhiyuan},
-  journal = {National Science Review},
-  volume  = {6},
-  number  = {5},
-  pages   = {877--881},
+@Article{al-arydah.carraro:reviewing,
+  doi     = {10.1016/j.camwa.2018.08.001},
   year    = {2019},
-  publisher = {Oxford University Press},
-  doi     = {10.1093/nsr/nwz123}
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {77},
+  number  = {6},
+  pages   = {1425--1436},
+  author  = {Mo'tassem Al-arydah and Thomas Carraro},
+  title   = {Reviewing the mathematical validity of a fuel cell cathode model. Existence of weak bounded solution},
+  journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{heron.peace.ea:segmentation,
-  author  = {Heron, P. J. and Peace, A. L. and McCaffrey, K. J. W. and Welford, J. K. and Wilson, R. and van Hunen, J. and Pysklywec, R. N.},
-  title   = {Segmentation of Rifts Through Structural Inheritance: Creation of the Davis Strait},
-  journal = {Tectonics},
-  volume  = {38},
-  number  = {7},
-  pages   = {2411-2430},
-  keywords = {inheritance, lithosphere deformation, suture, rifting, North Atlantic, mantle lithosphere},
-  doi     = {10.1029/2019TC005578},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019TC005578},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019TC005578},
+@PhDThesis{alzetta:coupling,
+  author  = {Alzetta, Giovanni},
+  title   = {Coupling methods for non-matching meshes through distributed Lagrange multipliers},
+  url     = {http://hdl.handle.net/20.500.11767/103034},
+  school  = {Scuola Internazionale Superiore di Studi Avanzati},
   year    = {2019}
 }
 
-@Article{gonzalez-valverde.garcia-aznar:agent-based,
-  doi     = {10.1007/s40571-018-0199-2},
+@Article{ambartsumyan.khattatov.ea:higher,
+  doi     = {10.1142/s0218202519500167},
+  year    = {2019},
+  month   = jun,
+  publisher = {World Scientific Pub Co Pte Lt},
+  volume  = {29},
+  number  = {06},
+  pages   = {1037--1077},
+  author  = {Ilona Ambartsumyan and Eldar Khattatov and Jeonghun J. Lee and Ivan Yotov},
+  title   = {Higher order multipoint flux mixed finite element methods on quadrilaterals and hexahedra},
+  journal = {Mathematical Models and Methods in Applied Sciences}
+}
+
+@MastersThesis{ameri:improving,
+  doi     = {10.13140/RG.2.2.25335.78247},
+  url     = {http://rgdoi.net/10.13140/RG.2.2.25335.78247},
+  author  = {Abtin Ameri},
+  language = {en},
+  title   = {Improving the Numerical Stability of Higher Order Methods with Applications to Fluid Dynamics},
+  publisher = {Unpublished},
+  year    = {2019},
+  note    = {Honors thesis}
+}
+
+@PhDThesis{araujo-cabarcas:reliable,
+  author  = {Araujo-Cabarcas, J. C.},
+  title   = {Reliable hp finite element computations of scattering resonances in nano optics},
+  url     = {https://www.diva-portal.org/smash/record.jsf?pid=diva2:1316711},
+  school  = {Umea University},
+  year    = {2019}
+}
+
+@InProceedings{arbogast.huang.ea:von,
+  doi     = {10.2118/193817-ms},
+  year    = {2019},
+  publisher = {Society of Petroleum Engineers},
+  author  = {Todd Arbogast and Chieh-Sen Huang and Xikai Zhao},
+  title   = {Von Neumann Stable, Implicit, High Order, Finite Volume {WENO} Schemes},
+  booktitle = {{SPE} Reservoir Simulation Conference}
+}
+
+@Article{arbogast.tao:direct,
+  doi     = {10.1007/s10596-019-09871-2},
+  year    = {2019},
+  month   = aug,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {23},
+  number  = {5},
+  pages   = {1141--1160},
+  author  = {Todd Arbogast and Zhen Tao},
+  title   = {A direct mixed{\textendash}enriched Galerkin method on quadrilaterals for two-phase Darcy flow},
+  journal = {Computational Geosciences}
+}
+
+@Article{arndt.bangerth.ea:deal-ii,
+  title   = {The \texttt{deal.II} Library, Version 9.1},
+  author  = {D. Arndt and W. Bangerth and T. C. Clevenger and D. Davydov and M. Fehling and D. Garcia-Sanchez and G. Harper and T. Heister and L. Heltai and M. Kronbichler and R. M. Kynch and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
+  journal = {Journal of Numerical Mathematics},
+  volume  = {27},
+  number  = {4},
+  pages   = {203--213},
+  year    = {2019},
+  doi     = {10.1515/jnma-2019-0064},
+  url     = {https://dealii.org/deal91-preprint.pdf}
+}
+
+@Article{aulisa.capodaglio.ea:construction,
+  doi     = {10.1137/18m1175409},
   year    = {2019},
   month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {6},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {41},
   number  = {1},
-  pages   = {85--96},
-  author  = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
-  title   = {An agent-based and {FE} approach to simulate cell jamming and collective motion in epithelial layers},
-  journal = {Computational Particle Mechanics}
+  pages   = {A480--A507},
+  author  = {Eugenio Aulisa and Giacomo Capodaglio and Guoyi Ke},
+  title   = {Construction of H-Refined Continuous Finite Element Spaces with Arbitrary Hanging Node Configurations and Applications to Multigrid Algorithms},
+  journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@Article{babaei.basak.ea:algorithmic,
+  doi     = {10.1007/s00466-019-01699-y},
+  year    = {2019},
+  month   = apr,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {64},
+  number  = {4},
+  pages   = {1177--1197},
+  author  = {Hamed Babaei and Anup Basak and Valery I. Levitas},
+  title   = {Algorithmic aspects and finite element solutions for advanced phase field approach to martensitic phase transformation under large strains},
+  journal = {Computational Mechanics}
+}
+
+@Article{babaei.levitas:effect,
+  doi     = {10.1016/j.actamat.2019.07.021},
+  year    = {2019},
+  month   = sep,
+  publisher = {Elsevier {BV}},
+  volume  = {177},
+  pages   = {178--186},
+  author  = {Hamed Babaei and Valery I. Levitas},
+  title   = {Effect of $60^\circ$ dislocation on transformation stresses, nucleation, and growth for phase transformations between silicon I and silicon {II} under triaxial loading: Phase-field study},
+  journal = {Acta Materialia}
+}
+
+@MastersThesis{balicki:abstrakte,
+  doi     = {10.25673/13842},
+  url     = {https://opendata.uni-halle.de//handle/1981185920/13968},
+  author  = {Balicki, Linus},
+  keywords = {Mathematik, 510},
+  language = {de},
+  title   = {Eine abstrakte Implementierung der Low-Rank ADI Iteration f\"{u}r Lyapunovgleichungen in pyMOR},
+  publisher = {Otto von Guericke University Library, Magdeburg, Germany},
+  school  = {Otto-von-Guericke-Universit{\"a}t Magdeburg},
+  year    = {2019},
+  copyright = {Creative Commons Attribution Share Alike 4.0 International},
+  note    = {Bachelor's thesis}
+}
+
+@Article{basak.levitas:finite,
+  author  = {Anup Basak and Valery I. Levitas},
+  title   = {Finite element procedure and simulations for a multiphase phase field approach to martensitic phase transformations at large strains and with interfacial stresses},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2019},
+  volume  = {343},
+  pages   = {368--406},
+  month   = jan,
+  doi     = {10.1016/j.cma.2018.08.006},
+  publisher = {Elsevier {BV}},
+  url     = {https://www.researchgate.net/profile/Anup_Basak/publication/326847352_Finite_element_procedure_and_simulations_for_a_multiphase_phase_field_approach_to_martensitic_phase_transformations_at_large_strains_and_with_interfacial_stresses/links/5baae99da6fdccd3cb733c04/Finite-element-procedure-and-simulations-for-a-multiphase-phase-field-approach-to-martensitic-phase-transformations-at-large-strains-and-with-interfacial-stresses.pdf}
+}
+
+@InProceedings{berselli.wells.ea:spatial,
+  author  = "Berselli, L. C. and Wells, D. and Xie, X. and Iliescu, T.",
+  editor  = "Salvetti, Maria Vittoria and Armenio, Vincenzo and Fr{\"o}hlich, Jochen and Geurts, Bernard J. and Kuerten, Hans",
+  title   = "Spatial Filtering for Reduced Order Modeling",
+  booktitle = "Direct and Large-Eddy Simulation XI",
+  year    = "2019",
+  publisher = "Springer International Publishing",
+  address = "Cham",
+  pages   = "151--157",
+  doi     = "10.1007/978-3-030-04915-7_21"
+}
+
+@PhDThesis{bettendorf:optimum,
+  doi     = {10.11588/HEIDOK.00027345},
+  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/27345},
+  author  = {Bettendorf, Anja},
+  title   = {Optimum experimental design for parameter estimation with 2D partial differential equation models},
+  school  = {University of Heidelberg, Germany},
+  year    = {2019}
+}
+
+@Article{bobadilla.carraro.ea:age,
+  doi     = {10.1007/s11538-019-00625-w},
+  year    = {2019},
+  month   = jun,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {81},
+  number  = {7},
+  pages   = {2706--2724},
+  author  = {Ana Victoria Ponce Bobadilla and Thomas Carraro and Helen M. Byrne and Philip K. Maini and Tom{\'{a}}s Alarc{\'{o}}n},
+  title   = {Age Structure Can Account for Delayed Logistic Proliferation of Scratch Assays},
+  journal = {Bulletin of Mathematical Biology}
+}
+
+@Article{boddu.davydov.ea:cutoff-based,
+  doi     = {10.1007/s42493-019-00027-z},
+  year    = {2019},
+  month   = oct,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {1},
+  number  = {4},
+  pages   = {299--317},
+  author  = {Vishal Boddu and Denis Davydov and Bernhard Eidel and Paul Steinmann},
+  title   = {Cutoff-Based Modeling of Coulomb Interactions for Atomistic-to-Continuum Multiscale Methods},
+  journal = {Multiscale Science and Engineering}
+}
+
+@Article{bonetti.cavaterra.ea:nonlinear,
+  author  = {Bonetti, E. and Cavaterra, C. and Freddi, F. and Grasselli, M. and Natalini, R.},
+  title   = {A nonlinear model for marble sulphation including surface rugosity: Theoretical and numerical results},
+  journal = {Communications on Pure and Applied Analysis},
+  year    = {2019},
+  volume  = {18},
+  number  = {2},
+  pages   = {977-998}
+}
+
+@Article{bonito.demlow:posteriori,
+  doi     = {10.1137/18m1169278},
+  year    = {2019},
+  month   = jan,
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {57},
+  number  = {3},
+  pages   = {973--996},
+  author  = {Andrea Bonito and Alan Demlow},
+  title   = {A Posteriori Error Estimates for the Laplace--Beltrami Operator on Parametric $C^2$ Surfaces},
+  journal = {{SIAM} Journal on Numerical Analysis}
+}
+
+@Article{bonito.lei.ea:numerical,
+  doi     = {10.1007/s00211-019-01025-x},
+  year    = {2019},
+  month   = feb,
+  publisher = {Society for Mining, Metallurgy and Exploration Inc.},
+  volume  = {142},
+  number  = {2},
+  pages   = {235--278},
+  author  = {Andrea Bonito and Wenyu Lei and Joseph E. Pasciak},
+  title   = {Numerical approximation of the integral fractional Laplacian},
+  journal = {Numerische Mathematik}
+}
+
+@Article{borregales.kumar.ea:partially,
+  doi     = {10.1016/j.camwa.2018.09.005},
+  year    = {2019},
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {77},
+  number  = {6},
+  pages   = {1466--1478},
+  author  = {Manuel Borregales and Kundan Kumar and Florin Adrian Radu and Carmen Rodrigo and Francisco Jos{\'{e}} Gaspar},
+  title   = {A partially parallel-in-time fixed-stress splitting method for Biot's consolidation model},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
+@InProceedings{borregales.radu:higher,
+  doi     = {10.1007/978-3-319-96415-7_49},
+  author  = "Borregales, Manuel and Radu, Florin Adrian",
+  editor  = "Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin",
+  title   = "Higher Order Space-Time Elements for a Non-linear Biot Model",
+  booktitle = "Numerical Mathematics and Advanced Applications ENUMATH 2017",
+  year    = "2019",
+  publisher = "Springer International Publishing",
+  address = "Cham",
+  pages   = "541--549"
+}
+
+@InCollection{both.kocher:numerical,
+  doi     = {10.1007/978-3-319-96415-7_74},
+  year    = {2019},
+  publisher = {Springer International Publishing},
+  pages   = {789--797},
+  author  = {Jakub W. Both and Uwe K\"{o}cher},
+  title   = {Numerical Investigation on the Fixed-Stress Splitting Scheme for {Biot}'s Equations: Optimality of the Tuning Parameter},
+  booktitle = {Lecture Notes in Computational Science and Engineering}
+}
+
+@Article{brands.davydov.ea:reduced-order,
+  doi     = {10.3390/mca24010020},
+  year    = {2019},
+  month   = feb,
+  publisher = {{MDPI} {AG}},
+  volume  = {24},
+  number  = {1},
+  pages   = {20},
+  author  = {Benjamin Brands and Denis Davydov and Julia Mergheim and Paul Steinmann},
+  title   = {Reduced-Order Modelling and Homogenisation in Magneto-Mechanics: A Numerical Comparison of Established Hyper-Reduction Methods},
+  journal = {Mathematical and Computational Applications}
+}
+
+@Article{bruchhauser.schwegler.ea:numerical,
+  title   = {Numerical {S}tudy of {G}oal-{O}riented {E}rror {C}ontrol for {S}tabilized {F}inite {E}lement {M}ethods},
+  isbn    = {9783030142445},
+  issn    = {2197-7100},
+  doi     = {10.1007/978-3-030-14244-5_5},
+  journal = {Advanced Finite Element Methods with Applications},
+  publisher = {Springer International Publishing},
+  author  = {Bruchh{\"a}user, Marius Paul and Schwegler, Kristina and Bause, Markus},
+  year    = {2019},
+  pages   = {85-106}
+}
+
+@PhDThesis{brun:upscaling,
+  author  = {Brun, Mats Kirkes{\ae}ther},
+  title   = {Upscaling, analysis, and iterative numerical solution schemes for thermo-poroelasticity},
+  url     = {http://bora.uib.no/handle/1956/20657},
+  school  = {University of Bergen},
+  year    = {2019}
+}
+
+@Article{bryant.sun:micromorphically,
+  doi     = {10.1016/j.cma.2019.05.003},
+  year    = {2019},
+  month   = sep,
+  publisher = {Elsevier {BV}},
+  volume  = {354},
+  pages   = {56--95},
+  author  = {Eric C. Bryant and WaiChing Sun},
+  title   = {A micromorphically regularized Cam-clay model for capturing size-dependent anisotropy of geomaterials},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{bucci.christensen:modeling,
+  doi     = {10.1016/j.jpowsour.2019.227186},
+  year    = {2019},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {441},
+  pages   = {227186},
+  author  = {Giovanna Bucci and Jake Christensen},
+  title   = {Modeling of lithium electrodeposition at the lithium/ceramic electrolyte interface: The role of interfacial resistance and surface defects},
+  journal = {Journal of Power Sources}
+}
+
+@Article{bzowski.rauch.ea:selection,
+  doi     = {10.1088/1757-899x/627/1/012018},
+  year    = {2019},
+  month   = oct,
+  publisher = {{IOP} Publishing},
+  volume  = {627},
+  pages   = {012018},
+  author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk},
+  title   = {Selection of the optimal heat treatment conditions using advanced phase transformation models},
+  journal = {{IOP} Conference Series: Materials Science and Engineering}
+}
+
+@PhDThesis{bzowski:application,
+  author  = {Krzysztof Bzowski},
+  title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
+  school  = {AGH University of Science and Technology},
+  year    = {2019},
+  note    = {Available in Polish only}
+}
+
+@PhDThesis{cajuhi:fracture,
+  author  = {Cajuhi, Tuanny},
+  title   = {Fracture in porous media: phase-field modeling, simulation and experimental validation},
+  url     = {https://core.ac.uk/download/pdf/196653165.pdf},
+  school  = {Technischen Universit{\"a}t Carolo-Wilhelmina zu Braunschweig},
+  year    = {2019}
+}
+
+@Article{carreno.bergamaschi.ea:block,
+  doi     = {10.3390/mca24010009},
+  year    = {2019},
+  month   = jan,
+  publisher = {{MDPI} {AG}},
+  volume  = {24},
+  number  = {1},
+  pages   = {9},
+  author  = {Amanda Carre{\~{n}}o and Luca Bergamaschi and Angeles Martinez and Antoni Vidal-Ferr{\'{a}}ndiz and Damian Ginestar and Gumersindo Verd{\'{u}}},
+  title   = {Block Preconditioning Matrices for the Newton Method to Compute the Dominant $\lambda$-Modes Associated with the Neutron Diffusion Equation},
+  journal = {Mathematical and Computational Applications}
+}
+
+@InCollection{carreno.vidal-ferrandiz.ea:matrix-free,
+  doi     = {10.1007/978-3-030-22750-0_68},
+  year    = {2019},
+  publisher = {Springer International Publishing},
+  pages   = {702--709},
+  author  = {Amanda Carre{\~{n}}o and Antoni Vidal-Ferr{\`{a}}ndiz and Damian Ginestar and Gumersindo Verd{\'{u}}},
+  title   = {A Matrix-Free Eigenvalue Solver for the Multigroup Neutron Diffusion Equation},
+  booktitle = {Lecture Notes in Computer Science}
+}
+
+@Article{carreno.vidal-ferrandiz.ea:modal,
+  doi     = {10.1016/j.pnucene.2019.03.040},
+  year    = {2019},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {115},
+  pages   = {181--193},
+  author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
+  title   = {Modal methods for the neutron diffusion equation using different spatial modes},
+  journal = {Progress in Nuclear Energy}
+}
+
+@InProceedings{castelli.dorfler:efficient,
+  author  = {Castelli, G. F. and D{\"o}rfler, W.},
+  title   = {An Efficient Matrix-Free Finite Element Solver for the {Cahn--Hiliard} Equation},
+  editor  = {Gleim, T. and Lange, S.},
+  booktitle = {Proceedings of 8th {GACM} Colloquium on Computational Mechanics},
+  year    = {2019},
+  publisher = {Kassel University Press},
+  pages   = {441--444},
+  doi     = {10.19211/KUP978737650939}
+}
+
+@Article{castelli.dorfler:numerical,
+  author  = {Castelli, G. F. and D{\"o}rfler, W.},
+  title   = {The numerical study of a microscale model for lithium-ion batteries},
+  journal = {Computers \& Mathematics with Applications},
+  year    = {2019},
+  volume  = {77},
+  number  = {6},
+  pages   = {1527--1540},
+  doi     = {10.1016/j.camwa.2018.08.067}
+}
+
+@Article{cerroni.penati.ea:multiscale,
+  doi     = {10.3390/geosciences9110465},
+  year    = {2019},
+  month   = oct,
+  publisher = {{MDPI} {AG}},
+  volume  = {9},
+  number  = {11},
+  pages   = {465},
+  author  = {Daniele Cerroni and Mattia Penati and Giovanni Porta and Edie Miglio and Paolo Zunino and Paolo Ruffo},
+  title   = {Multiscale Modeling of Glacial Loading by a 3D Thermo-Hydro-Mechanical Approach Including Erosion and Isostasy},
+  journal = {Geosciences}
+}
+
+@Article{charnyi.heister.ea:efficient,
+  doi     = {10.1016/j.apnum.2018.11.013},
+  year    = {2019},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {141},
+  pages   = {220--233},
+  author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
+  title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier--Stokes equations},
+  journal = {Applied Numerical Mathematics}
+}
+
+@Article{cheng.yu.ea:openifem,
+  doi     = {10.32604/cmes.2019.04318},
+  year    = {2019},
+  publisher = {Computers, Materials and Continua (Tech Science Press)},
+  volume  = {119},
+  number  = {1},
+  pages   = {91--124},
+  author  = {Jie Cheng and Feimi Yu and Lucy T. Zhang},
+  title   = {{OpenIFEM}: A High Performance Modular Open-Source Software of the Immersed Finite Element Method for Fluid-Structure Interactions},
+  journal = {Computer Modeling in Engineering {\&} Sciences}
+}
+
+@Article{choo:stabilized,
+  doi     = {10.1016/j.cma.2019.112568},
+  year    = {2019},
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {357},
+  pages   = {112568},
+  author  = {Jinhyun Choo},
+  title   = {Stabilized mixed continuous/enriched Galerkin formulations for locally mass conservative poromechanics},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@PhDThesis{clevenger:parallel,
+  title   = {A {P}arallel {G}eometric {M}ultigrid {M}ethod for {A}daptive {F}inite {E}lements},
+  author  = {Thomas C. Clevenger},
+  school  = {Clemson University},
+  year    = {2019},
+  url     = {https://tigerprints.clemson.edu/all_dissertations/2523/}
+}
+
+@Article{corti.cioni.ea:aborted-propagation-of-the-ethiopian-rift-caused-by-linkage-with-the-kenyan-rift,
+  author  = {Giacomo Corti and Raffaello Cioni and Zara Franceschini and Federico Sani and St{\'{e}}phane Scaillet and Paola Molin and Ilaria Isola and Francesco Mazzarini and Sascha Brune and Derek Keir and Asfaw Erbello and Ameha Muluneh and Finnigan Illsley-Kemp and Anne Glerum},
+  doi     = {10.1038/s41467-019-09335-2},
+  journal = {Nature Communications},
+  pages   = {1309},
+  title   = {{Aborted propagation of the Ethiopian rift caused by linkage with the Kenyan rift}},
+  volume  = {10},
+  year    = {2019}
+}
+
+@Article{dang.do.ea:effective,
+  doi     = {10.1155/2019/7560724},
+  year    = {2019},
+  month   = feb,
+  publisher = {Hindawi Limited},
+  volume  = {2019},
+  pages   = {1--21},
+  author  = {Hong-Lam Dang and Duc Phi Do and Dashnor Hoxha},
+  title   = {Effective Elastic and Hydraulic Properties of Fractured Rock Masses with High Contrast of Permeability: Numerical Calculation by an Embedded Fracture Continuum Approach},
+  journal = {Advances in Civil Engineering}
+}
+
+@Article{dang:modeling,
+  doi     = {10.1155/2019/4034860},
+  year    = {2019},
+  month   = jul,
+  publisher = {Hindawi Limited},
+  volume  = {2019},
+  pages   = {1--10},
+  author  = {Hong-Lam Dang},
+  title   = {Modeling the Effect of Intersected Fractures on Oil Production Rate of Fractured Reservoirs by Embedded Fracture Continuum Approach},
+  journal = {Modelling and Simulation in Engineering}
+}
+
+@Article{dannberg.gassmoller.ea:new,
+  doi     = {10.1093/gji/ggz190},
+  title   = {A new formulation for coupled magma/mantle dynamics},
+  author  = {Dannberg, Juliane and Gassm{\"o}ller, Rene and Grove, Ryan and Heister, Timo},
+  journal = {Geophysical Journal International},
+  volume  = {219},
+  number  = {1},
+  pages   = {94--107},
+  year    = {2019},
+  publisher = {Oxford University Press}
+}
+
+@InProceedings{das.motamarri.ea:fast,
+  author  = {Sambit Das and Phani Motamarri and Vikram Gavini and Bruno Turcksin and Ying Wai Li and Brent Leback},
+  title   = {{F}ast, {S}calable and {A}ccurate {F}inite-{E}lements {B}ased {A}b {I}nitio {C}alculations {U}sing {M}ixed {P}recision {C}omputing: 46 {PFLOPS} {S}imulation of a {M}etallic {D}islocation {S}ystem},
+  booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage, and Analysis},
+  series  = {SC '19},
+  year    = {2019},
+  pages   = {2:1--2:11},
+  articleno = {2},
+  numpages = {11},
+  doi     = {10.1145/3295500.3357157},
+  publisher = {ACM},
+  address = {New York, NY, USA}
+}
+
+@PhDThesis{das:large,
+  author  = {Das, Sambit},
+  title   = {Large Scale Electronic Structure Studies on the Energetics of Dislocations in Al-Mg Materials System and Its Connection to Mesoscale Models},
+  url     = {https://deepblue.lib.umich.edu/handle/2027.42/153417},
+  school  = {University of Michigan},
+  year    = {2019}
+}
+
+@Article{deolmi.muller.ea:reduced,
+  doi     = {10.1016/j.amc.2018.11.059},
+  year    = {2019},
+  month   = may,
+  publisher = {Elsevier {BV}},
+  volume  = {348},
+  pages   = {234--256},
+  author  = {G. Deolmi and S. M\"{u}ller and M. Albers and P.S. Meysonnat and W. Schr\"{o}der},
+  title   = {A reduced order model to simulate compressible flows over an actuated riblet surface},
+  journal = {Applied Mathematics and Computation}
+}
+
+@InProceedings{dong.lee.ea:numerical,
+  doi     = {10.2118/193862-ms},
+  year    = {2019},
+  publisher = {Society of Petroleum Engineers},
+  author  = {Rencheng Dong and Sanghyun Lee and Mary Wheeler},
+  title   = {Numerical Simulation of Matrix Acidizing in Fractured Carbonate Reservoirs Using Adaptive Enriched Galerkin Method},
+  booktitle = {{SPE} Reservoir Simulation Conference}
+}
+
+@Article{duijn.mikelic.ea:thermoporoelasticity,
+  doi     = {10.1016/j.ijengsci.2019.02.005},
+  year    = {2019},
+  month   = may,
+  publisher = {Elsevier {BV}},
+  volume  = {138},
+  pages   = {1--25},
+  author  = {C.J. van Duijn and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
+  title   = {Thermoporoelasticity via homogenization: Modeling and formal two-scale expansions},
+  journal = {International Journal of Engineering Science}
+}
+
+@Article{endtmayer.langer.ea:mesh,
+  author  = {Endtmayer, Bernhard and Langer, Ulrich and Neitzel, Ira and Wick, Thomas and Wollner, Winnifried},
+  title   = {Mesh adaptivity and error estimates applied to a regularized p-Laplacian constrainted optimal control problem for multiple quantities of interest},
+  journal = {PAMM},
+  volume  = {19},
+  number  = {1},
+  pages   = {e201900231},
+  doi     = {10.1002/pamm.201900231},
+  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.201900231},
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.201900231},
+  year    = {2019}
+}
+
+@PhDThesis{exner:extended,
+  doi     = {10.13140/RG.2.2.18015.41123},
+  url     = {https://dspace.tul.cz/handle/15240/153160},
+  author  = {Exner, Pavel},
+  language = {en},
+  title   = {Extended finite element method for approximation of singularities in groundwater flow},
+  publisher = {Unpublished},
+  year    = {2019}
+}
+
+@InProceedings{fan.wick.ea:phase-field,
+  author  = "Meng Fan and Thomas Wick and Yan Jin",
+  editor  = "Tobias Gleim and Stephan Lange",
+  title   = "A phase-field model for mixed-mode fracture",
+  booktitle = "8th GACM Colloquium on Computational Mechanics",
+  publisher = "Kassel University Press",
+  pages   = "51--54",
+  year    = "2019",
+  url     = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
+}
+
+@Article{fehn.kronbichler.ea:high-order,
+  title   = {High-order DG solvers for underresolved turbulent incompressible flows: A comparison of L2 and H(div) methods},
+  author  = {Fehn, Niklas and Kronbichler, Martin and Lehrenfeld, Christoph and Lube, Gert and Schroeder, Philipp W},
+  journal = {International Journal for Numerical Methods in Fluids},
+  volume  = {91},
+  number  = {11},
+  pages   = {533--556},
+  year    = {2019},
+  publisher = {Wiley Online Library},
+  doi     = {10.1002/fld.4763}
+}
+
+@Article{fehn.wall.ea:matrix-free,
+  title   = {A matrix-free high-order discontinuous Galerkin compressible Navier-Stokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
+  author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
+  journal = {International Journal for Numerical Methods in Fluids},
+  volume  = {89},
+  number  = {3},
+  pages   = {71--102},
+  year    = {2019},
+  publisher = {Wiley Online Library},
+  doi     = {10.1002/fld.4683}
+}
+
+@Article{fehn.wall.ea:modern,
+  title   = {Modern discontinuous Galerkin methods for the simulation of transitional and turbulent flows in biomedical engineering: A comprehensive LES study of the FDA benchmark nozzle model},
+  author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
+  journal = {International journal for numerical methods in biomedical engineering},
+  volume  = {35},
+  number  = {12},
+  pages   = {e3228},
+  year    = {2019},
+  publisher = {Wiley Online Library},
+  doi     = {10.1002/cnm.3228}
+}
+
+@Article{fei.choo:phase-field,
+  doi     = {10.1002/nme.6242},
+  year    = {2019},
+  month   = nov,
+  publisher = {Wiley},
+  volume  = {121},
+  number  = {4},
+  pages   = {740--762},
+  author  = {Fan Fei and Jinhyun Choo},
+  title   = {A phase-field method for modeling cracks with frictional contact},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@Article{fraters.bangerth.ea:efficient,
+  author  = {M. R. T. Fraters and W. Bangerth and C. Thieulot and A. C. Glerum and W. Spakman},
+  title   = {Efficient and practical {N}ewton solvers for nonlinear {S}tokes systems in geodynamics problems},
+  journal = {Geophysics Journal International},
+  volume  = {218},
+  number  = {2},
+  pages   = {873-894},
+  year    = {2019},
+  month   = apr,
+  issn    = {0956-540X},
+  doi     = {10.1093/gji/ggz183},
+  eprint  = {http://oup.prod.sis.lan/gji/article-pdf/218/2/873/28693654/ggz183.pdf}
+}
+
+@PhDThesis{fraters:towards,
+  author  = {Fraters, Menno R. T.},
+  title   = {Towards numerical modelling of natural subduction systems with an application to Eastern Caribbean subduction},
+  url     = {https://dspace.library.uu.nl/handle/1874/379767},
+  school  = {Utrecht University},
+  year    = {2019}
+}
+
+@Article{freddi:fracture,
+  doi     = {10.1016/j.mechrescom.2019.01.009},
+  year    = {2019},
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {96},
+  pages   = {29--36},
+  author  = {Francesco Freddi},
+  title   = {Fracture energy in phase field models},
+  journal = {Mechanics Research Communications}
 }
 
 @Article{fu.jin.ea:parameter-free,
@@ -87,16 +734,206 @@
   journal = {{IMA} Journal of Numerical Analysis}
 }
 
-@Article{heinlein.rheinbach.ea:applying,
-  doi     = {10.1002/pamm.201900337},
+@Article{gassmoller.lokavarapu.ea:evaluating,
+  doi     = {10.1093/gji/ggz405},
+  title   = {Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible Stokes flow},
+  author  = {Gassm{\"o}ller, Rene and Lokavarapu, Harsha and Bangerth, Wolfgang and Puckett, Elbridge Gerry},
+  journal = {Geophysical Journal International},
+  volume  = {219},
+  number  = {3},
+  pages   = {1915--1938},
   year    = {2019},
-  month   = nov,
-  publisher = {Wiley},
-  volume  = {19},
+  publisher = {Oxford University Press}
+}
+
+@Article{gedicke.khan:divergence-conforming,
+  doi     = {10.1007/s00211-019-01095-x},
+  year    = {2019},
+  month   = dec,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {144},
+  number  = {3},
+  pages   = {585--614},
+  author  = {Joscha Gedicke and Arbaz Khan},
+  title   = {Divergence-conforming discontinuous Galerkin finite elements for Stokes eigenvalue problems},
+  journal = {Numerische Mathematik}
+}
+
+@PhDThesis{gerken:dynamic,
+  title   = {Dynamic Inverse Problems for Wave Phenomena},
+  url     = {http://nbn-resolving.de/urn:nbn:de:gbv:46-00107730-18},
+  author  = {Gerken, Thies},
+  year    = {2019},
+  school  = {Universit{\"a}t Bremen}
+}
+
+@Article{german.ragusa:reduced-order,
+  doi     = {10.1016/j.anucene.2019.05.049},
+  year    = {2019},
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {134},
+  pages   = {144--157},
+  author  = {P{\'{e}}ter German and Jean C. Ragusa},
+  title   = {Reduced-order modeling of parameterized multi-group diffusion k-eigenvalue problems},
+  journal = {Annals of Nuclear Energy}
+}
+
+@Article{ghesmati.bangerth.ea:residual-based,
+  doi     = {10.1515/jnma-2018-0047},
+  year    = {2019},
+  month   = dec,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {27},
+  number  = {4},
+  pages   = {237--252},
+  author  = {Arezou Ghesmati and Wolfgang Bangerth and Bruno Turcksin},
+  title   = {Residual-based a posteriori error estimation for hp-adaptive finite element methods for the Stokes equations},
+  journal = {Journal of Numerical Mathematics}
+}
+
+@Article{giuliani:blacknufft,
+  doi     = {10.1016/j.cpc.2018.10.005},
+  year    = {2019},
+  month   = feb,
+  publisher = {Elsevier {BV}},
+  volume  = {235},
+  pages   = {324--335},
+  author  = {Nicola Giuliani},
+  title   = {{BlackNUFFT}: Modular customizable black box hybrid parallelization of type 3 {NUFFT} in 3D},
+  journal = {Computer Physics Communications}
+}
+
+@PhDThesis{glerum:geodynamics-of-complex-plate-boundary-regions,
+  author  = {Glerum, Anne},
+  school  = {{Universiteit Utrecht}},
+  title   = {{Geodynamics of complex plate boundary regions}},
+  url     = {https://dspace.library.uu.nl/handle/1874/377338},
+  year    = {2019}
+}
+
+@Article{gong.chen.ea:quantitative,
+  doi     = {10.1016/j.ijheatmasstransfer.2019.01.104},
+  year    = {2019},
+  month   = jun,
+  publisher = {Elsevier {BV}},
+  volume  = {135},
+  pages   = {262--273},
+  author  = {Tong Zhao Gong and Yun Chen and Dian Zhong Li and Yan Fei Cao and Pai Xian Fu},
+  title   = {Quantitative comparison of dendritic growth under forced flow between 2D and 3D phase-field simulation},
+  journal = {International Journal of Heat and Mass Transfer}
+}
+
+@Article{gonzalez-valverde.garcia-aznar:agent-based,
+  doi     = {10.1007/s40571-018-0199-2},
+  year    = {2019},
+  month   = jan,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {6},
   number  = {1},
-  author  = {Alexander Heinlein and Oliver Rheinbach and Friederike R\"{o}ver and Stefan Sandfeld and Dominik Steinberger},
-  title   = {Applying the {FROSch} Overlapping Schwarz Preconditioner to Dislocation Mechanics in Deal.{II}},
-  journal = {{PAMM}}
+  pages   = {85--96},
+  author  = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
+  title   = {An agent-based and {FE} approach to simulate cell jamming and collective motion in epithelial layers},
+  journal = {Computational Particle Mechanics}
+}
+
+@Article{grayver.driel.ea:three-dimensional,
+  title   = {Three-dimensional magnetotelluric modelling in spherical {Earth}},
+  author  = {Grayver, Alexander V. and van Driel, Martin and Kuvshinov, Alexey V.},
+  journal = {Geophysical Journal International},
+  volume  = {217},
+  number  = {1},
+  pages   = {532--557},
+  year    = {2019},
+  publisher = {Oxford University Press},
+  doi     = {10.1093/gji/ggz030}
+}
+
+@Article{grayver.olsen:magnetic,
+  doi     = {10.1029/2019gl082400},
+  year    = {2019},
+  month   = apr,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {46},
+  number  = {8},
+  pages   = {4230--4238},
+  author  = {Alexander V. Grayver and Nils Olsen},
+  title   = {The Magnetic Signatures of the M2, N2, and O1 Oceanic Tides Observed in Swarm and {CHAMP} Satellite Magnetic Data},
+  journal = {Geophysical Research Letters}
+}
+
+@InCollection{guermond.popov.ea:arbitrary,
+  doi     = {10.1007/978-3-319-78325-3_14},
+  year    = {2019},
+  publisher = {Springer International Publishing},
+  pages   = {251--272},
+  author  = {Jean-Luc Guermond and Bojan Popov and Laura Saavedra and Yong Yang},
+  title   = {Arbitrary Lagrangian-Eulerian Finite Element Method Preserving Convex Invariants of Hyperbolic Systems},
+  booktitle = {Computational Methods in Applied Sciences}
+}
+
+@Article{gulevich.koshelets.ea:bridging,
+  doi     = {10.1103/physrevb.99.060501},
+  year    = {2019},
+  month   = feb,
+  publisher = {American Physical Society ({APS})},
+  volume  = {99},
+  number  = {6},
+  author  = {D. R. Gulevich and V. P. Koshelets and F.~V. Kusmartsev},
+  title   = {Bridging the terahertz gap for chaotic sources with superconducting junctions},
+  journal = {Physical Review B}
+}
+
+@Article{guo.wu.ea:numerical,
+  doi     = {10.2118/195580-pa},
+  year    = {2019},
+  month   = aug,
+  publisher = {Society of Petroleum Engineers ({SPE})},
+  volume  = {24},
+  number  = {04},
+  pages   = {1884--1902},
+  author  = {Xuyang Guo and Kan Wu and Cheng An and Jizhou Tang and John Killough},
+  title   = {Numerical Investigation of Effects of Subsequent Parent-Well Injection on Interwell Fracturing Interference Using Reservoir-Geomechanics-Fracturing Modeling},
+  journal = {{SPE} Journal}
+}
+
+@Article{guo.wu.ea:understanding,
+  doi     = {10.2118/194493-pa},
+  year    = {2019},
+  month   = feb,
+  publisher = {Society of Petroleum Engineers ({SPE})},
+  volume  = {22},
+  number  = {03},
+  pages   = {842--860},
+  author  = {X. Guo and K. Wu and J. Killough and J. Tang},
+  title   = {Understanding the Mechanism of Interwell Fracturing Interference With Reservoir/Geomechanics/Fracturing Modeling in Eagle Ford Shale},
+  journal = {{SPE} Reservoir Evaluation {\&} Engineering}
+}
+
+@Article{gupta.keulen.ea:design,
+  doi     = {10.1002/nme.6217},
+  year    = {2019},
+  month   = oct,
+  publisher = {Wiley},
+  volume  = {121},
+  number  = {3},
+  pages   = {450--476},
+  author  = {Deepak K. Gupta and Fred Keulen and Matthijs Langelaar},
+  title   = {Design and analysis adaptivity in multiresolution topology optimization},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@Article{hagstrom.kim:complete,
+  doi     = {10.1007/s00211-018-1012-0},
+  year    = {2019},
+  month   = jan,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {141},
+  number  = {4},
+  pages   = {917--966},
+  author  = {Thomas Hagstrom and Seungil Kim},
+  title   = {Complete radiation boundary conditions for the Helmholtz equation I: waveguides},
+  journal = {Numerische Mathematik}
 }
 
 @Article{hai.bause.ea:modeling,
@@ -136,1255 +973,25 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@PhDThesis{jonathan-perry-hout:geodynamic-origin-of-the-columbia-river-flood-basalts,
-  author  = {{Jonathan Perry-Hout}},
-  school  = {University of Oregon},
-  title   = {{Geodynamic Origin of the Columbia River Flood Basalts}},
-  url     = {http://hdl.handle.net/1794/24526},
-  year    = {2019}
-}
-
-@Article{guo.wu.ea:understanding,
-  doi     = {10.2118/194493-pa},
+@Article{han.park.ea:dteq,
+  doi     = {10.1080/15361055.2018.1554391},
   year    = {2019},
   month   = feb,
-  publisher = {Society of Petroleum Engineers ({SPE})},
-  volume  = {22},
-  number  = {03},
-  pages   = {842--860},
-  author  = {X. Guo and K. Wu and J. Killough and J. Tang},
-  title   = {Understanding the Mechanism of Interwell Fracturing Interference With Reservoir/Geomechanics/Fracturing Modeling in Eagle Ford Shale},
-  journal = {{SPE} Reservoir Evaluation {\&} Engineering}
-}
-
-@Article{guo.wu.ea:numerical,
-  doi     = {10.2118/195580-pa},
-  year    = {2019},
-  month   = aug,
-  publisher = {Society of Petroleum Engineers ({SPE})},
-  volume  = {24},
-  number  = {04},
-  pages   = {1884--1902},
-  author  = {Xuyang Guo and Kan Wu and Cheng An and Jizhou Tang and John Killough},
-  title   = {Numerical Investigation of Effects of Subsequent Parent-Well Injection on Interwell Fracturing Interference Using Reservoir-Geomechanics-Fracturing Modeling},
-  journal = {{SPE} Journal}
-}
-
-@Article{gassmoller.lokavarapu.ea:evaluating,
-  doi     = {10.1093/gji/ggz405},
-  title   = {Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible Stokes flow},
-  author  = {Gassm{\"o}ller, Rene and Lokavarapu, Harsha and Bangerth, Wolfgang and Puckett, Elbridge Gerry},
-  journal = {Geophysical Journal International},
-  volume  = {219},
-  number  = {3},
-  pages   = {1915--1938},
-  year    = {2019},
-  publisher = {Oxford University Press}
-}
-
-@Article{gulevich.koshelets.ea:bridging,
-  doi     = {10.1103/physrevb.99.060501},
-  year    = {2019},
-  month   = feb,
-  publisher = {American Physical Society ({APS})},
-  volume  = {99},
-  number  = {6},
-  author  = {D. R. Gulevich and V. P. Koshelets and F.~V. Kusmartsev},
-  title   = {Bridging the terahertz gap for chaotic sources with superconducting junctions},
-  journal = {Physical Review B}
-}
-
-@Article{german.ragusa:reduced-order,
-  doi     = {10.1016/j.anucene.2019.05.049},
-  year    = {2019},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {134},
-  pages   = {144--157},
-  author  = {P{\'{e}}ter German and Jean C. Ragusa},
-  title   = {Reduced-order modeling of parameterized multi-group diffusion k-eigenvalue problems},
-  journal = {Annals of Nuclear Energy}
-}
-
-@PhDThesis{gerken:dynamic,
-  title   = {Dynamic Inverse Problems for Wave Phenomena},
-  url     = {http://nbn-resolving.de/urn:nbn:de:gbv:46-00107730-18},
-  author  = {Gerken, Thies},
-  year    = {2019},
-  school  = {Universit{\"a}t Bremen}
-}
-
-@PhDThesis{exner:extended,
-  doi     = {10.13140/RG.2.2.18015.41123},
-  url     = {https://dspace.tul.cz/handle/15240/153160},
-  author  = {Exner, Pavel},
-  language = {en},
-  title   = {Extended finite element method for approximation of singularities in groundwater flow},
-  publisher = {Unpublished},
-  year    = {2019}
-}
-
-@Article{deolmi.muller.ea:reduced,
-  doi     = {10.1016/j.amc.2018.11.059},
-  year    = {2019},
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = {348},
-  pages   = {234--256},
-  author  = {G. Deolmi and S. M\"{u}ller and M. Albers and P.S. Meysonnat and W. Schr\"{o}der},
-  title   = {A reduced order model to simulate compressible flows over an actuated riblet surface},
-  journal = {Applied Mathematics and Computation}
-}
-
-@Article{bzowski.rauch.ea:selection,
-  doi     = {10.1088/1757-899x/627/1/012018},
-  year    = {2019},
-  month   = oct,
-  publisher = {{IOP} Publishing},
-  volume  = {627},
-  pages   = {012018},
-  author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk},
-  title   = {Selection of the optimal heat treatment conditions using advanced phase transformation models},
-  journal = {{IOP} Conference Series: Materials Science and Engineering}
-}
-
-@PhDThesis{bzowski:application,
-  author  = {Krzysztof Bzowski},
-  title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
-  school  = {AGH University of Science and Technology},
-  year    = {2019},
-  note    = {Available in Polish only}
-}
-
-@PhDThesis{ponce-bobadilla:mathematical,
-  doi     = {10.11588/HEIDOK.00027466},
-  url     = {http://www.ub.uni-heidelberg.de/archiv/27466},
-  author  = {Ponce Bobadilla, Ana Victoria},
-  keywords = {500 Natural sciences and mathematics, 510 Mathematics},
-  title   = {Mathematical Models of Cell Migration and Proliferation in Scratch Assays},
-  publisher = {Heidelberg University Library},
-  year    = {2019}
-}
-
-@Article{basak.levitas:finite,
-  author  = {Anup Basak and Valery I. Levitas},
-  title   = {Finite element procedure and simulations for a multiphase phase field approach to martensitic phase transformations at large strains and with interfacial stresses},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2019},
-  volume  = {343},
-  pages   = {368--406},
-  month   = jan,
-  doi     = {10.1016/j.cma.2018.08.006},
-  publisher = {Elsevier {BV}},
-  url     = {https://www.researchgate.net/profile/Anup_Basak/publication/326847352_Finite_element_procedure_and_simulations_for_a_multiphase_phase_field_approach_to_martensitic_phase_transformations_at_large_strains_and_with_interfacial_stresses/links/5baae99da6fdccd3cb733c04/Finite-element-procedure-and-simulations-for-a-multiphase-phase-field-approach-to-martensitic-phase-transformations-at-large-strains-and-with-interfacial-stresses.pdf}
-}
-
-@Article{arbogast.tao:direct,
-  doi     = {10.1007/s10596-019-09871-2},
-  year    = {2019},
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {23},
-  number  = {5},
-  pages   = {1141--1160},
-  author  = {Todd Arbogast and Zhen Tao},
-  title   = {A direct mixed{\textendash}enriched Galerkin method on quadrilaterals for two-phase Darcy flow},
-  journal = {Computational Geosciences}
-}
-
-@InProceedings{arbogast.huang.ea:von,
-  doi     = {10.2118/193817-ms},
-  year    = {2019},
-  publisher = {Society of Petroleum Engineers},
-  author  = {Todd Arbogast and Chieh-Sen Huang and Xikai Zhao},
-  title   = {Von Neumann Stable, Implicit, High Order, Finite Volume {WENO} Schemes},
-  booktitle = {{SPE} Reservoir Simulation Conference}
-}
-
-@MastersThesis{ameri:improving,
-  doi     = {10.13140/RG.2.2.25335.78247},
-  url     = {http://rgdoi.net/10.13140/RG.2.2.25335.78247},
-  author  = {Abtin Ameri},
-  language = {en},
-  title   = {Improving the Numerical Stability of Higher Order Methods with Applications to Fluid Dynamics},
-  publisher = {Unpublished},
-  year    = {2019},
-  note    = {Honors thesis}
-}
-
-@Article{endtmayer.langer.ea:mesh,
-  author  = {Endtmayer, Bernhard and Langer, Ulrich and Neitzel, Ira and Wick, Thomas and Wollner, Winnifried},
-  title   = {Mesh adaptivity and error estimates applied to a regularized p-Laplacian constrainted optimal control problem for multiple quantities of interest},
-  journal = {PAMM},
-  volume  = {19},
-  number  = {1},
-  pages   = {e201900231},
-  doi     = {10.1002/pamm.201900231},
-  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.201900231},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.201900231},
-  year    = {2019}
-}
-
-@PhDThesis{africa:scalable,
-  author  = {Pasquale Claudio Africa},
-  title   = {Scalable adaptive simulation of organic thin-film transistors},
-  school  = {Politecnico di Milano},
-  year    = {2019},
-  month   = feb,
-  url     = {http://hdl.handle.net/10589/144819}
-}
-
-@Article{yaghoobi.ganesan.ea:prisms-plasticity,
-  doi     = {10.1016/j.commatsci.2019.109078},
-  year    = {2019},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {169},
-  pages   = {109078},
-  author  = {Mohammadreza Yaghoobi and Sriram Ganesan and Srihari Sundar and Aaditya Lakshmanan and Shiva Rudraraju and John E. Allison and Veera Sundararaghavan},
-  title   = {{PRISMS}-Plasticity: An open-source crystal plasticity finite element software},
-  journal = {Computational Materials Science}
-}
-
-@Article{rom.muller:new,
-  doi     = {10.1016/j.triboint.2018.12.030},
-  year    = {2019},
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = {133},
-  pages   = {55--66},
-  author  = {Michael Rom and Siegfried M\"{u}ller},
-  title   = {A new model for textured surface lubrication based on a modified Reynolds equation including inertia effects},
-  journal = {Tribology International}
-}
-
-@Article{bonito.lei.ea:numerical,
-  doi     = {10.1007/s00211-019-01025-x},
-  year    = {2019},
-  month   = feb,
-  publisher = {Society for Mining, Metallurgy and Exploration Inc.},
-  volume  = {142},
+  publisher = {Informa {UK} Limited},
+  volume  = {75},
   number  = {2},
-  pages   = {235--278},
-  author  = {Andrea Bonito and Wenyu Lei and Joseph E. Pasciak},
-  title   = {Numerical approximation of the integral fractional Laplacian},
-  journal = {Numerische Mathematik}
+  pages   = {137--147},
+  author  = {K. S. Han and B. H. Park and A. Y. Aydemir and J. Seol},
+  title   = {The {DTEQ} Code for Toroidal {MHD} Equilibria with Diamagnetic Current Modeling Using the deal.{II} Finite Element Library},
+  journal = {Fusion Science and Technology}
 }
 
-@Article{bonito.demlow:posteriori,
-  doi     = {10.1137/18m1169278},
-  year    = {2019},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {57},
-  number  = {3},
-  pages   = {973--996},
-  author  = {Andrea Bonito and Alan Demlow},
-  title   = {A Posteriori Error Estimates for the Laplace--Beltrami Operator on Parametric $C^2$ Surfaces},
-  journal = {{SIAM} Journal on Numerical Analysis}
-}
-
-@Article{hagstrom.kim:complete,
-  doi     = {10.1007/s00211-018-1012-0},
-  year    = {2019},
-  month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {141},
-  number  = {4},
-  pages   = {917--966},
-  author  = {Thomas Hagstrom and Seungil Kim},
-  title   = {Complete radiation boundary conditions for the Helmholtz equation I: waveguides},
-  journal = {Numerische Mathematik}
-}
-
-@Article{luo.zhao:numerical,
-  doi     = {10.1007/s00170-019-03947-0},
-  year    = {2019},
-  month   = jun,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {104},
-  number  = {5-8},
-  pages   = {1615--1635},
-  author  = {Zhibo Luo and Yaoyao Zhao},
-  title   = {Numerical simulation of part-level temperature fields during selective laser melting of stainless steel 316L},
-  journal = {International Journal of Advanced Manufacturing Technology}
-}
-
-@Article{carreno.vidal-ferrandiz.ea:modal,
-  doi     = {10.1016/j.pnucene.2019.03.040},
-  year    = {2019},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {115},
-  pages   = {181--193},
-  author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
-  title   = {Modal methods for the neutron diffusion equation using different spatial modes},
-  journal = {Progress in Nuclear Energy}
-}
-
-@InCollection{carreno.vidal-ferrandiz.ea:matrix-free,
-  doi     = {10.1007/978-3-030-22750-0_68},
-  year    = {2019},
-  publisher = {Springer International Publishing},
-  pages   = {702--709},
-  author  = {Amanda Carre{\~{n}}o and Antoni Vidal-Ferr{\`{a}}ndiz and Damian Ginestar and Gumersindo Verd{\'{u}}},
-  title   = {A Matrix-Free Eigenvalue Solver for the Multigroup Neutron Diffusion Equation},
-  booktitle = {Lecture Notes in Computer Science}
-}
-
-@Article{carreno.bergamaschi.ea:block,
-  doi     = {10.3390/mca24010009},
-  year    = {2019},
-  month   = jan,
-  publisher = {{MDPI} {AG}},
-  volume  = {24},
-  number  = {1},
-  pages   = {9},
-  author  = {Amanda Carre{\~{n}}o and Luca Bergamaschi and Angeles Martinez and Antoni Vidal-Ferr{\'{a}}ndiz and Damian Ginestar and Gumersindo Verd{\'{u}}},
-  title   = {Block Preconditioning Matrices for the Newton Method to Compute the Dominant $\lambda$-Modes Associated with the Neutron Diffusion Equation},
-  journal = {Mathematical and Computational Applications}
-}
-
-@Article{schutz.beneyton.ea:rational,
-  doi     = {10.1039/c9lc00149b},
-  year    = {2019},
-  publisher = {Royal Society of Chemistry ({RSC})},
-  volume  = {19},
-  number  = {13},
-  pages   = {2220--2232},
-  author  = {Simon S. Sch\"{u}tz and Thomas Beneyton and Jean-Christophe Baret and Tobias M. Schneider},
-  title   = {Rational design of a high-throughput droplet sorter},
-  journal = {Lab on a Chip}
-}
-
-@Article{bryant.sun:micromorphically,
-  doi     = {10.1016/j.cma.2019.05.003},
-  year    = {2019},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {354},
-  pages   = {56--95},
-  author  = {Eric C. Bryant and WaiChing Sun},
-  title   = {A micromorphically regularized Cam-clay model for capturing size-dependent anisotropy of geomaterials},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{white.castelletto.ea:two-stage,
-  doi     = {10.1016/j.cma.2019.112575},
-  year    = {2019},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {357},
-  pages   = {112575},
-  author  = {Joshua A. White and Nicola Castelletto and Sergey Klevtsov and Quan M. Bui and Daniel Osei-Kuffuor and Hamdi A. Tchelepi},
-  title   = {A two-stage preconditioner for multiphase poromechanics in reservoir simulation},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{odster.kvamsdal.ea:simple,
-  doi     = {10.1016/j.cma.2018.09.003},
-  year    = {2019},
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = {343},
-  pages   = {572--601},
-  author  = {Lars H. Ods{\ae}ter and Trond Kvamsdal and Mats G. Larson},
-  title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{uluocak.pysklywec.ea:multi-dimensional,
-  doi     = {10.1029/2019gc008277},
-  year    = {2019},
-  month   = jun,
-  publisher = {American Geophysical Union ({AGU})},
-  author  = {E. {\c{S}}eng\"{u}l Uluocak and R.N. Pysklywec and O.H. G\"{o}{\u{g}}\"{u}{\c{s}} and E.U. Ulugergerli},
-  title   = {Multi-Dimensional Geodynamic Modeling in the Southeast Carpathians: Upper Mantle Flow Induced Surface Topography Anomalies},
-  journal = {Geochemistry, Geophysics, Geosystems}
-}
-
-@Article{corti.cioni.ea:aborted-propagation-of-the-ethiopian-rift-caused-by-linkage-with-the-kenyan-rift,
-  author  = {Giacomo Corti and Raffaello Cioni and Zara Franceschini and Federico Sani and St{\'{e}}phane Scaillet and Paola Molin and Ilaria Isola and Francesco Mazzarini and Sascha Brune and Derek Keir and Asfaw Erbello and Ameha Muluneh and Finnigan Illsley-Kemp and Anne Glerum},
-  doi     = {10.1038/s41467-019-09335-2},
-  journal = {Nature Communications},
-  pages   = {1309},
-  title   = {{Aborted propagation of the Ethiopian rift caused by linkage with the Kenyan rift}},
-  volume  = {10},
+@MastersThesis{hanophy:performance,
+  author  = {Hanophy, Joshua Thomas},
+  title   = {Performance of parallel approximate ideal restriction multigrid for transport applications},
+  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/187540},
+  school  = {Texas A{\&}M University},
   year    = {2019}
-}
-
-@PhDThesis{araujo-cabarcas:reliable,
-  author  = {Araujo-Cabarcas, J. C.},
-  title   = {Reliable hp finite element computations of scattering resonances in nano optics},
-  url     = {https://www.diva-portal.org/smash/record.jsf?pid=diva2:1316711},
-  school  = {Umea University},
-  year    = {2019}
-}
-
-@MastersThesis{balicki:abstrakte,
-  doi     = {10.25673/13842},
-  url     = {https://opendata.uni-halle.de//handle/1981185920/13968},
-  author  = {Balicki, Linus},
-  keywords = {Mathematik, 510},
-  language = {de},
-  title   = {Eine abstrakte Implementierung der Low-Rank ADI Iteration f\"{u}r Lyapunovgleichungen in pyMOR},
-  publisher = {Otto von Guericke University Library, Magdeburg, Germany},
-  school  = {Otto-von-Guericke-Universit{\"a}t Magdeburg},
-  year    = {2019},
-  copyright = {Creative Commons Attribution Share Alike 4.0 International},
-  note    = {Bachelor's thesis}
-}
-
-@Article{liu.yin:unconditionally,
-  doi     = {10.1007/s10915-019-01038-6},
-  year    = {2019},
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {81},
-  number  = {2},
-  pages   = {789--819},
-  author  = {Hailiang Liu and Peimeng Yin},
-  title   = {Unconditionally Energy Stable {DG} Schemes for the Swift--Hohenberg Equation},
-  journal = {Journal of Scientific Computing}
-}
-
-@Article{hochbruck.maier.ea:heterogeneous,
-  doi     = {10.1137/18m1234072},
-  year    = {2019},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {17},
-  number  = {4},
-  pages   = {1147--1171},
-  author  = {Marlis Hochbruck and Bernhard Maier and Christian Stohrer},
-  title   = {Heterogeneous Multiscale Method for Maxwell's Equations},
-  journal = {Multiscale Modeling {\&} Simulation}
-}
-
-@Article{stoop.waisbord.ea:disorder-induced,
-  doi     = {10.1016/j.jnnfm.2019.05.002},
-  year    = {2019},
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = {268},
-  pages   = {66--74},
-  author  = {Norbert Stoop and Nicolas Waisbord and Vasily Kantsler and Vili Heinonen and Jeffrey S. Guasto and J\"{o}rn Dunkel},
-  title   = {Disorder-induced topological transition in porous media flow networks},
-  journal = {Journal of Non-Newtonian Fluid Mechanics}
-}
-
-@Article{aggul.kaya.ea:two,
-  doi     = {10.1016/j.amc.2018.12.074},
-  year    = {2019},
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = {358},
-  pages   = {25--36},
-  author  = {Mustafa Aggul and Songul Kaya and Alexander E. Labovsky},
-  title   = {Two approaches to creating a turbulence model with increased temporal accuracy},
-  journal = {Applied Mathematics and Computation}
-}
-
-@Article{bobadilla.carraro.ea:age,
-  doi     = {10.1007/s11538-019-00625-w},
-  year    = {2019},
-  month   = jun,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {81},
-  number  = {7},
-  pages   = {2706--2724},
-  author  = {Ana Victoria Ponce Bobadilla and Thomas Carraro and Helen M. Byrne and Philip K. Maini and Tom{\'{a}}s Alarc{\'{o}}n},
-  title   = {Age Structure Can Account for Delayed Logistic Proliferation of Scratch Assays},
-  journal = {Bulletin of Mathematical Biology}
-}
-
-@InCollection{wang.harper.ea:deal,
-  doi     = {10.1007/978-3-030-22747-0_37},
-  year    = {2019},
-  publisher = {Springer International Publishing},
-  pages   = {495--509},
-  author  = {Zhuoran Wang and Graham Harper and Patrick O'Leary and Jiangguo Liu and Simon Tavener},
-  title   = {deal.{II} Implementation of a Weak Galerkin Finite Element Solver for Darcy Flow},
-  booktitle = {Lecture Notes in Computer Science}
-}
-
-@Article{mikelic.wheeler.ea:phase-field,
-  doi     = {10.1007/s13137-019-0113-y},
-  year    = {2019},
-  month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {10},
-  number  = {1},
-  author  = {A. Mikeli{\'{c}} and M. F. Wheeler and T. Wick},
-  title   = {Phase-field modeling through iterative splitting of hydraulic fractures in a poroelastic medium},
-  journal = {{GEM} -- International Journal on Geomathematics}
-}
-
-@InProceedings{fan.wick.ea:phase-field,
-  author  = "Meng Fan and Thomas Wick and Yan Jin",
-  editor  = "Tobias Gleim and Stephan Lange",
-  title   = "A phase-field model for mixed-mode fracture",
-  booktitle = "8th GACM Colloquium on Computational Mechanics",
-  publisher = "Kassel University Press",
-  pages   = "51--54",
-  year    = "2019",
-  url     = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
-}
-
-@Article{duijn.mikelic.ea:thermoporoelasticity,
-  doi     = {10.1016/j.ijengsci.2019.02.005},
-  year    = {2019},
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = {138},
-  pages   = {1--25},
-  author  = {C.J. van Duijn and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
-  title   = {Thermoporoelasticity via homogenization: Modeling and formal two-scale expansions},
-  journal = {International Journal of Engineering Science}
-}
-
-@Article{noii.wick:phase-field,
-  title   = {A phase-field description for pressurized and non-isothermal propagating fractures},
-  volume  = {351},
-  issn    = {0045-7825},
-  doi     = {10.1016/j.cma.2019.03.058},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  publisher = {Elsevier BV},
-  author  = {Noii, Nima and Wick, Thomas},
-  year    = {2019},
-  month   = jul,
-  pages   = {860--890}
-}
-
-@Article{mehnert.hossain.ea:experimental,
-  doi     = {10.1016/j.euromechsol.2019.103797},
-  year    = {2019},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {77},
-  pages   = {103797},
-  author  = {Markus Mehnert and Mokarram Hossain and Paul Steinmann},
-  title   = {Experimental and numerical investigations of the electro-viscoelastic behavior of {VHB} $4905^{TM}$},
-  journal = {European Journal of Mechanics - A/Solids}
-}
-
-@Article{qinami.bryant.ea:circumventing,
-  doi     = {10.1007/s10704-019-00349-x},
-  year    = {2019},
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
-  author  = {Aurel Qinami and Eric Cushman Bryant and WaiChing Sun and Michael Kaliske},
-  title   = {Circumventing mesh bias by r- and h-adaptive techniques for variational eigenfracture},
-  journal = {International Journal of Fracture}
-}
-
-@InProceedings{berselli.wells.ea:spatial,
-  author  = "Berselli, L. C. and Wells, D. and Xie, X. and Iliescu, T.",
-  editor  = "Salvetti, Maria Vittoria and Armenio, Vincenzo and Fr{\"o}hlich, Jochen and Geurts, Bernard J. and Kuerten, Hans",
-  title   = "Spatial Filtering for Reduced Order Modeling",
-  booktitle = "Direct and Large-Eddy Simulation XI",
-  year    = "2019",
-  publisher = "Springer International Publishing",
-  address = "Cham",
-  pages   = "151--157",
-  doi     = "10.1007/978-3-030-04915-7_21"
-}
-
-@Article{ponce-bobadilla.carraro.ea:age-structure,
-  author  = {Ponce Bobadilla, Ana Victoria and Carraro, Thomas and Byrne, Helen M. and Maini, Philip K. and Alarcon, Tomas},
-  title   = {Age-structure as key to delayed logistic proliferation of scratch assays},
-  year    = {2019},
-  doi     = {10.1101/540526},
-  publisher = {Cold Spring Harbor Laboratory},
-  url     = {https://www.biorxiv.org/content/early/2019/02/04/540526},
-  journal = {bioRxiv}
-}
-
-@PhDThesis{mousavi:crustal,
-  author  = {Naeim Mousavi},
-  title   = {Crustal and (sub)lithospheric structure beneath the Iranian Plateau from geophysical modeling},
-  school  = {University of Kiel, Germany},
-  year    = 2019,
-  url     = {https://macau.uni-kiel.de/receive/diss_mods_00025884}
-}
-
-@Article{rudraraju.moulton.ea:computational,
-  doi     = {10.1371/journal.pcbi.1007213},
-  year    = {2019},
-  month   = jul,
-  publisher = {Public Library of Science ({PLoS})},
-  volume  = {15},
-  number  = {7},
-  pages   = {e1007213},
-  author  = {Shiva Rudraraju and Derek E. Moulton and R{\'{e}}gis Chirat and Alain Goriely and Krishna Garikipati},
-  editor  = {Qing Nie},
-  title   = {A computational framework for the morpho-elastic development of molluskan shells by surface and volume growth},
-  journal = {{PLOS} Computational Biology}
-}
-
-@Article{jiang.garikipati.ea:diffuse,
-  doi     = {10.1007/s11538-019-00577-1},
-  year    = {2019},
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {81},
-  number  = {8},
-  pages   = {3282--3300},
-  author  = {J. Jiang and K. Garikipati and S. Rudraraju},
-  title   = {A Diffuse Interface Framework for Modeling the Evolution of Multi-cell Aggregates as a Soft Packing Problem Driven by the Growth and Division of Cells},
-  journal = {Bulletin of Mathematical Biology}
-}
-
-@Article{morschhauser.grayver.ea:tippers,
-  title   = {Tippers at island geomagnetic observatories constrain electrical conductivity of oceanic lithosphere and upper mantle},
-  author  = {Morschhauser, Achim and Grayver, Alexander and Kuvshinov, Alexey and Samrock, Friedemann and Matzka, J{\"u}rgen},
-  journal = {Earth, Planets and Space},
-  volume  = {71},
-  number  = {1},
-  pages   = {17},
-  year    = {2019},
-  publisher = {SpringerOpen},
-  doi     = {10.1186/s40623-019-0991-0}
-}
-
-@Article{zhao.heister:preconditioner,
-  author  = {Liang Zhao and Timo Heister},
-  title   = {A preconditioner for the incompressible Navier-Stokes equations in velocity-vorticity form},
-  journal = {submitted},
-  year    = {2019},
-  note    = {submitted}
-}
-
-@Article{castelli.dorfler:numerical,
-  author  = {Castelli, G. F. and D{\"o}rfler, W.},
-  title   = {The numerical study of a microscale model for lithium-ion batteries},
-  journal = {Computers \& Mathematics with Applications},
-  year    = {2019},
-  volume  = {77},
-  number  = {6},
-  pages   = {1527--1540},
-  doi     = {10.1016/j.camwa.2018.08.067}
-}
-
-@Article{grayver.driel.ea:three-dimensional,
-  title   = {Three-dimensional magnetotelluric modelling in spherical {Earth}},
-  author  = {Grayver, Alexander V. and van Driel, Martin and Kuvshinov, Alexey V.},
-  journal = {Geophysical Journal International},
-  volume  = {217},
-  number  = {1},
-  pages   = {532--557},
-  year    = {2019},
-  publisher = {Oxford University Press},
-  doi     = {10.1093/gji/ggz030}
-}
-
-@Article{grayver.olsen:magnetic,
-  doi     = {10.1029/2019gl082400},
-  year    = {2019},
-  month   = apr,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {46},
-  number  = {8},
-  pages   = {4230--4238},
-  author  = {Alexander V. Grayver and Nils Olsen},
-  title   = {The Magnetic Signatures of the M2, N2, and O1 Oceanic Tides Observed in Swarm and {CHAMP} Satellite Magnetic Data},
-  journal = {Geophysical Research Letters}
-}
-
-@Article{bonetti.cavaterra.ea:nonlinear,
-  author  = {Bonetti, E. and Cavaterra, C. and Freddi, F. and Grasselli, M. and Natalini, R.},
-  title   = {A nonlinear model for marble sulphation including surface rugosity: Theoretical and numerical results},
-  journal = {Communications on Pure and Applied Analysis},
-  year    = {2019},
-  volume  = {18},
-  number  = {2},
-  pages   = {977-998}
-}
-
-@Article{freddi:fracture,
-  doi     = {10.1016/j.mechrescom.2019.01.009},
-  year    = {2019},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {96},
-  pages   = {29--36},
-  author  = {Francesco Freddi},
-  title   = {Fracture energy in phase field models},
-  journal = {Mechanics Research Communications}
-}
-
-@Article{cheng.yu.ea:openifem,
-  doi     = {10.32604/cmes.2019.04318},
-  year    = {2019},
-  publisher = {Computers, Materials and Continua (Tech Science Press)},
-  volume  = {119},
-  number  = {1},
-  pages   = {91--124},
-  author  = {Jie Cheng and Feimi Yu and Lucy T. Zhang},
-  title   = {{OpenIFEM}: A High Performance Modular Open-Source Software of the Immersed Finite Element Method for Fluid-Structure Interactions},
-  journal = {Computer Modeling in Engineering {\&} Sciences}
-}
-
-@InProceedings{dong.lee.ea:numerical,
-  doi     = {10.2118/193862-ms},
-  year    = {2019},
-  publisher = {Society of Petroleum Engineers},
-  author  = {Rencheng Dong and Sanghyun Lee and Mary Wheeler},
-  title   = {Numerical Simulation of Matrix Acidizing in Fractured Carbonate Reservoirs Using Adaptive Enriched Galerkin Method},
-  booktitle = {{SPE} Reservoir Simulation Conference}
-}
-
-@InProceedings{wheeler.srinivasan.ea:unconventional,
-  doi     = {10.2118/193830-ms},
-  year    = {2019},
-  publisher = {Society of Petroleum Engineers},
-  author  = {Mary F. Wheeler and Sanjay Srinivasan and Sanghyun Lee and Manik Singh},
-  title   = {Unconventional Reservoir Management Modeling Coupling Diffusive Zone/Phase Field Fracture Modeling and Fracture Probability Maps},
-  booktitle = {{SPE} Reservoir Simulation Conference}
-}
-
-@Article{shiozawa.lee.ea:effect,
-  author  = {Shiozawa, Sogo and Lee, Sanghyun and Wheeler, Mary F.},
-  title   = {The effect of stress boundary conditions on fluid-driven fracture propagation in porous media using a phase-field modeling approach},
-  journal = {International Journal for Numerical and Analytical Methods in Geomechanics},
-  volume  = {43},
-  year    = {2019},
-  number  = {6},
-  pages   = {1316-1340},
-  keywords = {fluid-driven fracture, phase field, porous media, stress boundary conditions},
-  doi     = {10.1002/nag.2899},
-  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nag.2899},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
-}
-
-@Article{adler.he.ea:vector-potential,
-  doi     = {10.1016/j.camwa.2018.09.051},
-  year    = {2019},
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = {77},
-  number  = {2},
-  pages   = {476--493},
-  author  = {James H. Adler and Yunhui He and Xiaozhe Hu and Scott P. MacLachlan},
-  title   = {Vector-potential finite-element formulations for two-dimensional resistive magnetohydrodynamics},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{song.maier.ea:adaptive,
-  author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
-  doi     = {10.1016/j.cma.2019.03.039},
-  title   = {Adaptive finite element simulations of waveguide configurations involving parallel 2D material sheets},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2019},
-  volume  = {351},
-  pages   = {20--34}
-}
-
-@Article{sticko.kreiss:higher,
-  doi     = {10.1007/s10915-019-01004-2},
-  year    = {2019},
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {80},
-  number  = {3},
-  pages   = {1867--1887},
-  author  = {Simon Sticko and Gunilla Kreiss},
-  title   = {Higher Order Cut Finite Elements for the Wave Equation},
-  journal = {Journal of Scientific Computing}
-}
-
-@Article{soldner.mergheim:thermal,
-  doi     = {10.1016/j.camwa.2018.04.036},
-  year    = {2019},
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = {78},
-  number  = {7},
-  pages   = {2183--2196},
-  author  = {Dominic Soldner and Julia Mergheim},
-  title   = {Thermal modelling of selective beam melting processes using heterogeneous time step sizes},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{ghesmati.bangerth.ea:residual-based,
-  doi     = {10.1515/jnma-2018-0047},
-  year    = {2019},
-  month   = dec,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {27},
-  number  = {4},
-  pages   = {237--252},
-  author  = {Arezou Ghesmati and Wolfgang Bangerth and Bruno Turcksin},
-  title   = {Residual-based a posteriori error estimation for hp-adaptive finite element methods for the Stokes equations},
-  journal = {Journal of Numerical Mathematics}
-}
-
-@Article{maday.marcati:regularity,
-  doi     = {10.1142/s0218202519500295},
-  year    = {2019},
-  month   = jul,
-  publisher = {World Scientific Pub Co Pte Lt},
-  volume  = {29},
-  number  = {08},
-  pages   = {1585--1617},
-  author  = {Yvon Maday and Carlo Marcati},
-  title   = {Regularity and hp discontinuous Galerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
-  journal = {Mathematical Models and Methods in Applied Sciences}
-}
-
-@Article{wick.wollner:on,
-  doi     = {10.1007/s00021-019-0439-0},
-  year    = {2019},
-  month   = jun,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {21},
-  number  = {3},
-  author  = {Thomas Wick and Winnifried Wollner},
-  title   = {On the Differentiability of Fluid-Structure Interaction Problems with Respect to the Problem Data},
-  journal = {Journal of Mathematical Fluid Mechanics}
-}
-
-@Article{bruchhauser.schwegler.ea:numerical,
-  title   = {Numerical {S}tudy of {G}oal-{O}riented {E}rror {C}ontrol for {S}tabilized {F}inite {E}lement {M}ethods},
-  isbn    = {9783030142445},
-  issn    = {2197-7100},
-  doi     = {10.1007/978-3-030-14244-5_5},
-  journal = {Advanced Finite Element Methods with Applications},
-  publisher = {Springer International Publishing},
-  author  = {Bruchh{\"a}user, Marius Paul and Schwegler, Kristina and Bause, Markus},
-  year    = {2019},
-  pages   = {85-106}
-}
-
-@Article{njinju.atekwana.ea:lithospheric,
-  doi     = {10.1029/2019tc005549},
-  year    = {2019},
-  month   = oct,
-  publisher = {American Geophysical Union ({AGU})},
-  author  = {Emmanuel A. Njinju and Estella A. Atekwana and D. Sarah Stamps and Mohamed G. Abdelsalam and Eliot A. Atekwana and Kevin L. Mickus and Stewart Fishwick and Folarin Kolawole and Tahiry A. Rajaonarison and Victor N. Nyalugwe},
-  title   = {Lithospheric Structure of the Malawi Rift: Implications for Magma-Poor Rifting Processes},
-  journal = {Tectonics}
-}
-
-@Article{dannberg.gassmoller.ea:new,
-  doi     = {10.1093/gji/ggz190},
-  title   = {A new formulation for coupled magma/mantle dynamics},
-  author  = {Dannberg, Juliane and Gassm{\"o}ller, Rene and Grove, Ryan and Heister, Timo},
-  journal = {Geophysical Journal International},
-  volume  = {219},
-  number  = {1},
-  pages   = {94--107},
-  year    = {2019},
-  publisher = {Oxford University Press}
-}
-
-@Misc{mang.wick:numerical,
-  doi     = {10.15488/5129},
-  url     = {https://www.repo.uni-hannover.de/handle/123456789/5175},
-  author  = {Mang, Katrin and Wick, Thomas},
-  keywords = {phase-field fracture, fracture mechanics, numerical methods, lecture notes, Phasenfeld, Rissbildung, Numerische Methoden, Vorlesungsskriptum, Dewey Decimal Classification::500 | Naturwissenschaften, Dewey Decimal Classification::500 | Naturwissenschaften::510 | Mathematik},
-  language = {en},
-  title   = {Numerical Methods for Variational Phase-Field Fracture Problems},
-  publisher = {Hannover : Institutionelles Repositorium der Leibniz Universit\"{a}t Hannover},
-  year    = {2019},
-  copyright = {CC BY 3.0 DE}
-}
-
-@Article{mang.wick.ea:phase-field,
-  doi     = {10.1007/s00466-019-01752-w},
-  year    = {2019},
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {65},
-  number  = {1},
-  pages   = {61--78},
-  author  = {Katrin Mang and Thomas Wick and Winnifried Wollner},
-  title   = {A phase-field model for fractures in nearly incompressible solids},
-  journal = {Computational Mechanics}
-}
-
-@Article{mang.walloth.ea:mesh,
-  doi     = {10.1002/gamm.202000003},
-  year    = {2019},
-  month   = aug,
-  publisher = {Wiley},
-  volume  = {43},
-  number  = {1},
-  author  = {K. Mang and M. Walloth and T. Wick and W. Wollner},
-  title   = {Mesh adaptivity for quasi-static phase-field fractures based on a residual-type a posteriori error estimator},
-  journal = {{GAMM}-Mitteilungen}
-}
-
-@Book{pelteret.steinmann:magneto-active,
-  title   = {{M}agneto-{A}ctive {P}olymers: {F}abrication, characterisation, modelling and simulation at the micro- and macro-scale},
-  publisher = {Walter de Gruyter {GmbH}},
-  year    = {2019},
-  author  = {Jean-Paul Pelteret and Paul Steinmann},
-  isbn    = {3110419513},
-  doi     = {10.1515/9783110418576},
-  url     = {https://www.degruyter.com/view/product/455548}
-}
-
-@PhDThesis{clevenger:parallel,
-  title   = {A {P}arallel {G}eometric {M}ultigrid {M}ethod for {A}daptive {F}inite {E}lements},
-  author  = {Thomas C. Clevenger},
-  school  = {Clemson University},
-  year    = {2019},
-  url     = {https://tigerprints.clemson.edu/all_dissertations/2523/}
-}
-
-@Article{fei.choo:phase-field,
-  doi     = {10.1002/nme.6242},
-  year    = {2019},
-  month   = nov,
-  publisher = {Wiley},
-  volume  = {121},
-  number  = {4},
-  pages   = {740--762},
-  author  = {Fan Fei and Jinhyun Choo},
-  title   = {A phase-field method for modeling cracks with frictional contact},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{kronbichler.ljungkvist:multigrid,
-  title   = {Multigrid for matrix-free high-order finite element computations on graphics processors},
-  author  = {Kronbichler, Martin and Ljungkvist, Karl},
-  journal = {ACM Transactions on Parallel Computing (TOPC)},
-  volume  = {6},
-  number  = {1},
-  pages   = {1--32},
-  year    = {2019},
-  publisher = {ACM New York, NY, USA},
-  doi     = {10.1145/3322813}
-}
-
-@Article{kronbichler.kormann:fast,
-  title   = {Fast matrix-free evaluation of discontinuous Galerkin finite element operators},
-  author  = {Kronbichler, Martin and Kormann, Katharina},
-  journal = {ACM Transactions on Mathematical Software (TOMS)},
-  volume  = {45},
-  number  = {3},
-  pages   = {1--40},
-  year    = {2019},
-  publisher = {ACM New York, NY, USA},
-  doi     = {10.1145/3325864}
-}
-
-@Article{kronbichler.kormann.ea:hermite-like,
-  title   = {A Hermite-like basis for faster matrix-free evaluation of interior penalty discontinuous Galerkin operators},
-  author  = {Kronbichler, Martin and Kormann, Katharina and Fehn, Niklas and Munch, Peter and Witte, Julius},
-  journal = {arXiv preprint arXiv:1907.08492},
-  year    = {2019}
-}
-
-@Article{fehn.kronbichler.ea:high-order,
-  title   = {High-order DG solvers for underresolved turbulent incompressible flows: A comparison of L2 and H(div) methods},
-  author  = {Fehn, Niklas and Kronbichler, Martin and Lehrenfeld, Christoph and Lube, Gert and Schroeder, Philipp W},
-  journal = {International Journal for Numerical Methods in Fluids},
-  volume  = {91},
-  number  = {11},
-  pages   = {533--556},
-  year    = {2019},
-  publisher = {Wiley Online Library},
-  doi     = {10.1002/fld.4763}
-}
-
-@Article{fehn.wall.ea:modern,
-  title   = {Modern discontinuous Galerkin methods for the simulation of transitional and turbulent flows in biomedical engineering: A comprehensive LES study of the FDA benchmark nozzle model},
-  author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
-  journal = {International journal for numerical methods in biomedical engineering},
-  volume  = {35},
-  number  = {12},
-  pages   = {e3228},
-  year    = {2019},
-  publisher = {Wiley Online Library},
-  doi     = {10.1002/cnm.3228}
-}
-
-@Article{fehn.wall.ea:matrix-free,
-  title   = {A matrix-free high-order discontinuous Galerkin compressible Navier-Stokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
-  author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
-  journal = {International Journal for Numerical Methods in Fluids},
-  volume  = {89},
-  number  = {3},
-  pages   = {71--102},
-  year    = {2019},
-  publisher = {Wiley Online Library},
-  doi     = {10.1002/fld.4683}
-}
-
-@PhDThesis{schoeder:efficient,
-  author  = {Schoeder, Svenja Madeleine},
-  title   = {Efficient Discontinuous Galerkin Methods for Wave Propagation and Iterative Optoacoustic Image Reconstruction},
-  school  = {Technical University of Munich},
-  year    = {2019},
-  url     = {https://mediatum.ub.tum.de/1451984}
-}
-
-@InProceedings{kronbichler.kormann.ea:fast,
-  author  = {Martin Kronbichler and Katharina Kormann and Wolfgang A. Wall},
-  title   = {Fast matrix-free evaluation of hybridizable discontinuous Galerkin operators},
-  editor  = {Florin A. Radu and Kundan Kumar and Inga Berre and Jan M. Nordbotten and Iuliu S. Pop},
-  booktitle = {Numerical Mathematics and Advanced Applications: ENUMATH 2017},
-  volume  = {126},
-  series  = {Lecture Notes in Computational Science and Engineering},
-  year    = {2019},
-  pages   = {581--589},
-  doi     = {10.1007/978-3-319-96415-7_53}
-}
-
-@Article{krank.kronbichler.ea:wall,
-  doi     = {10.1016/j.compfluid.2018.07.019},
-  year    = {2019},
-  publisher = {Elsevier {BV}},
-  volume  = {179},
-  pages   = {718--725},
-  author  = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
-  title   = {Wall modeling via function enrichment: Extension to detached-eddy simulation},
-  journal = {Computers {\&} Fluids}
-}
-
-@Article{krank.kronbichler.ea:multiscale,
-  doi     = {10.1002/fld.4712},
-  year    = {2019},
-  publisher = {Wiley},
-  volume  = {90},
-  number  = {2},
-  pages   = {81--113},
-  author  = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
-  title   = {A multiscale approach to hybrid {RANS}/{LES} wall modeling within a high-order discontinuous {G}alerkin scheme using function enrichment},
-  journal = {International Journal for Numerical Methods in Fluids}
-}
-
-@PhDThesis{wichmann:performance,
-  author  = {Wichmann, Karl-Robert Klaus},
-  title   = {Performance Aspects of Incompressible {N}avier-{S}tokes Solvers: {L}attice-{B}oltzmann Method vs. Finite Difference Method},
-  school  = {Technical University of Munich},
-  year    = {2019},
-  url     = {https://mediatum.ub.tum.de/1437209}
-}
-
-@Article{arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.1},
-  author  = {D. Arndt and W. Bangerth and T. C. Clevenger and D. Davydov and M. Fehling and D. Garcia-Sanchez and G. Harper and T. Heister and L. Heltai and M. Kronbichler and R. M. Kynch and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
-  journal = {Journal of Numerical Mathematics},
-  volume  = {27},
-  number  = {4},
-  pages   = {203--213},
-  year    = {2019},
-  doi     = {10.1515/jnma-2019-0064},
-  url     = {https://dealii.org/deal91-preprint.pdf}
-}
-
-@MastersThesis{sashko:enhancing,
-  title   = {Enhancing data locality in a matrix-free conjugate gradient method on modern computer architectures},
-  author  = {Dmytro Sashko},
-  school  = {Technical University of Munich},
-  year    = {2019}
-}
-
-@PhDThesis{reveron:iterative,
-  author  = {Manuel Antonio Borregales Rever\'on},
-  title   = {Iterative solvers for poromechanics},
-  school  = {Department of Mathematics, University of Bergen},
-  year    = {2019},
-  month   = aug,
-  url     = {http://bora.uib.no/handle/1956/21143}
-}
-
-@InProceedings{borregales.radu:higher,
-  doi     = {10.1007/978-3-319-96415-7_49},
-  author  = "Borregales, Manuel and Radu, Florin Adrian",
-  editor  = "Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin",
-  title   = "Higher Order Space-Time Elements for a Non-linear Biot Model",
-  booktitle = "Numerical Mathematics and Advanced Applications ENUMATH 2017",
-  year    = "2019",
-  publisher = "Springer International Publishing",
-  address = "Cham",
-  pages   = "541--549"
-}
-
-@Article{borregales.kumar.ea:partially,
-  doi     = {10.1016/j.camwa.2018.09.005},
-  year    = {2019},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {77},
-  number  = {6},
-  pages   = {1466--1478},
-  author  = {Manuel Borregales and Kundan Kumar and Florin Adrian Radu and Carmen Rodrigo and Francisco Jos{\'{e}} Gaspar},
-  title   = {A partially parallel-in-time fixed-stress splitting method for Biot's consolidation model},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Misc{holmgren.kreiss:hydrodynamic,
-  title   = {A Hydrodynamic Model of Movement of a Contact Line Over a Curved Wall},
-  author  = {Hanna Holmgren and Gunilla Kreiss},
-  year    = {2019},
-  eprint  = {1905.08788},
-  archiveprefix = {arXiv},
-  primaryclass = {physics.flu-dyn}
-}
-
-@MastersThesis{zimmerman:modeling,
-  title   = {Modeling and simulation of heat source trajectories through phase-change materials},
-  author  = {Alexander Gary Zimmerman},
-  year    = {2019},
-  school  = {RWTH Aachen},
-  url     = {https://arxiv.org/abs/1909.08882}
-}
-
-@Misc{he:simulating,
-  title   = {Simulating the scattering of low-frequency Gravitational Waves by compact objects using the finite element method},
-  author  = {Jian-hua He},
-  year    = {2019},
-  eprint  = {1912.00325},
-  archiveprefix = {arXiv},
-  primaryclass = {gr-qc}
-}
-
-@Article{aulisa.capodaglio.ea:construction,
-  doi     = {10.1137/18m1175409},
-  year    = {2019},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {41},
-  number  = {1},
-  pages   = {A480--A507},
-  author  = {Eugenio Aulisa and Giacomo Capodaglio and Guoyi Ke},
-  title   = {Construction of H-Refined Continuous Finite Element Spaces with Arbitrary Hanging Node Configurations and Applications to Multigrid Algorithms},
-  journal = {{SIAM} Journal on Scientific Computing}
-}
-
-@Article{brands.davydov.ea:reduced-order,
-  doi     = {10.3390/mca24010020},
-  year    = {2019},
-  month   = feb,
-  publisher = {{MDPI} {AG}},
-  volume  = {24},
-  number  = {1},
-  pages   = {20},
-  author  = {Benjamin Brands and Denis Davydov and Julia Mergheim and Paul Steinmann},
-  title   = {Reduced-Order Modelling and Homogenisation in Magneto-Mechanics: A Numerical Comparison of Established Hyper-Reduction Methods},
-  journal = {Mathematical and Computational Applications}
-}
-
-@Article{kocher.bruchhauser.ea:efficient,
-  doi     = {10.1016/j.softx.2019.100239},
-  year    = {2019},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {10},
-  pages   = {100239},
-  author  = {Uwe K\"{o}cher and Marius Paul Bruchh\"{a}user and Markus Bause},
-  title   = {Efficient and scalable data structures and algorithms for goal-oriented adaptivity of space--time {FEM} codes},
-  journal = {{SoftwareX}}
-}
-
-@PhDThesis{renaud:study,
-  title   = {A Study of the Tidal and Thermal Evolution of Rocky \& Icy Worlds Utilizing Advanced Rheological Models},
-  author  = {Renaud, Joseph P.},
-  year    = {2019},
-  school  = {George Mason University},
-  url     = {https://search.proquest.com/docview/2303307944}
-}
-
-@Article{ma.bakhti.ea:laser-generated,
-  doi     = {10.1021/acs.jpcc.9b05561},
-  year    = {2019},
-  month   = sep,
-  publisher = {American Chemical Society ({ACS})},
-  volume  = {123},
-  number  = {42},
-  pages   = {25898--25907},
-  author  = {Hongfeng Ma and Said Bakhti and Anton Rudenko and Francis Vocanson and Daniel S. Slaughter and Nathalie Destouches and Tatiana E. Itina},
-  title   = {Laser-Generated Ag Nanoparticles in Mesoporous {TiO}2 Films: Formation Processes and Modeling-Based Size Prediction},
-  journal = {The Journal of Physical Chemistry C}
-}
-
-@Article{giuliani:blacknufft,
-  doi     = {10.1016/j.cpc.2018.10.005},
-  year    = {2019},
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = {235},
-  pages   = {324--335},
-  author  = {Nicola Giuliani},
-  title   = {{BlackNUFFT}: Modular customizable black box hybrid parallelization of type 3 {NUFFT} in 3D},
-  journal = {Computer Physics Communications}
-}
-
-@Article{al-arydah.carraro:reviewing,
-  doi     = {10.1016/j.camwa.2018.08.001},
-  year    = {2019},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {77},
-  number  = {6},
-  pages   = {1425--1436},
-  author  = {Mo'tassem Al-arydah and Thomas Carraro},
-  title   = {Reviewing the mathematical validity of a fuel cell cathode model. Existence of weak bounded solution},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{koepf.soldner.ea:numerical,
-  doi     = {10.1016/j.commatsci.2019.03.004},
-  year    = {2019},
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = {162},
-  pages   = {148--155},
-  author  = {J.A. Koepf and D. Soldner and M. Ramsperger and J. Mergheim and M. Markl and C. K\"{o}rner},
-  title   = {Numerical microstructure prediction by a coupled finite element cellular automaton model for selective electron beam melting},
-  journal = {Computational Materials Science}
-}
-
-@Article{walker.kramer.ea:accelerating,
-  doi     = {10.1002/cpe.5265},
-  year    = {2019},
-  month   = apr,
-  publisher = {Wiley},
-  pages   = {e5265},
-  author  = {David W. Walker and Stephan C. Kramer and Fabian R. A. Biebl and Paul D. Ledger and Malcolm Brown},
-  title   = {Accelerating magnetic induction tomography-based imaging through heterogeneous parallel computing},
-  journal = {Concurrency and Computation: Practice and Experience}
-}
-
-@Article{babaei.basak.ea:algorithmic,
-  doi     = {10.1007/s00466-019-01699-y},
-  year    = {2019},
-  month   = apr,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {64},
-  number  = {4},
-  pages   = {1177--1197},
-  author  = {Hamed Babaei and Anup Basak and Valery I. Levitas},
-  title   = {Algorithmic aspects and finite element solutions for advanced phase field approach to martensitic phase transformation under large strains},
-  journal = {Computational Mechanics}
-}
-
-@Article{babaei.levitas:effect,
-  doi     = {10.1016/j.actamat.2019.07.021},
-  year    = {2019},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {177},
-  pages   = {178--186},
-  author  = {Hamed Babaei and Valery I. Levitas},
-  title   = {Effect of $60^\circ$ dislocation on transformation stresses, nucleation, and growth for phase transformations between silicon I and silicon {II} under triaxial loading: Phase-field study},
-  journal = {Acta Materialia}
-}
-
-@Article{zhao.li.ea:linear,
-  doi     = {10.1016/j.aml.2019.05.029},
-  year    = {2019},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {98},
-  pages   = {142--148},
-  author  = {Yucan Zhao and Jun Li and Jia Zhao and Qi Wang},
-  title   = {A linear energy and entropy-production-rate preserving scheme for thermodynamically consistent crystal growth models},
-  journal = {Applied Mathematics Letters}
 }
 
 @Article{hao.yang:convergence,
@@ -1400,62 +1007,243 @@
   journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
 }
 
-@Article{dang.do.ea:effective,
-  doi     = {10.1155/2019/7560724},
+@Misc{he:simulating,
+  title   = {Simulating the scattering of low-frequency Gravitational Waves by compact objects using the finite element method},
+  author  = {Jian-hua He},
   year    = {2019},
-  month   = feb,
-  publisher = {Hindawi Limited},
-  volume  = {2019},
-  pages   = {1--21},
-  author  = {Hong-Lam Dang and Duc Phi Do and Dashnor Hoxha},
-  title   = {Effective Elastic and Hydraulic Properties of Fractured Rock Masses with High Contrast of Permeability: Numerical Calculation by an Embedded Fracture Continuum Approach},
-  journal = {Advances in Civil Engineering}
+  eprint  = {1912.00325},
+  archiveprefix = {arXiv},
+  primaryclass = {gr-qc}
 }
 
-@Article{dang:modeling,
-  doi     = {10.1155/2019/4034860},
+@Article{heinlein.rheinbach.ea:applying,
+  doi     = {10.1002/pamm.201900337},
   year    = {2019},
-  month   = jul,
-  publisher = {Hindawi Limited},
-  volume  = {2019},
-  pages   = {1--10},
-  author  = {Hong-Lam Dang},
-  title   = {Modeling the Effect of Intersected Fractures on Oil Production Rate of Fractured Reservoirs by Embedded Fracture Continuum Approach},
-  journal = {Modelling and Simulation in Engineering}
+  month   = nov,
+  publisher = {Wiley},
+  volume  = {19},
+  number  = {1},
+  author  = {Alexander Heinlein and Oliver Rheinbach and Friederike R\"{o}ver and Stefan Sandfeld and Dominik Steinberger},
+  title   = {Applying the {FROSch} Overlapping Schwarz Preconditioner to Dislocation Mechanics in Deal.{II}},
+  journal = {{PAMM}}
 }
 
-@PhDThesis{glerum:geodynamics-of-complex-plate-boundary-regions,
-  author  = {Glerum, Anne},
-  school  = {{Universiteit Utrecht}},
-  title   = {{Geodynamics of complex plate boundary regions}},
-  url     = {https://dspace.library.uu.nl/handle/1874/377338},
+@Article{heltai.caiazzo:multiscale,
+  doi     = {10.1002/cnm.3264},
+  year    = {2019},
+  month   = dec,
+  publisher = {Wiley},
+  volume  = {35},
+  number  = {12},
+  author  = {Luca Heltai and Alfonso Caiazzo},
+  title   = {Multiscale modeling of vascularized tissues via nonmatching immersed methods},
+  journal = {International Journal for Numerical Methods in Biomedical Engineering}
+}
+
+@Article{heltai.rotundo:error,
+  doi     = {10.1016/j.camwa.2019.05.029},
+  year    = {2019},
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {78},
+  number  = {11},
+  pages   = {3586--3604},
+  author  = {Luca Heltai and Nella Rotundo},
+  title   = {Error estimates in weighted Sobolev norms for finite element immersed interface methods},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
+@Article{heron.peace.ea:segmentation,
+  author  = {Heron, P. J. and Peace, A. L. and McCaffrey, K. J. W. and Welford, J. K. and Wilson, R. and van Hunen, J. and Pysklywec, R. N.},
+  title   = {Segmentation of Rifts Through Structural Inheritance: Creation of the Davis Strait},
+  journal = {Tectonics},
+  volume  = {38},
+  number  = {7},
+  pages   = {2411-2430},
+  keywords = {inheritance, lithosphere deformation, suture, rifting, North Atlantic, mantle lithosphere},
+  doi     = {10.1029/2019TC005578},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019TC005578},
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019TC005578},
   year    = {2019}
 }
 
-@Article{fraters.bangerth.ea:efficient,
-  author  = {M. R. T. Fraters and W. Bangerth and C. Thieulot and A. C. Glerum and W. Spakman},
-  title   = {Efficient and practical {N}ewton solvers for nonlinear {S}tokes systems in geodynamics problems},
-  journal = {Geophysics Journal International},
-  volume  = {218},
-  number  = {2},
-  pages   = {873-894},
+@Article{heron.pysklywec.ea:deformation,
+  doi     = {10.1130/g45690.1},
   year    = {2019},
-  month   = apr,
-  issn    = {0956-540X},
-  doi     = {10.1093/gji/ggz183},
-  eprint  = {http://oup.prod.sis.lan/gji/article-pdf/218/2/873/28693654/ggz183.pdf}
+  month   = dec,
+  publisher = {Geological Society of America},
+  volume  = {47},
+  number  = {2},
+  pages   = {147--150},
+  author  = {P. J. Heron and R. N. Pysklywec and R. Stephenson and J. van Hunen},
+  title   = {Deformation driven by deep and distant structures: Influence of a mantle lithosphere suture in the Ouachita orogeny, southeastern United States},
+  journal = {Geology}
 }
 
-@Article{bucci.christensen:modeling,
-  doi     = {10.1016/j.jpowsour.2019.227186},
+@Article{hochbruck.leibold:finite,
+  doi     = {10.1553/etna_vol53s522},
+  year    = {2020},
+  publisher = {Osterreichische Akademie der Wissenschaften},
+  volume  = {53},
+  pages   = {522--540},
+  author  = {Marlis Hochbruck and Jan Leibold},
+  title   = {Finite element discretization of semilinear acoustic wave equations with kinetic boundary conditions},
+  journal = {{ETNA} - Electronic Transactions on Numerical Analysis}
+}
+
+@Article{hochbruck.maier.ea:heterogeneous,
+  doi     = {10.1137/18m1234072},
+  year    = {2019},
+  month   = jan,
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {17},
+  number  = {4},
+  pages   = {1147--1171},
+  author  = {Marlis Hochbruck and Bernhard Maier and Christian Stohrer},
+  title   = {Heterogeneous Multiscale Method for Maxwell's Equations},
+  journal = {Multiscale Modeling {\&} Simulation}
+}
+
+@Misc{holmgren.kreiss:hydrodynamic,
+  title   = {A Hydrodynamic Model of Movement of a Contact Line Over a Curved Wall},
+  author  = {Hanna Holmgren and Gunilla Kreiss},
+  year    = {2019},
+  eprint  = {1905.08788},
+  archiveprefix = {arXiv},
+  primaryclass = {physics.flu-dyn}
+}
+
+@MastersThesis{janssen:comparison,
+  title   = {A comparison of {GOCO05c} satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
+  author  = {Janssen, W. J.},
+  year    = {2019},
+  school  = {Utrecht University},
+  url     = {https://dspace.library.uu.nl/handle/1874/393839}
+}
+
+@Article{jiang.garikipati.ea:diffuse,
+  doi     = {10.1007/s11538-019-00577-1},
+  year    = {2019},
+  month   = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {81},
+  number  = {8},
+  pages   = {3282--3300},
+  author  = {J. Jiang and K. Garikipati and S. Rudraraju},
+  title   = {A Diffuse Interface Framework for Modeling the Evolution of Multi-cell Aggregates as a Soft Packing Problem Driven by the Growth and Division of Cells},
+  journal = {Bulletin of Mathematical Biology}
+}
+
+@PhDThesis{jonathan-perry-hout:geodynamic-origin-of-the-columbia-river-flood-basalts,
+  author  = {{Jonathan Perry-Hout}},
+  school  = {University of Oregon},
+  title   = {{Geodynamic Origin of the Columbia River Flood Basalts}},
+  url     = {http://hdl.handle.net/1794/24526},
+  year    = {2019}
+}
+
+@InProceedings{kauffman.george.ea:overset,
+  doi     = {10.2514/6.2019-1986},
+  year    = {2019},
+  month   = jan,
+  publisher = {American Institute of Aeronautics and Astronautics},
+  author  = {Justin A. Kauffman and William L. George and Jonathan S. Pitt},
+  title   = {An Overset Mesh Framework for an Isentropic {ALE} Navier-Stokes {HDG} Formulation},
+  booktitle = {{AIAA} Scitech 2019 Forum}
+}
+
+@InProceedings{kazemi.vaziri.ea:topology,
+  doi     = {10.1115/detc2019-97370},
+  year    = {2019},
+  month   = aug,
+  publisher = {American Society of Mechanical Engineers},
+  author  = {Hesaneh Kazemi and Ashkan Vaziri and Juli{\'{a}}n Norato},
+  title   = {Topology Optimization of Multi-Material Lattices for Maximal Bulk Modulus},
+  booktitle = {Volume 2A: 45th Design Automation Conference}
+}
+
+@Article{khattatov.yotov:domain,
+  doi     = {10.1051/m2an/2019057},
   year    = {2019},
   month   = nov,
+  publisher = {{EDP} Sciences},
+  volume  = {53},
+  number  = {6},
+  pages   = {2081--2108},
+  author  = {Eldar Khattatov and Ivan Yotov},
+  title   = {Domain decomposition and multiscale mortar mixed finite element methods for linear elasticity with weak stress symmetry},
+  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
+}
+
+@Article{kim.singh.ea:uncertainty,
+  doi     = {10.1016/j.jnnfm.2019.07.002},
+  year    = {2019},
+  month   = sep,
   publisher = {Elsevier {BV}},
-  volume  = {441},
-  pages   = {227186},
-  author  = {Giovanna Bucci and Jake Christensen},
-  title   = {Modeling of lithium electrodeposition at the lithium/ceramic electrolyte interface: The role of interfacial resistance and surface defects},
-  journal = {Journal of Power Sources}
+  volume  = {271},
+  pages   = {104138},
+  author  = {Jaekwang Kim and Piyush K. Singh and Jonathan B. Freund and Randy H. Ewoldt},
+  title   = {Uncertainty propagation in simulation predictions of generalized Newtonian fluid flows},
+  journal = {Journal of Non-Newtonian Fluid Mechanics}
+}
+
+@Article{kim:error,
+  doi     = {10.1051/m2an/2019026},
+  year    = {2019},
+  month   = jul,
+  publisher = {{EDP} Sciences},
+  volume  = {53},
+  number  = {4},
+  pages   = {1191--1222},
+  author  = {Seungil Kim},
+  title   = {Error analysis of {PML}-{FEM} approximations for the Helmholtz equation in waveguides},
+  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
+}
+
+@Article{kocher.bruchhauser.ea:efficient,
+  doi     = {10.1016/j.softx.2019.100239},
+  year    = {2019},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {10},
+  pages   = {100239},
+  author  = {Uwe K\"{o}cher and Marius Paul Bruchh\"{a}user and Markus Bause},
+  title   = {Efficient and scalable data structures and algorithms for goal-oriented adaptivity of space--time {FEM} codes},
+  journal = {{SoftwareX}}
+}
+
+@InCollection{kocher:influence,
+  doi     = {10.1007/978-3-319-96415-7_18},
+  year    = {2019},
+  publisher = {Springer International Publishing},
+  pages   = {215--223},
+  author  = {Uwe K\"{o}cher},
+  title   = {Influence of the {SIPG} Penalisation on the Numerical Properties of Linear Systems for Elastic Wave Propagation},
+  booktitle = {Lecture Notes in Computational Science and Engineering}
+}
+
+@Article{koepf.soldner.ea:numerical,
+  doi     = {10.1016/j.commatsci.2019.03.004},
+  year    = {2019},
+  month   = may,
+  publisher = {Elsevier {BV}},
+  volume  = {162},
+  pages   = {148--155},
+  author  = {J.A. Koepf and D. Soldner and M. Ramsperger and J. Mergheim and M. Markl and C. K\"{o}rner},
+  title   = {Numerical microstructure prediction by a coupled finite element cellular automaton model for selective electron beam melting},
+  journal = {Computational Materials Science}
+}
+
+@Article{kohler.rheinbach.ea:feti-dp,
+  doi     = {10.1002/pamm.201900292},
+  year    = {2019},
+  month   = nov,
+  publisher = {Wiley},
+  volume  = {19},
+  number  = {1},
+  author  = {Stephan K\"{o}hler and Oliver Rheinbach and Stefan Sandfeld and Dominik Steinberger},
+  title   = {{FETI}-{DP} Solvers and Deal.{II} for Problems in Dislocation Mechanics},
+  journal = {{PAMM}}
 }
 
 @Article{konig.rom.ea:numerical,
@@ -1469,56 +1257,6 @@
   author  = {V. K\"{o}nig and M. Rom and S. M\"{u}ller and M. Selzer and S. Schweikert and J. Von Wolfersdorf},
   title   = {Numerical and Experimental Investigation of Transpiration Cooling with Carbon/Carbon Characteristic Outflow Distributions},
   journal = {Journal of Thermophysics and Heat Transfer}
-}
-
-@Article{vassaux.richardson.ea:heterogeneous,
-  doi     = {10.1098/rsta.2018.0150},
-  year    = {2019},
-  month   = feb,
-  publisher = {The Royal Society},
-  volume  = {377},
-  number  = {2142},
-  pages   = {20180150},
-  author  = {M. Vassaux and R. A. Richardson and P. V. Coveney},
-  title   = {The heterogeneous multiscale method applied to inelastic polymer mechanics},
-  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences}
-}
-
-@Article{vassaux.sinclair.ea:role,
-  doi     = {10.1002/adts.201800168},
-  year    = {2019},
-  month   = feb,
-  publisher = {Wiley},
-  volume  = {2},
-  number  = {5},
-  pages   = {1800168},
-  author  = {Maxime Vassaux and Robert C. Sinclair and Robin A. Richardson and James L. Suter and Peter V. Coveney},
-  title   = {The Role of Graphene in Enhancing the Material Properties of Thermosetting Polymers},
-  journal = {Advanced Theory and Simulations}
-}
-
-@Article{santis.shams:advanced,
-  doi     = {10.1016/j.anucene.2019.02.049},
-  year    = {2019},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {130},
-  pages   = {218--231},
-  author  = {Dante De Santis and Afaque Shams},
-  title   = {An advanced numerical framework for the simulation of flow induced vibration for nuclear applications},
-  journal = {Annals of Nuclear Energy}
-}
-
-@Article{choo:stabilized,
-  doi     = {10.1016/j.cma.2019.112568},
-  year    = {2019},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {357},
-  pages   = {112568},
-  author  = {Jinhyun Choo},
-  title   = {Stabilized mixed continuous/enriched Galerkin formulations for locally mass conservative poromechanics},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
 @Article{konschin.lechleiter:reconstruction,
@@ -1554,87 +1292,291 @@
   journal = {Annals of Nuclear Energy}
 }
 
-@Article{steinmann.kerganer.ea:novel,
-  doi     = {10.1016/j.jmps.2019.103680},
+@Article{krank.kronbichler.ea:multiscale,
+  doi     = {10.1002/fld.4712},
   year    = {2019},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {132},
-  pages   = {103680},
-  author  = {Paul Steinmann and Andreas Kerga{\ss}ner and Philipp Landkammer and Hussein M. Zbib},
-  title   = {A novel continuum approach to gradient plasticity based on the complementing concepts of dislocation and disequilibrium densities},
-  journal = {Journal of the Mechanics and Physics of Solids}
-}
-
-@Article{kohler.rheinbach.ea:feti-dp,
-  doi     = {10.1002/pamm.201900292},
-  year    = {2019},
-  month   = nov,
   publisher = {Wiley},
-  volume  = {19},
-  number  = {1},
-  author  = {Stephan K\"{o}hler and Oliver Rheinbach and Stefan Sandfeld and Dominik Steinberger},
-  title   = {{FETI}-{DP} Solvers and Deal.{II} for Problems in Dislocation Mechanics},
-  journal = {{PAMM}}
-}
-
-@Article{steinberger.bredow.ea:widespread,
-  author  = {Steinberger, Bernhard and Bredow, Eva and Lebedev, Sergei and Schaeffer, Andrew and Torsvik, Trond H},
-  journal = {Nature Geoscience},
-  number  = {1},
-  pages   = {61},
-  publisher = {Nature Publishing Group},
-  title   = {Widespread volcanism in the {G}reenland-{N}orth {A}tlantic region explained by the {I}celand plume},
-  volume  = {12},
-  year    = {2019},
-  doi     = {10.1038/s41561-018-0251-0}
-}
-
-@Article{cerroni.penati.ea:multiscale,
-  doi     = {10.3390/geosciences9110465},
-  year    = {2019},
-  month   = oct,
-  publisher = {{MDPI} {AG}},
-  volume  = {9},
-  number  = {11},
-  pages   = {465},
-  author  = {Daniele Cerroni and Mattia Penati and Giovanni Porta and Edie Miglio and Paolo Zunino and Paolo Ruffo},
-  title   = {Multiscale Modeling of Glacial Loading by a 3D Thermo-Hydro-Mechanical Approach Including Erosion and Isostasy},
-  journal = {Geosciences}
-}
-
-@Article{han.park.ea:dteq,
-  doi     = {10.1080/15361055.2018.1554391},
-  year    = {2019},
-  month   = feb,
-  publisher = {Informa {UK} Limited},
-  volume  = {75},
+  volume  = {90},
   number  = {2},
-  pages   = {137--147},
-  author  = {K. S. Han and B. H. Park and A. Y. Aydemir and J. Seol},
-  title   = {The {DTEQ} Code for Toroidal {MHD} Equilibria with Diamagnetic Current Modeling Using the deal.{II} Finite Element Library},
-  journal = {Fusion Science and Technology}
+  pages   = {81--113},
+  author  = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
+  title   = {A multiscale approach to hybrid {RANS}/{LES} wall modeling within a high-order discontinuous {G}alerkin scheme using function enrichment},
+  journal = {International Journal for Numerical Methods in Fluids}
 }
 
-@Article{samii.kazhyken.ea:comparison,
-  doi     = {10.1007/s10915-019-01007-z},
+@Article{krank.kronbichler.ea:wall,
+  doi     = {10.1016/j.compfluid.2018.07.019},
+  year    = {2019},
+  publisher = {Elsevier {BV}},
+  volume  = {179},
+  pages   = {718--725},
+  author  = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
+  title   = {Wall modeling via function enrichment: Extension to detached-eddy simulation},
+  journal = {Computers {\&} Fluids}
+}
+
+@PhDThesis{krank:wall,
+  author  = {Krank, Benjamin},
+  title   = {Wall Modeling via Function Enrichment for Computational Fluid Dynamics},
+  type    = {Dissertation},
+  school  = {Technische Universit{\"a}t M{\"u}nchen},
+  address = {M{\"u}nchen},
+  year    = {2019}
+}
+
+@InProceedings{kronbichler.kormann.ea:fast,
+  author  = {Martin Kronbichler and Katharina Kormann and Wolfgang A. Wall},
+  title   = {Fast matrix-free evaluation of hybridizable discontinuous Galerkin operators},
+  editor  = {Florin A. Radu and Kundan Kumar and Inga Berre and Jan M. Nordbotten and Iuliu S. Pop},
+  booktitle = {Numerical Mathematics and Advanced Applications: ENUMATH 2017},
+  volume  = {126},
+  series  = {Lecture Notes in Computational Science and Engineering},
+  year    = {2019},
+  pages   = {581--589},
+  doi     = {10.1007/978-3-319-96415-7_53}
+}
+
+@Article{kronbichler.kormann.ea:hermite-like,
+  title   = {A Hermite-like basis for faster matrix-free evaluation of interior penalty discontinuous Galerkin operators},
+  author  = {Kronbichler, Martin and Kormann, Katharina and Fehn, Niklas and Munch, Peter and Witte, Julius},
+  journal = {arXiv preprint arXiv:1907.08492},
+  year    = {2019}
+}
+
+@Article{kronbichler.kormann:fast,
+  title   = {Fast matrix-free evaluation of discontinuous Galerkin finite element operators},
+  author  = {Kronbichler, Martin and Kormann, Katharina},
+  journal = {ACM Transactions on Mathematical Software (TOMS)},
+  volume  = {45},
+  number  = {3},
+  pages   = {1--40},
+  year    = {2019},
+  publisher = {ACM New York, NY, USA},
+  doi     = {10.1145/3325864}
+}
+
+@Article{kronbichler.ljungkvist:multigrid,
+  title   = {Multigrid for matrix-free high-order finite element computations on graphics processors},
+  author  = {Kronbichler, Martin and Ljungkvist, Karl},
+  journal = {ACM Transactions on Parallel Computing (TOPC)},
+  volume  = {6},
+  number  = {1},
+  pages   = {1--32},
+  year    = {2019},
+  publisher = {ACM New York, NY, USA},
+  doi     = {10.1145/3322813}
+}
+
+@Article{lin.xu.ea:mantle,
+  title   = {Mantle upwelling beneath the South China Sea and links to surrounding subduction systems},
+  author  = {Lin, Jian and Xu, Yigang and Sun, Zhen and Zhou, Zhiyuan},
+  journal = {National Science Review},
+  volume  = {6},
+  number  = {5},
+  pages   = {877--881},
+  year    = {2019},
+  publisher = {Oxford University Press},
+  doi     = {10.1093/nsr/nwz123}
+}
+
+@Article{liu.king:benchmark,
+  doi     = {10.1093/gji/ggz036},
+  year    = {2019},
+  month   = jan,
+  publisher = {Oxford University Press ({OUP})},
+  volume  = {217},
+  number  = {1},
+  pages   = {650--667},
+  author  = {Shangxin Liu and Scott D King},
+  title   = {A benchmark study of incompressible Stokes flow in a 3-D spherical shell using {ASPECT}},
+  journal = {Geophysical Journal International}
+}
+
+@Article{liu.reina:dynamic,
+  doi     = {10.1007/s00466-018-1662-x},
   year    = {2019},
   month   = jul,
   publisher = {Springer Science and Business Media {LLC}},
-  volume  = {80},
-  number  = {3},
-  pages   = {1936--1956},
-  author  = {Ali Samii and Kazbek Kazhyken and Craig Michoski and Clint Dawson},
-  title   = {A Comparison of the Explicit and Implicit Hybridizable Discontinuous Galerkin Methods for Nonlinear Shallow Water Equations},
+  volume  = {64},
+  number  = {1},
+  pages   = {147--161},
+  author  = {Chenchen Liu and Celia Reina},
+  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
+  journal = {Computational Mechanics}
+}
+
+@Article{liu.yin:unconditionally,
+  doi     = {10.1007/s10915-019-01038-6},
+  year    = {2019},
+  month   = aug,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {81},
+  number  = {2},
+  pages   = {789--819},
+  author  = {Hailiang Liu and Peimeng Yin},
+  title   = {Unconditionally Energy Stable {DG} Schemes for the Swift--Hohenberg Equation},
   journal = {Journal of Scientific Computing}
 }
 
-@MastersThesis{janssen:comparison,
-  title   = {A comparison of {GOCO05c} satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
-  author  = {Janssen, W. J.},
+@Article{luo.zhao:numerical,
+  doi     = {10.1007/s00170-019-03947-0},
   year    = {2019},
-  school  = {Utrecht University},
-  url     = {https://dspace.library.uu.nl/handle/1874/393839}
+  month   = jun,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {104},
+  number  = {5-8},
+  pages   = {1615--1635},
+  author  = {Zhibo Luo and Yaoyao Zhao},
+  title   = {Numerical simulation of part-level temperature fields during selective laser melting of stainless steel 316L},
+  journal = {International Journal of Advanced Manufacturing Technology}
+}
+
+@Article{ma.bakhti.ea:laser-generated,
+  doi     = {10.1021/acs.jpcc.9b05561},
+  year    = {2019},
+  month   = sep,
+  publisher = {American Chemical Society ({ACS})},
+  volume  = {123},
+  number  = {42},
+  pages   = {25898--25907},
+  author  = {Hongfeng Ma and Said Bakhti and Anton Rudenko and Francis Vocanson and Daniel S. Slaughter and Nathalie Destouches and Tatiana E. Itina},
+  title   = {Laser-Generated Ag Nanoparticles in Mesoporous {TiO}2 Films: Formation Processes and Modeling-Based Size Prediction},
+  journal = {The Journal of Physical Chemistry C}
+}
+
+@Article{maday.marcati:regularity,
+  doi     = {10.1142/s0218202519500295},
+  year    = {2019},
+  month   = jul,
+  publisher = {World Scientific Pub Co Pte Lt},
+  volume  = {29},
+  number  = {08},
+  pages   = {1585--1617},
+  author  = {Yvon Maday and Carlo Marcati},
+  title   = {Regularity and hp discontinuous Galerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
+  journal = {Mathematical Models and Methods in Applied Sciences}
+}
+
+@Article{maier.mattheakis.ea:homogenization,
+  doi     = {10.1098/rspa.2019.0220},
+  year    = {2019},
+  month   = oct,
+  publisher = {The Royal Society},
+  volume  = {475},
+  number  = {2230},
+  pages   = {20190220},
+  author  = {M. Maier and M. Mattheakis and E. Kaxiras and M. Luskin and D. Margetis},
+  title   = {Homogenization of plasmonic crystals: seeking the epsilon-near-zero effect},
+  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
+}
+
+@Article{mang.walloth.ea:mesh,
+  doi     = {10.1002/gamm.202000003},
+  year    = {2019},
+  month   = aug,
+  publisher = {Wiley},
+  volume  = {43},
+  number  = {1},
+  author  = {K. Mang and M. Walloth and T. Wick and W. Wollner},
+  title   = {Mesh adaptivity for quasi-static phase-field fractures based on a residual-type a posteriori error estimator},
+  journal = {{GAMM}-Mitteilungen}
+}
+
+@Article{mang.wick.ea:phase-field,
+  doi     = {10.1007/s00466-019-01752-w},
+  year    = {2019},
+  month   = jul,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {65},
+  number  = {1},
+  pages   = {61--78},
+  author  = {Katrin Mang and Thomas Wick and Winnifried Wollner},
+  title   = {A phase-field model for fractures in nearly incompressible solids},
+  journal = {Computational Mechanics}
+}
+
+@Misc{mang.wick:numerical,
+  doi     = {10.15488/5129},
+  url     = {https://www.repo.uni-hannover.de/handle/123456789/5175},
+  author  = {Mang, Katrin and Wick, Thomas},
+  keywords = {phase-field fracture, fracture mechanics, numerical methods, lecture notes, Phasenfeld, Rissbildung, Numerische Methoden, Vorlesungsskriptum, Dewey Decimal Classification::500 | Naturwissenschaften, Dewey Decimal Classification::500 | Naturwissenschaften::510 | Mathematik},
+  language = {en},
+  title   = {Numerical Methods for Variational Phase-Field Fracture Problems},
+  publisher = {Hannover : Institutionelles Repositorium der Leibniz Universit\"{a}t Hannover},
+  year    = {2019},
+  copyright = {CC BY 3.0 DE}
+}
+
+@InProceedings{mcbride.davydov.ea:modelling,
+  doi     = {10.1201/9780429426506},
+  url     = {https://books.google.com/books?id=4natDwAAQBAJ&pg=PA278},
+  year    = {2019},
+  author  = {McBride, A. and Davydov, D. and Steinmann, P.},
+  title   = {Modelling the Flexoelectric Effect in Solids},
+  pages   = {278--279},
+  booktitle = {Advances in Engineering Materials, Structures and Systems: Innovations, Mechanics and Applications. Proceedings of the 7th International Conference on Structural Engineering, Mechanics and Computation (SEMC 2019), September 2-4, 2019, Cape Town, South Africa.}
+}
+
+@Article{mehnert.hossain.ea:experimental,
+  doi     = {10.1016/j.euromechsol.2019.103797},
+  year    = {2019},
+  month   = sep,
+  publisher = {Elsevier {BV}},
+  volume  = {77},
+  pages   = {103797},
+  author  = {Markus Mehnert and Mokarram Hossain and Paul Steinmann},
+  title   = {Experimental and numerical investigations of the electro-viscoelastic behavior of {VHB} $4905^{TM}$},
+  journal = {European Journal of Mechanics - A/Solids}
+}
+
+@Article{mikelic.wheeler.ea:phase-field,
+  doi     = {10.1007/s13137-019-0113-y},
+  year    = {2019},
+  month   = jan,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {10},
+  number  = {1},
+  author  = {A. Mikeli{\'{c}} and M. F. Wheeler and T. Wick},
+  title   = {Phase-field modeling through iterative splitting of hydraulic fractures in a poroelastic medium},
+  journal = {{GEM} -- International Journal on Geomathematics}
+}
+
+@Article{morschhauser.grayver.ea:tippers,
+  title   = {Tippers at island geomagnetic observatories constrain electrical conductivity of oceanic lithosphere and upper mantle},
+  author  = {Morschhauser, Achim and Grayver, Alexander and Kuvshinov, Alexey and Samrock, Friedemann and Matzka, J{\"u}rgen},
+  journal = {Earth, Planets and Space},
+  volume  = {71},
+  number  = {1},
+  pages   = {17},
+  year    = {2019},
+  publisher = {SpringerOpen},
+  doi     = {10.1186/s40623-019-0991-0}
+}
+
+@PhDThesis{mousavi:crustal,
+  author  = {Naeim Mousavi},
+  title   = {Crustal and (sub)lithospheric structure beneath the Iranian Plateau from geophysical modeling},
+  school  = {University of Kiel, Germany},
+  year    = 2019,
+  url     = {https://macau.uni-kiel.de/receive/diss_mods_00025884}
+}
+
+@PhDThesis{mulita:smoothed-adaptive-finite-element-methods,
+  title   = {{Smoothed Adaptive Finite Element Methods}},
+  author  = {Mulita, Ornela},
+  url     = {http://hdl.handle.net/20.500.11767/103102},
+  school  = {{Scuola Internazionale Superiore di Studi Avanzati (SISSA)}},
+  year    = {2019},
+  month   = sep,
+  pdf     = {https://iris.sissa.it/retrieve/handle/20.500.11767/103102/107276/PhD_thesis_dissertation_Mulita.pdf}
+}
+
+@PhDThesis{murphy:mathematical,
+  author  = {Murphy, Laura},
+  title   = {Mathematical studies of a mechanobiochemical model for 3D cell migration},
+  url     = {http://sro.sussex.ac.uk/id/eprint/83522/},
+  school  = {University of Sussex},
+  year    = {2019}
 }
 
 @Article{na.bryant.ea:configurational,
@@ -1647,6 +1589,159 @@
   author  = {SeonHong Na and Eric C. Bryant and WaiChing Sun},
   title   = {A configurational force for adaptive re-meshing of gradient-enhanced poromechanics problems with history-dependent variables},
   journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{neitzel.wick.ea:optimal,
+  doi     = {10.1137/18m122385x},
+  year    = {2019},
+  month   = jan,
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {57},
+  number  = {3},
+  pages   = {1672--1690},
+  author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
+  title   = {An Optimal Control Problem Governed by a Regularized Phase-Field Fracture Propagation Model. Part {II}: The Regularization Limit},
+  journal = {{SIAM} Journal on Control and Optimization}
+}
+
+@Article{njinju.atekwana.ea:lithospheric,
+  doi     = {10.1029/2019tc005549},
+  year    = {2019},
+  month   = oct,
+  publisher = {American Geophysical Union ({AGU})},
+  author  = {Emmanuel A. Njinju and Estella A. Atekwana and D. Sarah Stamps and Mohamed G. Abdelsalam and Eliot A. Atekwana and Kevin L. Mickus and Stewart Fishwick and Folarin Kolawole and Tahiry A. Rajaonarison and Victor N. Nyalugwe},
+  title   = {Lithospheric Structure of the Malawi Rift: Implications for Magma-Poor Rifting Processes},
+  journal = {Tectonics}
+}
+
+@Article{noii.wick:phase-field,
+  title   = {A phase-field description for pressurized and non-isothermal propagating fractures},
+  volume  = {351},
+  issn    = {0045-7825},
+  doi     = {10.1016/j.cma.2019.03.058},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  publisher = {Elsevier BV},
+  author  = {Noii, Nima and Wick, Thomas},
+  year    = {2019},
+  month   = jul,
+  pages   = {860--890}
+}
+
+@Article{odster.kvamsdal.ea:simple,
+  doi     = {10.1016/j.cma.2018.09.003},
+  year    = {2019},
+  month   = jan,
+  publisher = {Elsevier {BV}},
+  volume  = {343},
+  pages   = {572--601},
+  author  = {Lars H. Ods{\ae}ter and Trond Kvamsdal and Mats G. Larson},
+  title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Book{pelteret.steinmann:magneto-active,
+  title   = {{M}agneto-{A}ctive {P}olymers: {F}abrication, characterisation, modelling and simulation at the micro- and macro-scale},
+  publisher = {Walter de Gruyter {GmbH}},
+  year    = {2019},
+  author  = {Jean-Paul Pelteret and Paul Steinmann},
+  isbn    = {3110419513},
+  doi     = {10.1515/9783110418576},
+  url     = {https://www.degruyter.com/view/product/455548}
+}
+
+@Article{perry-houts.karlstrom:anisotropic-viscosity-and-time-evolving-lithospheric-instabilities-due-to-aligned-igneous-intrusions,
+  author  = {Perry-Houts, Jonathan and Karlstrom, Leif},
+  journal = {Geophysical Journal International},
+  number  = {2},
+  pages   = {794--802},
+  publisher = {Oxford University Press},
+  title   = {{Anisotropic viscosity and time-evolving lithospheric instabilities due to aligned igneous intrusions}},
+  volume  = {216},
+  year    = {2019},
+  doi     = {10.1093/gji/ggy466}
+}
+
+@Article{pitton.heltai:accelerating,
+  doi     = {10.1002/nla.2211},
+  year    = {2019},
+  month   = jan,
+  publisher = {Wiley},
+  volume  = {26},
+  number  = {1},
+  pages   = {e2211},
+  author  = {G. Pitton and L. Heltai},
+  title   = {Accelerating the iterative solution of convection-diffusion problems using singular value decomposition},
+  journal = {Numerical Linear Algebra with Applications}
+}
+
+@Article{ponce-bobadilla.carraro.ea:age-structure,
+  author  = {Ponce Bobadilla, Ana Victoria and Carraro, Thomas and Byrne, Helen M. and Maini, Philip K. and Alarcon, Tomas},
+  title   = {Age-structure as key to delayed logistic proliferation of scratch assays},
+  year    = {2019},
+  doi     = {10.1101/540526},
+  publisher = {Cold Spring Harbor Laboratory},
+  url     = {https://www.biorxiv.org/content/early/2019/02/04/540526},
+  journal = {bioRxiv}
+}
+
+@PhDThesis{ponce-bobadilla:mathematical,
+  doi     = {10.11588/HEIDOK.00027466},
+  url     = {http://www.ub.uni-heidelberg.de/archiv/27466},
+  author  = {Ponce Bobadilla, Ana Victoria},
+  keywords = {500 Natural sciences and mathematics, 510 Mathematics},
+  title   = {Mathematical Models of Cell Migration and Proliferation in Scratch Assays},
+  publisher = {Heidelberg University Library},
+  year    = {2019}
+}
+
+@Article{potschka:backward,
+  doi     = {10.1007/s11075-018-0539-6},
+  year    = {2019},
+  month   = may,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {81},
+  number  = {1},
+  pages   = {151--180},
+  author  = {Andreas Potschka},
+  title   = {Backward step control for Hilbert space problems},
+  journal = {Numerical Algorithms}
+}
+
+@PhDThesis{prince:reduced-order-modeling-of-neutron-diffusion-and-transport-using-proper-generalized-decomposition,
+  title   = {{Reduced Order Modeling of Neutron Diffusion and Transport Using Proper Generalized Decomposition}},
+  author  = {Prince, Zachary Merritt},
+  url     = {https://hdl.handle.net/1969.1/186463},
+  school  = {{Texas A{\&}M University}},
+  year    = {2019},
+  month   = jul,
+  pdf     = {https://oaktrust.library.tamu.edu/bitstream/handle/1969.1/186463/PRINCE-DISSERTATION-2019.pdf}
+}
+
+@Article{qinami.bryant.ea:circumventing,
+  doi     = {10.1007/s10704-019-00349-x},
+  year    = {2019},
+  month   = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  author  = {Aurel Qinami and Eric Cushman Bryant and WaiChing Sun and Michael Kaliske},
+  title   = {Circumventing mesh bias by r- and h-adaptive techniques for variational eigenfracture},
+  journal = {International Journal of Fracture}
+}
+
+@PhDThesis{renaud:study,
+  title   = {A Study of the Tidal and Thermal Evolution of Rocky \& Icy Worlds Utilizing Advanced Rheological Models},
+  author  = {Renaud, Joseph P.},
+  year    = {2019},
+  school  = {George Mason University},
+  url     = {https://search.proquest.com/docview/2303307944}
+}
+
+@PhDThesis{reveron:iterative,
+  author  = {Manuel Antonio Borregales Rever\'on},
+  title   = {Iterative solvers for poromechanics},
+  school  = {Department of Mathematics, University of Bergen},
+  year    = {2019},
+  month   = aug,
+  url     = {http://bora.uib.no/handle/1956/21143}
 }
 
 @Article{robey.puckett:implementation,
@@ -1669,138 +1764,6 @@
   year    = {2019}
 }
 
-@Article{charnyi.heister.ea:efficient,
-  doi     = {10.1016/j.apnum.2018.11.013},
-  year    = {2019},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {141},
-  pages   = {220--233},
-  author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
-  title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier--Stokes equations},
-  journal = {Applied Numerical Mathematics}
-}
-
-@Article{zhang.choo.ea:on,
-  doi     = {10.1016/j.cma.2019.04.037},
-  year    = {2019},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {353},
-  pages   = {570--592},
-  author  = {Qi Zhang and Jinhyun Choo and Ronaldo I. Borja},
-  title   = {On the preferential flow patterns induced by transverse isotropy and non-Darcy flow in double porosity media},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@PhDThesis{zhang:topology,
-  author  = {Zhang, Shanglong},
-  title   = {Topology Optimization with Geometric Primitives},
-  url     = {https://www.researchgate.net/profile/Shanglong_Zhang/publication/330873130_Topology_Optimization_with_Geometric_Primitives/links/5e62bf364585153fb3c818d9/Topology-Optimization-with-Geometric-Primitives.pdf},
-  school  = {University of Connecticut},
-  year    = {2019}
-}
-
-@Article{zhang.yue:high-order,
-  title   = {A high-order and interface-preserving discontinuous Galerkin method for level-set reinitialization},
-  journal = {Journal of Computational Physics},
-  volume  = {378},
-  pages   = {634 - 664},
-  year    = {2019},
-  issn    = {0021-9991},
-  doi     = {10.1016/j.jcp.2018.11.029},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0021999118307733},
-  author  = {Jiaqi Zhang and Pengtao Yue},
-  keywords = {Hamilton-Jacobi equation, Numerical flux, Second-derivative limiter, Weighted local projection, Moving contact line}
-}
-
-@Article{heltai.rotundo:error,
-  doi     = {10.1016/j.camwa.2019.05.029},
-  year    = {2019},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {78},
-  number  = {11},
-  pages   = {3586--3604},
-  author  = {Luca Heltai and Nella Rotundo},
-  title   = {Error estimates in weighted Sobolev norms for finite element immersed interface methods},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@Article{heltai.caiazzo:multiscale,
-  doi     = {10.1002/cnm.3264},
-  year    = {2019},
-  month   = dec,
-  publisher = {Wiley},
-  volume  = {35},
-  number  = {12},
-  author  = {Luca Heltai and Alfonso Caiazzo},
-  title   = {Multiscale modeling of vascularized tissues via nonmatching immersed methods},
-  journal = {International Journal for Numerical Methods in Biomedical Engineering}
-}
-
-@Article{teichert.garikipati:machine,
-  doi     = {10.1016/j.cma.2018.10.025},
-  year    = {2019},
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = {344},
-  pages   = {666--693},
-  author  = {Gregory H. Teichert and Krishna Garikipati},
-  title   = {Machine learning materials physics: Surrogate optimization and multi-fidelity algorithms predict precipitate morphology in an alternative to phase field dynamics},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{kim.singh.ea:uncertainty,
-  doi     = {10.1016/j.jnnfm.2019.07.002},
-  year    = {2019},
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = {271},
-  pages   = {104138},
-  author  = {Jaekwang Kim and Piyush K. Singh and Jonathan B. Freund and Randy H. Ewoldt},
-  title   = {Uncertainty propagation in simulation predictions of generalized Newtonian fluid flows},
-  journal = {Journal of Non-Newtonian Fluid Mechanics}
-}
-
-@Article{kim:error,
-  doi     = {10.1051/m2an/2019026},
-  year    = {2019},
-  month   = jul,
-  publisher = {{EDP} Sciences},
-  volume  = {53},
-  number  = {4},
-  pages   = {1191--1222},
-  author  = {Seungil Kim},
-  title   = {Error analysis of {PML}-{FEM} approximations for the Helmholtz equation in waveguides},
-  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
-}
-
-@Article{liu.king:benchmark,
-  doi     = {10.1093/gji/ggz036},
-  year    = {2019},
-  month   = jan,
-  publisher = {Oxford University Press ({OUP})},
-  volume  = {217},
-  number  = {1},
-  pages   = {650--667},
-  author  = {Shangxin Liu and Scott D King},
-  title   = {A benchmark study of incompressible Stokes flow in a 3-D spherical shell using {ASPECT}},
-  journal = {Geophysical Journal International}
-}
-
-@Article{gong.chen.ea:quantitative,
-  doi     = {10.1016/j.ijheatmasstransfer.2019.01.104},
-  year    = {2019},
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = {135},
-  pages   = {262--273},
-  author  = {Tong Zhao Gong and Yun Chen and Dian Zhong Li and Yan Fei Cao and Pai Xian Fu},
-  title   = {Quantitative comparison of dendritic growth under forced flow between 2D and 3D phase-field simulation},
-  journal = {International Journal of Heat and Mass Transfer}
-}
-
 @Article{roelofs.dovizio.ea:core,
   doi     = {10.1016/j.nucengdes.2019.110322},
   year    = {2019},
@@ -1813,251 +1776,55 @@
   journal = {Nuclear Engineering and Design}
 }
 
-@InProceedings{kauffman.george.ea:overset,
-  doi     = {10.2514/6.2019-1986},
+@Article{rom.muller:new,
+  doi     = {10.1016/j.triboint.2018.12.030},
   year    = {2019},
-  month   = jan,
-  publisher = {American Institute of Aeronautics and Astronautics},
-  author  = {Justin A. Kauffman and William L. George and Jonathan S. Pitt},
-  title   = {An Overset Mesh Framework for an Isentropic {ALE} Navier-Stokes {HDG} Formulation},
-  booktitle = {{AIAA} Scitech 2019 Forum}
+  month   = may,
+  publisher = {Elsevier {BV}},
+  volume  = {133},
+  pages   = {55--66},
+  author  = {Michael Rom and Siegfried M\"{u}ller},
+  title   = {A new model for textured surface lubrication based on a modified Reynolds equation including inertia effects},
+  journal = {Tribology International}
 }
 
-@Article{gedicke.khan:divergence-conforming,
-  doi     = {10.1007/s00211-019-01095-x},
+@Article{rudraraju.moulton.ea:computational,
+  doi     = {10.1371/journal.pcbi.1007213},
   year    = {2019},
-  month   = dec,
+  month   = jul,
+  publisher = {Public Library of Science ({PLoS})},
+  volume  = {15},
+  number  = {7},
+  pages   = {e1007213},
+  author  = {Shiva Rudraraju and Derek E. Moulton and R{\'{e}}gis Chirat and Alain Goriely and Krishna Garikipati},
+  editor  = {Qing Nie},
+  title   = {A computational framework for the morpho-elastic development of molluskan shells by surface and volume growth},
+  journal = {{PLOS} Computational Biology}
+}
+
+@Article{samii.kazhyken.ea:comparison,
+  doi     = {10.1007/s10915-019-01007-z},
+  year    = {2019},
+  month   = jul,
   publisher = {Springer Science and Business Media {LLC}},
-  volume  = {144},
+  volume  = {80},
   number  = {3},
-  pages   = {585--614},
-  author  = {Joscha Gedicke and Arbaz Khan},
-  title   = {Divergence-conforming discontinuous Galerkin finite elements for Stokes eigenvalue problems},
-  journal = {Numerische Mathematik}
+  pages   = {1936--1956},
+  author  = {Ali Samii and Kazbek Kazhyken and Craig Michoski and Clint Dawson},
+  title   = {A Comparison of the Explicit and Implicit Hybridizable Discontinuous Galerkin Methods for Nonlinear Shallow Water Equations},
+  journal = {Journal of Scientific Computing}
 }
 
-@Article{ambartsumyan.khattatov.ea:higher,
-  doi     = {10.1142/s0218202519500167},
-  year    = {2019},
-  month   = jun,
-  publisher = {World Scientific Pub Co Pte Lt},
-  volume  = {29},
-  number  = {06},
-  pages   = {1037--1077},
-  author  = {Ilona Ambartsumyan and Eldar Khattatov and Jeonghun J. Lee and Ivan Yotov},
-  title   = {Higher order multipoint flux mixed finite element methods on quadrilaterals and hexahedra},
-  journal = {Mathematical Models and Methods in Applied Sciences}
-}
-
-@Article{boddu.davydov.ea:cutoff-based,
-  doi     = {10.1007/s42493-019-00027-z},
-  year    = {2019},
-  month   = oct,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {1},
-  number  = {4},
-  pages   = {299--317},
-  author  = {Vishal Boddu and Denis Davydov and Bernhard Eidel and Paul Steinmann},
-  title   = {Cutoff-Based Modeling of Coulomb Interactions for Atomistic-to-Continuum Multiscale Methods},
-  journal = {Multiscale Science and Engineering}
-}
-
-@PhDThesis{brun:upscaling,
-  author  = {Brun, Mats Kirkes{\ae}ther},
-  title   = {Upscaling, analysis, and iterative numerical solution schemes for thermo-poroelasticity},
-  url     = {http://bora.uib.no/handle/1956/20657},
-  school  = {University of Bergen},
-  year    = {2019}
-}
-
-@PhDThesis{murphy:mathematical,
-  author  = {Murphy, Laura},
-  title   = {Mathematical studies of a mechanobiochemical model for 3D cell migration},
-  url     = {http://sro.sussex.ac.uk/id/eprint/83522/},
-  school  = {University of Sussex},
-  year    = {2019}
-}
-
-@PhDThesis{uatay:multiscale,
-  author  = {Uatay, Aydar},
-  title   = {Multiscale mathematical modeling of cell migration: from single cells to populations},
-  url     = {https://kluedo.ub.uni-kl.de/frontdoor/index/index/docId/5625},
-  school  = {Technische Universit{\"a}t Kaiserslautern},
-  year    = {2019}
-}
-
-@PhDThesis{van-liedekerke:quantitative-modeling-of-cell-and-tissue-mechanics-with-agent-based-models,
-  title   = {{Quantitative modeling of cell and tissue mechanics with agent-based models}},
-  author  = {Van Liedekerke, Paul},
-  url     = {https://hal.inria.fr/tel-02064216},
-  school  = {{Inria Paris, Sobonne Universit{\'e}}},
-  year    = {2019},
-  month   = mar,
-  keywords = {Agent-based models ; Cell migration ; Cell mechanics ; Mod{\`e}les {\`a} base d'agents ; Mechanique cellulaire},
-  type    = {Habilitation {\`a} diriger des recherches},
-  pdf     = {https://hal.inria.fr/tel-02064216/file/HDR_pvl.pdf},
-  hal_id  = {tel-02064216},
-  hal_version = {v1}
-}
-
-@MastersThesis{hanophy:performance,
-  author  = {Hanophy, Joshua Thomas},
-  title   = {Performance of parallel approximate ideal restriction multigrid for transport applications},
-  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/187540},
-  school  = {Texas A{\&}M University},
-  year    = {2019}
-}
-
-@PhDThesis{wei:numerical,
-  author  = {Wei, Peng},
-  title   = {Numerical Approximation of Time Dependent Fractional Diffusion With Drift: Numerical Analysis and Applications to Surface Quasi-Geostrophic Dynamics and Electroconvection},
-  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/186239},
-  school  = {Texas A{\&}M University},
-  year    = {2019}
-}
-
-@PhDThesis{scherff:modellierung,
-  doi     = {10.22028/D291-28367},
-  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/27748},
-  author  = {Scherff, Marc Frederik},
-  title   = {Modellierung der Gef\"{u}ge-Eigenschafts-Korrelation bei Dualphasenstahl},
-  school  = {Universit\"{a}t des Saarlandes},
-  year    = {2019}
-}
-
-@PhDThesis{bettendorf:optimum,
-  doi     = {10.11588/HEIDOK.00027345},
-  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/27345},
-  author  = {Bettendorf, Anja},
-  title   = {Optimum experimental design for parameter estimation with 2D partial differential equation models},
-  school  = {University of Heidelberg, Germany},
-  year    = {2019}
-}
-
-@PhDThesis{krank:wall,
-  author  = {Krank, Benjamin},
-  title   = {Wall Modeling via Function Enrichment for Computational Fluid Dynamics},
-  type    = {Dissertation},
-  school  = {Technische Universit{\"a}t M{\"u}nchen},
-  address = {M{\"u}nchen},
-  year    = {2019}
-}
-
-@PhDThesis{das:large,
-  author  = {Das, Sambit},
-  title   = {Large Scale Electronic Structure Studies on the Energetics of Dislocations in Al-Mg Materials System and Its Connection to Mesoscale Models},
-  url     = {https://deepblue.lib.umich.edu/handle/2027.42/153417},
-  school  = {University of Michigan},
-  year    = {2019}
-}
-
-@InProceedings{das.motamarri.ea:fast,
-  author  = {Sambit Das and Phani Motamarri and Vikram Gavini and Bruno Turcksin and Ying Wai Li and Brent Leback},
-  title   = {{F}ast, {S}calable and {A}ccurate {F}inite-{E}lements {B}ased {A}b {I}nitio {C}alculations {U}sing {M}ixed {P}recision {C}omputing: 46 {PFLOPS} {S}imulation of a {M}etallic {D}islocation {S}ystem},
-  booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage, and Analysis},
-  series  = {SC '19},
-  year    = {2019},
-  pages   = {2:1--2:11},
-  articleno = {2},
-  numpages = {11},
-  doi     = {10.1145/3295500.3357157},
-  publisher = {ACM},
-  address = {New York, NY, USA}
-}
-
-@PhDThesis{fraters:towards,
-  author  = {Fraters, Menno R. T.},
-  title   = {Towards numerical modelling of natural subduction systems with an application to Eastern Caribbean subduction},
-  url     = {https://dspace.library.uu.nl/handle/1874/379767},
-  school  = {Utrecht University},
-  year    = {2019}
-}
-
-@Article{hochbruck.leibold:finite,
-  doi     = {10.1553/etna_vol53s522},
-  year    = {2020},
-  publisher = {Osterreichische Akademie der Wissenschaften},
-  volume  = {53},
-  pages   = {522--540},
-  author  = {Marlis Hochbruck and Jan Leibold},
-  title   = {Finite element discretization of semilinear acoustic wave equations with kinetic boundary conditions},
-  journal = {{ETNA} - Electronic Transactions on Numerical Analysis}
-}
-
-@PhDThesis{alzetta:coupling,
-  author  = {Alzetta, Giovanni},
-  title   = {Coupling methods for non-matching meshes through distributed Lagrange multipliers},
-  url     = {http://hdl.handle.net/20.500.11767/103034},
-  school  = {Scuola Internazionale Superiore di Studi Avanzati},
-  year    = {2019}
-}
-
-@PhDThesis{cajuhi:fracture,
-  author  = {Cajuhi, Tuanny},
-  title   = {Fracture in porous media: phase-field modeling, simulation and experimental validation},
-  url     = {https://core.ac.uk/download/pdf/196653165.pdf},
-  school  = {Technischen Universit{\"a}t Carolo-Wilhelmina zu Braunschweig},
-  year    = {2019}
-}
-
-@InProceedings{castelli.dorfler:efficient,
-  author  = {Castelli, G. F. and D{\"o}rfler, W.},
-  title   = {An Efficient Matrix-Free Finite Element Solver for the {Cahn--Hiliard} Equation},
-  editor  = {Gleim, T. and Lange, S.},
-  booktitle = {Proceedings of 8th {GACM} Colloquium on Computational Mechanics},
-  year    = {2019},
-  publisher = {Kassel University Press},
-  pages   = {441--444},
-  doi     = {10.19211/KUP978737650939}
-}
-
-@InProceedings{kazemi.vaziri.ea:topology,
-  doi     = {10.1115/detc2019-97370},
+@Article{santis.shams:advanced,
+  doi     = {10.1016/j.anucene.2019.02.049},
   year    = {2019},
   month   = aug,
-  publisher = {American Society of Mechanical Engineers},
-  author  = {Hesaneh Kazemi and Ashkan Vaziri and Juli{\'{a}}n Norato},
-  title   = {Topology Optimization of Multi-Material Lattices for Maximal Bulk Modulus},
-  booktitle = {Volume 2A: 45th Design Automation Conference}
-}
-
-@Article{gupta.keulen.ea:design,
-  doi     = {10.1002/nme.6217},
-  year    = {2019},
-  month   = oct,
-  publisher = {Wiley},
-  volume  = {121},
-  number  = {3},
-  pages   = {450--476},
-  author  = {Deepak K. Gupta and Fred Keulen and Matthijs Langelaar},
-  title   = {Design and analysis adaptivity in multiresolution topology optimization},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{maier.mattheakis.ea:homogenization,
-  doi     = {10.1098/rspa.2019.0220},
-  year    = {2019},
-  month   = oct,
-  publisher = {The Royal Society},
-  volume  = {475},
-  number  = {2230},
-  pages   = {20190220},
-  author  = {M. Maier and M. Mattheakis and E. Kaxiras and M. Luskin and D. Margetis},
-  title   = {Homogenization of plasmonic crystals: seeking the epsilon-near-zero effect},
-  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
-}
-
-@Article{neitzel.wick.ea:optimal,
-  doi     = {10.1137/18m122385x},
-  year    = {2019},
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {57},
-  number  = {3},
-  pages   = {1672--1690},
-  author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
-  title   = {An Optimal Control Problem Governed by a Regularized Phase-Field Fracture Propagation Model. Part {II}: The Regularization Limit},
-  journal = {{SIAM} Journal on Control and Optimization}
+  publisher = {Elsevier {BV}},
+  volume  = {130},
+  pages   = {218--231},
+  author  = {Dante De Santis and Afaque Shams},
+  title   = {An advanced numerical framework for the simulation of flow induced vibration for nuclear applications},
+  journal = {Annals of Nuclear Energy}
 }
 
 @PhDThesis{sarna:entropy,
@@ -2074,6 +1841,22 @@
   year    = {2019}
 }
 
+@MastersThesis{sashko:enhancing,
+  title   = {Enhancing data locality in a matrix-free conjugate gradient method on modern computer architectures},
+  author  = {Dmytro Sashko},
+  school  = {Technical University of Munich},
+  year    = {2019}
+}
+
+@PhDThesis{scherff:modellierung,
+  doi     = {10.22028/D291-28367},
+  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/27748},
+  author  = {Scherff, Marc Frederik},
+  title   = {Modellierung der Gef\"{u}ge-Eigenschafts-Korrelation bei Dualphasenstahl},
+  school  = {Universit\"{a}t des Saarlandes},
+  year    = {2019}
+}
+
 @Article{schoeder.wall.ea:exwave,
   doi     = {10.1016/j.softx.2019.01.001},
   year    = {2019},
@@ -2086,24 +1869,135 @@
   journal = {{SoftwareX}}
 }
 
-@PhDThesis{mulita:smoothed-adaptive-finite-element-methods,
-  title   = {{Smoothed Adaptive Finite Element Methods}},
-  author  = {Mulita, Ornela},
-  url     = {http://hdl.handle.net/20.500.11767/103102},
-  school  = {{Scuola Internazionale Superiore di Studi Avanzati (SISSA)}},
+@PhDThesis{schoeder:efficient,
+  author  = {Schoeder, Svenja Madeleine},
+  title   = {Efficient Discontinuous Galerkin Methods for Wave Propagation and Iterative Optoacoustic Image Reconstruction},
+  school  = {Technical University of Munich},
   year    = {2019},
-  month   = sep,
-  pdf     = {https://iris.sissa.it/retrieve/handle/20.500.11767/103102/107276/PhD_thesis_dissertation_Mulita.pdf}
+  url     = {https://mediatum.ub.tum.de/1451984}
 }
 
-@PhDThesis{prince:reduced-order-modeling-of-neutron-diffusion-and-transport-using-proper-generalized-decomposition,
-  title   = {{Reduced Order Modeling of Neutron Diffusion and Transport Using Proper Generalized Decomposition}},
-  author  = {Prince, Zachary Merritt},
-  url     = {https://hdl.handle.net/1969.1/186463},
-  school  = {{Texas A{\&}M University}},
+@Article{schussnig.fries:concept,
+  doi     = {10.1002/pamm.201900100},
+  year    = {2019},
+  month   = sep,
+  publisher = {Wiley},
+  volume  = {19},
+  number  = {1},
+  author  = {Richard Schussnig and Thomas-Peter Fries},
+  title   = {A concept for aortic dissection with fluid-structure-crack interaction},
+  journal = {{PAMM}}
+}
+
+@Article{schutz.beneyton.ea:rational,
+  doi     = {10.1039/c9lc00149b},
+  year    = {2019},
+  publisher = {Royal Society of Chemistry ({RSC})},
+  volume  = {19},
+  number  = {13},
+  pages   = {2220--2232},
+  author  = {Simon S. Sch\"{u}tz and Thomas Beneyton and Jean-Christophe Baret and Tobias M. Schneider},
+  title   = {Rational design of a high-throughput droplet sorter},
+  journal = {Lab on a Chip}
+}
+
+@Article{shiozawa.lee.ea:effect,
+  author  = {Shiozawa, Sogo and Lee, Sanghyun and Wheeler, Mary F.},
+  title   = {The effect of stress boundary conditions on fluid-driven fracture propagation in porous media using a phase-field modeling approach},
+  journal = {International Journal for Numerical and Analytical Methods in Geomechanics},
+  volume  = {43},
+  year    = {2019},
+  number  = {6},
+  pages   = {1316-1340},
+  keywords = {fluid-driven fracture, phase field, porous media, stress boundary conditions},
+  doi     = {10.1002/nag.2899},
+  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nag.2899},
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
+}
+
+@Article{silva.igreja.ea:formulacao,
+  author  = {Emerson J. da Silva and Iury Igreja and Bernardo M. Rocha},
+  title   = {Formula{\c{c}}{\~{a}}o H{\'{i}}brida de Elementos Finitos de Alta Ordem para a Resolu{\c{c}}{\~{a}}o de Problemas de Rea{\c{c}}{\~{a}}o-Difus{\~{a}}o},
+  journal = {Mec{\'{a}}nica Computacional},
+  volume  = {37},
+  number  = {24},
+  pages   = {943--952},
+  year    = {2019},
+  month   = nov,
+  url     = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/view/5882},
+  pdf     = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/download/5882/5869}
+}
+
+@Article{soldner.mergheim:thermal,
+  doi     = {10.1016/j.camwa.2018.04.036},
+  year    = {2019},
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = {78},
+  number  = {7},
+  pages   = {2183--2196},
+  author  = {Dominic Soldner and Julia Mergheim},
+  title   = {Thermal modelling of selective beam melting processes using heterogeneous time step sizes},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
+@Article{song.maier.ea:adaptive,
+  author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
+  doi     = {10.1016/j.cma.2019.03.039},
+  title   = {Adaptive finite element simulations of waveguide configurations involving parallel 2D material sheets},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2019},
+  volume  = {351},
+  pages   = {20--34}
+}
+
+@Article{steinberger.bredow.ea:widespread,
+  author  = {Steinberger, Bernhard and Bredow, Eva and Lebedev, Sergei and Schaeffer, Andrew and Torsvik, Trond H},
+  journal = {Nature Geoscience},
+  number  = {1},
+  pages   = {61},
+  publisher = {Nature Publishing Group},
+  title   = {Widespread volcanism in the {G}reenland-{N}orth {A}tlantic region explained by the {I}celand plume},
+  volume  = {12},
+  year    = {2019},
+  doi     = {10.1038/s41561-018-0251-0}
+}
+
+@Article{steinmann.kerganer.ea:novel,
+  doi     = {10.1016/j.jmps.2019.103680},
+  year    = {2019},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {132},
+  pages   = {103680},
+  author  = {Paul Steinmann and Andreas Kerga{\ss}ner and Philipp Landkammer and Hussein M. Zbib},
+  title   = {A novel continuum approach to gradient plasticity based on the complementing concepts of dislocation and disequilibrium densities},
+  journal = {Journal of the Mechanics and Physics of Solids}
+}
+
+@Article{sticko.kreiss:higher,
+  doi     = {10.1007/s10915-019-01004-2},
   year    = {2019},
   month   = jul,
-  pdf     = {https://oaktrust.library.tamu.edu/bitstream/handle/1969.1/186463/PRINCE-DISSERTATION-2019.pdf}
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {80},
+  number  = {3},
+  pages   = {1867--1887},
+  author  = {Simon Sticko and Gunilla Kreiss},
+  title   = {Higher Order Cut Finite Elements for the Wave Equation},
+  journal = {Journal of Scientific Computing}
+}
+
+@Article{stoop.waisbord.ea:disorder-induced,
+  doi     = {10.1016/j.jnnfm.2019.05.002},
+  year    = {2019},
+  month   = jun,
+  publisher = {Elsevier {BV}},
+  volume  = {268},
+  pages   = {66--74},
+  author  = {Norbert Stoop and Nicolas Waisbord and Vasily Kantsler and Vili Heinonen and Jeffrey S. Guasto and J\"{o}rn Dunkel},
+  title   = {Disorder-induced topological transition in porous media flow networks},
+  journal = {Journal of Non-Newtonian Fluid Mechanics}
 }
 
 @TechReport{sun:integrated,
@@ -2124,111 +2018,217 @@
   school  = {University of Connecticut}
 }
 
-@Article{silva.igreja.ea:formulacao,
-  author  = {Emerson J. da Silva and Iury Igreja and Bernardo M. Rocha},
-  title   = {Formula{\c{c}}{\~{a}}o H{\'{i}}brida de Elementos Finitos de Alta Ordem para a Resolu{\c{c}}{\~{a}}o de Problemas de Rea{\c{c}}{\~{a}}o-Difus{\~{a}}o},
-  journal = {Mec{\'{a}}nica Computacional},
-  volume  = {37},
-  number  = {24},
-  pages   = {943--952},
+@Article{teichert.garikipati:machine,
+  doi     = {10.1016/j.cma.2018.10.025},
   year    = {2019},
-  month   = nov,
-  url     = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/view/5882},
-  pdf     = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/download/5882/5869}
+  month   = feb,
+  publisher = {Elsevier {BV}},
+  volume  = {344},
+  pages   = {666--693},
+  author  = {Gregory H. Teichert and Krishna Garikipati},
+  title   = {Machine learning materials physics: Surrogate optimization and multi-fidelity algorithms predict precipitate morphology in an alternative to phase field dynamics},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@InProceedings{mcbride.davydov.ea:modelling,
-  doi     = {10.1201/9780429426506},
-  url     = {https://books.google.com/books?id=4natDwAAQBAJ&pg=PA278},
-  year    = {2019},
-  author  = {McBride, A. and Davydov, D. and Steinmann, P.},
-  title   = {Modelling the Flexoelectric Effect in Solids},
-  pages   = {278--279},
-  booktitle = {Advances in Engineering Materials, Structures and Systems: Innovations, Mechanics and Applications. Proceedings of the 7th International Conference on Structural Engineering, Mechanics and Computation (SEMC 2019), September 2-4, 2019, Cape Town, South Africa.}
+@PhDThesis{uatay:multiscale,
+  author  = {Uatay, Aydar},
+  title   = {Multiscale mathematical modeling of cell migration: from single cells to populations},
+  url     = {https://kluedo.ub.uni-kl.de/frontdoor/index/index/docId/5625},
+  school  = {Technische Universit{\"a}t Kaiserslautern},
+  year    = {2019}
 }
 
-@Article{khattatov.yotov:domain,
-  doi     = {10.1051/m2an/2019057},
+@Article{uluocak.pysklywec.ea:multi-dimensional,
+  doi     = {10.1029/2019gc008277},
   year    = {2019},
-  month   = nov,
-  publisher = {{EDP} Sciences},
-  volume  = {53},
-  number  = {6},
-  pages   = {2081--2108},
-  author  = {Eldar Khattatov and Ivan Yotov},
-  title   = {Domain decomposition and multiscale mortar mixed finite element methods for linear elasticity with weak stress symmetry},
-  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
+  month   = jun,
+  publisher = {American Geophysical Union ({AGU})},
+  author  = {E. {\c{S}}eng\"{u}l Uluocak and R.N. Pysklywec and O.H. G\"{o}{\u{g}}\"{u}{\c{s}} and E.U. Ulugergerli},
+  title   = {Multi-Dimensional Geodynamic Modeling in the Southeast Carpathians: Upper Mantle Flow Induced Surface Topography Anomalies},
+  journal = {Geochemistry, Geophysics, Geosystems}
 }
 
-@Article{schussnig.fries:concept,
-  doi     = {10.1002/pamm.201900100},
+@PhDThesis{van-liedekerke:quantitative-modeling-of-cell-and-tissue-mechanics-with-agent-based-models,
+  title   = {{Quantitative modeling of cell and tissue mechanics with agent-based models}},
+  author  = {Van Liedekerke, Paul},
+  url     = {https://hal.inria.fr/tel-02064216},
+  school  = {{Inria Paris, Sobonne Universit{\'e}}},
   year    = {2019},
-  month   = sep,
+  month   = mar,
+  keywords = {Agent-based models ; Cell migration ; Cell mechanics ; Mod{\`e}les {\`a} base d'agents ; Mechanique cellulaire},
+  type    = {Habilitation {\`a} diriger des recherches},
+  pdf     = {https://hal.inria.fr/tel-02064216/file/HDR_pvl.pdf},
+  hal_id  = {tel-02064216},
+  hal_version = {v1}
+}
+
+@Article{vassaux.richardson.ea:heterogeneous,
+  doi     = {10.1098/rsta.2018.0150},
+  year    = {2019},
+  month   = feb,
+  publisher = {The Royal Society},
+  volume  = {377},
+  number  = {2142},
+  pages   = {20180150},
+  author  = {M. Vassaux and R. A. Richardson and P. V. Coveney},
+  title   = {The heterogeneous multiscale method applied to inelastic polymer mechanics},
+  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences}
+}
+
+@Article{vassaux.sinclair.ea:role,
+  doi     = {10.1002/adts.201800168},
+  year    = {2019},
+  month   = feb,
   publisher = {Wiley},
-  volume  = {19},
-  number  = {1},
-  author  = {Richard Schussnig and Thomas-Peter Fries},
-  title   = {A concept for aortic dissection with fluid-structure-crack interaction},
-  journal = {{PAMM}}
+  volume  = {2},
+  number  = {5},
+  pages   = {1800168},
+  author  = {Maxime Vassaux and Robert C. Sinclair and Robin A. Richardson and James L. Suter and Peter V. Coveney},
+  title   = {The Role of Graphene in Enhancing the Material Properties of Thermosetting Polymers},
+  journal = {Advanced Theory and Simulations}
 }
 
-@Article{liu.reina:dynamic,
-  doi     = {10.1007/s00466-018-1662-x},
+@Article{walker.kramer.ea:accelerating,
+  doi     = {10.1002/cpe.5265},
   year    = {2019},
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {64},
-  number  = {1},
-  pages   = {147--161},
-  author  = {Chenchen Liu and Celia Reina},
-  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
-  journal = {Computational Mechanics}
-}
-
-@Article{pitton.heltai:accelerating,
-  doi     = {10.1002/nla.2211},
-  year    = {2019},
-  month   = jan,
+  month   = apr,
   publisher = {Wiley},
-  volume  = {26},
-  number  = {1},
-  pages   = {e2211},
-  author  = {G. Pitton and L. Heltai},
-  title   = {Accelerating the iterative solution of convection-diffusion problems using singular value decomposition},
-  journal = {Numerical Linear Algebra with Applications}
+  pages   = {e5265},
+  author  = {David W. Walker and Stephan C. Kramer and Fabian R. A. Biebl and Paul D. Ledger and Malcolm Brown},
+  title   = {Accelerating magnetic induction tomography-based imaging through heterogeneous parallel computing},
+  journal = {Concurrency and Computation: Practice and Experience}
 }
 
-@Article{potschka:backward,
-  doi     = {10.1007/s11075-018-0539-6},
-  year    = {2019},
-  month   = may,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {81},
-  number  = {1},
-  pages   = {151--180},
-  author  = {Andreas Potschka},
-  title   = {Backward step control for Hilbert space problems},
-  journal = {Numerical Algorithms}
-}
-
-@InCollection{both.kocher:numerical,
-  doi     = {10.1007/978-3-319-96415-7_74},
+@InCollection{wang.harper.ea:deal,
+  doi     = {10.1007/978-3-030-22747-0_37},
   year    = {2019},
   publisher = {Springer International Publishing},
-  pages   = {789--797},
-  author  = {Jakub W. Both and Uwe K\"{o}cher},
-  title   = {Numerical Investigation on the Fixed-Stress Splitting Scheme for {Biot}'s Equations: Optimality of the Tuning Parameter},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
+  pages   = {495--509},
+  author  = {Zhuoran Wang and Graham Harper and Patrick O'Leary and Jiangguo Liu and Simon Tavener},
+  title   = {deal.{II} Implementation of a Weak Galerkin Finite Element Solver for Darcy Flow},
+  booktitle = {Lecture Notes in Computer Science}
 }
 
-@InCollection{kocher:influence,
-  doi     = {10.1007/978-3-319-96415-7_18},
+@PhDThesis{wei:numerical,
+  author  = {Wei, Peng},
+  title   = {Numerical Approximation of Time Dependent Fractional Diffusion With Drift: Numerical Analysis and Applications to Surface Quasi-Geostrophic Dynamics and Electroconvection},
+  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/186239},
+  school  = {Texas A{\&}M University},
+  year    = {2019}
+}
+
+@InProceedings{wheeler.srinivasan.ea:unconventional,
+  doi     = {10.2118/193830-ms},
   year    = {2019},
-  publisher = {Springer International Publishing},
-  pages   = {215--223},
-  author  = {Uwe K\"{o}cher},
-  title   = {Influence of the {SIPG} Penalisation on the Numerical Properties of Linear Systems for Elastic Wave Propagation},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
+  publisher = {Society of Petroleum Engineers},
+  author  = {Mary F. Wheeler and Sanjay Srinivasan and Sanghyun Lee and Manik Singh},
+  title   = {Unconventional Reservoir Management Modeling Coupling Diffusive Zone/Phase Field Fracture Modeling and Fracture Probability Maps},
+  booktitle = {{SPE} Reservoir Simulation Conference}
+}
+
+@Article{white.castelletto.ea:two-stage,
+  doi     = {10.1016/j.cma.2019.112575},
+  year    = {2019},
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {357},
+  pages   = {112575},
+  author  = {Joshua A. White and Nicola Castelletto and Sergey Klevtsov and Quan M. Bui and Daniel Osei-Kuffuor and Hamdi A. Tchelepi},
+  title   = {A two-stage preconditioner for multiphase poromechanics in reservoir simulation},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@PhDThesis{wichmann:performance,
+  author  = {Wichmann, Karl-Robert Klaus},
+  title   = {Performance Aspects of Incompressible {N}avier-{S}tokes Solvers: {L}attice-{B}oltzmann Method vs. Finite Difference Method},
+  school  = {Technical University of Munich},
+  year    = {2019},
+  url     = {https://mediatum.ub.tum.de/1437209}
+}
+
+@Article{wick.wollner:on,
+  doi     = {10.1007/s00021-019-0439-0},
+  year    = {2019},
+  month   = jun,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {21},
+  number  = {3},
+  author  = {Thomas Wick and Winnifried Wollner},
+  title   = {On the Differentiability of Fluid-Structure Interaction Problems with Respect to the Problem Data},
+  journal = {Journal of Mathematical Fluid Mechanics}
+}
+
+@Article{yaghoobi.ganesan.ea:prisms-plasticity,
+  doi     = {10.1016/j.commatsci.2019.109078},
+  year    = {2019},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {169},
+  pages   = {109078},
+  author  = {Mohammadreza Yaghoobi and Sriram Ganesan and Srihari Sundar and Aaditya Lakshmanan and Shiva Rudraraju and John E. Allison and Veera Sundararaghavan},
+  title   = {{PRISMS}-Plasticity: An open-source crystal plasticity finite element software},
+  journal = {Computational Materials Science}
+}
+
+@Article{zhang.choo.ea:on,
+  doi     = {10.1016/j.cma.2019.04.037},
+  year    = {2019},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {353},
+  pages   = {570--592},
+  author  = {Qi Zhang and Jinhyun Choo and Ronaldo I. Borja},
+  title   = {On the preferential flow patterns induced by transverse isotropy and non-Darcy flow in double porosity media},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{zhang.yue:high-order,
+  title   = {A high-order and interface-preserving discontinuous Galerkin method for level-set reinitialization},
+  journal = {Journal of Computational Physics},
+  volume  = {378},
+  pages   = {634 - 664},
+  year    = {2019},
+  issn    = {0021-9991},
+  doi     = {10.1016/j.jcp.2018.11.029},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0021999118307733},
+  author  = {Jiaqi Zhang and Pengtao Yue},
+  keywords = {Hamilton-Jacobi equation, Numerical flux, Second-derivative limiter, Weighted local projection, Moving contact line}
+}
+
+@PhDThesis{zhang:topology,
+  author  = {Zhang, Shanglong},
+  title   = {Topology Optimization with Geometric Primitives},
+  url     = {https://www.researchgate.net/profile/Shanglong_Zhang/publication/330873130_Topology_Optimization_with_Geometric_Primitives/links/5e62bf364585153fb3c818d9/Topology-Optimization-with-Geometric-Primitives.pdf},
+  school  = {University of Connecticut},
+  year    = {2019}
+}
+
+@Article{zhao.heister:preconditioner,
+  author  = {Liang Zhao and Timo Heister},
+  title   = {A preconditioner for the incompressible Navier-Stokes equations in velocity-vorticity form},
+  journal = {submitted},
+  year    = {2019},
+  note    = {submitted}
+}
+
+@Article{zhao.li.ea:linear,
+  doi     = {10.1016/j.aml.2019.05.029},
+  year    = {2019},
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {98},
+  pages   = {142--148},
+  author  = {Yucan Zhao and Jun Li and Jia Zhao and Qi Wang},
+  title   = {A linear energy and entropy-production-rate preserving scheme for thermodynamically consistent crystal growth models},
+  journal = {Applied Mathematics Letters}
+}
+
+@MastersThesis{zimmerman:modeling,
+  title   = {Modeling and simulation of heat source trajectories through phase-change materials},
+  author  = {Alexander Gary Zimmerman},
+  year    = {2019},
+  school  = {RWTH Aachen},
+  url     = {https://arxiv.org/abs/1909.08882}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -1,26 +1,671 @@
 % Encoding: US-ASCII
 
-@Article{naliboff.glerum.ea:development,
-  author  = "Naliboff, J.B. and Glerum, A. and Brune, S. and Peron-Pinvidic, G. and Wrona, T.",
-  title   = "Development of 3-D rift heterogeneity through fault network evolution",
-  journal = "Geophysical Research Letters",
-  year    = "2020",
-  volume  = "47",
-  number  = "e2019GL086611",
-  doi     = "10.1029/2019GL086611",
-  opturl  = "https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GL086611"
+@Article{alzetta.heltai:multiscale,
+  author  = {Giovanni Alzetta and Luca Heltai},
+  journal = {Computers {\&} Structures},
+  pages   = {106334},
+  title   = {Multiscale modeling of fiber reinforced materials via non-matching immersed methods},
+  volume  = {239},
+  year    = {2020},
+  doi     = {10.1016/j.compstruc.2020.106334}
 }
 
-@Article{negredo.mancilla.ea:geodynamic,
-  author  = {Negredo, A. M. and Mancilla, F. d. L. and Clemente, C. and Morales, J. and Fullea, J.},
-  title   = {Geodynamic Modeling of Edge-Delamination Driven by Subduction-Transform Edge Propagator Faults: The Westernmost Mediterranean Margin (Central Betic Orogen) Case Study},
-  journal = {Frontiers in Earth Science},
-  volume  = {8},
-  pages   = {435},
+@Article{anzt.cojean.ea:ginkgo,
+  doi     = {10.21105/joss.02260},
   year    = {2020},
-  url     = {https://www.frontiersin.org/article/10.3389/feart.2020.533392},
-  doi     = {10.3389/feart.2020.533392},
-  issn    = {2296-6463}
+  month   = aug,
+  publisher = {The Open Journal},
+  volume  = {5},
+  number  = {52},
+  pages   = {2260},
+  author  = {Hartwig Anzt and Terry Cojean and Yen-Chen Chen and Goran Flegar and Fritz G\"{o}bel and Thomas Gr\"{u}tzmacher and Pratik Nayak and Tobias Ribizel and Yu-Hsiang Tsai},
+  title   = {Ginkgo: A high performance numerical linear algebra library},
+  journal = {Journal of Open Source Software}
+}
+
+@Article{araujo.campos.ea:computation,
+  author  = {Ara\'{u}jo, Juan C. and Campos, Carmen and Engstr\"{o}m, Christian and Roman, Jose E.},
+  title   = {Computation of scattering resonances in absorptive and dispersive media with applications to metal-dielectric nano-structures},
+  journal = {Journal of Computational Physics},
+  volume  = {407},
+  pages   = {109220},
+  year    = {2020},
+  issn    = {0021-9991},
+  doi     = {10.1016/j.jcp.2019.109220},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0021999119309258}
+}
+
+@Article{arndt.bangerth.ea:deal-ii,
+  title   = {The \texttt{deal.II} Library, Version 9.2},
+  author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Thomas C. Clevenger and Marc Fehling and Alexander V. Grayver and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Reza Rastak and Ignacio Thomas and Bruno Turcksin and Zhuoran Wang and David Wells},
+  journal = {Journal of Numerical Mathematics},
+  publisher = {De Gruyter},
+  year    = {2020},
+  volume  = {28},
+  number  = {3},
+  pages   = {131-146},
+  doi     = {10.1515/jnma-2020-0043},
+  url     = {https://dealii.org/deal92-preprint.pdf}
+}
+
+@InProceedings{arndt.fehn.ea:exadg,
+  author  = {Arndt, Daniel and Fehn, Niklas and Kanschat, Guido and Kormann, Katharina and Kronbichler, Martin and Munch, Peter and Wall, Wolfgang A. and Witte, Julius},
+  editor  = {Bungartz, Hans-Joachim and Reiz, Severin and Uekermann, Benjamin and Neumann, Philipp and Nagel, Wolfgang E.},
+  title   = {Exa{DG}: {H}igh-{O}rder {D}iscontinuous {G}alerkin for the {E}xa-{S}cale},
+  booktitle = {Software for Exascale Computing - SPPEXA 2016-2019},
+  year    = {2020},
+  publisher = {Springer International Publishing},
+  address = {Cham},
+  pages   = {189--224},
+  isbn    = {978-3-030-47956-5},
+  doi     = {10.1007/978-3-030-47956-5_8}
+}
+
+@Article{arndt.kanschat:differentiable,
+  title   = {A Differentiable Mapping of Mesh Cells Based on Finite Elements on Quadrilateral and Hexahedral Meshes},
+  author  = {Arndt, Daniel and Kanschat, Guido},
+  journal = {Computational Methods in Applied Mathematics},
+  volume  = {1},
+  year    = {2020},
+  publisher = {De Gruyter},
+  doi     = {10.1515/cmam-2020-0159}
+}
+
+@Article{assanelli.luoni.ea:tectono-metamorphic,
+  author  = "Assanelli, M. and Luoni, P. and Rebay, G. and Roda, M. and Spalla, M. I.",
+  title   = "Tectono-Metamorphic Evolution of Serpentinites from Lanzo Valleys Subduction Complex (Piemonte--Sesia-Lanzo Zone Boundary, Western Italian Alps)",
+  journal = "Minerals",
+  year    = "2020",
+  volume  = "10",
+  number  = "11",
+  pages   = "985",
+  issn    = "2075-163X",
+  doi     = "10.3390/min10110985",
+  url     = "https://www.mdpi.com/2075-163X/10/11/985"
+}
+
+@Article{badia.martin.ea:generic,
+  doi     = {10.1137/20m1328786},
+  year    = {2020},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {42},
+  number  = {6},
+  pages   = {C436--C468},
+  author  = {Santiago Badia and Alberto F. Mart{\'{i}}n and Eric Neiva and Francesc Verdugo},
+  title   = {A Generic Finite Element Framework on Parallel Tree-Based Adaptive Meshes},
+  journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@Article{benbow.kawama.ea:coupled,
+  doi     = {10.3390/cryst10090767},
+  year    = {2020},
+  month   = aug,
+  publisher = {{MDPI} {AG}},
+  volume  = {10},
+  number  = {9},
+  pages   = {767},
+  author  = {Steven J. Benbow and Daisuke Kawama and Hiroyasu Takase and Hiroyuki Shimizu and Chie Oda and Fumio Hirano and Yusuke Takayama and Morihiro Mihara and Akira Honda},
+  title   = {A Coupled Modeling Simulator for Near-Field Processes in Cement Engineered Barrier Systems for Radioactive Waste Disposal},
+  journal = {Crystals}
+}
+
+@Article{blais.barbeau.ea:lethe,
+  doi     = {10.1016/j.softx.2020.100579},
+  year    = {2020},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {12},
+  pages   = {100579},
+  author  = {Bruno Blais and Lucka Barbeau and Val{\'{e}}rie Bibeau and Simon Gauvin and Toni El Geitani and Shahab Golshan and Rajeshwari Kamble and Ghazaleh Mirakhori and Jamal Chaouki},
+  title   = {Lethe: An open-source parallel high-order adaptative {CFD} solver for incompressible flows},
+  journal = {{SoftwareX}}
+}
+
+@Article{brun.wick.ea:iterative,
+  doi     = {10.1016/j.cma.2019.112752},
+  year    = {2020},
+  month   = apr,
+  publisher = {Elsevier {BV}},
+  volume  = {361},
+  pages   = {112752},
+  author  = {Mats Kirkes{\ae}ther Brun and Thomas Wick and Inga Berre and Jan Martin Nordbotten and Florin Adrian Radu},
+  title   = {An iterative staggered scheme for phase field brittle fracture propagation with stabilizing parameters},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{bruna-rosso.mergheim.ea:finite,
+  doi     = {10.1177/0954406220943225},
+  year    = {2020},
+  month   = aug,
+  publisher = {{SAGE} Publications},
+  pages   = {095440622094322},
+  author  = {Claire Bruna-Rosso and Julia Mergheim and Barbara Previtali},
+  title   = {Finite element modeling of residual stress and geometrical error formations in selective laser melting of metals},
+  journal = {Proceedings of the Institution of Mechanical Engineers, Part C: Journal of Mechanical Engineering Science}
+}
+
+@Article{cangiani.georgoulis.ea:posteriori,
+  doi     = {10.1007/s10915-020-01130-2},
+  year    = {2020},
+  month   = jan,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {82},
+  number  = {2},
+  author  = {Andrea Cangiani and Emmanuil H. Georgoulis and Mohammad Sabawi},
+  title   = {A Posteriori Error Analysis for Implicit--Explicit hp-Discontinuous Galerkin Timestepping Methods for Semilinear Parabolic Problems},
+  journal = {Journal of Scientific Computing}
+}
+
+@Article{choi.lee:optimal,
+  doi     = {10.1016/j.apnum.2019.09.010},
+  year    = {2020},
+  month   = apr,
+  publisher = {Elsevier {BV}},
+  volume  = {150},
+  pages   = {76--104},
+  author  = {Woocheol Choi and Sanghyun Lee},
+  title   = {Optimal error estimate of elliptic problems with Dirac sources for discontinuous and enriched Galerkin methods},
+  journal = {Applied Numerical Mathematics}
+}
+
+@Article{citron.lourenco.ea:effects,
+  title   = {Effects of Heat-Producing Elements on the Stability of Deep Mantle Thermochemical Piles},
+  author  = {Citron, Robert I. and Louren{\c{c}}o, Diogo L. and Wilson, Alfred J. and Grima, Antoniette G. and Wipperfurth, Scott A. and Rudolph, Maxwell L. and Cottaar, Sanne and Mont{\'e}si, Laurent G. J.},
+  journal = {Geochemistry, Geophysics, Geosystems},
+  volume  = {21},
+  number  = {4},
+  pages   = {e2019GC008895},
+  year    = {2020},
+  publisher = {Wiley Online Library},
+  doi     = {10.1029/2019GC008895}
+}
+
+@Article{cobb.dommain.ea:carbon,
+  doi     = {10.1088/1748-9326/aba867},
+  year    = {2020},
+  month   = oct,
+  publisher = {{IOP} Publishing},
+  volume  = {15},
+  number  = {11},
+  pages   = {114009},
+  author  = {Alexander R. Cobb and Ren{\'{e}} Dommain and Fangyi Tan and Naomi Hwee En Heng and Charles F Harvey},
+  title   = {Carbon storage capacity of tropical peatlands in natural and artificial drainage networks},
+  journal = {Environmental Research Letters}
+}
+
+@Article{comellas.budday.ea:modeling,
+  doi     = {10.1016/J.CMA.2020.113128},
+  issn    = {0045-7825},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  month   = sep,
+  pages   = {113128},
+  publisher = {North-Holland},
+  author  = {Ester Comellas and Silvia Budday and Jean-Paul Pelteret and Gerhard A. Holzapfel and Paul Steinmann},
+  title   = {Modeling the porous and viscous responses of human brain tissue behavior},
+  volume  = {369},
+  year    = {2020}
+}
+
+@Article{davydov.kronbichler:algorithms,
+  doi     = {10.1145/3399736},
+  title   = {Algorithms and data structures for matrix-free finite element operators with MPI-parallel sparse multi-vectors},
+  author  = {Davydov, Denis and Kronbichler, Martin},
+  journal = {ACM Transactions on Parallel Computing},
+  volume  = {7},
+  number  = {3},
+  pages   = {20:1--20:30},
+  year    = {2020},
+  month   = jun
+}
+
+@Article{davydov.pelteret.ea:matrix-free,
+  doi     = {10.1002/nme.6336},
+  year    = {2020},
+  month   = jul,
+  publisher = {Wiley},
+  volume  = {121},
+  number  = 13,
+  pages   = {2874--2895},
+  author  = {Denis Davydov and Jean-Paul Pelteret and Daniel Arndt and Martin Kronbichler and Paul Steinmann},
+  title   = {A matrix-free approach for finite-strain hyperelastic problems using geometric multigrid},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@Article{dewitt.rudraraju.ea:prisms-pf,
+  doi     = {10.1038/s41524-020-0298-5},
+  year    = {2020},
+  month   = mar,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {6},
+  number  = {1},
+  author  = {Stephen DeWitt and Shiva Rudraraju and David Montiel and W. Beck Andrews and Katsuyo Thornton},
+  title   = {{PRISMS}-{PF}: A general framework for phase-field modeling with a matrix-free finite element method},
+  journal = {npj Computational Materials}
+}
+
+@InCollection{endtmayer.langer.ea:hierarchical,
+  doi     = {10.1007/978-3-030-55874-1_35},
+  year    = {2020},
+  month   = aug,
+  publisher = {Springer International Publishing},
+  pages   = {363--372},
+  author  = {B. Endtmayer and U. Langer and J. P. Thiele and T. Wick},
+  title   = {Hierarchical {DWR} Error Estimates for the Navier-Stokes Equations: h and p Enrichment},
+  booktitle = {Lecture Notes in Computational Science and Engineering}
+}
+
+@Article{endtmayer.langer.ea:multigoal-oriented,
+  title   = "Multigoal-oriented optimal control problems with nonlinear PDE constraints",
+  journal = "Computers {\&} Mathematics with Applications",
+  volume  = "79",
+  number  = "10",
+  pages   = "3001 - 3026",
+  year    = "2020",
+  issn    = "0898-1221",
+  doi     = "10.1016/j.camwa.2020.01.005",
+  author  = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
+}
+
+@Article{endtmayer.langer.ea:two-side,
+  doi     = {10.1137/18m1227275},
+  year    = {2020},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {42},
+  number  = {1},
+  pages   = {A371--A394},
+  author  = {B. Endtmayer and U. Langer and T. Wick},
+  title   = {Two-Side a Posteriori Error Estimates for the Dual-Weighted Residual Method},
+  journal = {{SIAM} Journal on Scientific Computing}
+}
+
+@InCollection{engwer.pop.ea:dynamic,
+  doi     = {10.1007/978-3-030-55874-1_117},
+  year    = {2020},
+  month   = aug,
+  publisher = {Springer International Publishing},
+  pages   = {1177--1184},
+  author  = {Christian Engwer and Iuliu Sorin Pop and Thomas Wick},
+  title   = {Dynamic and Weighted Stabilizations of the L-scheme Applied to a Phase-Field Model for Fracture Propagation},
+  booktitle = {Lecture Notes in Computational Science and Engineering}
+}
+
+@Article{farangitakis.heron.ea:impact,
+  doi     = {10.1016/j.epsl.2020.116277},
+  year    = {2020},
+  month   = jul,
+  publisher = {Elsevier {BV}},
+  volume  = {541},
+  pages   = {116277},
+  author  = {G. P. Farangitakis and P. J. Heron and K. J. W. McCaffrey and J. van Hunen and L. M. Kalnins},
+  title   = {The impact of oblique inheritance and changes in relative plate motion on the development of rift-transform systems},
+  journal = {Earth and Planetary Science Letters}
+}
+
+@PhDThesis{fehling:algorithms,
+  author  = {Marc Fehling},
+  title   = {Algorithms for massively parallel generic $hp$-adaptive finite element methods},
+  school  = {Bergische Universit{\"a}t Wuppertal},
+  year    = {2020},
+  url     = {https://juser.fz-juelich.de/record/878206},
+  address = {J{\"u}lich},
+  publisher = {Forschungszentrum J{\"u}lich GmbH Zentralbibliothek, Verlag},
+  reportid = {FZJ-2020-02694},
+  isbn    = {978-3-95806-486-7},
+  series  = {Schriften des Forschungszentrums J{\"u}lich IAS Series},
+  volume  = {43},
+  pages   = {vii, 78 pp},
+  urn     = {urn:nbn:de:0001-2020071402}
+}
+
+@Article{fehn.munch.ea:hybrid,
+  doi     = {10.1016/j.jcp.2020.109538},
+  year    = {2020},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  volume  = {415},
+  pages   = {109538},
+  author  = {Niklas Fehn and Peter Munch and Wolfgang A. Wall and Martin Kronbichler},
+  title   = {Hybrid multigrid methods for high-order discontinuous {G}alerkin discretizations},
+  journal = {Journal of Computational Physics}
+}
+
+@Article{finlay.kloss.ea:chaos-7,
+  title   = {The CHAOS-7 geomagnetic field model and observed changes in the South Atlantic Anomaly},
+  author  = {Finlay, Christopher C and Kloss, Clemens and Olsen, Nils and Hammer, Magnus D and T{\o}ffner-Clausen, Lars and Grayver, Alexander and Kuvshinov, Alexey},
+  journal = {Earth, Planets and Space},
+  volume  = {72},
+  number  = {1},
+  pages   = {1--31},
+  year    = {2020},
+  publisher = {SpringerOpen},
+  doi     = {10.1186/s40623-020-01252-9}
+}
+
+@Article{fischer.min.ea:scalability,
+  doi     = {10.1177/1094342020915762},
+  year    = {2020},
+  month   = jun,
+  publisher = {{SAGE} Publications},
+  volume  = {34},
+  number  = {5},
+  pages   = {562--586},
+  author  = {Paul Fischer and Misun Min and Thilina Rathnayake and Som Dutta and Tzanio Kolev and Veselin Dobrev and Jean-Sylvain Camier and Martin Kronbichler and Tim Warburton and Kasia {\'{S}}wirydowicz and Jed Brown},
+  title   = {Scalability of high-performance {PDE} solvers},
+  journal = {The International Journal of High Performance Computing Applications}
+}
+
+@Article{gassmoller.dannberg.ea:on,
+  doi     = {10.1093/gji/ggaa078},
+  year    = {2020},
+  month   = feb,
+  publisher = {Oxford University Press ({OUP})},
+  volume  = {221},
+  number  = {2},
+  pages   = {1264--1280},
+  author  = {Rene Gassm\"{o}ller and Juliane Dannberg and Wolfgang Bangerth and Timo Heister and Robert Myhill},
+  title   = {On formulations of compressible mantle convection},
+  journal = {Geophysical Journal International}
+}
+
+@Article{glerum.brune.ea:victoria,
+  author  = "Glerum, A. and Brune, S. and Stamps, D. S. and Strecker, M. R.",
+  title   = "Victoria continental microplate dynamics controlled by the lithospheric strength distribution of the East African Rift",
+  journal = "Nature Communications",
+  year    = "2020",
+  volume  = "11",
+  number  = "1",
+  issn    = "2041-1723",
+  doi     = "10.1038/s41467-020-16176-x",
+  url     = "http://www.nature.com/articles/s41467-020-16176-x"
+}
+
+@Article{grieshaber.mcbride.ea:convergence,
+  doi     = {10.1016/j.cma.2020.113233},
+  year    = {2020},
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = {370},
+  pages   = {113233},
+  author  = {Beverley J. Grieshaber and Andrew T. McBride and B. Daya Reddy},
+  title   = {Convergence in the incompressible limit of new discontinuous Galerkin methods with general quadrilateral and hexahedral elements},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{gurkan.sticko.ea:stabilized,
+  title   = {Stabilized {Cut} {Discontinuous} {Galerkin} {Methods} for {Advection}-{Reaction} {Problems}},
+  volume  = {42},
+  issn    = {1064-8275, 1095-7197},
+  url     = {https://epubs.siam.org/doi/10.1137/18M1206461},
+  doi     = {10.1137/18M1206461},
+  language = {en},
+  number  = {5},
+  journal = {SIAM Journal on Scientific Computing},
+  author  = {G\"{u}rkan, Ceren and Sticko, Simon and Massing, Andr\'{e}},
+  month   = sep,
+  year    = {2020},
+  pages   = {A2620--A2654}
+}
+
+@Article{heister.wick:pfm-cracks,
+  title   = "pfm-cracks: A parallel-adaptive framework for phase-field fracture propagation",
+  journal = "Software Impacts",
+  volume  = "6",
+  pages   = "100045",
+  year    = "2020",
+  issn    = "2665-9638",
+  doi     = "10.1016/j.simpa.2020.100045",
+  url     = "http://www.sciencedirect.com/science/article/pii/S2665963820300361",
+  author  = "Timo Heister and Thomas Wick"
+}
+
+@Article{heltai.lei:priori,
+  author  = {Luca Heltai and Wenyu Lei},
+  journal = {Numerische Mathematik},
+  number  = {3},
+  pages   = {571--596},
+  title   = {A priori error estimates of regularized elliptic problems},
+  volume  = {146},
+  year    = {2020},
+  doi     = {10.1007/s00211-020-01152-w}
+}
+
+@Article{heron.murphy.ea:pannotias,
+  author  = {Heron, Philip J. and Murphy, J. Brendan and Nance, R. Damian and Pysklywec, R. N.},
+  title   = {Pannotia{\textquoteright}s mantle signature: the quest for supercontinent identification},
+  volume  = {503},
+  elocation-id = {SP503-2020-7},
+  year    = {2020},
+  doi     = {10.1144/SP503-2020-7},
+  publisher = {Geological Society of London},
+  issn    = {0305-8719},
+  url     = {https://sp.lyellcollection.org/content/early/2020/07/14/SP503-2020-7},
+  journal = {Geological Society, London, Special Publications}
+}
+
+@Article{heyn.conrad.ea:core-mantle,
+  title   = "Core-mantle boundary topography and its relation to the viscosity structure of the lowermost mantle",
+  journal = "Earth and Planetary Science Letters",
+  volume  = "543",
+  pages   = "116358",
+  year    = "2020",
+  issn    = "0012-821X",
+  doi     = "10.1016/j.epsl.2020.116358",
+  url     = "http://www.sciencedirect.com/science/article/pii/S0012821X20303022",
+  author  = "Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes"
+}
+
+@Article{heyn.conrad.ea:how,
+  author  = {Heyn, Bj{\"o}rn H. and Conrad, Clinton P. and Tr{\o}nnes, Reidar G.},
+  title   = {How Thermochemical Piles Can (Periodically) Generate Plumes at Their Edges},
+  journal = {Journal of Geophysical Research: Solid Earth},
+  volume  = {125},
+  number  = {6},
+  pages   = {e2019JB018726},
+  doi     = {10.1029/2019JB018726},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019JB018726},
+  year    = {2020}
+}
+
+@InBook{hoggard.austermann.ea:mantle,
+  author  = "Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon",
+  editor  = "H. Marquardt, M. Ballmer",
+  chapter = "Observational estimates of dynamic topography through space and time",
+  title   = "Mantle convection and surface expressions",
+  series  = "AGU Geophysical Monograph Series",
+  year    = "2021",
+  address = "Washington, D.C.",
+  publisher = "AGU",
+  doi     = "10.1002/9781119528609.ch15"
+}
+
+@Article{jerg.austermuhl.ea:diffuse,
+  title   = {Diffuse domain method for needle insertion simulations},
+  author  = {Jerg, Katharina I and Austerm{\"u}hl, Ren{\'e} Phillip and Roth, Karsten and Gro{\ss}e Sundrup, Jonas and Kanschat, Guido and Hesser, J{\"u}rgen W and Wittmayer, Lisa},
+  journal = {International journal for numerical methods in biomedical engineering},
+  volume  = {36},
+  number  = {9},
+  pages   = {e3377},
+  year    = {2020},
+  publisher = {Wiley Online Library},
+  doi     = {10.1002/cnm.3377}
+}
+
+@Article{jodlbauer.langer.ea:matrix-free,
+  title   = "Matrix-free multigrid solvers for phase-field fracture problems",
+  journal = "Computer Methods in Applied Mechanics and Engineering",
+  volume  = "372",
+  pages   = "113431",
+  year    = "2020",
+  issn    = "0045-7825",
+  doi     = "10.1016/j.cma.2020.113431",
+  author  = "D. Jodlbauer and U. Langer and T. Wick"
+}
+
+@Article{jodlbauer.langer.ea:parallel,
+  author  = {Jodlbauer, D. and Langer, U. and Wick, T.},
+  title   = {Parallel Matrix-Free Higher-Order Finite Element Solvers for Phase-Field Fracture Problems},
+  journal = {Mathematical and Computational Applications},
+  volume  = {25},
+  number  = {3},
+  pages   = {40},
+  year    = {2020},
+  doi     = {10.3390/mca25030040}
+}
+
+@Article{kaufl.grayver.ea:magnetotelluric,
+  title   = {Magnetotelluric multiscale 3-{D} inversion reveals crustal and upper mantle structure beneath the Hangai and {G}obi-{A}ltai region in {M}ongolia},
+  author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Comeau, Matthew J and Kuvshinov, Alexey V and Becken, Michael and Kamm, Jochen and Batmagnai, Erdenechimeg and Demberel, Sodnomsambuu},
+  journal = {Geophysical Journal International},
+  volume  = {221},
+  number  = {2},
+  pages   = {1002--1028},
+  year    = {2020},
+  publisher = {Oxford University Press},
+  doi     = {10.1093/gji/ggaa039}
+}
+
+@MastersThesis{khimin:numerische,
+  author  = {D. Khimin},
+  title   = {Numerische Modellierung von Optimalsteuerungsproblemen f{\"u}r Phasenfeld-Riss-Ausbreitung},
+  school  = {Leibniz University Hannover},
+  month   = jun,
+  year    = {2020}
+}
+
+@Article{kim:application,
+  doi     = {10.1016/j.cam.2019.112458},
+  year    = {2020},
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {367},
+  pages   = {112458},
+  author  = {Seungil Kim},
+  title   = {Application of a complete radiation boundary condition for the Helmholtz equation in locally perturbed waveguides},
+  journal = {Journal of Computational and Applied Mathematics}
+}
+
+@Article{kramer.wilde.ea:lattice-boltzmann-simulations-on-irregular-grids--introduction-of-the-natrium-library,
+  author  = {Kr{\"{a}}mer, Andreas and Wilde, Dominik and K{\"{u}}llmer, Knut and Reith, Dirk and Foysi, Holger and Joppich, Wolfgang},
+  doi     = {10.1016/j.camwa.2018.10.041},
+  issn    = {08981221},
+  journal = {Comput. Math. with Appl.},
+  number  = {1},
+  pages   = {34--54},
+  publisher = {Elsevier Ltd},
+  title   = {{Lattice Boltzmann simulations on irregular grids: Introduction of the NATriuM library}},
+  volume  = {79},
+  year    = {2020}
+}
+
+@Article{lee.shon.ea:adaptive,
+  doi     = {10.5757/asct.2020.29.3.062},
+  year    = {2020},
+  month   = may,
+  publisher = {The Korean Vacuum Society},
+  volume  = {29},
+  number  = {3},
+  pages   = {62--66},
+  author  = {Sora Lee and Yejin Shon and Dong-gil Kim and Deuk-Chul Kwon and Hee Hwan Choe},
+  title   = {Adaptive Mesh Method Applied to Poisson Solver Module for 3D Capacitively Coupled Plasma Discharge Simulation},
+  journal = {Applied Science and Convergence Technology}
+}
+
+@Article{lesher.dannberg.ea:iron,
+  title   = {Iron isotope fractionation at the core--mantle boundary by thermodiffusion},
+  author  = {Lesher, Charles E. and Dannberg, Juliane and Barfod, Gry H. and Bennett, Neil R. and Glessner, Justin J. G. and Lacks, Daniel J. and Brenan, James M.},
+  journal = {Nature Geoscience},
+  volume  = {13},
+  number  = {5},
+  pages   = {382--386},
+  year    = {2020},
+  publisher = {Nature Publishing Group},
+  doi     = {10.1038/s41561-020-0560-y}
+}
+
+@Article{liu.mcbride.ea:assessment-of-an-isogeometric-approach-with-catmull-clark-subdivision-surfaces-using-the-laplace-beltrami-problems,
+  author  = {Liu, Zhaowei and McBride, Andrew and Saxena, Prashant and Steinmann, Paul},
+  doi     = {10.1007/s00466-020-01877-3},
+  issn    = {14320924},
+  journal = {Computational Mechanics},
+  title   = {{Assessment of an isogeometric approach with Catmull-Clark subdivision surfaces using the Laplace-Beltrami problems}},
+  year    = {2020}
+}
+
+@Article{lorentzon.revstedt:numerical,
+  author  = {Lorentzon, Johan and Revstedt, Johan},
+  title   = {A numerical study of partitioned fluid-structure interaction applied to a cantilever in incompressible turbulent flow},
+  journal = {International Journal for Numerical Methods in Engineering},
+  volume  = {121},
+  number  = {5},
+  pages   = {806-827},
+  keywords = {deal.II, FSI, LES, OpenFOAM, strongly coupled},
+  doi     = {10.1002/nme.6245},
+  year    = {2020}
+}
+
+@Article{louis-napoleon.gerbault.ea:3-d,
+  title   = {3-D numerical modelling of crustal polydiapirs with volume-of-fluid methods},
+  author  = {Louis-Napol{\'e}on, Aur{\'e}lie and Gerbault, Muriel and Bonometti, Thomas and Thieulot, C{\'e}dric and Martin, Roland and Vanderhaeghe, Olivier},
+  journal = {Geophysical Journal International},
+  volume  = {222},
+  number  = {1},
+  pages   = {474--506},
+  year    = {2020},
+  publisher = {Oxford University Press},
+  doi     = {10.1093/gji/ggaa141}
+}
+
+@Article{maier.margetis.ea:finite-size,
+  author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
+  title   = {Finite-size effects in wave transmission through plasmonic crystals: A tale of two scales},
+  doi     = {10.1103/PhysRevB.102.075308},
+  journal = {Physical Review B},
+  year    = {2020},
+  volume  = {102},
+  pages   = {075308}
+}
+
+@Article{mcbride.davydov.ea:modelling,
+  doi     = {10.1016/j.cma.2020.113320},
+  year    = {2020},
+  month   = nov,
+  publisher = {Elsevier {BV}},
+  volume  = {371},
+  pages   = {113320},
+  author  = {A.T. McBride and D. Davydov and P. Steinmann},
+  title   = {Modelling the flexoelectric effect in solids: A micromorphic approach},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@PhDThesis{mcgovern:high,
+  author  = {Sean McGovern},
+  title   = {High Performance Computing in Basin Modeling: Simulating Mechanical Compaction with the Level Set Method},
+  school  = {Rheinische Friedrich-Wilhelms-Universit{\"a}t Bonn},
+  year    = {2020},
+  url     = {https://hdl.handle.net/20.500.11811/8443}
+}
+
+@Article{mitrovica.austermann.ea:dynamic,
+  author  = {Mitrovica, J. X. and Austermann, J. and Coulson, S. and Creveling, J. R. and Hoggard, M. J. and Jarvis, G. T. and Richards, F. D.},
+  title   = {Dynamic Topography and Ice Age Paleoclimate},
+  journal = {Annual Review of Earth and Planetary Sciences},
+  volume  = {48},
+  number  = {1},
+  pages   = {585-621},
+  year    = {2020},
+  doi     = {10.1146/annurev-earth-082517-010225}
+}
+
+@Article{motamarri.das.ea:dft-fe,
+  doi     = {10.1016/j.cpc.2019.07.016},
+  year    = {2020},
+  month   = jan,
+  publisher = {Elsevier {BV}},
+  volume  = {246},
+  pages   = {106853},
+  author  = {Phani Motamarri and Sambit Das and Shiva Rudraraju and Krishnendu Ghosh and Denis Davydov and Vikram Gavini},
+  title   = {{DFT}-{FE} -- A massively parallel adaptive finite-element code for large-scale density functional theory calculations},
+  journal = {Computer Physics Communications}
 }
 
 @Article{muluneh.brune.ea:mechanism,
@@ -38,61 +683,239 @@
   year    = {2020}
 }
 
-@Book{wick:multiphysics,
-  author  = "Thomas Wick",
-  title   = "Multiphysics Phase-Field Fracture: Modeling, Adaptive Discretizations, and Solvers",
-  year    = "2020",
-  publisher = "De Gruyter",
-  address = "Berlin, Boston",
-  isbn    = "978-3-11-049739-7",
-  doi     = "10.1515/9783110497397",
-  url     = "https://www.degruyter.com/view/title/523232"
-}
-
-@Article{heister.wick:pfm-cracks,
-  title   = "pfm-cracks: A parallel-adaptive framework for phase-field fracture propagation",
-  journal = "Software Impacts",
-  volume  = "6",
-  pages   = "100045",
-  year    = "2020",
-  issn    = "2665-9638",
-  doi     = "10.1016/j.simpa.2020.100045",
-  url     = "http://www.sciencedirect.com/science/article/pii/S2665963820300361",
-  author  = "Timo Heister and Thomas Wick"
-}
-
-@Article{jodlbauer.langer.ea:matrix-free,
-  title   = "Matrix-free multigrid solvers for phase-field fracture problems",
-  journal = "Computer Methods in Applied Mechanics and Engineering",
-  volume  = "372",
-  pages   = "113431",
-  year    = "2020",
-  issn    = "0045-7825",
-  doi     = "10.1016/j.cma.2020.113431",
-  author  = "D. Jodlbauer and U. Langer and T. Wick"
-}
-
-@Article{louis-napoleon.gerbault.ea:3-d,
-  title   = {3-D numerical modelling of crustal polydiapirs with volume-of-fluid methods},
-  author  = {Louis-Napol{\'e}on, Aur{\'e}lie and Gerbault, Muriel and Bonometti, Thomas and Thieulot, C{\'e}dric and Martin, Roland and Vanderhaeghe, Olivier},
-  journal = {Geophysical Journal International},
-  volume  = {222},
-  number  = {1},
-  pages   = {474--506},
+@Article{murphy.madzvamuse:moving,
+  doi     = {10.1016/j.apnum.2020.08.004},
   year    = {2020},
-  publisher = {Oxford University Press},
-  doi     = {10.1093/gji/ggaa141}
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = {158},
+  pages   = {336--359},
+  author  = {Laura Murphy and Anotida Madzvamuse},
+  title   = {A moving grid finite element method applied to a mechanobiochemical model for 3D cell migration},
+  journal = {Applied Numerical Mathematics}
 }
 
-@Article{jodlbauer.langer.ea:parallel,
-  author  = {Jodlbauer, D. and Langer, U. and Wick, T.},
-  title   = {Parallel Matrix-Free Higher-Order Finite Element Solvers for Phase-Field Fracture Problems},
-  journal = {Mathematical and Computational Applications},
+@Article{naliboff.glerum.ea:development,
+  author  = "Naliboff, J.B. and Glerum, A. and Brune, S. and Peron-Pinvidic, G. and Wrona, T.",
+  title   = "Development of 3-D rift heterogeneity through fault network evolution",
+  journal = "Geophysical Research Letters",
+  year    = "2020",
+  volume  = "47",
+  number  = "e2019GL086611",
+  doi     = "10.1029/2019GL086611",
+  opturl  = "https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GL086611"
+}
+
+@Article{nayak.cojean.ea:evaluating,
+  doi     = {10.1177/1094342020946814},
+  year    = {2020},
+  month   = aug,
+  publisher = {{SAGE} Publications},
+  pages   = {109434202094681},
+  author  = {Pratik Nayak and Terry Cojean and Hartwig Anzt},
+  title   = {Evaluating asynchronous Schwarz solvers on {GPUs}},
+  journal = {The International Journal of High Performance Computing Applications}
+}
+
+@Article{negredo.mancilla.ea:geodynamic,
+  author  = {Negredo, A. M. and Mancilla, F. d. L. and Clemente, C. and Morales, J. and Fullea, J.},
+  title   = {Geodynamic Modeling of Edge-Delamination Driven by Subduction-Transform Edge Propagator Faults: The Westernmost Mediterranean Margin (Central Betic Orogen) Case Study},
+  journal = {Frontiers in Earth Science},
+  volume  = {8},
+  pages   = {435},
+  year    = {2020},
+  url     = {https://www.frontiersin.org/article/10.3389/feart.2020.533392},
+  doi     = {10.3389/feart.2020.533392},
+  issn    = {2296-6463}
+}
+
+@Article{nitzler.biehler.ea:generalized,
+  title   = {A Generalized Probabilistic Learning Approach for Multi-Fidelity Uncertainty Propagation in Complex Physical Simulations},
+  author  = {Nitzler, Jonas and Biehler, Jonas and Fehn, Niklas and Koutsourelakis, Phaedon-Stelios and Wall, Wolfgang A},
+  journal = {arXiv preprint arXiv:2001.02892},
+  year    = {2020}
+}
+
+@Article{njinju.stamps.ea:lithospheric,
+  doi     = {10.1002/essoar.10503939.1},
+  pages   = {37},
+  year    = {2020},
+  month   = aug,
+  journal = {Earth and Space Science Open Archive},
+  author  = {Emmanuel A. Njinju and D. Sarah Stamps and James Gallagher and Kodi Neumiller},
+  title   = {Lithospheric Control of Melt Generation Beneath the Rungwe Volcanic Province, East Africa}
+}
+
+@InCollection{paula.quinelato.ea:numerical,
+  doi     = {10.1007/978-3-030-50436-6_2},
+  year    = {2020},
+  publisher = {Springer International Publishing},
+  pages   = {18--31},
+  author  = {Filipe Fernandes de Paula and Thiago Quinelato and Iury Igreja and Grigori Chapiro},
+  title   = {A Numerical Algorithm to Solve the Two-Phase Flow in Porous Media Including Foam Displacement},
+  booktitle = {Lecture Notes in Computer Science}
+}
+
+@Article{rajaonarison.stamps.ea:numerical,
+  title   = {Numerical Modeling of Mantle Flow Beneath Madagascar to Constrain Upper Mantle Rheology Beneath Continental Regions},
+  author  = {Rajaonarison, T. A. and Stamps, D. S. and Fishwick, S. and Brune, Sascha and Glerum, A. and Hu, J.},
+  journal = {Journal of Geophysical Research. Solid Earth},
+  volume  = {125},
+  number  = {2},
+  pages   = {Art--No},
+  year    = {2020},
+  publisher = {American Geophysical Union},
+  doi     = {10.1029/2019JB018560}
+}
+
+@Article{reveron.kumar.ea:iterative,
+  doi     = {10.1007/s10596-020-09983-0},
+  year    = {2020},
+  month   = jul,
+  publisher = {Springer Science and Business Media {LLC}},
   volume  = {25},
-  number  = {3},
-  pages   = {40},
+  number  = {2},
+  pages   = {687--699},
+  author  = {Manuel Antonio Borregales Rever{\'{o}}n and Kundan Kumar and Jan Martin Nordbotten and Florin Adrian Radu},
+  title   = {Iterative solvers for Biot model under small and large deformations},
+  journal = {Computational Geosciences}
+}
+
+@MastersThesis{roth:geometric,
+  author  = {Roth, Julian},
+  title   = {Geometric Multigrid Methods for Maxwell's Equations},
+  school  = {Leibniz Universit{\"a}t Hannover},
   year    = {2020},
-  doi     = {10.3390/mca25030040}
+  month   = jul,
+  url     = {https://julianroth.org/res/bachelorarbeit.pdf},
+  note    = {Bachelor's Thesis}
+}
+
+@Article{ryan.dominguez.ea:energy,
+  doi     = {10.3389/fphys.2020.538522},
+  year    = {2020},
+  month   = nov,
+  publisher = {Frontiers Media {SA}},
+  volume  = {11},
+  author  = {David S. Ryan and Sebasti{\'{a}}n Dom{\'{i}}nguez and Stephanie A. Ross and Nilima Nigam and James M. Wakeling},
+  title   = {The Energy of Muscle Contraction. {II}. Transverse Compression and Work},
+  journal = {Frontiers in Physiology}
+}
+
+@Article{schoeder.sticko.ea:high-order,
+  doi     = {10.1002/nme.6343},
+  year    = {2020},
+  month   = jul,
+  publisher = {Wiley},
+  volume  = {121},
+  number  = 13,
+  pages   = {2979--3003},
+  author  = {Svenja Schoeder and Simon Sticko and Gunilla Kreiss and Martin Kronbichler},
+  title   = {High-order cut discontinuous {G}alerkin methods with local time stepping for acoustics},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@Article{schroder.wick.ea:selection,
+  title   = {A Selection of Benchmark Problems in Solid Mechanics and Applied Mathematics},
+  author  = {Schr\"{o}der, J\"{o}rg and Wick, Thomas and Reese, Stefanie and Wriggers, Peter and M\"{u}ller, Ralf and Kollmannsberger, Stefan and K\"{a}stner, Markus and Schwarz, Alexander and Igelb\"{u}scher, Maximilian and Viebahn, Nils and Bayat, Hamid Reza and Wulfinghoff, Stephan and Mang, Katrin and Rank, Ernst and Bog, Tino and D'Angella, Davide and Elhaddad, Mohamed and Hennig, Paul and D\"{u}ster, Alexander and Garhuom, Wadhah and Hubrich, Simeon and Walloth, Mirjam and Wollner, Winnifried and Kuhn, Charlotte and Heister, Timo},
+  journal = {Archives of Computational Methods in Engineering},
+  year    = {2020},
+  doi     = {10.1007/s11831-020-09477-3}
+}
+
+@Article{schuh-senlis.thieulot.ea:towards,
+  doi     = {10.5194/se-11-1909-2020},
+  year    = {2020},
+  month   = oct,
+  publisher = {Copernicus {GmbH}},
+  volume  = {11},
+  number  = {5},
+  pages   = {1909--1930},
+  author  = {Melchior Schuh-Senlis and Cedric Thieulot and Paul Cupillard and Guillaume Caumon},
+  title   = {Towards the application of Stokes flow equations to structural restoration simulations},
+  journal = {Solid Earth}
+}
+
+@Article{song.maier.ea:nonlinear,
+  author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
+  title   = {Nonlinear eigenvalue problems for coupled {H}elmholtz equations modeling gradient-index graphene waveguides},
+  doi     = {10.1016/j.jcp.2020.109871},
+  journal = {Journal of Computational Physics},
+  year    = {2020},
+  volume  = {423},
+  number  = {15},
+  pages   = {109871}
+}
+
+@Article{stella.vergara.ea:integration,
+  doi     = {10.1016/j.compbiomed.2020.104047},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0010482520303784},
+  year    = {2020},
+  month   = oct,
+  publisher = {Elsevier},
+  volume  = {127},
+  pages   = {104047},
+  author  = {Simone Stella and Christian Vergara and Massimiliano Maines and Domenico Catanzariti and Pasquale Claudio Africa and Cristina Dematt{\`{e}} and Maurizio Centonze and Fabio Nobile and Maurizio Del Greco and Alfio Quarteroni},
+  title   = {Integration of activation maps of epicardial veins in computational cardiac electrophysiology},
+  journal = {Computers in Biology and Medicine}
+}
+
+@Article{sticko.ludvigsson.ea:high-order,
+  title   = {High-order cut finite elements for the elastic wave equation},
+  volume  = {46},
+  issn    = {1572-9044},
+  doi     = {10.1007/s10444-020-09785-z},
+  language = {en},
+  number  = {3},
+  journal = {Advances in Computational Mathematics},
+  author  = {Sticko, Simon and Ludvigsson, Gustav and Kreiss, Gunilla},
+  month   = may,
+  year    = {2020},
+  pages   = {45}
+}
+
+@Article{wakeling.ross.ea:energy,
+  doi     = {10.3389/fphys.2020.00813},
+  year    = {2020},
+  month   = aug,
+  publisher = {Frontiers Media {SA}},
+  volume  = {11},
+  author  = {James M. Wakeling and Stephanie A. Ross and David S. Ryan and Bart Bolsterlee and Ryan Konno and Sebasti{\'{a}}n Dom{\'{i}}nguez and Nilima Nigam},
+  title   = {The Energy of Muscle Contraction. I. Tissue Force and Deformation During Fixed-End Contractions},
+  journal = {Frontiers in Physiology}
+}
+
+@Article{wang.marshak.ea:cpu,
+  doi     = {10.1111/cgf.13958},
+  year    = {2020},
+  month   = jun,
+  publisher = {Wiley},
+  volume  = {39},
+  number  = {3},
+  pages   = {1--12},
+  author  = {Feng Wang and Nathan Marshak and Will Usher and Carsten Burstedde and Aaron Knoll and Timo Heister and Chris R. Johnson},
+  title   = {{CPU} Ray Tracing of Tree-Based Adaptive Mesh Refinement Data},
+  journal = {Computer Graphics Forum}
+}
+
+@PhDThesis{wang:two-field,
+  author  = {Zhuoran Wang},
+  title   = {Two-field finite element solvers for poroelasticity},
+  school  = {Colorado State University},
+  year    = {2020},
+  url     = {https://hdl.handle.net/10217/211801}
+}
+
+@Article{welper:transformed,
+  doi     = {10.1137/19m126356x},
+  year    = {2020},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
+  volume  = {42},
+  number  = {4},
+  pages   = {A2037--A2061},
+  author  = {G. Welper},
+  title   = {Transformed Snapshot Interpolation with High Resolution Transforms},
+  journal = {{SIAM} Journal on Scientific Computing}
 }
 
 @Article{wheeler.wick.ea:ipacs--integrated-phase-field-advanced-crack-propagation-simulator--an-adaptive--parallel--physics-based-discretization-phase-field-framework-for-fracture-propagation-in-porous-media,
@@ -121,177 +944,15 @@
   eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6372}
 }
 
-@Article{heron.murphy.ea:pannotias,
-  author  = {Heron, Philip J. and Murphy, J. Brendan and Nance, R. Damian and Pysklywec, R. N.},
-  title   = {Pannotia{\textquoteright}s mantle signature: the quest for supercontinent identification},
-  volume  = {503},
-  elocation-id = {SP503-2020-7},
-  year    = {2020},
-  doi     = {10.1144/SP503-2020-7},
-  publisher = {Geological Society of London},
-  issn    = {0305-8719},
-  url     = {https://sp.lyellcollection.org/content/early/2020/07/14/SP503-2020-7},
-  journal = {Geological Society, London, Special Publications}
-}
-
-@Article{endtmayer.langer.ea:multigoal-oriented,
-  title   = "Multigoal-oriented optimal control problems with nonlinear PDE constraints",
-  journal = "Computers {\&} Mathematics with Applications",
-  volume  = "79",
-  number  = "10",
-  pages   = "3001 - 3026",
+@Book{wick:multiphysics,
+  author  = "Thomas Wick",
+  title   = "Multiphysics Phase-Field Fracture: Modeling, Adaptive Discretizations, and Solvers",
   year    = "2020",
-  issn    = "0898-1221",
-  doi     = "10.1016/j.camwa.2020.01.005",
-  author  = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
-}
-
-@Article{stella.vergara.ea:integration,
-  doi     = {10.1016/j.compbiomed.2020.104047},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0010482520303784},
-  year    = {2020},
-  month   = oct,
-  publisher = {Elsevier},
-  volume  = {127},
-  pages   = {104047},
-  author  = {Simone Stella and Christian Vergara and Massimiliano Maines and Domenico Catanzariti and Pasquale Claudio Africa and Cristina Dematt{\`{e}} and Maurizio Centonze and Fabio Nobile and Maurizio Del Greco and Alfio Quarteroni},
-  title   = {Integration of activation maps of epicardial veins in computational cardiac electrophysiology},
-  journal = {Computers in Biology and Medicine}
-}
-
-@Article{farangitakis.heron.ea:impact,
-  doi     = {10.1016/j.epsl.2020.116277},
-  year    = {2020},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {541},
-  pages   = {116277},
-  author  = {G. P. Farangitakis and P. J. Heron and K. J. W. McCaffrey and J. van Hunen and L. M. Kalnins},
-  title   = {The impact of oblique inheritance and changes in relative plate motion on the development of rift-transform systems},
-  journal = {Earth and Planetary Science Letters}
-}
-
-@Article{cobb.dommain.ea:carbon,
-  doi     = {10.1088/1748-9326/aba867},
-  year    = {2020},
-  month   = oct,
-  publisher = {{IOP} Publishing},
-  volume  = {15},
-  number  = {11},
-  pages   = {114009},
-  author  = {Alexander R. Cobb and Ren{\'{e}} Dommain and Fangyi Tan and Naomi Hwee En Heng and Charles F Harvey},
-  title   = {Carbon storage capacity of tropical peatlands in natural and artificial drainage networks},
-  journal = {Environmental Research Letters}
-}
-
-@Article{citron.lourenco.ea:effects,
-  title   = {Effects of Heat-Producing Elements on the Stability of Deep Mantle Thermochemical Piles},
-  author  = {Citron, Robert I. and Louren{\c{c}}o, Diogo L. and Wilson, Alfred J. and Grima, Antoniette G. and Wipperfurth, Scott A. and Rudolph, Maxwell L. and Cottaar, Sanne and Mont{\'e}si, Laurent G. J.},
-  journal = {Geochemistry, Geophysics, Geosystems},
-  volume  = {21},
-  number  = {4},
-  pages   = {e2019GC008895},
-  year    = {2020},
-  publisher = {Wiley Online Library},
-  doi     = {10.1029/2019GC008895}
-}
-
-@Article{lesher.dannberg.ea:iron,
-  title   = {Iron isotope fractionation at the core--mantle boundary by thermodiffusion},
-  author  = {Lesher, Charles E. and Dannberg, Juliane and Barfod, Gry H. and Bennett, Neil R. and Glessner, Justin J. G. and Lacks, Daniel J. and Brenan, James M.},
-  journal = {Nature Geoscience},
-  volume  = {13},
-  number  = {5},
-  pages   = {382--386},
-  year    = {2020},
-  publisher = {Nature Publishing Group},
-  doi     = {10.1038/s41561-020-0560-y}
-}
-
-@Article{schuh-senlis.thieulot.ea:towards,
-  doi     = {10.5194/se-11-1909-2020},
-  year    = {2020},
-  month   = oct,
-  publisher = {Copernicus {GmbH}},
-  volume  = {11},
-  number  = {5},
-  pages   = {1909--1930},
-  author  = {Melchior Schuh-Senlis and Cedric Thieulot and Paul Cupillard and Guillaume Caumon},
-  title   = {Towards the application of Stokes flow equations to structural restoration simulations},
-  journal = {Solid Earth}
-}
-
-@Article{anzt.cojean.ea:ginkgo,
-  doi     = {10.21105/joss.02260},
-  year    = {2020},
-  month   = aug,
-  publisher = {The Open Journal},
-  volume  = {5},
-  number  = {52},
-  pages   = {2260},
-  author  = {Hartwig Anzt and Terry Cojean and Yen-Chen Chen and Goran Flegar and Fritz G\"{o}bel and Thomas Gr\"{u}tzmacher and Pratik Nayak and Tobias Ribizel and Yu-Hsiang Tsai},
-  title   = {Ginkgo: A high performance numerical linear algebra library},
-  journal = {Journal of Open Source Software}
-}
-
-@Article{benbow.kawama.ea:coupled,
-  doi     = {10.3390/cryst10090767},
-  year    = {2020},
-  month   = aug,
-  publisher = {{MDPI} {AG}},
-  volume  = {10},
-  number  = {9},
-  pages   = {767},
-  author  = {Steven J. Benbow and Daisuke Kawama and Hiroyasu Takase and Hiroyuki Shimizu and Chie Oda and Fumio Hirano and Yusuke Takayama and Morihiro Mihara and Akira Honda},
-  title   = {A Coupled Modeling Simulator for Near-Field Processes in Cement Engineered Barrier Systems for Radioactive Waste Disposal},
-  journal = {Crystals}
-}
-
-@Article{heyn.conrad.ea:how,
-  author  = {Heyn, Bj{\"o}rn H. and Conrad, Clinton P. and Tr{\o}nnes, Reidar G.},
-  title   = {How Thermochemical Piles Can (Periodically) Generate Plumes at Their Edges},
-  journal = {Journal of Geophysical Research: Solid Earth},
-  volume  = {125},
-  number  = {6},
-  pages   = {e2019JB018726},
-  doi     = {10.1029/2019JB018726},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019JB018726},
-  year    = {2020}
-}
-
-@Article{njinju.stamps.ea:lithospheric,
-  doi     = {10.1002/essoar.10503939.1},
-  pages   = {37},
-  year    = {2020},
-  month   = aug,
-  journal = {Earth and Space Science Open Archive},
-  author  = {Emmanuel A. Njinju and D. Sarah Stamps and James Gallagher and Kodi Neumiller},
-  title   = {Lithospheric Control of Melt Generation Beneath the Rungwe Volcanic Province, East Africa}
-}
-
-@InProceedings{arndt.fehn.ea:exadg,
-  author  = {Arndt, Daniel and Fehn, Niklas and Kanschat, Guido and Kormann, Katharina and Kronbichler, Martin and Munch, Peter and Wall, Wolfgang A. and Witte, Julius},
-  editor  = {Bungartz, Hans-Joachim and Reiz, Severin and Uekermann, Benjamin and Neumann, Philipp and Nagel, Wolfgang E.},
-  title   = {Exa{DG}: {H}igh-{O}rder {D}iscontinuous {G}alerkin for the {E}xa-{S}cale},
-  booktitle = {Software for Exascale Computing - SPPEXA 2016-2019},
-  year    = {2020},
-  publisher = {Springer International Publishing},
-  address = {Cham},
-  pages   = {189--224},
-  isbn    = {978-3-030-47956-5},
-  doi     = {10.1007/978-3-030-47956-5_8}
-}
-
-@Article{heyn.conrad.ea:core-mantle,
-  title   = "Core-mantle boundary topography and its relation to the viscosity structure of the lowermost mantle",
-  journal = "Earth and Planetary Science Letters",
-  volume  = "543",
-  pages   = "116358",
-  year    = "2020",
-  issn    = "0012-821X",
-  doi     = "10.1016/j.epsl.2020.116358",
-  url     = "http://www.sciencedirect.com/science/article/pii/S0012821X20303022",
-  author  = "Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes"
+  publisher = "De Gruyter",
+  address = "Berlin, Boston",
+  isbn    = "978-3-11-049739-7",
+  doi     = "10.1515/9783110497397",
+  url     = "https://www.degruyter.com/view/title/523232"
 }
 
 @Article{wilde.kramer.ea:semi-lagrangian-lattice-boltzmann-method-for-compressible-flows,
@@ -309,306 +970,16 @@
   year    = {2020}
 }
 
-@Article{kramer.wilde.ea:lattice-boltzmann-simulations-on-irregular-grids--introduction-of-the-natrium-library,
-  author  = {Kr{\"{a}}mer, Andreas and Wilde, Dominik and K{\"{u}}llmer, Knut and Reith, Dirk and Foysi, Holger and Joppich, Wolfgang},
-  doi     = {10.1016/j.camwa.2018.10.041},
-  issn    = {08981221},
-  journal = {Comput. Math. with Appl.},
-  number  = {1},
-  pages   = {34--54},
-  publisher = {Elsevier Ltd},
-  title   = {{Lattice Boltzmann simulations on irregular grids: Introduction of the NATriuM library}},
-  volume  = {79},
-  year    = {2020}
-}
-
-@MastersThesis{roth:geometric,
-  author  = {Roth, Julian},
-  title   = {Geometric Multigrid Methods for Maxwell's Equations},
-  school  = {Leibniz Universit{\"a}t Hannover},
+@Article{witte.arndt.ea:fast,
+  doi     = {10.1515/cmam-2020-0078},
   year    = {2020},
-  month   = jul,
-  url     = {https://julianroth.org/res/bachelorarbeit.pdf},
-  note    = {Bachelor's Thesis}
-}
-
-@Article{liu.mcbride.ea:assessment-of-an-isogeometric-approach-with-catmull-clark-subdivision-surfaces-using-the-laplace-beltrami-problems,
-  author  = {Liu, Zhaowei and McBride, Andrew and Saxena, Prashant and Steinmann, Paul},
-  doi     = {10.1007/s00466-020-01877-3},
-  issn    = {14320924},
-  journal = {Computational Mechanics},
-  title   = {{Assessment of an isogeometric approach with Catmull-Clark subdivision surfaces using the Laplace-Beltrami problems}},
-  year    = {2020}
-}
-
-@Article{grieshaber.mcbride.ea:convergence,
-  doi     = {10.1016/j.cma.2020.113233},
-  year    = {2020},
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = {370},
-  pages   = {113233},
-  author  = {Beverley J. Grieshaber and Andrew T. McBride and B. Daya Reddy},
-  title   = {Convergence in the incompressible limit of new discontinuous Galerkin methods with general quadrilateral and hexahedral elements},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{glerum.brune.ea:victoria,
-  author  = "Glerum, A. and Brune, S. and Stamps, D. S. and Strecker, M. R.",
-  title   = "Victoria continental microplate dynamics controlled by the lithospheric strength distribution of the East African Rift",
-  journal = "Nature Communications",
-  year    = "2020",
-  volume  = "11",
-  number  = "1",
-  issn    = "2041-1723",
-  doi     = "10.1038/s41467-020-16176-x",
-  url     = "http://www.nature.com/articles/s41467-020-16176-x"
-}
-
-@Article{mitrovica.austermann.ea:dynamic,
-  author  = {Mitrovica, J. X. and Austermann, J. and Coulson, S. and Creveling, J. R. and Hoggard, M. J. and Jarvis, G. T. and Richards, F. D.},
-  title   = {Dynamic Topography and Ice Age Paleoclimate},
-  journal = {Annual Review of Earth and Planetary Sciences},
-  volume  = {48},
-  number  = {1},
-  pages   = {585-621},
-  year    = {2020},
-  doi     = {10.1146/annurev-earth-082517-010225}
-}
-
-@InCollection{paula.quinelato.ea:numerical,
-  doi     = {10.1007/978-3-030-50436-6_2},
-  year    = {2020},
-  publisher = {Springer International Publishing},
-  pages   = {18--31},
-  author  = {Filipe Fernandes de Paula and Thiago Quinelato and Iury Igreja and Grigori Chapiro},
-  title   = {A Numerical Algorithm to Solve the Two-Phase Flow in Porous Media Including Foam Displacement},
-  booktitle = {Lecture Notes in Computer Science}
-}
-
-@Article{comellas.budday.ea:modeling,
-  doi     = {10.1016/J.CMA.2020.113128},
-  issn    = {0045-7825},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  month   = sep,
-  pages   = {113128},
-  publisher = {North-Holland},
-  author  = {Ester Comellas and Silvia Budday and Jean-Paul Pelteret and Gerhard A. Holzapfel and Paul Steinmann},
-  title   = {Modeling the porous and viscous responses of human brain tissue behavior},
-  volume  = {369},
-  year    = {2020}
-}
-
-@Article{lorentzon.revstedt:numerical,
-  author  = {Lorentzon, Johan and Revstedt, Johan},
-  title   = {A numerical study of partitioned fluid-structure interaction applied to a cantilever in incompressible turbulent flow},
-  journal = {International Journal for Numerical Methods in Engineering},
-  volume  = {121},
-  number  = {5},
-  pages   = {806-827},
-  keywords = {deal.II, FSI, LES, OpenFOAM, strongly coupled},
-  doi     = {10.1002/nme.6245},
-  year    = {2020}
-}
-
-@Article{lee.shon.ea:adaptive,
-  doi     = {10.5757/asct.2020.29.3.062},
-  year    = {2020},
-  month   = may,
-  publisher = {The Korean Vacuum Society},
-  volume  = {29},
-  number  = {3},
-  pages   = {62--66},
-  author  = {Sora Lee and Yejin Shon and Dong-gil Kim and Deuk-Chul Kwon and Hee Hwan Choe},
-  title   = {Adaptive Mesh Method Applied to Poisson Solver Module for 3D Capacitively Coupled Plasma Discharge Simulation},
-  journal = {Applied Science and Convergence Technology}
-}
-
-@Article{assanelli.luoni.ea:tectono-metamorphic,
-  author  = "Assanelli, M. and Luoni, P. and Rebay, G. and Roda, M. and Spalla, M. I.",
-  title   = "Tectono-Metamorphic Evolution of Serpentinites from Lanzo Valleys Subduction Complex (Piemonte--Sesia-Lanzo Zone Boundary, Western Italian Alps)",
-  journal = "Minerals",
-  year    = "2020",
-  volume  = "10",
-  number  = "11",
-  pages   = "985",
-  issn    = "2075-163X",
-  doi     = "10.3390/min10110985",
-  url     = "https://www.mdpi.com/2075-163X/10/11/985"
-}
-
-@Article{motamarri.das.ea:dft-fe,
-  doi     = {10.1016/j.cpc.2019.07.016},
-  year    = {2020},
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = {246},
-  pages   = {106853},
-  author  = {Phani Motamarri and Sambit Das and Shiva Rudraraju and Krishnendu Ghosh and Denis Davydov and Vikram Gavini},
-  title   = {{DFT}-{FE} -- A massively parallel adaptive finite-element code for large-scale density functional theory calculations},
-  journal = {Computer Physics Communications}
-}
-
-@Article{rajaonarison.stamps.ea:numerical,
-  title   = {Numerical Modeling of Mantle Flow Beneath Madagascar to Constrain Upper Mantle Rheology Beneath Continental Regions},
-  author  = {Rajaonarison, T. A. and Stamps, D. S. and Fishwick, S. and Brune, Sascha and Glerum, A. and Hu, J.},
-  journal = {Journal of Geophysical Research. Solid Earth},
-  volume  = {125},
-  number  = {2},
-  pages   = {Art--No},
-  year    = {2020},
-  publisher = {American Geophysical Union},
-  doi     = {10.1029/2019JB018560}
-}
-
-@Article{kaufl.grayver.ea:magnetotelluric,
-  title   = {Magnetotelluric multiscale 3-{D} inversion reveals crustal and upper mantle structure beneath the Hangai and {G}obi-{A}ltai region in {M}ongolia},
-  author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Comeau, Matthew J and Kuvshinov, Alexey V and Becken, Michael and Kamm, Jochen and Batmagnai, Erdenechimeg and Demberel, Sodnomsambuu},
-  journal = {Geophysical Journal International},
-  volume  = {221},
-  number  = {2},
-  pages   = {1002--1028},
-  year    = {2020},
-  publisher = {Oxford University Press},
-  doi     = {10.1093/gji/ggaa039}
-}
-
-@Article{nitzler.biehler.ea:generalized,
-  title   = {A Generalized Probabilistic Learning Approach for Multi-Fidelity Uncertainty Propagation in Complex Physical Simulations},
-  author  = {Nitzler, Jonas and Biehler, Jonas and Fehn, Niklas and Koutsourelakis, Phaedon-Stelios and Wall, Wolfgang A},
-  journal = {arXiv preprint arXiv:2001.02892},
-  year    = {2020}
-}
-
-@Article{fischer.min.ea:scalability,
-  doi     = {10.1177/1094342020915762},
-  year    = {2020},
-  month   = jun,
-  publisher = {{SAGE} Publications},
-  volume  = {34},
-  number  = {5},
-  pages   = {562--586},
-  author  = {Paul Fischer and Misun Min and Thilina Rathnayake and Som Dutta and Tzanio Kolev and Veselin Dobrev and Jean-Sylvain Camier and Martin Kronbichler and Tim Warburton and Kasia {\'{S}}wirydowicz and Jed Brown},
-  title   = {Scalability of high-performance {PDE} solvers},
-  journal = {The International Journal of High Performance Computing Applications}
-}
-
-@Article{zhao.choo:stabilized,
-  doi     = {10.1016/j.cma.2019.112742},
-  year    = {2020},
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = {362},
-  pages   = {112742},
-  author  = {Yidong Zhao and Jinhyun Choo},
-  title   = {Stabilized material point methods for coupled large deformation and fluid flow in porous materials},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{davydov.pelteret.ea:matrix-free,
-  doi     = {10.1002/nme.6336},
-  year    = {2020},
-  month   = jul,
-  publisher = {Wiley},
-  volume  = {121},
-  number  = 13,
-  pages   = {2874--2895},
-  author  = {Denis Davydov and Jean-Paul Pelteret and Daniel Arndt and Martin Kronbichler and Paul Steinmann},
-  title   = {A matrix-free approach for finite-strain hyperelastic problems using geometric multigrid},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{schoeder.sticko.ea:high-order,
-  doi     = {10.1002/nme.6343},
-  year    = {2020},
-  month   = jul,
-  publisher = {Wiley},
-  volume  = {121},
-  number  = 13,
-  pages   = {2979--3003},
-  author  = {Svenja Schoeder and Simon Sticko and Gunilla Kreiss and Martin Kronbichler},
-  title   = {High-order cut discontinuous {G}alerkin methods with local time stepping for acoustics},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{dewitt.rudraraju.ea:prisms-pf,
-  doi     = {10.1038/s41524-020-0298-5},
-  year    = {2020},
-  month   = mar,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {6},
-  number  = {1},
-  author  = {Stephen DeWitt and Shiva Rudraraju and David Montiel and W. Beck Andrews and Katsuyo Thornton},
-  title   = {{PRISMS}-{PF}: A general framework for phase-field modeling with a matrix-free finite element method},
-  journal = {npj Computational Materials}
-}
-
-@PhDThesis{mcgovern:high,
-  author  = {Sean McGovern},
-  title   = {High Performance Computing in Basin Modeling: Simulating Mechanical Compaction with the Level Set Method},
-  school  = {Rheinische Friedrich-Wilhelms-Universit{\"a}t Bonn},
-  year    = {2020},
-  url     = {https://hdl.handle.net/20.500.11811/8443}
-}
-
-@PhDThesis{fehling:algorithms,
-  author  = {Marc Fehling},
-  title   = {Algorithms for massively parallel generic $hp$-adaptive finite element methods},
-  school  = {Bergische Universit{\"a}t Wuppertal},
-  year    = {2020},
-  url     = {https://juser.fz-juelich.de/record/878206},
-  address = {J{\"u}lich},
-  publisher = {Forschungszentrum J{\"u}lich GmbH Zentralbibliothek, Verlag},
-  reportid = {FZJ-2020-02694},
-  isbn    = {978-3-95806-486-7},
-  series  = {Schriften des Forschungszentrums J{\"u}lich IAS Series},
-  volume  = {43},
-  pages   = {vii, 78 pp},
-  urn     = {urn:nbn:de:0001-2020071402}
-}
-
-@PhDThesis{wang:two-field,
-  author  = {Zhuoran Wang},
-  title   = {Two-field finite element solvers for poroelasticity},
-  school  = {Colorado State University},
-  year    = {2020},
-  url     = {https://hdl.handle.net/10217/211801}
-}
-
-@Article{davydov.kronbichler:algorithms,
-  doi     = {10.1145/3399736},
-  title   = {Algorithms and data structures for matrix-free finite element operators with MPI-parallel sparse multi-vectors},
-  author  = {Davydov, Denis and Kronbichler, Martin},
-  journal = {ACM Transactions on Parallel Computing},
-  volume  = {7},
-  number  = {3},
-  pages   = {20:1--20:30},
-  year    = {2020},
-  month   = jun
-}
-
-@Article{fehn.munch.ea:hybrid,
-  doi     = {10.1016/j.jcp.2020.109538},
-  year    = {2020},
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = {415},
-  pages   = {109538},
-  author  = {Niklas Fehn and Peter Munch and Wolfgang A. Wall and Martin Kronbichler},
-  title   = {Hybrid multigrid methods for high-order discontinuous {G}alerkin discretizations},
-  journal = {Journal of Computational Physics}
-}
-
-@Article{kim:application,
-  doi     = {10.1016/j.cam.2019.112458},
-  year    = {2020},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {367},
-  pages   = {112458},
-  author  = {Seungil Kim},
-  title   = {Application of a complete radiation boundary condition for the Helmholtz equation in locally perturbed waveguides},
-  journal = {Journal of Computational and Applied Mathematics}
+  month   = nov,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {0},
+  number  = {0},
+  author  = {Julius Witte and Daniel Arndt and Guido Kanschat},
+  title   = {Fast Tensor Product Schwarz Smoothers for High-Order Discontinuous Galerkin Methods},
+  journal = {Computational Methods in Applied Mathematics}
 }
 
 @Article{zhang.yue:level-set,
@@ -632,387 +1003,16 @@
   school  = {Virginia Tech}
 }
 
-@Article{arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.2},
-  author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Thomas C. Clevenger and Marc Fehling and Alexander V. Grayver and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Reza Rastak and Ignacio Thomas and Bruno Turcksin and Zhuoran Wang and David Wells},
-  journal = {Journal of Numerical Mathematics},
-  publisher = {De Gruyter},
-  year    = {2020},
-  volume  = {28},
-  number  = {3},
-  pages   = {131-146},
-  doi     = {10.1515/jnma-2020-0043},
-  url     = {https://dealii.org/deal92-preprint.pdf}
-}
-
-@Article{bruna-rosso.mergheim.ea:finite,
-  doi     = {10.1177/0954406220943225},
-  year    = {2020},
-  month   = aug,
-  publisher = {{SAGE} Publications},
-  pages   = {095440622094322},
-  author  = {Claire Bruna-Rosso and Julia Mergheim and Barbara Previtali},
-  title   = {Finite element modeling of residual stress and geometrical error formations in selective laser melting of metals},
-  journal = {Proceedings of the Institution of Mechanical Engineers, Part C: Journal of Mechanical Engineering Science}
-}
-
-@Article{nayak.cojean.ea:evaluating,
-  doi     = {10.1177/1094342020946814},
-  year    = {2020},
-  month   = aug,
-  publisher = {{SAGE} Publications},
-  pages   = {109434202094681},
-  author  = {Pratik Nayak and Terry Cojean and Hartwig Anzt},
-  title   = {Evaluating asynchronous Schwarz solvers on {GPUs}},
-  journal = {The International Journal of High Performance Computing Applications}
-}
-
-@Article{blais.barbeau.ea:lethe,
-  doi     = {10.1016/j.softx.2020.100579},
-  year    = {2020},
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = {12},
-  pages   = {100579},
-  author  = {Bruno Blais and Lucka Barbeau and Val{\'{e}}rie Bibeau and Simon Gauvin and Toni El Geitani and Shahab Golshan and Rajeshwari Kamble and Ghazaleh Mirakhori and Jamal Chaouki},
-  title   = {Lethe: An open-source parallel high-order adaptative {CFD} solver for incompressible flows},
-  journal = {{SoftwareX}}
-}
-
-@Article{wang.marshak.ea:cpu,
-  doi     = {10.1111/cgf.13958},
-  year    = {2020},
-  month   = jun,
-  publisher = {Wiley},
-  volume  = {39},
-  number  = {3},
-  pages   = {1--12},
-  author  = {Feng Wang and Nathan Marshak and Will Usher and Carsten Burstedde and Aaron Knoll and Timo Heister and Chris R. Johnson},
-  title   = {{CPU} Ray Tracing of Tree-Based Adaptive Mesh Refinement Data},
-  journal = {Computer Graphics Forum}
-}
-
-@Article{gassmoller.dannberg.ea:on,
-  doi     = {10.1093/gji/ggaa078},
-  year    = {2020},
-  month   = feb,
-  publisher = {Oxford University Press ({OUP})},
-  volume  = {221},
-  number  = {2},
-  pages   = {1264--1280},
-  author  = {Rene Gassm\"{o}ller and Juliane Dannberg and Wolfgang Bangerth and Timo Heister and Robert Myhill},
-  title   = {On formulations of compressible mantle convection},
-  journal = {Geophysical Journal International}
-}
-
-@InBook{hoggard.austermann.ea:mantle,
-  author  = "Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon",
-  editor  = "H. Marquardt, M. Ballmer",
-  chapter = "Observational estimates of dynamic topography through space and time",
-  title   = "Mantle convection and surface expressions",
-  series  = "AGU Geophysical Monograph Series",
-  year    = "2021",
-  address = "Washington, D.C.",
-  publisher = "AGU",
-  doi     = "10.1002/9781119528609.ch15"
-}
-
-@Article{schroder.wick.ea:selection,
-  title   = {A Selection of Benchmark Problems in Solid Mechanics and Applied Mathematics},
-  author  = {Schr\"{o}der, J\"{o}rg and Wick, Thomas and Reese, Stefanie and Wriggers, Peter and M\"{u}ller, Ralf and Kollmannsberger, Stefan and K\"{a}stner, Markus and Schwarz, Alexander and Igelb\"{u}scher, Maximilian and Viebahn, Nils and Bayat, Hamid Reza and Wulfinghoff, Stephan and Mang, Katrin and Rank, Ernst and Bog, Tino and D'Angella, Davide and Elhaddad, Mohamed and Hennig, Paul and D\"{u}ster, Alexander and Garhuom, Wadhah and Hubrich, Simeon and Walloth, Mirjam and Wollner, Winnifried and Kuhn, Charlotte and Heister, Timo},
-  journal = {Archives of Computational Methods in Engineering},
-  year    = {2020},
-  doi     = {10.1007/s11831-020-09477-3}
-}
-
-@Article{finlay.kloss.ea:chaos-7,
-  title   = {The CHAOS-7 geomagnetic field model and observed changes in the South Atlantic Anomaly},
-  author  = {Finlay, Christopher C and Kloss, Clemens and Olsen, Nils and Hammer, Magnus D and T{\o}ffner-Clausen, Lars and Grayver, Alexander and Kuvshinov, Alexey},
-  journal = {Earth, Planets and Space},
-  volume  = {72},
-  number  = {1},
-  pages   = {1--31},
-  year    = {2020},
-  publisher = {SpringerOpen},
-  doi     = {10.1186/s40623-020-01252-9}
-}
-
-@Article{cangiani.georgoulis.ea:posteriori,
-  doi     = {10.1007/s10915-020-01130-2},
-  year    = {2020},
-  month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {82},
-  number  = {2},
-  author  = {Andrea Cangiani and Emmanuil H. Georgoulis and Mohammad Sabawi},
-  title   = {A Posteriori Error Analysis for Implicit--Explicit hp-Discontinuous Galerkin Timestepping Methods for Semilinear Parabolic Problems},
-  journal = {Journal of Scientific Computing}
-}
-
-@Article{arndt.kanschat:differentiable,
-  title   = {A Differentiable Mapping of Mesh Cells Based on Finite Elements on Quadrilateral and Hexahedral Meshes},
-  author  = {Arndt, Daniel and Kanschat, Guido},
-  journal = {Computational Methods in Applied Mathematics},
-  volume  = {1},
-  year    = {2020},
-  publisher = {De Gruyter},
-  doi     = {10.1515/cmam-2020-0159}
-}
-
-@Article{wakeling.ross.ea:energy,
-  doi     = {10.3389/fphys.2020.00813},
-  year    = {2020},
-  month   = aug,
-  publisher = {Frontiers Media {SA}},
-  volume  = {11},
-  author  = {James M. Wakeling and Stephanie A. Ross and David S. Ryan and Bart Bolsterlee and Ryan Konno and Sebasti{\'{a}}n Dom{\'{i}}nguez and Nilima Nigam},
-  title   = {The Energy of Muscle Contraction. I. Tissue Force and Deformation During Fixed-End Contractions},
-  journal = {Frontiers in Physiology}
-}
-
-@Article{ryan.dominguez.ea:energy,
-  doi     = {10.3389/fphys.2020.538522},
-  year    = {2020},
-  month   = nov,
-  publisher = {Frontiers Media {SA}},
-  volume  = {11},
-  author  = {David S. Ryan and Sebasti{\'{a}}n Dom{\'{i}}nguez and Stephanie A. Ross and Nilima Nigam and James M. Wakeling},
-  title   = {The Energy of Muscle Contraction. {II}. Transverse Compression and Work},
-  journal = {Frontiers in Physiology}
-}
-
-@Article{araujo.campos.ea:computation,
-  author  = {Ara\'{u}jo, Juan C. and Campos, Carmen and Engstr\"{o}m, Christian and Roman, Jose E.},
-  title   = {Computation of scattering resonances in absorptive and dispersive media with applications to metal-dielectric nano-structures},
-  journal = {Journal of Computational Physics},
-  volume  = {407},
-  pages   = {109220},
-  year    = {2020},
-  issn    = {0021-9991},
-  doi     = {10.1016/j.jcp.2019.109220},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0021999119309258}
-}
-
-@Article{gurkan.sticko.ea:stabilized,
-  title   = {Stabilized {Cut} {Discontinuous} {Galerkin} {Methods} for {Advection}-{Reaction} {Problems}},
-  volume  = {42},
-  issn    = {1064-8275, 1095-7197},
-  url     = {https://epubs.siam.org/doi/10.1137/18M1206461},
-  doi     = {10.1137/18M1206461},
-  language = {en},
-  number  = {5},
-  journal = {SIAM Journal on Scientific Computing},
-  author  = {G\"{u}rkan, Ceren and Sticko, Simon and Massing, Andr\'{e}},
-  month   = sep,
-  year    = {2020},
-  pages   = {A2620--A2654}
-}
-
-@Article{sticko.ludvigsson.ea:high-order,
-  title   = {High-order cut finite elements for the elastic wave equation},
-  volume  = {46},
-  issn    = {1572-9044},
-  doi     = {10.1007/s10444-020-09785-z},
-  language = {en},
-  number  = {3},
-  journal = {Advances in Computational Mathematics},
-  author  = {Sticko, Simon and Ludvigsson, Gustav and Kreiss, Gunilla},
-  month   = may,
-  year    = {2020},
-  pages   = {45}
-}
-
-@Article{reveron.kumar.ea:iterative,
-  doi     = {10.1007/s10596-020-09983-0},
-  year    = {2020},
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {25},
-  number  = {2},
-  pages   = {687--699},
-  author  = {Manuel Antonio Borregales Rever{\'{o}}n and Kundan Kumar and Jan Martin Nordbotten and Florin Adrian Radu},
-  title   = {Iterative solvers for Biot model under small and large deformations},
-  journal = {Computational Geosciences}
-}
-
-@Article{mcbride.davydov.ea:modelling,
-  doi     = {10.1016/j.cma.2020.113320},
-  year    = {2020},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {371},
-  pages   = {113320},
-  author  = {A.T. McBride and D. Davydov and P. Steinmann},
-  title   = {Modelling the flexoelectric effect in solids: A micromorphic approach},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{jerg.austermuhl.ea:diffuse,
-  title   = {Diffuse domain method for needle insertion simulations},
-  author  = {Jerg, Katharina I and Austerm{\"u}hl, Ren{\'e} Phillip and Roth, Karsten and Gro{\ss}e Sundrup, Jonas and Kanschat, Guido and Hesser, J{\"u}rgen W and Wittmayer, Lisa},
-  journal = {International journal for numerical methods in biomedical engineering},
-  volume  = {36},
-  number  = {9},
-  pages   = {e3377},
-  year    = {2020},
-  publisher = {Wiley Online Library},
-  doi     = {10.1002/cnm.3377}
-}
-
-@Article{choi.lee:optimal,
-  doi     = {10.1016/j.apnum.2019.09.010},
+@Article{zhao.choo:stabilized,
+  doi     = {10.1016/j.cma.2019.112742},
   year    = {2020},
   month   = apr,
   publisher = {Elsevier {BV}},
-  volume  = {150},
-  pages   = {76--104},
-  author  = {Woocheol Choi and Sanghyun Lee},
-  title   = {Optimal error estimate of elliptic problems with Dirac sources for discontinuous and enriched Galerkin methods},
-  journal = {Applied Numerical Mathematics}
-}
-
-@Article{maier.margetis.ea:finite-size,
-  author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
-  title   = {Finite-size effects in wave transmission through plasmonic crystals: A tale of two scales},
-  doi     = {10.1103/PhysRevB.102.075308},
-  journal = {Physical Review B},
-  year    = {2020},
-  volume  = {102},
-  pages   = {075308}
-}
-
-@Article{song.maier.ea:nonlinear,
-  author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
-  title   = {Nonlinear eigenvalue problems for coupled {H}elmholtz equations modeling gradient-index graphene waveguides},
-  doi     = {10.1016/j.jcp.2020.109871},
-  journal = {Journal of Computational Physics},
-  year    = {2020},
-  volume  = {423},
-  number  = {15},
-  pages   = {109871}
-}
-
-@MastersThesis{khimin:numerische,
-  author  = {D. Khimin},
-  title   = {Numerische Modellierung von Optimalsteuerungsproblemen f{\"u}r Phasenfeld-Riss-Ausbreitung},
-  school  = {Leibniz University Hannover},
-  month   = jun,
-  year    = {2020}
-}
-
-@Article{alzetta.heltai:multiscale,
-  author  = {Giovanni Alzetta and Luca Heltai},
-  journal = {Computers {\&} Structures},
-  pages   = {106334},
-  title   = {Multiscale modeling of fiber reinforced materials via non-matching immersed methods},
-  volume  = {239},
-  year    = {2020},
-  doi     = {10.1016/j.compstruc.2020.106334}
-}
-
-@Article{heltai.lei:priori,
-  author  = {Luca Heltai and Wenyu Lei},
-  journal = {Numerische Mathematik},
-  number  = {3},
-  pages   = {571--596},
-  title   = {A priori error estimates of regularized elliptic problems},
-  volume  = {146},
-  year    = {2020},
-  doi     = {10.1007/s00211-020-01152-w}
-}
-
-@Article{witte.arndt.ea:fast,
-  doi     = {10.1515/cmam-2020-0078},
-  year    = {2020},
-  month   = nov,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {0},
-  number  = {0},
-  author  = {Julius Witte and Daniel Arndt and Guido Kanschat},
-  title   = {Fast Tensor Product Schwarz Smoothers for High-Order Discontinuous Galerkin Methods},
-  journal = {Computational Methods in Applied Mathematics}
-}
-
-@Article{brun.wick.ea:iterative,
-  doi     = {10.1016/j.cma.2019.112752},
-  year    = {2020},
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = {361},
-  pages   = {112752},
-  author  = {Mats Kirkes{\ae}ther Brun and Thomas Wick and Inga Berre and Jan Martin Nordbotten and Florin Adrian Radu},
-  title   = {An iterative staggered scheme for phase field brittle fracture propagation with stabilizing parameters},
+  volume  = {362},
+  pages   = {112742},
+  author  = {Yidong Zhao and Jinhyun Choo},
+  title   = {Stabilized material point methods for coupled large deformation and fluid flow in porous materials},
   journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{endtmayer.langer.ea:two-side,
-  doi     = {10.1137/18m1227275},
-  year    = {2020},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {42},
-  number  = {1},
-  pages   = {A371--A394},
-  author  = {B. Endtmayer and U. Langer and T. Wick},
-  title   = {Two-Side a Posteriori Error Estimates for the Dual-Weighted Residual Method},
-  journal = {{SIAM} Journal on Scientific Computing}
-}
-
-@InCollection{endtmayer.langer.ea:hierarchical,
-  doi     = {10.1007/978-3-030-55874-1_35},
-  year    = {2020},
-  month   = aug,
-  publisher = {Springer International Publishing},
-  pages   = {363--372},
-  author  = {B. Endtmayer and U. Langer and J. P. Thiele and T. Wick},
-  title   = {Hierarchical {DWR} Error Estimates for the Navier-Stokes Equations: h and p Enrichment},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
-}
-
-@Article{murphy.madzvamuse:moving,
-  doi     = {10.1016/j.apnum.2020.08.004},
-  year    = {2020},
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = {158},
-  pages   = {336--359},
-  author  = {Laura Murphy and Anotida Madzvamuse},
-  title   = {A moving grid finite element method applied to a mechanobiochemical model for 3D cell migration},
-  journal = {Applied Numerical Mathematics}
-}
-
-@Article{welper:transformed,
-  doi     = {10.1137/19m126356x},
-  year    = {2020},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {42},
-  number  = {4},
-  pages   = {A2037--A2061},
-  author  = {G. Welper},
-  title   = {Transformed Snapshot Interpolation with High Resolution Transforms},
-  journal = {{SIAM} Journal on Scientific Computing}
-}
-
-@Article{badia.martin.ea:generic,
-  doi     = {10.1137/20m1328786},
-  year    = {2020},
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume  = {42},
-  number  = {6},
-  pages   = {C436--C468},
-  author  = {Santiago Badia and Alberto F. Mart{\'{i}}n and Eric Neiva and Francesc Verdugo},
-  title   = {A Generic Finite Element Framework on Parallel Tree-Based Adaptive Meshes},
-  journal = {{SIAM} Journal on Scientific Computing}
-}
-
-@InCollection{engwer.pop.ea:dynamic,
-  doi     = {10.1007/978-3-030-55874-1_117},
-  year    = {2020},
-  month   = aug,
-  publisher = {Springer International Publishing},
-  pages   = {1177--1184},
-  author  = {Christian Engwer and Iuliu Sorin Pop and Thomas Wick},
-  title   = {Dynamic and Weighted Stabilizations of the L-scheme Applied to a Phase-Field Model for Fracture Propagation},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -1,425 +1,15 @@
 % Encoding: US-ASCII
 
-@Article{arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.3},
-  author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Uwe K{\"o}cher and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Sebastian Proell and Konrad Simon and Bruno Turcksin and David Wells and Jiaqi Zhang},
-  journal = {Journal of Numerical Mathematics},
+@Article{anselmann.bause:higher,
+  doi     = {10.1016/j.matcom.2020.10.027},
   year    = {2021},
-  url     = {https://dealii.org/deal93-preprint.pdf},
-  doi     = {10.1515/jnma-2021-0081},
-  volume  = {29},
-  number  = {3},
-  pages   = {171--186}
-}
-
-@Article{golshan.blais:load-balancing,
-  title   = {Load-Balancing Strategies in Discrete Element Method Simulations},
-  author  = {Golshan, Shahab and Blais, Bruno},
-  journal = {Processes},
-  volume  = {10},
-  number  = {1},
-  pages   = {79},
-  year    = {2021},
-  doi     = {10.3390/pr10010079},
-  publisher = {MDPI}
-}
-
-@Article{kourakos.harter:simulation,
-  author  = {Kourakos, Georgios and Harter, Thomas},
-  title   = {Simulation of Unconfined Aquifer Flow Based on Parallel Adaptive Mesh Refinement},
-  journal = {Water Resources Research},
-  year    = {2021},
-  volume  = {57},
-  number  = {12},
-  pages   = {e2020WR029354},
-  doi     = {10.1029/2020WR029354},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020WR029354}
-}
-
-@MastersThesis{withers:modelling,
-  author  = "Withers, Craig",
-  title   = "Modelling slab age and crustal thickness: numerical approaches to drivers of compressive stresses in the overriding plate in Andean style subduction zone systems",
-  year    = "2021",
-  publisher = "Durham University",
-  school  = "Durham theses",
-  opturl  = "http://etheses.dur.ac.uk/13836/"
-}
-
-@Article{greiner.reiter.ea:poro-viscoelastic,
-  author  = {Greiner, Alexander and Reiter, Nina and Paulsen, Friedrich and Holzapfel, Gerhard A. and Steinmann, Paul and Comellas, Ester and Budday, Silvia},
-  doi     = {10.3389/fmech.2021.708350},
-  journal = {Frontiers in Mechanical Engineering},
-  number  = {708350},
-  pages   = {1--18},
-  title   = {Poro-Viscoelastic Effects During Biomechanical Testing of Human Brain Tissue},
-  volume  = {7},
-  year    = {2021}
-}
-
-@Article{kinnewig.roth.ea:geometric,
-  title   = {Geometric multigrid with multiplicative Schwarz smoothers for eddy-current and Maxwell's equations in deal.II},
-  journal = {Examples and Counterexamples},
-  volume  = {1},
-  pages   = {100027},
-  year    = {2021},
-  issn    = {2666-657X},
-  doi     = {10.1016/j.exco.2021.100027},
-  url     = {https://www.sciencedirect.com/science/article/pii/S2666657X2100015X},
-  author  = {Sebastian Kinnewig and Julian Roth and Thomas Wick},
-  keywords = {Time-harmonic Maxwell, Eddy-current problem, Finite elements, Geometric multigrid, Multiplicative Schwarz smoother},
-  abstract = {In this work, we consider the design of a geometric multigrid method with multiplicative Schwarz smoothers for the eddy-current problem and the time-harmonic Maxwell equations. The main purpose is to show numerically that a straightforward application works for the former problem, but not for the latter. The well-known key is a special decomposition of the function spaces within the multigrid algorithm. The failures and performance are shown with the help of a numerical test, implemented in the modern finite element library deal.II, including a github link to the eddy-current implementation.}
-}
-
-@Article{barrionuevo.liu.ea:influence,
-  author  = "Barrionuevo, M. and Liu, S. and Mescua, J. and Yagupsky, D. and Quinteros, J. and Giambiagi, L. and Sobolev, S. V. and Piceda, C. R. and Strecker, M. R.",
-  title   = "The influence of variations in crustal composition and lithospheric strength on the evolution of deformation processes in the southern Central Andes: insights from geodynamic models",
-  journal = "International Journal of Earth Sciences",
-  year    = "2021",
-  doi     = "10.1007/s00531-021-01982-5"
-}
-
-@Article{saxena.choi.ea:seismicity-in-the-central-and-southeastern-united-states-due-to-upper-mantle-heterogeneities,
-  author  = {Saxena, Arushi and Choi, Eunseo and Powell, Christine A and Aslam, Khurram S},
-  title   = "{Seismicity in the central and southeastern United States due to upper mantle heterogeneities}",
-  journal = {Geophysical Journal International},
-  volume  = {225},
-  number  = {3},
-  pages   = {1624-1636},
-  year    = {2021},
-  month   = mar,
-  doi     = {10.1093/gji/ggab051}
-}
-
-@Article{heckenbach.brune.ea:is,
-  author  = {Heckenbach, Esther L. and Brune, Sascha and Glerum, Anne C. and Bott, Judith},
-  title   = {Is there a Speed Limit for the Thermal Steady-State Assumption in Continental Rifts?},
-  journal = {Geochemistry, Geophysics, Geosystems},
-  volume  = {22},
-  number  = {3},
-  pages   = {e2020GC009577},
-  doi     = {10.1029/2020GC009577},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020GC009577},
-  year    = {2021}
-}
-
-@Article{lees.rudge.ea:gravity,
-  author  = {Lees, Matthew E. and Rudge, John F. and McKenzie, Dan},
-  title   = {Gravity, Topography, and Melt Generation Rates From Simple 3-D Models of Mantle Convection},
-  journal = {Geochemistry, Geophysics, Geosystems},
-  volume  = {21},
-  number  = {4},
-  pages   = {e2019GC008809},
-  doi     = {10.1029/2019GC008809},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
-  note    = {e2019GC008809 10.1029/2019GC008809},
-  year    = {2020}
-}
-
-@Article{camargo.white.ea:macroelement,
-  doi     = {10.1007/s10596-020-09964-3},
-  year    = {2021},
-  month   = apr,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {25},
-  number  = {2},
-  pages   = {775--792},
-  author  = {Julia T. Camargo and Joshua A. White and Ronaldo I. Borja},
-  title   = {A macroelement stabilization for mixed finite element/finite volume discretizations of multiphase poromechanics},
-  journal = {Computational Geosciences}
-}
-
-@Article{meier.fuchs.ea:physics-based,
-  author  = {Meier, Christoph and Fuchs, Sebastian L. and Much, Nils and Nitzler, Jonas and Penny, Ryan W. and Praegla, Patrick M. and Proell, Sebastian D. and Sun, Yushen and Weissbach, Reimar and Schreter, Magdalena and Hodge, Neil E. and John Hart, A. and Wall, Wolfgang A.},
-  title   = {Physics-based modeling and predictive simulation of powder bed fusion additive manufacturing across length scales},
-  journal = {GAMM-Mitteilungen},
-  year    = {2021},
-  pages   = {e202100014},
-  doi     = {10.1002/gamm.202100014}
-}
-
-@MastersThesis{roth:proper,
-  author  = {Roth, Julian},
-  title   = {Proper Orthogonal Decomposition for Fluid Mechanics Problems},
-  school  = {Leibniz Universit{\"a}t Hannover},
-  year    = {2021},
-  month   = aug,
-  url     = {https://julianroth.org/res/Master_Thesis_Julian_Roth.pdf}
-}
-
-@Article{fan.jin.ea:quasi-monolithic,
-  doi     = {10.1007/s00366-021-01423-6},
-  author  = {M. Fan and Y. Jin and T. Wick},
-  title   = {A quasi-monolithic phase-field description for mixed-mode fracture using predictor-corrector mesh adaptivity},
-  journal = {Engineering with Computers (EWCO)},
-  note    = {Accepted},
-  year    = {2021}
-}
-
-@Article{wick:dual-weighted,
-  doi     = {10.1515/cmam-2020-0038},
-  year    = {2021},
-  month   = jun,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = {21},
-  number  = {3},
-  pages   = {693--707},
-  author  = {Thomas Wick},
-  title   = {Dual-Weighted Residual A Posteriori Error Estimates for a Penalized Phase-Field Slit Discontinuity Problem},
-  journal = {Computational Methods in Applied Mathematics}
-}
-
-@Article{frei.richter.ea:locmodfe--locally-modified-finite-elements-for-approximating-interface-problems-in-deal-ii,
-  title   = {{LocModFE: Locally modified finite elements for approximating interface problems in deal.II}},
-  journal = {Software Impacts},
-  volume  = {8},
-  pages   = {100070},
-  year    = {2021},
-  issn    = {2665-9638},
-  doi     = {10.1016/j.simpa.2021.100070},
-  url     = {https://www.sciencedirect.com/science/article/pii/S266596382100018X},
-  author  = {Stefan Frei and Thomas Richter and Thomas Wick},
-  keywords = {Locally modified finite elements, Fitted finite elements, Interface problems, Deal.II}
-}
-
-@Article{endtmayer.langer.ea:reliability,
-  author  = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
-  doi     = {10.1515/cmam-2020-0036},
-  title   = {Reliability and Efficiency of DWR-Type A Posteriori Error Estimates with Smart Sensitivity Weight Recovering},
-  journal = {Computational Methods in Applied Mathematics},
-  volume  = {21},
-  number  = {2},
-  year    = {2021}
-}
-
-@Article{jammoul.wheeler.ea:phase-field,
-  title   = {A phase-field multirate scheme with stabilized iterative coupling for pressure driven fracture propagation in porous media},
-  journal = {Computers {\&} Mathematics with Applications},
-  volume  = {91},
-  pages   = {176-191},
-  year    = {2021},
-  note    = {Robust and Reliable Finite Element Methods in Poromechanics},
-  issn    = {0898-1221},
-  doi     = {10.1016/j.camwa.2020.11.009},
-  url     = {https://www.sciencedirect.com/science/article/pii/S089812212030434X},
-  author  = {Mohamad Jammoul and Mary F. Wheeler and Thomas Wick},
-  keywords = {Phase-field fracture, Porous media, Multirate, Iterative coupling, Benchmarks},
-  abstract = {Phase-field methods have the potential to simulate large scale evolution of networks of fractures in porous media without the need to explicitly track interfaces. Practical field simulations require however that robust and efficient decoupling techniques can be applied for solving these complex systems. In this work, we focus on the mechanics-step that involves the coupling of elasticity and the phase-field variable. We develop a multirate scheme in which a coarser time grid is employed for the mechanics equation (i.e., the displacements) and a finer time grid is taken for the phase-field problem. The performance of this algorithm is demonstrated for two test cases.}
-}
-
-@InProceedings{mang.wick:numerical-studies-of-different-mixed-phase-field-fracture-models-for-simulating-crack-propagation-in-punctured-epdm-strips,
-  author  = {K. Mang and T. Wick},
-  title   = {{Numerical Studies of Different Mixed Phase-Field Fracture Models for Simulating Crack Propagation in Punctured EPDM Strips}},
-  booktitle = {WCCM-ECCOMAS2020 conference proceedings},
-  year    = {2021},
-  url     = {https://www.scipedia.com/public/Mang_Wick_2021a}
-}
-
-@Article{mang.fehse.ea:mixed,
-  doi     = {10.1016/j.tafmec.2021.103076},
-  year    = {2021},
-  month   = aug,
+  month   = nov,
   publisher = {Elsevier {BV}},
-  pages   = {103076},
-  author  = {Katrin Mang and Andreas Fehse and Nils Hendrik Kr\"{o}ger and Thomas Wick},
-  title   = {A mixed phase-field fracture model for crack propagation in punctured {EPDM} strips},
-  journal = {Theoretical and Applied Fracture Mechanics}
-}
-
-@InProceedings{wick:on-the-adjoint-equation-in-fluid-structure-interaction,
-  author  = {T. Wick},
-  title   = {{On the Adjoint Equation in Fluid-Structure Interaction}},
-  booktitle = {WCCM-ECCOMAS2020 conference proceedings},
-  year    = {2021},
-  url     = {https://www.scipedia.com/public/Wick_2021}
-}
-
-@Article{fehse.kroger.ea:crack,
-  author  = {Fehse, Andreas and Kr{\"o}ger, Nils Hendrik and Mang, Katrin and Wick, Thomas},
-  title   = {Crack path comparisons of a mixed phase-field fracture model and experiments in punctured EPDM strips},
-  journal = {PAMM},
-  volume  = {20},
-  number  = {1},
-  pages   = {e202000335},
-  doi     = {10.1002/pamm.202000335},
-  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202000335},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202000335},
-  year    = {2021}
-}
-
-@Article{stark:on,
-  author  = {Sebastian Stark},
-  title   = {On a certain class of one step temporal integration methods for standard dissipative continua},
-  journal = {Computational Mechanics},
-  year    = {2021},
-  volume  = {67},
-  pages   = {265-287},
-  doi     = {10.1007/s00466-020-01931-0}
-}
-
-@Article{faccenna.becker.ea:mountain,
-  title   = {Mountain building, mantle convection, and supercontinents: Holmes (1931) revisited},
-  journal = {Earth and Planetary Science Letters},
-  volume  = {564},
-  pages   = {116905},
-  year    = {2021},
-  issn    = {0012-821X},
-  doi     = {10.1016/j.epsl.2021.116905},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X21001643},
-  author  = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pierre Brun}
-}
-
-@Article{salvador.fedele.ea:electromechanical,
-  author  = {Salvador, Matteo and Fedele, Marco and Africa, Pasquale Claudio and Sung, Eric and Dede', Luca and Prakosa, Adityo and Trayanova, Natalia and Chrispin, Jonathan and Quarteroni, Alfio},
-  title   = {Electromechanical modeling of human ventricles with ischemic cardiomyopathy: numerical simulations in sinus rhythm and under arrhythmia},
-  journal = {Computers in Biology and Medicine},
-  year    = {2021},
-  volume  = {136},
-  pages   = {104674},
-  doi     = {10.1016/j.compbiomed.2021.104674}
-}
-
-@Article{regazzoni.quarteroni:accelerating,
-  author  = {Regazzoni, F. and Quarteroni, A.},
-  title   = {Accelerating the convergence to a limit cycle in 3D cardiac electromechanical simulations through a data-driven 0D emulator},
-  journal = {Computers in Biology and Medicine},
-  volume  = {135},
-  pages   = {104641},
-  year    = {2021},
-  issn    = {0010-4825}
-}
-
-@Article{pagani.dede.ea:computational,
-  author  = {Pagani, S. and Dede', L. and Frontera, A. and Salvador, M. and Limite, L. R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. and Quarteroni, A.},
-  title   = {A Computational Study of the Electrophysiological Substrate in Patients Suffering From Atrial Fibrillation},
-  journal = {Frontiers in Physiology},
-  volume  = {12},
-  year    = {2021}
-}
-
-@Article{dede.quarteroni.ea:mathematical,
-  title   = {Mathematical and numerical models for the cardiac electromechanical function},
-  author  = {Ded{\`e}, L. and Quarteroni, A. and Regazzoni, F.},
-  journal = {Atti della Accademia Nazionale dei Lincei, Classe di Scienze Fisiche, Matematiche e Naturali. Rendiconti Lincei - Matematica e Applicazioni},
-  year    = {2021},
-  publisher = {EMS Press},
-  volume  = {32},
-  number  = {2},
-  pages   = {233--272},
-  issn    = {1120-6330}
-}
-
-@Article{dede.regazzoni.ea:modeling,
-  title   = {Modeling the cardiac response to hemodynamic changes associated with COVID-19: a computational study},
-  author  = {Ded{\`e}, Luca and Regazzoni, Francesco and Vergara, Christian and Zunino, Paolo and Guglielmo, Marco and Scrofani, Roberto and Fusini, Laura and Cogliati, Chiara and Pontone, Gianluca and Quarteroni, Alfio},
-  journal = {Mathematical Biosciences and Engineering},
-  volume  = {18},
-  number  = {4},
-  pages   = {3364--3383},
-  year    = {2021}
-}
-
-@Article{piersanti.africa.ea:modeling,
-  doi     = {10.1016/j.cma.2020.113468},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0045782520306538},
-  year    = {2021},
-  month   = jan,
-  publisher = {Elsevier},
-  volume  = {373},
-  pages   = {113468},
-  author  = {Roberto Piersanti and Pasquale Claudio Africa and Marco Fedele and Christian Vergara and Luca Ded{\`{e}} and Antonio F. Corno and Alfio Quarteroni},
-  title   = {Modeling cardiac muscle fibers in ventricular and atrial electrophysiology simulations},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@Article{neuharth.brune.ea:formation,
-  doi     = {10.1029/2020gc009615},
-  year    = {2021},
-  month   = apr,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {22},
-  number  = {4},
-  author  = {Derek Neuharth and Sascha Brune and Anne Glerum and Christian Heine and J. Kim Welford},
-  title   = {Formation of Continental Microplates Through Rift Linkage: Numerical Modeling and Its Application to the Flemish Cap and Sao Paulo Plateau},
-  journal = {Geochemistry, Geophysics, Geosystems}
-}
-
-@Article{gouiza.naliboff:rheological,
-  author  = {Gouiza, M. and Naliboff, J.},
-  title   = {Rheological inheritance controls the formation of segmented rifted margins in cratonic lithosphere},
-  journal = {Nature Communications},
-  year    = {2021},
-  volume  = {12},
-  number  = {1},
-  pages   = {4653},
-  issn    = {2041-1723},
-  doi     = {10.1038/s41467-021-24945-5}
-}
-
-@Article{arndt.bangerth.ea:deal-ii*1,
-  title   = {The {deal.II} finite element library: design, features, and insights},
-  author  = {Daniel Arndt and Wolfgang Bangerth and Denis Davydov and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Jean-Paul Pelteret and Bruno Turcksin and David Wells},
-  journal = {Computers \& Mathematics with Applications},
-  year    = {2021},
-  pages   = {407-422},
-  volume  = {81},
-  doi     = {10.1016/j.camwa.2020.02.022},
-  issn    = {0898-1221}
-}
-
-@Article{samrock.grayver.ea:integrated,
-  title   = {Integrated magnetotelluric and petrological analysis of felsic magma reservoirs: Insights from Ethiopian rift volcanoes},
-  author  = {Samrock, Friedemann and Grayver, Alexander V and Bachmann, Olivier and Karakas, {\"O}zge and Saar, Martin O},
-  journal = {Earth and Planetary Science Letters},
-  volume  = {559},
-  pages   = {116765},
-  year    = {2021},
-  publisher = {Elsevier}
-}
-
-@Article{grayver.kuvshinov.ea:time-domain,
-  author  = {Grayver, Alexander V. and Kuvshinov, Alexey and Werthm{\"u}ller, Dieter},
-  title   = {Time-domain modeling of 3-D Earth's and planetary electromagnetic induction effect in ground and satellite observations},
-  journal = {Journal of Geophysical Research: Space Physics},
-  volume  = {129},
-  year    = {2021},
-  pages   = {e2020JA028672},
-  doi     = {10.1029/2020JA028672}
-}
-
-@Article{ross.domnguez.ea:energy,
-  doi     = {10.3389/fphys.2021.628819},
-  year    = {2021},
-  month   = apr,
-  publisher = {Frontiers Media {SA}},
-  volume  = {12},
-  author  = {Stephanie A. Ross and Sebasti{\'{a}}n Dom{\'{\i}}nguez and Nilima Nigam and James M. Wakeling},
-  title   = {The Energy of Muscle Contraction. {III}. Kinetic Energy During Cyclic Contractions},
-  journal = {Frontiers in Physiology}
-}
-
-@InProceedings{castelli.dorfler:study,
-  author  = {Castelli, G. F. and D{\"o}rfler, W.},
-  title   = {Study on an Adaptive Finite Element Solver for the {Cahn--Hilliard} Equation},
-  editor  = {Vermolen, F. J. and Vuik, C.},
-  booktitle = {Numerical Mathematics and Advanced Applications {ENUMATH} 2019},
-  year    = {2021},
-  volume  = {139},
-  series  = {Lecture Notes in Computational Science and Engineering},
-  publisher = {Springer, Cham},
-  pages   = {245--253},
-  doi     = {10.1007/978-3-030-55874-1_23}
-}
-
-@Article{araujo.wadbro:shape,
-  author  = {Ara\'{u}jo, Juan C. and Wadbro, Eddie},
-  title   = {Shape optimization for the strong directional scattering of dielectric nanorods},
-  journal = {International Journal for Numerical Methods in Engineering},
-  volume  = {in press},
-  doi     = {10.1002/nme.6677},
-  year    = {2021},
-  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.6677},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6677}
+  volume  = {189},
+  pages   = {141--162},
+  author  = {Mathias Anselmann and Markus Bause},
+  title   = {Higher order Galerkin{\textendash}collocation time discretization with Nitsche's method for the Navier{\textendash}Stokes equations},
+  journal = {Mathematics and Computers in Simulation}
 }
 
 @Article{araujo.engstrom:on,
@@ -433,343 +23,46 @@
   doi     = {10.1016/j.jcp.2020.110024}
 }
 
-@Article{herrnbock.kumar.ea:geometrically,
-  doi     = {10.1007/s00466-020-01957-4},
-  year    = {2021},
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {67},
-  number  = {3},
-  pages   = {723--742},
-  author  = {Ludwig Herrnb\"{o}ck and Ajeet Kumar and Paul Steinmann},
-  title   = {Geometrically exact elastoplastic rods: determination of yield surface in terms of stress resultants},
-  journal = {Computational Mechanics}
-}
-
-@Article{castelli.kolzenberg.ea:efficient,
-  author  = {Castelli, G. F. and von Kolzenberg, L. and Horstmann, B. and Latz, A. and D{\"o}rfler, W.},
-  title   = {Efficient Simulation of Chemical-Mechanical Coupling in Battery Active Particles},
-  journal = {Energy Technology},
-  year    = {2021},
-  volume  = {9},
-  number  = {6},
-  pages   = {2000835},
-  doi     = {10.1002/ente.202000835}
-}
-
-@Article{veszelka.queisser.ea:impact,
-  author  = {Veszelka, Z. and Queisser, O. and Gontscharow, M. and Wetzel, T. and D{\"o}rfler, W.},
-  title   = {Impact of Numerical Methods in Thermal Modeling of {Li}-Ion Batteries on Temperature Distribution and Computation Time},
-  journal = {Energy Technology},
-  year    = {2021},
-  volume  = {9},
-  number  = {6},
-  pages   = {2000906},
-  doi     = {10.1002/ente.202000906}
-}
-
-@MastersThesis{rocha:bifurcating,
-  author  = {Lucas Almeida Rocha},
-  title   = {Bifurcating solutions of anisotropic disk problem in a constrained minimization theory of elasticity},
-  school  = {University of S{\~{a}}o Paulo},
-  year    = {2021},
-  month   = mar,
-  url     = {http://web.set.eesc.usp.br/static/media/producao/2021ME_LucasAlmeidaRocha.pdf}
-}
-
-@Article{he:gwsim,
-  doi     = {10.1093/mnras/stab2080},
-  year    = {2021},
-  month   = jul,
-  publisher = {Oxford University Press ({OUP})},
-  volume  = {506},
-  number  = {4},
-  pages   = {5278--5293},
-  author  = {Jian-hua He},
-  title   = {gwsim: a code to simulate gravitational waves propagating in a potential well},
-  journal = {Monthly Notices of the Royal Astronomical Society}
-}
-
-@Article{bredow.steinberger:mantle,
-  author  = {Bredow, Eva and Steinberger, Bernhard},
-  title   = {Mantle Convection and Possible Mantle Plumes beneath Antarctica - Insights from Geodynamic Models and Implications for Topography},
-  volume  = {56},
-  elocation-id = {M56-2020-2},
-  year    = {2021},
-  doi     = {10.1144/M56-2020-2},
-  publisher = {Geological Society of London},
-  issn    = {0435-4052},
-  url     = {https://mem.lyellcollection.org/content/early/2021/02/22/M56-2020-2},
-  eprint  = {https://mem.lyellcollection.org/content/early/2021/02/22/M56-2020-2.full.pdf},
-  journal = {Geological Society, London, Memoirs}
-}
-
-@MastersThesis{rigsby:analysis,
-  author  = {Christina Rigsby},
-  title   = {An analysis of domain decomposition methods using {deal.II}},
-  school  = {Colorado State University},
-  year    = 2021,
-  url     = {https://mountainscholar.org/handle/10217/234190}
-}
-
-@Article{wilde.kramer.ea:high-order,
-  doi     = {10.1103/physreve.104.025301},
-  year    = {2021},
-  month   = aug,
-  publisher = {American Physical Society ({APS})},
-  volume  = {104},
-  number  = {2},
-  author  = {Dominik Wilde and Andreas Kr\"{a}mer and Dirk Reith and Holger Foysi},
-  title   = {High-order semi-Lagrangian kinetic scheme for compressible turbulence},
-  journal = {Physical Review E}
-}
-
-@Article{munch.kormann.ea:hyper,
-  title   = {hyper.deal: An Efficient, Matrix-Free Finite-Element Library for High-Dimensional Partial Differential Equations},
-  author  = {Munch, Peter and Kormann, Katharina and Kronbichler, Martin},
-  year    = {2021},
-  issue_date = {December 2021},
-  publisher = {Association for Computing Machinery},
-  address = {New York, NY, USA},
-  volume  = {47},
-  number  = {4},
-  issn    = {0098-3500},
-  doi     = {10.1145/3469720},
-  journal = {ACM Trans. Math. Softw.},
-  month   = sep,
-  articleno = {33},
-  numpages = {34}
-}
-
-@Article{magni.naliboff.ea:ridge,
-  doi     = {10.3390/geosciences11110475},
-  year    = {2021},
-  month   = nov,
-  publisher = {{MDPI} {AG}},
-  volume  = {11},
-  number  = {11},
-  pages   = {475},
-  author  = {Valentina Magni and John Naliboff and Manel Prada and Carmen Gaina},
-  title   = {Ridge Jumps and Mantle Exhumation in Back-Arc Basins},
-  journal = {Geosciences}
-}
-
-@Article{fraters.billen:on,
-  doi     = {10.1029/2021gc009846},
-  year    = {2021},
-  month   = oct,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {22},
-  number  = {10},
-  author  = {M. R. T. Fraters and M. I. Billen},
-  title   = {On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling},
-  journal = {Geochemistry, Geophysics, Geosystems}
-}
-
-@Article{clevenger.heister:comparison,
-  title   = {Comparison Between Algebraic and Matrix-free Geometric Multigrid for a {S}tokes Problem on an Adaptive Mesh with Variable Viscosity},
-  author  = {Thomas C. Clevenger and Timo Heister},
-  journal = {Numerical Linear Algebra with Applications},
-  year    = {2021},
-  month   = mar,
-  doi     = {10.1002/nla.2375},
-  publisher = {Wiley}
-}
-
-@Article{clevenger.heister.ea:flexible,
-  doi     = {10.1145/3425193},
-  year    = {2021},
-  month   = mar,
-  publisher = {Association for Computing Machinery ({ACM})},
-  volume  = {47},
-  number  = {1},
-  pages   = {1--27},
-  author  = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
-  title   = {A Flexible, Parallel, Adaptive Geometric Multigrid Method for {FEM}},
-  journal = {{ACM} Transactions on Mathematical Software}
-}
-
-@Article{pagani.dede.ea:computational*1,
-  title   = {A computational study of the electrophysiological substrate in patients suffering from atrial fibrillation},
-  author  = {Pagani, S. and Ded{\`{e}}, L. and Frontera, A. and Salvador, M. and Limite, L.R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. Quarteroni, A.},
-  journal = {Frontiers in Physiology},
-  volume  = {12},
-  year    = {2021},
-  publisher = {Frontiers Media SA}
-}
-
-@Article{fehn.heinz.ea:high-order,
-  title   = {High-order arbitrary {L}agrangian--{E}ulerian discontinuous {G}alerkin methods for the incompressible {N}avier--{S}tokes equations},
-  journal = {Journal of Computational Physics},
-  volume  = {430},
-  pages   = {110040},
-  year    = {2021},
-  issn    = {0021-9991},
-  doi     = {10.1016/j.jcp.2020.110040},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0021999120308147},
-  author  = {Niklas Fehn and Johannes Heinz and Wolfgang A. Wall and Martin Kronbichler}
-}
-
-@InProceedings{kronbichler.fehn.ea:next-generation,
-  author  = {Kronbichler, Martin and Fehn, Niklas and Munch, Peter and Bergbauer, Maximilian and Wichmann, Karl-Robert and Geitner, Carolin and Allalen, Momme and Schulz, Martin and Wall, Wolfgang A.},
-  title   = {A Next-Generation Discontinuous {G}alerkin Fluid Dynamics Solver with Application to High-Resolution Lung Airflow Simulations},
-  year    = {2021},
-  isbn    = {9781450384421},
-  publisher = {Association for Computing Machinery},
-  address = {New York, NY, USA},
-  doi     = {10.1145/3458817.3476171},
-  booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis},
-  articleno = {21},
-  numpages = {15},
-  location = {St. Louis, Missouri},
-  series  = {SC '21}
-}
-
-@PhDThesis{fehn:robust,
-  title   = {Robust and Efficient Discontinuous {G}alerkin Methods for Incompressible Flows},
-  author  = {Fehn, Niklas},
-  year    = {2021},
-  school  = {Technische Universit{\"a}t M{\"u}nchen},
-  url     = {https://mediatum.ub.tum.de/1601025}
-}
-
-@Article{fehn.kronbichler.ea:numerical,
-  doi     = {10.1017/jfm.2021.1003},
-  year    = {2021},
-  month   = dec,
-  publisher = {Cambridge University Press ({CUP})},
-  volume  = {932},
-  author  = {Niklas Fehn and Martin Kronbichler and Peter Munch and Wolfgang A. Wall},
-  title   = {Numerical evidence of anomalous energy dissipation in incompressible Euler flows: towards grid-converged results for the inviscid Taylor{\textendash}Green problem},
-  journal = {Journal of Fluid Mechanics}
-}
-
-@PhDThesis{castelli:numerical,
-  author  = {Castelli, G. F.},
-  title   = {Numerical Investigation of {Cahn--Hilliard}-Type Phase-Field Models for Battery Active Particles},
-  school  = {Karlsruhe Institute of Technology (KIT)},
-  year    = {2021},
-  doi     = {10.5445/IR/1000141249}
-}
-
-@Article{castelli.dorfler:parallel,
-  author  = {Castelli, G. F. and D{\"o}rfler, W.},
-  title   = {A parallel matrix-free finite element solver for phase separation in electrode particles of lithium ion batteries},
-  journal = {Proceedings in Applied Mathematics \& Mechanics},
-  year    = {2021},
-  volume  = {21},
-  number  = {1},
-  pages   = {e202100169},
-  doi     = {10.1002/pamm.202100169}
-}
-
-@Article{heister.mang.ea:schur-type,
-  author  = {Timo Heister and Katrin Mang and Thomas Wick},
-  title   = {Schur-type preconditioning of a phase-field fracture model in mixed form},
-  journal = {{PAMM}},
-  year    = {2021},
-  volume  = {21},
-  number  = {1},
-  month   = dec,
-  doi     = {10.1002/pamm.202100065},
-  publisher = {Wiley}
-}
-
-@Article{guermond.maier.ea:second-order,
-  author  = {Jean-Luc Guermond and Matthias Maier and Bojan Popov and Ignacio Tomas},
-  title   = {Second-order invariant domain preserving approximation of the compressible Navier--Stokes equations},
-  doi     = {10.1016/j.cma.2020.113608},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2021},
-  volume  = {375},
-  number  = {1},
-  pages   = {113608}
-}
-
-@Article{maier.kronbichler:efficient,
-  author  = {Matthias Maier and Martin Kronbichler},
-  title   = {Efficient parallel 3D computation of the compressible Euler equations with an invariant-domain preserving second-order finite-element scheme},
-  doi     = {10.1145/3470637},
-  journal = {ACM Transactions on Parallel Computing},
-  year    = {2021},
-  volume  = {8},
-  number  = {3},
-  pages   = {16:1-30}
-}
-
-@Article{li.lipton.ea:lorentz,
-  author  = {Wei Li and Robert Lipton and Matthias Maier},
-  title   = {{L}orentz resonance in the homogenization of plasmonic crystals},
-  doi     = {10.1098/rspa.2021.0609},
-  journal = {Proceedings of the Royal Society A: Mathematical, Physical, and Engineering Sciences},
-  year    = {2021},
-  volume  = {477},
-  pages   = {20210609}
-}
-
-@Article{sabanskis.plate.ea:evaluation,
-  author  = {Sabanskis, Andrejs and Pl{\={a}}te, Mat{\={\i}}ss and Sattler, Andreas and Miller, Alfred and Virbulis, J{\={a}}nis},
-  journal = {Crystals},
-  title   = {Evaluation of the performance of published point defect parameter sets in cone and body phase of a 300 mm {Czochralski} silicon crystal},
-  year    = {2021},
-  issn    = {2073-4352},
-  number  = {5},
-  pages   = {460},
-  volume  = {11},
-  doi     = {10.3390/cryst11050460},
-  publisher = {{MDPI} {AG}}
-}
-
-@Article{pacheco.schussnig.ea:global,
-  author  = {Douglas R. Q. Pacheco and Richard Schussnig and Olaf Steinbach and Thomas-Peter Fries},
-  doi     = {10.1002/nme.6615},
-  issn    = {0029-5981},
-  issue   = {8},
+@Article{araujo.wadbro:shape,
+  author  = {Ara\'{u}jo, Juan C. and Wadbro, Eddie},
+  title   = {Shape optimization for the strong directional scattering of dielectric nanorods},
   journal = {International Journal for Numerical Methods in Engineering},
-  pages   = {2075-2094},
-  title   = {A global residual-based stabilization for equal-order finite element approximations of incompressible flows},
-  volume  = {122},
-  url     = {https://onlinelibrary.wiley.com/doi/10.1002/nme.6615},
-  year    = {2021}
-}
-
-@Article{pacheco.schussnig.ea:efficient,
-  author  = {Douglas R.Q. Pacheco and Richard Schussnig and Thomas-Peter Fries},
-  doi     = {10.1016/j.cma.2021.113888},
-  issn    = {00457825},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  pages   = {113888},
-  publisher = {Elsevier B.V.},
-  title   = {An efficient split-step framework for non-{N}ewtonian incompressible flow problems with consistent pressure boundary conditions},
-  volume  = {382},
-  url     = {https://linkinghub.elsevier.com/retrieve/pii/S0045782521002255},
-  year    = {2021}
-}
-
-@Article{schussnig.pacheco.ea:robust,
-  title   = {Robust stabilised finite element solvers for generalised {N}ewtonian fluid flows},
-  journal = {Journal of Computational Physics},
-  volume  = {442},
-  pages   = {110436},
+  volume  = {in press},
+  doi     = {10.1002/nme.6677},
   year    = {2021},
-  issn    = {0021-9991},
-  doi     = {10.1016/j.jcp.2021.110436},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0021999121003314},
-  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
+  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.6677},
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6677}
 }
 
-@InBook{khimin.steinbach.ea:optimal,
-  author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
-  editor  = {Aldakheel, Fadi and Hudobivnik, Bla{\v{z}} and Soleimani, Meisam and Wessels, Henning and Wei{\ss}enfels, Christian and Marino, Michele},
-  title   = {Optimal Control for Phase-Field Fracture: Algorithmic Concepts and Computations},
-  booktitle = {Current Trends and Open Problems in Computational Mechanics},
-  year    = {2022},
-  publisher = {Springer International Publishing},
-  address = {Cham},
-  pages   = {247--255},
-  abstract = {In this work, we present an algorithmic realization for computing optimal control problems with quasi-static phase-field fracture as a PDE constraint. The phase-field fracture problem is formulated in a quasi-monolithic approach resulting in a nonlinear forward problem. The optimization problem is formulated within a reduced approach, where the state variable is eliminated. To this end, a globalized reduced Newton algorithm is employed. Our algorithmic developments are substantiated with a numerical example.},
-  isbn    = {978-3-030-87312-7},
-  doi     = {10.1007/978-3-030-87312-7_24}
+@Article{arndt.bangerth.ea:deal-ii,
+  title   = {The \texttt{deal.II} Library, Version 9.3},
+  author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Uwe K{\"o}cher and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Sebastian Proell and Konrad Simon and Bruno Turcksin and David Wells and Jiaqi Zhang},
+  journal = {Journal of Numerical Mathematics},
+  year    = {2021},
+  url     = {https://dealii.org/deal93-preprint.pdf},
+  doi     = {10.1515/jnma-2021-0081},
+  volume  = {29},
+  number  = {3},
+  pages   = {171--186}
+}
+
+@Article{arndt.bangerth.ea:deal-ii*1,
+  title   = {The {deal.II} finite element library: design, features, and insights},
+  author  = {Daniel Arndt and Wolfgang Bangerth and Denis Davydov and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Jean-Paul Pelteret and Bruno Turcksin and David Wells},
+  journal = {Computers \& Mathematics with Applications},
+  year    = {2021},
+  pages   = {407-422},
+  volume  = {81},
+  doi     = {10.1016/j.camwa.2020.02.022},
+  issn    = {0898-1221}
+}
+
+@Article{barrionuevo.liu.ea:influence,
+  author  = "Barrionuevo, M. and Liu, S. and Mescua, J. and Yagupsky, D. and Quinteros, J. and Giambiagi, L. and Sobolev, S. V. and Piceda, C. R. and Strecker, M. R.",
+  title   = "The influence of variations in crustal composition and lithospheric strength on the evolution of deformation processes in the southern Central Andes: insights from geodynamic models",
+  journal = "International Journal of Earth Sciences",
+  year    = "2021",
+  doi     = "10.1007/s00531-021-01982-5"
 }
 
 @Article{beuchler.endtmayer.ea:goal,
@@ -800,18 +93,121 @@
   year    = {2021}
 }
 
-@Article{thiele.wick:space-time,
-  author  = {Thiele, Jan Philipp and Wick, Thomas},
-  title   = {Space-time PU-DWR error control and adaptivity for the heat equation},
-  journal = {PAMM},
+@Article{bonito.nochetto.ea:dg,
+  doi     = {10.1142/s0218202521500044},
+  year    = {2021},
+  publisher = {World Scientific Pub Co Pte Lt},
+  volume  = {31},
+  number  = {01},
+  pages   = {133--175},
+  author  = {Andrea Bonito and Ricardo H. Nochetto and Dimitrios Ntogkas},
+  title   = {{DG} approach to large bending plate deformations with isometry constraint},
+  journal = {Mathematical Models and Methods in Applied Sciences}
+}
+
+@Article{bredow.steinberger:mantle,
+  author  = {Bredow, Eva and Steinberger, Bernhard},
+  title   = {Mantle Convection and Possible Mantle Plumes beneath Antarctica - Insights from Geodynamic Models and Implications for Topography},
+  volume  = {56},
+  elocation-id = {M56-2020-2},
+  year    = {2021},
+  doi     = {10.1144/M56-2020-2},
+  publisher = {Geological Society of London},
+  issn    = {0435-4052},
+  url     = {https://mem.lyellcollection.org/content/early/2021/02/22/M56-2020-2},
+  eprint  = {https://mem.lyellcollection.org/content/early/2021/02/22/M56-2020-2.full.pdf},
+  journal = {Geological Society, London, Memoirs}
+}
+
+@Article{camargo.white.ea:macroelement,
+  doi     = {10.1007/s10596-020-09964-3},
+  year    = {2021},
+  month   = apr,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {25},
+  number  = {2},
+  pages   = {775--792},
+  author  = {Julia T. Camargo and Joshua A. White and Ronaldo I. Borja},
+  title   = {A macroelement stabilization for mixed finite element/finite volume discretizations of multiphase poromechanics},
+  journal = {Computational Geosciences}
+}
+
+@Article{castelli.dorfler:parallel,
+  author  = {Castelli, G. F. and D{\"o}rfler, W.},
+  title   = {A parallel matrix-free finite element solver for phase separation in electrode particles of lithium ion batteries},
+  journal = {Proceedings in Applied Mathematics \& Mechanics},
+  year    = {2021},
   volume  = {21},
   number  = {1},
-  pages   = {e202100174},
-  doi     = {10.1002/pamm.202100174},
-  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202100174},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100174},
-  abstract = {Abstract In this work, space-time goal-oriented a posteriori error estimation using a partition-of-unity localization is applied to the linear heat equation. The algorithmic developments are substantiated with a numerical example.},
-  year    = {2021}
+  pages   = {e202100169},
+  doi     = {10.1002/pamm.202100169}
+}
+
+@InProceedings{castelli.dorfler:study,
+  author  = {Castelli, G. F. and D{\"o}rfler, W.},
+  title   = {Study on an Adaptive Finite Element Solver for the {Cahn--Hilliard} Equation},
+  editor  = {Vermolen, F. J. and Vuik, C.},
+  booktitle = {Numerical Mathematics and Advanced Applications {ENUMATH} 2019},
+  year    = {2021},
+  volume  = {139},
+  series  = {Lecture Notes in Computational Science and Engineering},
+  publisher = {Springer, Cham},
+  pages   = {245--253},
+  doi     = {10.1007/978-3-030-55874-1_23}
+}
+
+@Article{castelli.kolzenberg.ea:efficient,
+  author  = {Castelli, G. F. and von Kolzenberg, L. and Horstmann, B. and Latz, A. and D{\"o}rfler, W.},
+  title   = {Efficient Simulation of Chemical-Mechanical Coupling in Battery Active Particles},
+  journal = {Energy Technology},
+  year    = {2021},
+  volume  = {9},
+  number  = {6},
+  pages   = {2000835},
+  doi     = {10.1002/ente.202000835}
+}
+
+@PhDThesis{castelli:numerical,
+  author  = {Castelli, G. F.},
+  title   = {Numerical Investigation of {Cahn--Hilliard}-Type Phase-Field Models for Battery Active Particles},
+  school  = {Karlsruhe Institute of Technology (KIT)},
+  year    = {2021},
+  doi     = {10.5445/IR/1000141249}
+}
+
+@Article{clevenger.heister.ea:flexible,
+  doi     = {10.1145/3425193},
+  year    = {2021},
+  month   = mar,
+  publisher = {Association for Computing Machinery ({ACM})},
+  volume  = {47},
+  number  = {1},
+  pages   = {1--27},
+  author  = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
+  title   = {A Flexible, Parallel, Adaptive Geometric Multigrid Method for {FEM}},
+  journal = {{ACM} Transactions on Mathematical Software}
+}
+
+@Article{clevenger.heister:comparison,
+  title   = {Comparison Between Algebraic and Matrix-free Geometric Multigrid for a {S}tokes Problem on an Adaptive Mesh with Variable Viscosity},
+  author  = {Thomas C. Clevenger and Timo Heister},
+  journal = {Numerical Linear Algebra with Applications},
+  year    = {2021},
+  month   = mar,
+  doi     = {10.1002/nla.2375},
+  publisher = {Wiley}
+}
+
+@Article{comeau.stein.ea:geodynamic,
+  doi     = {10.1029/2020jb021304},
+  year    = {2021},
+  month   = may,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {126},
+  number  = {5},
+  author  = {Matthew J. Comeau and Claudia Stein and Michael Becken and Ulrich Hansen},
+  title   = {Geodynamic Modeling of Lithospheric Removal and Surface Deformation: Application to Intraplate Uplift in {C}entral {M}ongolia},
+  journal = {Journal of Geophysical Research: Solid Earth}
 }
 
 @InProceedings{d-jodlbauer:efficient,
@@ -834,29 +230,6 @@
   pages   = {accepted}
 }
 
-@InProceedings{wick:adjoint-based,
-  author  = {T. Wick},
-  title   = {Adjoint-based methods for optimization and goal-oriented error control applied to fluid-structure interaction: implementation of a partition-of-unity dual-weighted residual estimator for stationary forward FSI problems in deal.II},
-  booktitle = {Book of VI ECCOMAS Young Investigators Conference YIC2021},
-  year    = {2021},
-  doi     = {10.4995/YIC2021.2021.12332},
-  publisher = {Editorial Universitat Politecnica de Valencia},
-  pages   = {257-266}
-}
-
-@Article{noii.fan.ea:quasi-monolithic,
-  title   = {A quasi-monolithic phase-field description for orthotropic anisotropic fracture with adaptive mesh refinement and primal-dual active set method},
-  journal = {Engineering Fracture Mechanics},
-  volume  = {258},
-  pages   = {108060},
-  year    = {2021},
-  issn    = {0013-7944},
-  doi     = {10.1016/j.engfracmech.2021.108060},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0013794421004744},
-  author  = {Nima Noii and Meng Fan and Thomas Wick and Yan Jin},
-  keywords = {Anisotropic brittle fracture, Phase-field modeling, Transversely isotropic, Orthotropic anisotropic, Primal-dual active set, Predictor-corrector mesh adaptivity}
-}
-
 @Article{dal-maso.heltai:numerical,
   author  = {Gianni {Dal Maso} and Luca Heltai},
   journal = {Journal of Convex Analysis},
@@ -868,6 +241,128 @@
   url     = {https://www.heldermann.de/JCA/JCA28/JCA282/jca28030.htm}
 }
 
+@Article{dede.quarteroni.ea:mathematical,
+  title   = {Mathematical and numerical models for the cardiac electromechanical function},
+  author  = {Ded{\`e}, L. and Quarteroni, A. and Regazzoni, F.},
+  journal = {Atti della Accademia Nazionale dei Lincei, Classe di Scienze Fisiche, Matematiche e Naturali. Rendiconti Lincei - Matematica e Applicazioni},
+  year    = {2021},
+  publisher = {EMS Press},
+  volume  = {32},
+  number  = {2},
+  pages   = {233--272},
+  issn    = {1120-6330}
+}
+
+@Article{dede.regazzoni.ea:modeling,
+  title   = {Modeling the cardiac response to hemodynamic changes associated with COVID-19: a computational study},
+  author  = {Ded{\`e}, Luca and Regazzoni, Francesco and Vergara, Christian and Zunino, Paolo and Guglielmo, Marco and Scrofani, Roberto and Fusini, Laura and Cogliati, Chiara and Pontone, Gianluca and Quarteroni, Alfio},
+  journal = {Mathematical Biosciences and Engineering},
+  volume  = {18},
+  number  = {4},
+  pages   = {3364--3383},
+  year    = {2021}
+}
+
+@Article{endtmayer.langer.ea:reliability,
+  author  = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
+  doi     = {10.1515/cmam-2020-0036},
+  title   = {Reliability and Efficiency of DWR-Type A Posteriori Error Estimates with Smart Sensitivity Weight Recovering},
+  journal = {Computational Methods in Applied Mathematics},
+  volume  = {21},
+  number  = {2},
+  year    = {2021}
+}
+
+@Article{faccenna.becker.ea:mountain,
+  title   = {Mountain building, mantle convection, and supercontinents: Holmes (1931) revisited},
+  journal = {Earth and Planetary Science Letters},
+  volume  = {564},
+  pages   = {116905},
+  year    = {2021},
+  issn    = {0012-821X},
+  doi     = {10.1016/j.epsl.2021.116905},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X21001643},
+  author  = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pierre Brun}
+}
+
+@Article{fan.jin.ea:quasi-monolithic,
+  doi     = {10.1007/s00366-021-01423-6},
+  author  = {M. Fan and Y. Jin and T. Wick},
+  title   = {A quasi-monolithic phase-field description for mixed-mode fracture using predictor-corrector mesh adaptivity},
+  journal = {Engineering with Computers (EWCO)},
+  note    = {Accepted},
+  year    = {2021}
+}
+
+@Article{fehn.heinz.ea:high-order,
+  title   = {High-order arbitrary {L}agrangian--{E}ulerian discontinuous {G}alerkin methods for the incompressible {N}avier--{S}tokes equations},
+  journal = {Journal of Computational Physics},
+  volume  = {430},
+  pages   = {110040},
+  year    = {2021},
+  issn    = {0021-9991},
+  doi     = {10.1016/j.jcp.2020.110040},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0021999120308147},
+  author  = {Niklas Fehn and Johannes Heinz and Wolfgang A. Wall and Martin Kronbichler}
+}
+
+@Article{fehn.kronbichler.ea:numerical,
+  doi     = {10.1017/jfm.2021.1003},
+  year    = {2021},
+  month   = dec,
+  publisher = {Cambridge University Press ({CUP})},
+  volume  = {932},
+  author  = {Niklas Fehn and Martin Kronbichler and Peter Munch and Wolfgang A. Wall},
+  title   = {Numerical evidence of anomalous energy dissipation in incompressible Euler flows: towards grid-converged results for the inviscid Taylor{\textendash}Green problem},
+  journal = {Journal of Fluid Mechanics}
+}
+
+@PhDThesis{fehn:robust,
+  title   = {Robust and Efficient Discontinuous {G}alerkin Methods for Incompressible Flows},
+  author  = {Fehn, Niklas},
+  year    = {2021},
+  school  = {Technische Universit{\"a}t M{\"u}nchen},
+  url     = {https://mediatum.ub.tum.de/1601025}
+}
+
+@Article{fehse.kroger.ea:crack,
+  author  = {Fehse, Andreas and Kr{\"o}ger, Nils Hendrik and Mang, Katrin and Wick, Thomas},
+  title   = {Crack path comparisons of a mixed phase-field fracture model and experiments in punctured EPDM strips},
+  journal = {PAMM},
+  volume  = {20},
+  number  = {1},
+  pages   = {e202000335},
+  doi     = {10.1002/pamm.202000335},
+  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202000335},
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202000335},
+  year    = {2021}
+}
+
+@Article{fraters.billen:on,
+  doi     = {10.1029/2021gc009846},
+  year    = {2021},
+  month   = oct,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {22},
+  number  = {10},
+  author  = {M. R. T. Fraters and M. I. Billen},
+  title   = {On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling},
+  journal = {Geochemistry, Geophysics, Geosystems}
+}
+
+@Article{frei.richter.ea:locmodfe--locally-modified-finite-elements-for-approximating-interface-problems-in-deal-ii,
+  title   = {{LocModFE: Locally modified finite elements for approximating interface problems in deal.II}},
+  journal = {Software Impacts},
+  volume  = {8},
+  pages   = {100070},
+  year    = {2021},
+  issn    = {2665-9638},
+  doi     = {10.1016/j.simpa.2021.100070},
+  url     = {https://www.sciencedirect.com/science/article/pii/S266596382100018X},
+  author  = {Stefan Frei and Thomas Richter and Thomas Wick},
+  keywords = {Locally modified finite elements, Fitted finite elements, Interface problems, Deal.II}
+}
+
 @Article{giani.grubisic.ea:smoothed-adaptive,
   author  = {Stefano Giani and Luka Grubisic and Luca Heltai and Ornela Mulita},
   journal = {Computational Methods in Applied Mathematics},
@@ -877,6 +372,99 @@
   volume  = {21},
   year    = {2021},
   doi     = {10.1515/cmam-2020-0027}
+}
+
+@Article{golshan.blais:load-balancing,
+  title   = {Load-Balancing Strategies in Discrete Element Method Simulations},
+  author  = {Golshan, Shahab and Blais, Bruno},
+  journal = {Processes},
+  volume  = {10},
+  number  = {1},
+  pages   = {79},
+  year    = {2021},
+  doi     = {10.3390/pr10010079},
+  publisher = {MDPI}
+}
+
+@Article{gouiza.naliboff:rheological,
+  author  = {Gouiza, M. and Naliboff, J.},
+  title   = {Rheological inheritance controls the formation of segmented rifted margins in cratonic lithosphere},
+  journal = {Nature Communications},
+  year    = {2021},
+  volume  = {12},
+  number  = {1},
+  pages   = {4653},
+  issn    = {2041-1723},
+  doi     = {10.1038/s41467-021-24945-5}
+}
+
+@Article{grayver.kuvshinov.ea:time-domain,
+  author  = {Grayver, Alexander V. and Kuvshinov, Alexey and Werthm{\"u}ller, Dieter},
+  title   = {Time-domain modeling of 3-D Earth's and planetary electromagnetic induction effect in ground and satellite observations},
+  journal = {Journal of Geophysical Research: Space Physics},
+  volume  = {129},
+  year    = {2021},
+  pages   = {e2020JA028672},
+  doi     = {10.1029/2020JA028672}
+}
+
+@Article{greiner.reiter.ea:poro-viscoelastic,
+  author  = {Greiner, Alexander and Reiter, Nina and Paulsen, Friedrich and Holzapfel, Gerhard A. and Steinmann, Paul and Comellas, Ester and Budday, Silvia},
+  doi     = {10.3389/fmech.2021.708350},
+  journal = {Frontiers in Mechanical Engineering},
+  number  = {708350},
+  pages   = {1--18},
+  title   = {Poro-Viscoelastic Effects During Biomechanical Testing of Human Brain Tissue},
+  volume  = {7},
+  year    = {2021}
+}
+
+@Article{guermond.maier.ea:second-order,
+  author  = {Jean-Luc Guermond and Matthias Maier and Bojan Popov and Ignacio Tomas},
+  title   = {Second-order invariant domain preserving approximation of the compressible Navier--Stokes equations},
+  doi     = {10.1016/j.cma.2020.113608},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2021},
+  volume  = {375},
+  number  = {1},
+  pages   = {113608}
+}
+
+@Article{he:gwsim,
+  doi     = {10.1093/mnras/stab2080},
+  year    = {2021},
+  month   = jul,
+  publisher = {Oxford University Press ({OUP})},
+  volume  = {506},
+  number  = {4},
+  pages   = {5278--5293},
+  author  = {Jian-hua He},
+  title   = {gwsim: a code to simulate gravitational waves propagating in a potential well},
+  journal = {Monthly Notices of the Royal Astronomical Society}
+}
+
+@Article{heckenbach.brune.ea:is,
+  author  = {Heckenbach, Esther L. and Brune, Sascha and Glerum, Anne C. and Bott, Judith},
+  title   = {Is there a Speed Limit for the Thermal Steady-State Assumption in Continental Rifts?},
+  journal = {Geochemistry, Geophysics, Geosystems},
+  volume  = {22},
+  number  = {3},
+  pages   = {e2020GC009577},
+  doi     = {10.1029/2020GC009577},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020GC009577},
+  year    = {2021}
+}
+
+@Article{heister.mang.ea:schur-type,
+  author  = {Timo Heister and Katrin Mang and Thomas Wick},
+  title   = {Schur-type preconditioning of a phase-field fracture model in mixed form},
+  journal = {{PAMM}},
+  year    = {2021},
+  volume  = {21},
+  number  = {1},
+  month   = dec,
+  doi     = {10.1002/pamm.202100065},
+  publisher = {Wiley}
 }
 
 @Article{heltai.bangerth.ea:propagating,
@@ -900,16 +488,97 @@
   doi     = {10.1007/s10439-021-02804-0}
 }
 
-@Article{uluocak.gogus.ea:geodynamics,
-  doi     = {10.1029/2021tc007031},
+@Article{herrnbock.kumar.ea:geometrically,
+  doi     = {10.1007/s00466-020-01957-4},
   year    = {2021},
-  month   = dec,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {40},
+  month   = feb,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {67},
+  number  = {3},
+  pages   = {723--742},
+  author  = {Ludwig Herrnb\"{o}ck and Ajeet Kumar and Paul Steinmann},
+  title   = {Geometrically exact elastoplastic rods: determination of yield surface in terms of stress resultants},
+  journal = {Computational Mechanics}
+}
+
+@Article{jammoul.wheeler.ea:phase-field,
+  title   = {A phase-field multirate scheme with stabilized iterative coupling for pressure driven fracture propagation in porous media},
+  journal = {Computers {\&} Mathematics with Applications},
+  volume  = {91},
+  pages   = {176-191},
+  year    = {2021},
+  note    = {Robust and Reliable Finite Element Methods in Poromechanics},
+  issn    = {0898-1221},
+  doi     = {10.1016/j.camwa.2020.11.009},
+  url     = {https://www.sciencedirect.com/science/article/pii/S089812212030434X},
+  author  = {Mohamad Jammoul and Mary F. Wheeler and Thomas Wick},
+  keywords = {Phase-field fracture, Porous media, Multirate, Iterative coupling, Benchmarks},
+  abstract = {Phase-field methods have the potential to simulate large scale evolution of networks of fractures in porous media without the need to explicitly track interfaces. Practical field simulations require however that robust and efficient decoupling techniques can be applied for solving these complex systems. In this work, we focus on the mechanics-step that involves the coupling of elasticity and the phase-field variable. We develop a multirate scheme in which a coarser time grid is employed for the mechanics equation (i.e., the displacements) and a finer time grid is taken for the phase-field problem. The performance of this algorithm is demonstrated for two test cases.}
+}
+
+@InBook{khimin.steinbach.ea:optimal,
+  author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
+  editor  = {Aldakheel, Fadi and Hudobivnik, Bla{\v{z}} and Soleimani, Meisam and Wessels, Henning and Wei{\ss}enfels, Christian and Marino, Michele},
+  title   = {Optimal Control for Phase-Field Fracture: Algorithmic Concepts and Computations},
+  booktitle = {Current Trends and Open Problems in Computational Mechanics},
+  year    = {2022},
+  publisher = {Springer International Publishing},
+  address = {Cham},
+  pages   = {247--255},
+  abstract = {In this work, we present an algorithmic realization for computing optimal control problems with quasi-static phase-field fracture as a PDE constraint. The phase-field fracture problem is formulated in a quasi-monolithic approach resulting in a nonlinear forward problem. The optimization problem is formulated within a reduced approach, where the state variable is eliminated. To this end, a globalized reduced Newton algorithm is employed. Our algorithmic developments are substantiated with a numerical example.},
+  isbn    = {978-3-030-87312-7},
+  doi     = {10.1007/978-3-030-87312-7_24}
+}
+
+@Article{kinnewig.roth.ea:geometric,
+  title   = {Geometric multigrid with multiplicative Schwarz smoothers for eddy-current and Maxwell's equations in deal.II},
+  journal = {Examples and Counterexamples},
+  volume  = {1},
+  pages   = {100027},
+  year    = {2021},
+  issn    = {2666-657X},
+  doi     = {10.1016/j.exco.2021.100027},
+  url     = {https://www.sciencedirect.com/science/article/pii/S2666657X2100015X},
+  author  = {Sebastian Kinnewig and Julian Roth and Thomas Wick},
+  keywords = {Time-harmonic Maxwell, Eddy-current problem, Finite elements, Geometric multigrid, Multiplicative Schwarz smoother},
+  abstract = {In this work, we consider the design of a geometric multigrid method with multiplicative Schwarz smoothers for the eddy-current problem and the time-harmonic Maxwell equations. The main purpose is to show numerically that a straightforward application works for the former problem, but not for the latter. The well-known key is a special decomposition of the function spaces within the multigrid algorithm. The failures and performance are shown with the help of a numerical test, implemented in the modern finite element library deal.II, including a github link to the eddy-current implementation.}
+}
+
+@InCollection{klein.schuster.ea:sequential,
+  doi     = {10.1007/978-3-030-57784-1_6},
+  year    = {2021},
+  publisher = {Springer International Publishing},
+  pages   = {165--190},
+  author  = {Rebecca Klein and Thomas Schuster and Anne Wald},
+  title   = {Sequential Subspace Optimization for Recovering Stored Energy Functions in Hyperelastic Materials from Time-Dependent Data},
+  booktitle = {Time-dependent Problems in Imaging and Parameter Identification}
+}
+
+@Article{kourakos.harter:simulation,
+  author  = {Kourakos, Georgios and Harter, Thomas},
+  title   = {Simulation of Unconfined Aquifer Flow Based on Parallel Adaptive Mesh Refinement},
+  journal = {Water Resources Research},
+  year    = {2021},
+  volume  = {57},
   number  = {12},
-  author  = {Ebru {\c{S}}eng\"{u}l Uluocak and O{\u{g}}uz H. G\"{o}{\u{g}}\"{u}{\c{s}} and Russell N. Pysklywec and Bo Chen},
-  title   = {Geodynamics of East Anatolia-Caucasus Domain: Inferences From 3D Thermo-Mechanical Models, Residual Topography, and Admittance Function Analyses},
-  journal = {Tectonics}
+  pages   = {e2020WR029354},
+  doi     = {10.1029/2020WR029354},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020WR029354}
+}
+
+@InProceedings{kronbichler.fehn.ea:next-generation,
+  author  = {Kronbichler, Martin and Fehn, Niklas and Munch, Peter and Bergbauer, Maximilian and Wichmann, Karl-Robert and Geitner, Carolin and Allalen, Momme and Schulz, Martin and Wall, Wolfgang A.},
+  title   = {A Next-Generation Discontinuous {G}alerkin Fluid Dynamics Solver with Application to High-Resolution Lung Airflow Simulations},
+  year    = {2021},
+  isbn    = {9781450384421},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  doi     = {10.1145/3458817.3476171},
+  booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis},
+  articleno = {21},
+  numpages = {15},
+  location = {St. Louis, Missouri},
+  series  = {SC '21}
 }
 
 @Article{lee.saxena.ea:contributions-from-lithospheric-and-upper-mantle-heterogeneities-to-upper-crustal-seismicity-in-the-korean-peninsula,
@@ -922,6 +591,42 @@
   doi     = {10.1093/gji/ggab527},
   note    = {ggab527},
   eprint  = {https://academic.oup.com/gji/advance-article-pdf/doi/10.1093/gji/ggab527/41971016/ggab527.pdf}
+}
+
+@Article{lees.rudge.ea:gravity,
+  author  = {Lees, Matthew E. and Rudge, John F. and McKenzie, Dan},
+  title   = {Gravity, Topography, and Melt Generation Rates From Simple 3-D Models of Mantle Convection},
+  journal = {Geochemistry, Geophysics, Geosystems},
+  volume  = {21},
+  number  = {4},
+  pages   = {e2019GC008809},
+  doi     = {10.1029/2019GC008809},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
+  note    = {e2019GC008809 10.1029/2019GC008809},
+  year    = {2020}
+}
+
+@Article{li.lipton.ea:lorentz,
+  author  = {Wei Li and Robert Lipton and Matthias Maier},
+  title   = {{L}orentz resonance in the homogenization of plasmonic crystals},
+  doi     = {10.1098/rspa.2021.0609},
+  journal = {Proceedings of the Royal Society A: Mathematical, Physical, and Engineering Sciences},
+  year    = {2021},
+  volume  = {477},
+  pages   = {20210609}
+}
+
+@Article{liu.moller.ea:balancing,
+  doi     = {10.1016/j.cam.2020.113219},
+  year    = {2021},
+  month   = apr,
+  publisher = {Elsevier {BV}},
+  volume  = {386},
+  pages   = {113219},
+  author  = {Jie Liu and Matthias M\"{o}ller and Henk M. Schuttelaars},
+  title   = {Balancing truncation and round-off errors in {FEM}: One-dimensional analysis},
+  journal = {Journal of Computational and Applied Mathematics}
 }
 
 @Article{lundin.dore.ea:utilization,
@@ -938,16 +643,56 @@
   journal = {Geological Society, London, Special Publications}
 }
 
-@Article{comeau.stein.ea:geodynamic,
-  doi     = {10.1029/2020jb021304},
+@Article{magni.naliboff.ea:ridge,
+  doi     = {10.3390/geosciences11110475},
   year    = {2021},
-  month   = may,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = {126},
-  number  = {5},
-  author  = {Matthew J. Comeau and Claudia Stein and Michael Becken and Ulrich Hansen},
-  title   = {Geodynamic Modeling of Lithospheric Removal and Surface Deformation: Application to Intraplate Uplift in {C}entral {M}ongolia},
-  journal = {Journal of Geophysical Research: Solid Earth}
+  month   = nov,
+  publisher = {{MDPI} {AG}},
+  volume  = {11},
+  number  = {11},
+  pages   = {475},
+  author  = {Valentina Magni and John Naliboff and Manel Prada and Carmen Gaina},
+  title   = {Ridge Jumps and Mantle Exhumation in Back-Arc Basins},
+  journal = {Geosciences}
+}
+
+@Article{maier.kronbichler:efficient,
+  author  = {Matthias Maier and Martin Kronbichler},
+  title   = {Efficient parallel 3D computation of the compressible Euler equations with an invariant-domain preserving second-order finite-element scheme},
+  doi     = {10.1145/3470637},
+  journal = {ACM Transactions on Parallel Computing},
+  year    = {2021},
+  volume  = {8},
+  number  = {3},
+  pages   = {16:1-30}
+}
+
+@Article{mang.fehse.ea:mixed,
+  doi     = {10.1016/j.tafmec.2021.103076},
+  year    = {2021},
+  month   = aug,
+  publisher = {Elsevier {BV}},
+  pages   = {103076},
+  author  = {Katrin Mang and Andreas Fehse and Nils Hendrik Kr\"{o}ger and Thomas Wick},
+  title   = {A mixed phase-field fracture model for crack propagation in punctured {EPDM} strips},
+  journal = {Theoretical and Applied Fracture Mechanics}
+}
+
+@InProceedings{mang.wick:numerical-studies-of-different-mixed-phase-field-fracture-models-for-simulating-crack-propagation-in-punctured-epdm-strips,
+  author  = {K. Mang and T. Wick},
+  title   = {{Numerical Studies of Different Mixed Phase-Field Fracture Models for Simulating Crack Propagation in Punctured EPDM Strips}},
+  booktitle = {WCCM-ECCOMAS2020 conference proceedings},
+  year    = {2021},
+  url     = {https://www.scipedia.com/public/Mang_Wick_2021a}
+}
+
+@Article{meier.fuchs.ea:physics-based,
+  author  = {Meier, Christoph and Fuchs, Sebastian L. and Much, Nils and Nitzler, Jonas and Penny, Ryan W. and Praegla, Patrick M. and Proell, Sebastian D. and Sun, Yushen and Weissbach, Reimar and Schreter, Magdalena and Hodge, Neil E. and John Hart, A. and Wall, Wolfgang A.},
+  title   = {Physics-based modeling and predictive simulation of powder bed fusion additive manufacturing across length scales},
+  journal = {GAMM-Mitteilungen},
+  year    = {2021},
+  pages   = {e202100014},
+  doi     = {10.1002/gamm.202100014}
 }
 
 @Article{mulita.giani.ea:quasi-optimal,
@@ -961,50 +706,305 @@
   doi     = {10.1137/19m1262097}
 }
 
-@Article{bonito.nochetto.ea:dg,
-  doi     = {10.1142/s0218202521500044},
+@Article{munch.kormann.ea:hyper,
+  title   = {hyper.deal: An Efficient, Matrix-Free Finite-Element Library for High-Dimensional Partial Differential Equations},
+  author  = {Munch, Peter and Kormann, Katharina and Kronbichler, Martin},
   year    = {2021},
-  publisher = {World Scientific Pub Co Pte Lt},
-  volume  = {31},
-  number  = {01},
-  pages   = {133--175},
-  author  = {Andrea Bonito and Ricardo H. Nochetto and Dimitrios Ntogkas},
-  title   = {{DG} approach to large bending plate deformations with isometry constraint},
-  journal = {Mathematical Models and Methods in Applied Sciences}
+  issue_date = {December 2021},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  volume  = {47},
+  number  = {4},
+  issn    = {0098-3500},
+  doi     = {10.1145/3469720},
+  journal = {ACM Trans. Math. Softw.},
+  month   = sep,
+  articleno = {33},
+  numpages = {34}
 }
 
-@InCollection{klein.schuster.ea:sequential,
-  doi     = {10.1007/978-3-030-57784-1_6},
-  year    = {2021},
-  publisher = {Springer International Publishing},
-  pages   = {165--190},
-  author  = {Rebecca Klein and Thomas Schuster and Anne Wald},
-  title   = {Sequential Subspace Optimization for Recovering Stored Energy Functions in Hyperelastic Materials from Time-Dependent Data},
-  booktitle = {Time-dependent Problems in Imaging and Parameter Identification}
-}
-
-@Article{liu.moller.ea:balancing,
-  doi     = {10.1016/j.cam.2020.113219},
+@Article{neuharth.brune.ea:formation,
+  doi     = {10.1029/2020gc009615},
   year    = {2021},
   month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = {386},
-  pages   = {113219},
-  author  = {Jie Liu and Matthias M\"{o}ller and Henk M. Schuttelaars},
-  title   = {Balancing truncation and round-off errors in {FEM}: One-dimensional analysis},
-  journal = {Journal of Computational and Applied Mathematics}
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {22},
+  number  = {4},
+  author  = {Derek Neuharth and Sascha Brune and Anne Glerum and Christian Heine and J. Kim Welford},
+  title   = {Formation of Continental Microplates Through Rift Linkage: Numerical Modeling and Its Application to the Flemish Cap and Sao Paulo Plateau},
+  journal = {Geochemistry, Geophysics, Geosystems}
 }
 
-@Article{anselmann.bause:higher,
-  doi     = {10.1016/j.matcom.2020.10.027},
+@Article{noii.fan.ea:quasi-monolithic,
+  title   = {A quasi-monolithic phase-field description for orthotropic anisotropic fracture with adaptive mesh refinement and primal-dual active set method},
+  journal = {Engineering Fracture Mechanics},
+  volume  = {258},
+  pages   = {108060},
   year    = {2021},
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = {189},
-  pages   = {141--162},
-  author  = {Mathias Anselmann and Markus Bause},
-  title   = {Higher order Galerkin{\textendash}collocation time discretization with Nitsche's method for the Navier{\textendash}Stokes equations},
-  journal = {Mathematics and Computers in Simulation}
+  issn    = {0013-7944},
+  doi     = {10.1016/j.engfracmech.2021.108060},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0013794421004744},
+  author  = {Nima Noii and Meng Fan and Thomas Wick and Yan Jin},
+  keywords = {Anisotropic brittle fracture, Phase-field modeling, Transversely isotropic, Orthotropic anisotropic, Primal-dual active set, Predictor-corrector mesh adaptivity}
+}
+
+@Article{pacheco.schussnig.ea:efficient,
+  author  = {Douglas R.Q. Pacheco and Richard Schussnig and Thomas-Peter Fries},
+  doi     = {10.1016/j.cma.2021.113888},
+  issn    = {00457825},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  pages   = {113888},
+  publisher = {Elsevier B.V.},
+  title   = {An efficient split-step framework for non-{N}ewtonian incompressible flow problems with consistent pressure boundary conditions},
+  volume  = {382},
+  url     = {https://linkinghub.elsevier.com/retrieve/pii/S0045782521002255},
+  year    = {2021}
+}
+
+@Article{pacheco.schussnig.ea:global,
+  author  = {Douglas R. Q. Pacheco and Richard Schussnig and Olaf Steinbach and Thomas-Peter Fries},
+  doi     = {10.1002/nme.6615},
+  issn    = {0029-5981},
+  issue   = {8},
+  journal = {International Journal for Numerical Methods in Engineering},
+  pages   = {2075-2094},
+  title   = {A global residual-based stabilization for equal-order finite element approximations of incompressible flows},
+  volume  = {122},
+  url     = {https://onlinelibrary.wiley.com/doi/10.1002/nme.6615},
+  year    = {2021}
+}
+
+@Article{pagani.dede.ea:computational,
+  author  = {Pagani, S. and Dede', L. and Frontera, A. and Salvador, M. and Limite, L. R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. and Quarteroni, A.},
+  title   = {A Computational Study of the Electrophysiological Substrate in Patients Suffering From Atrial Fibrillation},
+  journal = {Frontiers in Physiology},
+  volume  = {12},
+  year    = {2021}
+}
+
+@Article{pagani.dede.ea:computational*1,
+  title   = {A computational study of the electrophysiological substrate in patients suffering from atrial fibrillation},
+  author  = {Pagani, S. and Ded{\`{e}}, L. and Frontera, A. and Salvador, M. and Limite, L.R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. Quarteroni, A.},
+  journal = {Frontiers in Physiology},
+  volume  = {12},
+  year    = {2021},
+  publisher = {Frontiers Media SA}
+}
+
+@Article{piersanti.africa.ea:modeling,
+  doi     = {10.1016/j.cma.2020.113468},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0045782520306538},
+  year    = {2021},
+  month   = jan,
+  publisher = {Elsevier},
+  volume  = {373},
+  pages   = {113468},
+  author  = {Roberto Piersanti and Pasquale Claudio Africa and Marco Fedele and Christian Vergara and Luca Ded{\`{e}} and Antonio F. Corno and Alfio Quarteroni},
+  title   = {Modeling cardiac muscle fibers in ventricular and atrial electrophysiology simulations},
+  journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@Article{regazzoni.quarteroni:accelerating,
+  author  = {Regazzoni, F. and Quarteroni, A.},
+  title   = {Accelerating the convergence to a limit cycle in 3D cardiac electromechanical simulations through a data-driven 0D emulator},
+  journal = {Computers in Biology and Medicine},
+  volume  = {135},
+  pages   = {104641},
+  year    = {2021},
+  issn    = {0010-4825}
+}
+
+@MastersThesis{rigsby:analysis,
+  author  = {Christina Rigsby},
+  title   = {An analysis of domain decomposition methods using {deal.II}},
+  school  = {Colorado State University},
+  year    = 2021,
+  url     = {https://mountainscholar.org/handle/10217/234190}
+}
+
+@MastersThesis{rocha:bifurcating,
+  author  = {Lucas Almeida Rocha},
+  title   = {Bifurcating solutions of anisotropic disk problem in a constrained minimization theory of elasticity},
+  school  = {University of S{\~{a}}o Paulo},
+  year    = {2021},
+  month   = mar,
+  url     = {http://web.set.eesc.usp.br/static/media/producao/2021ME_LucasAlmeidaRocha.pdf}
+}
+
+@Article{ross.domnguez.ea:energy,
+  doi     = {10.3389/fphys.2021.628819},
+  year    = {2021},
+  month   = apr,
+  publisher = {Frontiers Media {SA}},
+  volume  = {12},
+  author  = {Stephanie A. Ross and Sebasti{\'{a}}n Dom{\'{\i}}nguez and Nilima Nigam and James M. Wakeling},
+  title   = {The Energy of Muscle Contraction. {III}. Kinetic Energy During Cyclic Contractions},
+  journal = {Frontiers in Physiology}
+}
+
+@MastersThesis{roth:proper,
+  author  = {Roth, Julian},
+  title   = {Proper Orthogonal Decomposition for Fluid Mechanics Problems},
+  school  = {Leibniz Universit{\"a}t Hannover},
+  year    = {2021},
+  month   = aug,
+  url     = {https://julianroth.org/res/Master_Thesis_Julian_Roth.pdf}
+}
+
+@Article{sabanskis.plate.ea:evaluation,
+  author  = {Sabanskis, Andrejs and Pl{\={a}}te, Mat{\={\i}}ss and Sattler, Andreas and Miller, Alfred and Virbulis, J{\={a}}nis},
+  journal = {Crystals},
+  title   = {Evaluation of the performance of published point defect parameter sets in cone and body phase of a 300 mm {Czochralski} silicon crystal},
+  year    = {2021},
+  issn    = {2073-4352},
+  number  = {5},
+  pages   = {460},
+  volume  = {11},
+  doi     = {10.3390/cryst11050460},
+  publisher = {{MDPI} {AG}}
+}
+
+@Article{salvador.fedele.ea:electromechanical,
+  author  = {Salvador, Matteo and Fedele, Marco and Africa, Pasquale Claudio and Sung, Eric and Dede', Luca and Prakosa, Adityo and Trayanova, Natalia and Chrispin, Jonathan and Quarteroni, Alfio},
+  title   = {Electromechanical modeling of human ventricles with ischemic cardiomyopathy: numerical simulations in sinus rhythm and under arrhythmia},
+  journal = {Computers in Biology and Medicine},
+  year    = {2021},
+  volume  = {136},
+  pages   = {104674},
+  doi     = {10.1016/j.compbiomed.2021.104674}
+}
+
+@Article{samrock.grayver.ea:integrated,
+  title   = {Integrated magnetotelluric and petrological analysis of felsic magma reservoirs: Insights from Ethiopian rift volcanoes},
+  author  = {Samrock, Friedemann and Grayver, Alexander V and Bachmann, Olivier and Karakas, {\"O}zge and Saar, Martin O},
+  journal = {Earth and Planetary Science Letters},
+  volume  = {559},
+  pages   = {116765},
+  year    = {2021},
+  publisher = {Elsevier}
+}
+
+@Article{saxena.choi.ea:seismicity-in-the-central-and-southeastern-united-states-due-to-upper-mantle-heterogeneities,
+  author  = {Saxena, Arushi and Choi, Eunseo and Powell, Christine A and Aslam, Khurram S},
+  title   = "{Seismicity in the central and southeastern United States due to upper mantle heterogeneities}",
+  journal = {Geophysical Journal International},
+  volume  = {225},
+  number  = {3},
+  pages   = {1624-1636},
+  year    = {2021},
+  month   = mar,
+  doi     = {10.1093/gji/ggab051}
+}
+
+@Article{schussnig.pacheco.ea:robust,
+  title   = {Robust stabilised finite element solvers for generalised {N}ewtonian fluid flows},
+  journal = {Journal of Computational Physics},
+  volume  = {442},
+  pages   = {110436},
+  year    = {2021},
+  issn    = {0021-9991},
+  doi     = {10.1016/j.jcp.2021.110436},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0021999121003314},
+  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
+}
+
+@Article{stark:on,
+  author  = {Sebastian Stark},
+  title   = {On a certain class of one step temporal integration methods for standard dissipative continua},
+  journal = {Computational Mechanics},
+  year    = {2021},
+  volume  = {67},
+  pages   = {265-287},
+  doi     = {10.1007/s00466-020-01931-0}
+}
+
+@Article{thiele.wick:space-time,
+  author  = {Thiele, Jan Philipp and Wick, Thomas},
+  title   = {Space-time PU-DWR error control and adaptivity for the heat equation},
+  journal = {PAMM},
+  volume  = {21},
+  number  = {1},
+  pages   = {e202100174},
+  doi     = {10.1002/pamm.202100174},
+  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202100174},
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100174},
+  abstract = {Abstract In this work, space-time goal-oriented a posteriori error estimation using a partition-of-unity localization is applied to the linear heat equation. The algorithmic developments are substantiated with a numerical example.},
+  year    = {2021}
+}
+
+@Article{uluocak.gogus.ea:geodynamics,
+  doi     = {10.1029/2021tc007031},
+  year    = {2021},
+  month   = dec,
+  publisher = {American Geophysical Union ({AGU})},
+  volume  = {40},
+  number  = {12},
+  author  = {Ebru {\c{S}}eng\"{u}l Uluocak and O{\u{g}}uz H. G\"{o}{\u{g}}\"{u}{\c{s}} and Russell N. Pysklywec and Bo Chen},
+  title   = {Geodynamics of East Anatolia-Caucasus Domain: Inferences From 3D Thermo-Mechanical Models, Residual Topography, and Admittance Function Analyses},
+  journal = {Tectonics}
+}
+
+@Article{veszelka.queisser.ea:impact,
+  author  = {Veszelka, Z. and Queisser, O. and Gontscharow, M. and Wetzel, T. and D{\"o}rfler, W.},
+  title   = {Impact of Numerical Methods in Thermal Modeling of {Li}-Ion Batteries on Temperature Distribution and Computation Time},
+  journal = {Energy Technology},
+  year    = {2021},
+  volume  = {9},
+  number  = {6},
+  pages   = {2000906},
+  doi     = {10.1002/ente.202000906}
+}
+
+@InProceedings{wick:adjoint-based,
+  author  = {T. Wick},
+  title   = {Adjoint-based methods for optimization and goal-oriented error control applied to fluid-structure interaction: implementation of a partition-of-unity dual-weighted residual estimator for stationary forward FSI problems in deal.II},
+  booktitle = {Book of VI ECCOMAS Young Investigators Conference YIC2021},
+  year    = {2021},
+  doi     = {10.4995/YIC2021.2021.12332},
+  publisher = {Editorial Universitat Politecnica de Valencia},
+  pages   = {257-266}
+}
+
+@Article{wick:dual-weighted,
+  doi     = {10.1515/cmam-2020-0038},
+  year    = {2021},
+  month   = jun,
+  publisher = {Walter de Gruyter {GmbH}},
+  volume  = {21},
+  number  = {3},
+  pages   = {693--707},
+  author  = {Thomas Wick},
+  title   = {Dual-Weighted Residual A Posteriori Error Estimates for a Penalized Phase-Field Slit Discontinuity Problem},
+  journal = {Computational Methods in Applied Mathematics}
+}
+
+@InProceedings{wick:on-the-adjoint-equation-in-fluid-structure-interaction,
+  author  = {T. Wick},
+  title   = {{On the Adjoint Equation in Fluid-Structure Interaction}},
+  booktitle = {WCCM-ECCOMAS2020 conference proceedings},
+  year    = {2021},
+  url     = {https://www.scipedia.com/public/Wick_2021}
+}
+
+@Article{wilde.kramer.ea:high-order,
+  doi     = {10.1103/physreve.104.025301},
+  year    = {2021},
+  month   = aug,
+  publisher = {American Physical Society ({APS})},
+  volume  = {104},
+  number  = {2},
+  author  = {Dominik Wilde and Andreas Kr\"{a}mer and Dirk Reith and Holger Foysi},
+  title   = {High-order semi-Lagrangian kinetic scheme for compressible turbulence},
+  journal = {Physical Review E}
+}
+
+@MastersThesis{withers:modelling,
+  author  = "Withers, Craig",
+  title   = "Modelling slab age and crustal thickness: numerical approaches to drivers of compressive stresses in the overriding plate in Andean style subduction zone systems",
+  year    = "2021",
+  publisher = "Durham University",
+  school  = "Durham theses",
+  opturl  = "http://etheses.dur.ac.uk/13836/"
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -8,120 +8,51 @@
   year    = {2022}
 }
 
-@Article{piersanti.regazzoni.ea:3d-0d,
-  doi     = {10.1016/j.cma.2022.114607},
-  title   = {3D--0D closed-loop model for the simulation of cardiac biventricular electromechanics},
-  author  = {Piersanti, Roberto and Regazzoni, Francesco and Salvador, Matteo and Corno, Antonio F and Vergara, Christian and Quarteroni, Alfio and others},
+@Article{aggul.labovsky.ea:ns-,
+  title   = {{NS}-$\omega$ model for fluid--fluid interaction problems at high {Reynolds} numbers},
   journal = {Computer Methods in Applied Mechanics and Engineering},
-  volume  = {391},
-  pages   = {114607},
-  year    = {2022},
-  month   = mar,
-  publisher = {Elsevier}
-}
-
-@Article{vergara.stella.ea:computational,
-  author  = {Vergara, Christian and Stella, Simone and Maines, Massimiliano and Africa, Pasquale Claudio and Catanzariti, Domenico and Dematt\`{e}, Cristina and Centonze, Maurizio and Nobile, Fabio and Quarteroni, Alfio and Del Greco, Maurizio},
-  title   = {Computational electrophysiology of the coronary sinus branches based on electro-anatomical mapping for the prediction of the latest activated region},
-  journal = {Medical \& Biological Engineering \& Computing},
-  volume  = {60},
-  number  = {8},
-  pages   = {2307--2319},
-  year    = {2022},
-  month   = jun,
-  doi     = {10.1007/s11517-022-02610-3}
-}
-
-@Article{zingaro.fumagalli.ea:geometric,
-  author  = {Zingaro, Alberto and Fumagalli, Ivan and Fedele, Marco and Africa, Pasquale Claudio and Dede', Luca and Quarteroni, Alfio and Corno, Antonio Francesco},
-  title   = {A geometric multiscale model for the numerical simulation of blood flow in the human left heart},
-  journal = {Discrete and Continuous Dynamical Systems - S},
-  volume  = {15},
-  number  = {8},
-  pages   = {2391--2427},
-  year    = {2022},
-  doi     = {10.3934/dcdss.2022052}
-}
-
-@Misc{zingaro.bucelli.ea:modeling,
-  doi     = {10.48550/ARXIV.2208.09435},
-  url     = {https://arxiv.org/abs/2208.09435},
-  author  = {Zingaro, Alberto and Bucelli, Michele and Fumagalli, Ivan and Dede', Luca and Quarteroni, Alfio},
-  keywords = {Numerical Analysis (math.NA), Fluid Dynamics (physics.flu-dyn), Medical Physics (physics.med-ph), Quantitative Methods (q-bio.QM), FOS: Mathematics, FOS: Mathematics, FOS: Physical sciences, FOS: Physical sciences, FOS: Biological sciences, FOS: Biological sciences, G.1; J.3, 65N30, 65M60, 65Z05, 76Z05, 76D05, 92C35},
-  title   = {Modeling isovolumetric phases in cardiac flows by an Augmented Resistive Immersed Implicit Surface Method},
-  publisher = {arXiv},
-  year    = {2022},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
-}
-
-@Article{regazzoni.salvador.ea:cardiac,
-  doi     = {10.1016/j.jcp.2022.111083},
-  author  = {F. Regazzoni and M. Salvador and P.C. Africa and M. Fedele and L. Dede{\`{e}} and A. Quarteroni},
-  title   = {A cardiac electromechanical model coupled with a lumped-parameter model for closed-loop blood circulation},
-  journal = {Journal of Computational Physics},
-  volume  = {457},
-  pages   = {111083},
+  volume  = {395},
+  pages   = {115052},
   year    = {2022},
   month   = may,
-  publisher = {Elsevier {BV}}
+  publisher = {Elsevier {BV}},
+  issn    = {0045-7825},
+  doi     = {10.1016/j.cma.2022.115052},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0045782522002663},
+  author  = {Mustafa Aggul and Alexander E. Labovsky and Kyle J. Schwiebert}
 }
 
-@Article{salvador.regazzoni.ea:role,
-  doi     = {10.1016/j.compbiomed.2021.105203},
-  title   = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
-  author  = {Salvador, Matteo and Regazzoni, Francesco and Pagani, Stefano and Dede', Luca and Trayanova, Natalia and Quarteroni, Alfio},
-  journal = {Computers in Biology and Medicine},
-  volume  = {142},
-  pages   = {105203},
+@Article{ahuja.endtmayer.ea:multigoal-oriented,
+  author  = {K. Ahuja and B. Endtmayer and M.C. Steinbach and T. Wick},
+  title   = {Multigoal-oriented error estimation and mesh adaptivity for fluid-structure interaction},
+  journal = {Journal of Computational and Applied Mathematics},
+  volume  = {412},
+  pages   = {114315},
   year    = {2022},
-  month   = mar,
-  publisher = {Elsevier}
+  issn    = {0377-0427},
+  doi     = {10.1016/j.cam.2022.114315},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0377042722001340},
+  keywords = {Fluid-structure interaction, Dual-weighted residuals, Multigoal-oriented error estimation, Mesh adaptivity, Deal.II}
 }
 
-@Article{fumagalli.vitullo.ea:image-based,
-  doi     = {10.3389/fphys.2021.787082},
-  title   = {Image-based computational hemodynamics analysis of systolic obstruction in hypertrophic cardiomyopathy},
-  author  = {Fumagalli, Ivan and Vitullo, Piermario and Vergara, Christian and Fedele, Marco and Corno, Antonio F and Ippolito, Sonia and Scrofani, Roberto and Quarteroni, Alfio},
-  journal = {Frontiers in Physiology},
-  volume  = {12},
-  pages   = {2437},
+@Article{arndt.bangerth.ea:deal-ii,
+  title   = {The \texttt{deal.II} Library, Version 9.4},
+  author  = {Daniel Arndt and Wolfgang Bangerth and Marco Feder and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Simon Sticko and Bruno Turcksin and David Wells},
+  journal = {Journal of Numerical Mathematics},
+  doi     = {10.1515/jnma-2022-0054},
   year    = {2022},
-  publisher = {Frontiers}
-}
-
-@Article{regazzoni.salvador.ea:machine,
-  doi     = {10.1016/j.cma.2022.114825},
-  title   = {A machine learning method for real-time numerical simulations of cardiac electromechanics},
-  author  = {Regazzoni, Francesco and Salvador, Matteo and Dede', Luca and Quarteroni, Alfio},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  volume  = {393},
-  pages   = {114825},
-  year    = {2022},
-  month   = apr,
-  publisher = {Elsevier}
-}
-
-@Article{quarteroni.dedee.ea:modeling,
-  doi     = {10.1090/bull/1738},
-  title   = {Modeling the cardiac electromechanical function: A mathematical journey},
-  author  = {Quarteroni, Alfio and Dede{\`{e}}, Luca and Regazzoni, Francesco},
-  journal = {Bulletin of the American Mathematical Society},
-  volume  = {59},
+  volume  = {30},
   number  = {3},
-  pages   = {371--403},
-  year    = {2022},
-  month   = feb,
-  publisher = {American Mathematical Society ({AMS})}
+  pages   = {231-246},
+  url     = {https://dealii.org/deal94-preprint.pdf}
 }
 
-@MastersThesis{lorencio-abril:modelo,
-  author  = "Lorencio Abril, Jose Antonio",
-  title   = "Un modelo en elementos finitos para estudiar las deformaciones del tejido mamario",
-  school  = "Universidad de Murcia",
-  year    = "2022",
-  month   = jul,
-  url     = "https://github.com/Lorenc1o/University_Notes/blob/main/ComputerScience/TFG/TFG_FEM.pdf",
-  note    = "Bachelor's Thesis"
+@Article{axelsson.dravins.ea:stage-parallel,
+  title   = {Stage-parallel preconditioners for implicit Runge-Kutta methods of arbitrary high order. Linear problems},
+  author  = {Owe Axelsson and Ivo Dravins and Maya Neytcheva},
+  journal = {submitted},
+  year    = {2022},
+  url     = {http://www.it.uu.se/research/publications/reports/2022-004/2022-004-nc.pdf}
 }
 
 @Article{barbeau.etienne.ea:development,
@@ -135,56 +66,127 @@
   publisher = {Elsevier}
 }
 
-@Article{palmiotto.ficini.ea:back-arc,
-  author  = {Palmiotto, Camilla and Ficini, Eleonora and Loreto, Maria Filomena and Muccini, Filippo and Cuffaro, Marco},
-  title   = {Back-Arc Spreading Centers and Superfast Subduction: {T}he Case of the {N}orthern {L}au Basin ({SW} {P}acific Ocean)},
-  journal = {Geosciences},
-  volume  = {12},
+@InCollection{basava.mang.ea:adaptive,
+  doi     = {10.1007/978-3-030-92672-4_8},
   year    = {2022},
-  number  = {2},
-  article-number = {50},
-  url     = {https://www.mdpi.com/2076-3263/12/2/50},
-  issn    = {2076-3263},
-  doi     = {10.3390/geosciences12020050}
+  publisher = {Springer International Publishing},
+  pages   = {191--215},
+  author  = {Seshadri Basava and Katrin Mang and Mirjam Walloth and Thomas Wick and Winnifried Wollner},
+  title   = {Adaptive and Pressure-Robust Discretization of Incompressible Pressure-Driven Phase-Field Fracture},
+  booktitle = {Non-standard Discretisation Methods in Solid Mechanics}
 }
 
-@Article{oneill.aulbach:destabilization,
-  author  = {Craig O'Neill and Sonja Aulbach },
-  title   = {Destabilization of deep oxidized mantle drove the Great Oxidation Event},
-  journal = {Science Advances},
-  volume  = {8},
-  number  = {7},
-  pages   = {eabg1626},
-  year    = {2022},
-  doi     = {10.1126/sciadv.abg1626},
-  url     = {https://www.science.org/doi/abs/10.1126/sciadv.abg1626},
-  eprint  = {https://www.science.org/doi/pdf/10.1126/sciadv.abg1626}
+@Article{behr.holt.ea:effects,
+  doi     = {10.1093/gji/ggac075},
+  url     = {https://doi.org/10.1093/gji/ggac075},
+  year    = 2022,
+  month   = feb,
+  publisher = {Oxford University Press ({OUP})},
+  author  = {Whitney M. Behr and Adam F. Holt and Thorsten W. Becker and Claudio Faccenna},
+  title   = {The effects of plate interface rheology on subduction kinematics and dynamics},
+  journal = {Geophysical Journal International}
 }
 
-@Article{stein.comeau.ea:numerical,
-  title   = {Numerical study on the style of delamination},
-  journal = {Tectonophysics},
-  pages   = {229276},
-  year    = {2022},
-  issn    = {0040-1951},
-  doi     = {10.1016/j.tecto.2022.229276},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0040195122000701},
-  author  = {Claudia Stein and Matthew Comeau and Michael Becken and Ulrich Hansen},
-  keywords = {Numerical modelling delamination, Rayleigh-Taylor instability phase transition rheology}
-}
-
-@Article{zha.lin.ea:effects,
-  author  = {Zha, Caicai and Lin, Jian and Zhou, Zhiyuan and Xu, Min and Zhang, Xubo},
-  title   = {Effects of Hotspot-Induced Long-Wavelength Mantle Melting Variations on Magmatic Segmentation at the {R}eykjanes Ridge: Insights From 3D Geodynamic Modeling},
-  journal = {Journal of Geophysical Research: Solid Earth},
-  volume  = {127},
-  number  = {3},
-  pages   = {e2021JB023244},
-  doi     = {10.1029/2021JB023244},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2021JB023244},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021JB023244},
-  note    = {e2021JB023244 2021JB023244},
+@Article{comellas.farkas.ea:local,
+  author  = {Comellas, Ester and Farkas, Johanna E. and Kleinberg, Giona and Lloyd, Katlyn and Mueller, Thomas and Duerr, Timothy J. and Mu{\~{n}}oz, Jose J. and Monaghan, James R. and Shefelbine, Sandra J.},
+  doi     = {10.1098/RSPB.2022.0621},
+  journal = {Proceedings of the Royal Society B},
+  number  = {1975},
+  pages   = {20220621},
+  title   = {Local mechanical stimuli correlate with tissue growth in axolotl salamander joint morphogenesis},
+  url     = {https://royalsocietypublishing.org/doi/10.1098/rspb.2022.0621},
+  volume  = {289},
   year    = {2022}
+}
+
+@Article{davies.kramer.ea:towards,
+  author  = {Davies, D. R. and Kramer, S. C. and Ghelichkhan, S. and Gibson, A.},
+  title   = {Towards automatic finite-element methods for geodynamics via {F}iredrake},
+  journal = {Geoscientific Model Development},
+  volume  = {15},
+  year    = {2022},
+  number  = {13},
+  pages   = {5127--5166},
+  url     = {https://gmd.copernicus.org/articles/15/5127/2022/},
+  doi     = {10.5194/gmd-15-5127-2022}
+}
+
+@Article{diehl.lipton.ea:comparative,
+  author  = {Diehl, Patrick and Lipton, Robert and Wick, Thomas and Tyagi, Mayank},
+  title   = {A comparative review of peridynamics and phase-field models for engineering fracture mechanics},
+  journal = {Computational Mechanics},
+  volume  = {69},
+  number  = {6},
+  pages   = {1259-1293},
+  year    = {2022},
+  publisher = {Springer},
+  doi     = {10.1007/s00466-022-02147-0}
+}
+
+@Article{fang.zhang.ea:causal,
+  title   = {The causal mechanism of the {S}angihe Forearc Thrust, {M}olucca {S}ea, northeast {I}ndonesia, from numerical simulation},
+  journal = {Journal of Asian Earth Sciences},
+  volume  = {237},
+  pages   = {105350},
+  year    = {2022},
+  issn    = {1367-9120},
+  doi     = {10.1016/j.jseaes.2022.105350},
+  url     = {https://www.sciencedirect.com/science/article/pii/S1367912022002814},
+  author  = {Gui Fang and Jian Zhang and Tianyao Hao and Miao Dong and Chenghao Jiang and Yubei He},
+  keywords = {Forearc collision, Sangihe Arc, Halmahera Arc, Forearc thrusting, Numerical modeling}
+}
+
+@Misc{fehling.bangerth:algorithms,
+  doi     = {10.48550/ARXIV.2206.06512},
+  url     = {https://arxiv.org/abs/2206.06512},
+  author  = {Fehling, Marc and Bangerth, Wolfgang},
+  keywords = {Numerical Analysis (math.NA), Mathematical Software (cs.MS), FOS: Mathematics, FOS: Computer and information sciences, G.1.8; G.4},
+  title   = {Algorithms for Parallel Generic $hp$-adaptive Finite Element Software},
+  publisher = {arXiv},
+  year    = {2022},
+  copyright = {arXiv.org perpetual, non-exclusive license}
+}
+
+@Misc{fuest.heydari.ea:global,
+  author  = {Fuest, Mario and Heydari, Shahin and Knobloch, Petr and Lankeit, Johannes and Wick, Thomas},
+  title   = {Global existence of classical solutions and numerical simulations of a cancer invasion model},
+  doi     = {10.48550/ARXIV.2205.08168},
+  url     = {https://arxiv.org/abs/2205.08168},
+  keywords = {Numerical Analysis (math.NA), Analysis of PDEs (math.AP), FOS: Mathematics, FOS: Mathematics},
+  publisher = {arXiv},
+  year    = {2022},
+  copyright = {arXiv.org perpetual, non-exclusive license}
+}
+
+@Article{fumagalli.vitullo.ea:image-based,
+  doi     = {10.3389/fphys.2021.787082},
+  title   = {Image-based computational hemodynamics analysis of systolic obstruction in hypertrophic cardiomyopathy},
+  author  = {Fumagalli, Ivan and Vitullo, Piermario and Vergara, Christian and Fedele, Marco and Corno, Antonio F and Ippolito, Sonia and Scrofani, Roberto and Quarteroni, Alfio},
+  journal = {Frontiers in Physiology},
+  volume  = {12},
+  pages   = {2437},
+  year    = {2022},
+  publisher = {Frontiers}
+}
+
+@Article{golshan.munch.ea:lethe-dem,
+  title   = {Lethe-DEM: An open-source parallel discrete element solver with load balancing},
+  author  = {Golshan, Shahab and Munch, Peter and Gassm{\"o}ller, Rene and Kronbichler, Martin and Blais, Bruno},
+  journal = {Computational Particle Mechanics},
+  pages   = {1--20},
+  year    = {2022},
+  doi     = {10.1007/s40571-022-00478-6},
+  publisher = {Springer}
+}
+
+@Article{guermond.kronbichler.ea:on,
+  author  = {Jean-Luc~Guermond and Martin Kronbichler and Matthias Maier and Bojan Popov and Ignacio Tomas},
+  title   = {On the implementation of a robust and efficient finite element-based parallel solver for the compressible Navier-stokes equations},
+  doi     = {10.1016/j.cma.2021.114250},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {2022},
+  volume  = {389},
+  pages   = {114250}
 }
 
 @Article{heyn.conrad:on,
@@ -202,49 +204,12 @@
   note    = {e2022GL098003 2022GL098003}
 }
 
-@Article{negredo.van-hunen.ea:on,
-  title   = {On the origin of the {C}anary {I}slands: {I}nsights from mantle convection modelling},
-  journal = {Earth and Planetary Science Letters},
-  volume  = {584},
-  pages   = {117506},
+@InProceedings{j-p-thiele:space-time,
+  author  = {J. P. Thiele, T. Wick},
+  title   = {Space-time error control using a partition-of-unity dual-weighted residual method applied to low mach number combustion},
+  booktitle = {Proceedings of ICOSAHOM, 2020+1},
   year    = {2022},
-  issn    = {0012-821X},
-  doi     = {10.1016/j.epsl.2022.117506},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X2200142X},
-  author  = {Ana M. Negredo and Jeroen {van Hunen} and Juan Rodr\'{i}guez-Gonz\'{a}lez and Javier Fullea},
-  keywords = {Canary Islands, edge-driven convection, hot spots, mantle convection}
-}
-
-@Article{behr.holt.ea:effects,
-  doi     = {10.1093/gji/ggac075},
-  url     = {https://doi.org/10.1093/gji/ggac075},
-  year    = 2022,
-  month   = feb,
-  publisher = {Oxford University Press ({OUP})},
-  author  = {Whitney M. Behr and Adam F. Holt and Thorsten W. Becker and Claudio Faccenna},
-  title   = {The effects of plate interface rheology on subduction kinematics and dynamics},
-  journal = {Geophysical Journal International}
-}
-
-@Article{root.sebera.ea:benchmark,
-  author  = {Root, B. C. and Sebera, J. and Szwillus, W. and Thieulot, C. and Martinec, Z. and Fullea, J.},
-  title   = {Benchmark forward gravity schemes: the gravity field of a realistic lithosphere model {WINTERC-G}},
-  journal = {Solid Earth},
-  volume  = {13},
-  year    = {2022},
-  number  = {5},
-  pages   = {849--873},
-  url     = {https://se.copernicus.org/articles/13/849/2022/},
-  doi     = {10.5194/se-13-849-2022}
-}
-
-@MastersThesis{quiroga:numerical,
-  author  = {Quiroga, David},
-  title   = {Numerical Models of Lithosphere Removal in the {S}ierra {N}evada de {S}anta {M}arta, {C}olombia},
-  pages   = {178},
-  school  = {University of Alberta},
-  year    = {2022},
-  doi     = {10.7939/r3-6mk4-sj26}
+  pages   = {accepted}
 }
 
 @PhDThesis{janbakhsh:numerical,
@@ -253,6 +218,40 @@
   school  = {University of Toronto},
   url     = {https://hdl.handle.net/1807/123260},
   year    = {2022}
+}
+
+@Article{jingchun.chengli.ea:on,
+  title   = {On the formation of thrust fault-related landforms in {M}ercury's {N}orthern {S}mooth {P}lains: {A} new mechanical model of the lithosphere},
+  journal = {Icarus},
+  pages   = {115197},
+  year    = {2022},
+  issn    = {0019-1035},
+  doi     = {10.1016/j.icarus.2022.115197},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0019103522002962},
+  author  = {Xie Jingchun and Huang Chengli and Zhang Mian},
+  keywords = {Mercury, Thrust fault, Lithospheric model, Formation, Numerical simulations}
+}
+
+@Misc{jodlbauer.langer.ea:matrix-free,
+  author  = {Jodlbauer, Daniel and Langer, Ulrich and Wick, Thomas and Zulehner, Walter},
+  title   = {Matrix-free Monolithic Multigrid Methods for Stokes and Generalized Stokes Problems},
+  doi     = {10.48550/ARXIV.2205.15770},
+  url     = {https://arxiv.org/abs/2205.15770},
+  keywords = {Numerical Analysis (math.NA), FOS: Mathematics, FOS: Mathematics, G.1.8, 65M55},
+  publisher = {arXiv},
+  year    = {2022},
+  copyright = {Creative Commons Attribution 4.0 International}
+}
+
+@Misc{khimin.steinbach.ea:computational,
+  author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
+  title   = {Computational performance studies for space-time phase-field fracture optimal control problems},
+  doi     = {10.48550/ARXIV.2203.14643},
+  url     = {https://arxiv.org/abs/2203.14643},
+  keywords = {Optimization and Control (math.OC), Numerical Analysis (math.NA), FOS: Mathematics, FOS: Mathematics, 74R10, 65N30, 49M15, 49K20, 35Q74},
+  publisher = {arXiv},
+  year    = {2022},
+  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
 }
 
 @Article{liu.king:dynamics,
@@ -270,87 +269,22 @@
   year    = {2022}
 }
 
-@Article{davies.kramer.ea:towards,
-  author  = {Davies, D. R. and Kramer, S. C. and Ghelichkhan, S. and Gibson, A.},
-  title   = {Towards automatic finite-element methods for geodynamics via {F}iredrake},
-  journal = {Geoscientific Model Development},
-  volume  = {15},
+@Article{liu.mcbride.ea:vibration,
+  author  = {Zhaowei Liu and Andrew McBride and Prashant Saxena and Luca Heltai and Yilin Qu and Paul Steinmann},
+  journal = {International Journal for Numerical Methods in Engineering},
+  title   = {Vibration Analysis of Piezoelectric {Kirchhoff-Love} shells based on {Catmull-Clark} Subdivision Surfaces},
   year    = {2022},
-  number  = {13},
-  pages   = {5127--5166},
-  url     = {https://gmd.copernicus.org/articles/15/5127/2022/},
-  doi     = {10.5194/gmd-15-5127-2022}
+  doi     = {10.1002/nme.7010}
 }
 
-@Article{zhang.shahabad.ea:3-dimensional,
-  author  = {Zhang, Zhi-Dong and Shahabad, Shahriar Imani and Ibhadode, Osezua and Dibia, Chinedu Francis and Bonakdar, Ali and Toyserkani, Ehsan},
-  title   = {3-Dimensional Heat Transfer Modeling for Laser Powder Bed Fusion Additive Manufacturing Using Parallel Computing and Adaptive Mesh},
-  journal = {SSRN Electronic Journal},
-  year    = {2022},
-  url     = {https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4108005},
-  doi     = {10.2139/ssrn.4108005}
-}
-
-@Article{golshan.munch.ea:lethe-dem,
-  title   = {Lethe-DEM: An open-source parallel discrete element solver with load balancing},
-  author  = {Golshan, Shahab and Munch, Peter and Gassm{\"o}ller, Rene and Kronbichler, Martin and Blais, Bruno},
-  journal = {Computational Particle Mechanics},
-  pages   = {1--20},
-  year    = {2022},
-  doi     = {10.1007/s40571-022-00478-6},
-  publisher = {Springer}
-}
-
-@Article{comellas.farkas.ea:local,
-  author  = {Comellas, Ester and Farkas, Johanna E. and Kleinberg, Giona and Lloyd, Katlyn and Mueller, Thomas and Duerr, Timothy J. and Mu{\~{n}}oz, Jose J. and Monaghan, James R. and Shefelbine, Sandra J.},
-  doi     = {10.1098/RSPB.2022.0621},
-  journal = {Proceedings of the Royal Society B},
-  number  = {1975},
-  pages   = {20220621},
-  title   = {Local mechanical stimuli correlate with tissue growth in axolotl salamander joint morphogenesis},
-  url     = {https://royalsocietypublishing.org/doi/10.1098/rspb.2022.0621},
-  volume  = {289},
-  year    = {2022}
-}
-
-@Article{salvador.regazzoni.ea:role*1,
-  doi     = {10.1016/j.compbiomed.2021.105203},
-  year    = {2022},
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = {142},
-  pages   = {105203},
-  author  = {Matteo Salvador and Francesco Regazzoni and Stefano Pagani and Luca Ded{\`{e}} and Natalia Trayanova and Alfio Quarteroni},
-  title   = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
-  journal = {Computers in Biology and Medicine}
-}
-
-@Article{tsagkari.connelly.ea:role,
-  doi     = {10.1038/s41522-022-00300-4},
-  year    = 2022,
-  month   = apr,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = {8},
-  number  = {1},
-  author  = {Erifyli Tsagkari and Stephanie Connelly and Zhaowei Liu and Andrew McBride and William T. Sloan},
-  title   = {The role of shear dynamics in biofilm formation},
-  journal = {npj Biofilms and Microbiomes}
-}
-
-@Article{roth.schroder.ea:neural,
-  author  = {Julian Roth and Max Schr{\"o}der and Thomas Wick},
-  title   = {Neural network guided adjoint computations in dual weighted residual error estimation},
-  journal = {SN Applied Sciences},
-  year    = {2022},
-  month   = jan,
-  day     = {31},
-  volume  = {4},
-  number  = {2},
-  pages   = {62},
-  abstract = {In this work, we are concerned with neural network guided goal-oriented a posteriori error estimation and adaptivity using the dual weighted residual method. The primal problem is solved using classical Galerkin finite elements. The adjoint problem is solved in strong form with a feedforward neural network using two or three hidden layers. The main objective of our approach is to explore alternatives for solving the adjoint problem with greater potential of a numerical cost reduction. The proposed algorithm is based on the general goal-oriented error estimation theorem including both linear and nonlinear stationary partial differential equations and goal functionals. Our developments are substantiated with some numerical experiments that include comparisons of neural network computed adjoints and classical finite element solutions of the adjoints. In the programming software, the open-source library deal.II is successfully coupled with LibTorch, the PyTorch C++
-            application programming interface.},
-  issn    = {2523-3971},
-  doi     = {10.1007/s42452-022-04938-9}
+@MastersThesis{lorencio-abril:modelo,
+  author  = "Lorencio Abril, Jose Antonio",
+  title   = "Un modelo en elementos finitos para estudiar las deformaciones del tejido mamario",
+  school  = "Universidad de Murcia",
+  year    = "2022",
+  month   = jul,
+  url     = "https://github.com/Lorenc1o/University_Notes/blob/main/ComputerScience/TFG/TFG_FEM.pdf",
+  note    = "Bachelor's Thesis"
 }
 
 @PhDThesis{mang:phase-field,
@@ -362,149 +296,11 @@
   school  = {Hannover: Institutionelles Repositorium der Leibniz Universit{\"a}t Hannover}
 }
 
-@Article{guermond.kronbichler.ea:on,
-  author  = {Jean-Luc~Guermond and Martin Kronbichler and Matthias Maier and Bojan Popov and Ignacio Tomas},
-  title   = {On the implementation of a robust and efficient finite element-based parallel solver for the compressible Navier-stokes equations},
-  doi     = {10.1016/j.cma.2021.114250},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  year    = {2022},
-  volume  = {389},
-  pages   = {114250}
-}
-
-@Article{orlando.della-rocca.ea:efficient,
-  title   = {An efficient and accurate implicit {DG} solver for the incompressible {N}avier-{S}tokes equations},
-  author  = {Orlando, G. and Della Rocca, A. and Barbante, P.F. and Bonaventura, L. and Parolini, N.},
-  doi     = {10.1002/fld.5098},
-  year    = {2022},
-  journal = {International Journal for Numerical Methods in Fluids}
-}
-
-@Article{sabanskis.dadzis.ea:application,
-  doi     = {10.3390/cryst12020174},
-  year    = {2022},
-  month   = jan,
-  publisher = {{MDPI} {AG}},
-  volume  = {12},
-  number  = {2},
-  pages   = {174},
-  author  = {Andrejs Sabanskis and Kaspars Dadzis and Robert Menzel and J{\={a}}nis Virbulis},
-  title   = {Application of the {A}lexander{\textendash}{H}aasen Model for Thermally Stimulated Dislocation Generation in {FZ} Silicon Crystals},
-  journal = {Crystals}
-}
-
-@Article{schussnig.pacheco.ea:efficient,
-  title   = {Efficient split-step schemes for fluid--structure interaction involving incompressible generalised {N}ewtonian flows},
-  journal = {Computers \& Structures},
-  volume  = {260},
-  pages   = {106718},
-  year    = {2022},
-  issn    = {0045-7949},
-  doi     = {10.1016/j.compstruc.2021.106718},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0045794921002406},
-  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
-}
-
-@InProceedings{j-p-thiele:space-time,
-  author  = {J. P. Thiele, T. Wick},
-  title   = {Space-time error control using a partition-of-unity dual-weighted residual method applied to low mach number combustion},
-  booktitle = {Proceedings of ICOSAHOM, 2020+1},
-  year    = {2022},
-  pages   = {accepted}
-}
-
-@Misc{khimin.steinbach.ea:computational,
-  author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
-  title   = {Computational performance studies for space-time phase-field fracture optimal control problems},
-  doi     = {10.48550/ARXIV.2203.14643},
-  url     = {https://arxiv.org/abs/2203.14643},
-  keywords = {Optimization and Control (math.OC), Numerical Analysis (math.NA), FOS: Mathematics, FOS: Mathematics, 74R10, 65N30, 49M15, 49K20, 35Q74},
-  publisher = {arXiv},
-  year    = {2022},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
-}
-
-@Article{diehl.lipton.ea:comparative,
-  author  = {Diehl, Patrick and Lipton, Robert and Wick, Thomas and Tyagi, Mayank},
-  title   = {A comparative review of peridynamics and phase-field models for engineering fracture mechanics},
-  journal = {Computational Mechanics},
-  volume  = {69},
-  number  = {6},
-  pages   = {1259-1293},
-  year    = {2022},
-  publisher = {Springer},
-  doi     = {10.1007/s00466-022-02147-0}
-}
-
-@Article{ahuja.endtmayer.ea:multigoal-oriented,
-  author  = {K. Ahuja and B. Endtmayer and M.C. Steinbach and T. Wick},
-  title   = {Multigoal-oriented error estimation and mesh adaptivity for fluid-structure interaction},
-  journal = {Journal of Computational and Applied Mathematics},
-  volume  = {412},
-  pages   = {114315},
-  year    = {2022},
-  issn    = {0377-0427},
-  doi     = {10.1016/j.cam.2022.114315},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0377042722001340},
-  keywords = {Fluid-structure interaction, Dual-weighted residuals, Multigoal-oriented error estimation, Mesh adaptivity, Deal.II}
-}
-
-@Misc{fuest.heydari.ea:global,
-  author  = {Fuest, Mario and Heydari, Shahin and Knobloch, Petr and Lankeit, Johannes and Wick, Thomas},
-  title   = {Global existence of classical solutions and numerical simulations of a cancer invasion model},
-  doi     = {10.48550/ARXIV.2205.08168},
-  url     = {https://arxiv.org/abs/2205.08168},
-  keywords = {Numerical Analysis (math.NA), Analysis of PDEs (math.AP), FOS: Mathematics, FOS: Mathematics},
-  publisher = {arXiv},
-  year    = {2022},
-  copyright = {arXiv.org perpetual, non-exclusive license}
-}
-
-@Misc{jodlbauer.langer.ea:matrix-free,
-  author  = {Jodlbauer, Daniel and Langer, Ulrich and Wick, Thomas and Zulehner, Walter},
-  title   = {Matrix-free Monolithic Multigrid Methods for Stokes and Generalized Stokes Problems},
-  doi     = {10.48550/ARXIV.2205.15770},
-  url     = {https://arxiv.org/abs/2205.15770},
-  keywords = {Numerical Analysis (math.NA), FOS: Mathematics, FOS: Mathematics, G.1.8, 65M55},
-  publisher = {arXiv},
-  year    = {2022},
-  copyright = {Creative Commons Attribution 4.0 International}
-}
-
-@Article{murer.formica.ea:coupled,
-  author  = {Murer, Mauro and Formica, Giovanni and Milicchio, Franco and Morganti, Simone and Auricchio, Ferdinando},
-  journal = {The International Journal of Advanced Manufacturing Technology},
-  number  = {5},
-  pages   = {3269-3286},
-  title   = {A coupled multiphase Lagrangian-Eulerian fluid-dynamics framework for numerical simulation of Laser Metal Deposition process},
-  volume  = {120},
-  year    = {2022},
-  doi     = {10.1007/s00170-022-08763-7}
-}
-
-@Article{aggul.labovsky.ea:ns-,
-  title   = {{NS}-$\omega$ model for fluid--fluid interaction problems at high {Reynolds} numbers},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  volume  = {395},
-  pages   = {115052},
-  year    = {2022},
-  month   = may,
-  publisher = {Elsevier {BV}},
-  issn    = {0045-7825},
-  doi     = {10.1016/j.cma.2022.115052},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0045782522002663},
-  author  = {Mustafa Aggul and Alexander E. Labovsky and Kyle J. Schwiebert}
-}
-
-@Misc{fehling.bangerth:algorithms,
-  doi     = {10.48550/ARXIV.2206.06512},
-  url     = {https://arxiv.org/abs/2206.06512},
-  author  = {Fehling, Marc and Bangerth, Wolfgang},
-  keywords = {Numerical Analysis (math.NA), Mathematical Software (cs.MS), FOS: Mathematics, FOS: Computer and information sciences, G.1.8; G.4},
-  title   = {Algorithms for Parallel Generic $hp$-adaptive Finite Element Software},
-  publisher = {arXiv},
-  year    = {2022},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+@Article{munch.dravins.ea:stage-parallel,
+  author  = {Peter Munch and Ivo Dravins and Martin Kronbichler and Maya Neytcheva},
+  title   = {Stage-parallel fully implicit Runge-Kutta implementations with optimal multilevel preconditioners at the scaling limit},
+  journal = {submitted},
+  year    = {2022}
 }
 
 @Article{munch.heister.ea:efficient,
@@ -528,27 +324,62 @@
   doi     = {10.1007/978-3-031-07312-0_7}
 }
 
-@Article{munch.dravins.ea:stage-parallel,
-  author  = {Peter Munch and Ivo Dravins and Martin Kronbichler and Maya Neytcheva},
-  title   = {Stage-parallel fully implicit Runge-Kutta implementations with optimal multilevel preconditioners at the scaling limit},
-  journal = {submitted},
-  year    = {2022}
+@Article{murer.formica.ea:coupled,
+  author  = {Murer, Mauro and Formica, Giovanni and Milicchio, Franco and Morganti, Simone and Auricchio, Ferdinando},
+  journal = {The International Journal of Advanced Manufacturing Technology},
+  number  = {5},
+  pages   = {3269-3286},
+  title   = {A coupled multiphase Lagrangian-Eulerian fluid-dynamics framework for numerical simulation of Laser Metal Deposition process},
+  volume  = {120},
+  year    = {2022},
+  doi     = {10.1007/s00170-022-08763-7}
 }
 
-@Article{axelsson.dravins.ea:stage-parallel,
-  title   = {Stage-parallel preconditioners for implicit Runge-Kutta methods of arbitrary high order. Linear problems},
-  author  = {Owe Axelsson and Ivo Dravins and Maya Neytcheva},
-  journal = {submitted},
+@Article{negredo.van-hunen.ea:on,
+  title   = {On the origin of the {C}anary {I}slands: {I}nsights from mantle convection modelling},
+  journal = {Earth and Planetary Science Letters},
+  volume  = {584},
+  pages   = {117506},
   year    = {2022},
-  url     = {http://www.it.uu.se/research/publications/reports/2022-004/2022-004-nc.pdf}
+  issn    = {0012-821X},
+  doi     = {10.1016/j.epsl.2022.117506},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X2200142X},
+  author  = {Ana M. Negredo and Jeroen {van Hunen} and Juan Rodr\'{i}guez-Gonz\'{a}lez and Javier Fullea},
+  keywords = {Canary Islands, edge-driven convection, hot spots, mantle convection}
 }
 
-@Article{liu.mcbride.ea:vibration,
-  author  = {Zhaowei Liu and Andrew McBride and Prashant Saxena and Luca Heltai and Yilin Qu and Paul Steinmann},
-  journal = {International Journal for Numerical Methods in Engineering},
-  title   = {Vibration Analysis of Piezoelectric {Kirchhoff-Love} shells based on {Catmull-Clark} Subdivision Surfaces},
+@Article{oneill.aulbach:destabilization,
+  author  = {Craig O'Neill and Sonja Aulbach },
+  title   = {Destabilization of deep oxidized mantle drove the Great Oxidation Event},
+  journal = {Science Advances},
+  volume  = {8},
+  number  = {7},
+  pages   = {eabg1626},
   year    = {2022},
-  doi     = {10.1002/nme.7010}
+  doi     = {10.1126/sciadv.abg1626},
+  url     = {https://www.science.org/doi/abs/10.1126/sciadv.abg1626},
+  eprint  = {https://www.science.org/doi/pdf/10.1126/sciadv.abg1626}
+}
+
+@Article{orlando.della-rocca.ea:efficient,
+  title   = {An efficient and accurate implicit {DG} solver for the incompressible {N}avier-{S}tokes equations},
+  author  = {Orlando, G. and Della Rocca, A. and Barbante, P.F. and Bonaventura, L. and Parolini, N.},
+  doi     = {10.1002/fld.5098},
+  year    = {2022},
+  journal = {International Journal for Numerical Methods in Fluids}
+}
+
+@Article{palmiotto.ficini.ea:back-arc,
+  author  = {Palmiotto, Camilla and Ficini, Eleonora and Loreto, Maria Filomena and Muccini, Filippo and Cuffaro, Marco},
+  title   = {Back-Arc Spreading Centers and Superfast Subduction: {T}he Case of the {N}orthern {L}au Basin ({SW} {P}acific Ocean)},
+  journal = {Geosciences},
+  volume  = {12},
+  year    = {2022},
+  number  = {2},
+  article-number = {50},
+  url     = {https://www.mdpi.com/2076-3263/12/2/50},
+  issn    = {2076-3263},
+  doi     = {10.3390/geosciences12020050}
 }
 
 @Article{peschka.heltai:model,
@@ -561,41 +392,175 @@
   doi     = {10.1016/j.jcp.2022.111325}
 }
 
-@Article{arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.4},
-  author  = {Daniel Arndt and Wolfgang Bangerth and Marco Feder and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Simon Sticko and Bruno Turcksin and David Wells},
-  journal = {Journal of Numerical Mathematics},
-  doi     = {10.1515/jnma-2022-0054},
+@Article{piersanti.regazzoni.ea:3d-0d,
+  doi     = {10.1016/j.cma.2022.114607},
+  title   = {3D--0D closed-loop model for the simulation of cardiac biventricular electromechanics},
+  author  = {Piersanti, Roberto and Regazzoni, Francesco and Salvador, Matteo and Corno, Antonio F and Vergara, Christian and Quarteroni, Alfio and others},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  volume  = {391},
+  pages   = {114607},
   year    = {2022},
-  volume  = {30},
+  month   = mar,
+  publisher = {Elsevier}
+}
+
+@Article{quarteroni.dedee.ea:modeling,
+  doi     = {10.1090/bull/1738},
+  title   = {Modeling the cardiac electromechanical function: A mathematical journey},
+  author  = {Quarteroni, Alfio and Dede{\`{e}}, Luca and Regazzoni, Francesco},
+  journal = {Bulletin of the American Mathematical Society},
+  volume  = {59},
   number  = {3},
-  pages   = {231-246},
-  url     = {https://dealii.org/deal94-preprint.pdf}
+  pages   = {371--403},
+  year    = {2022},
+  month   = feb,
+  publisher = {American Mathematical Society ({AMS})}
 }
 
-@Article{jingchun.chengli.ea:on,
-  title   = {On the formation of thrust fault-related landforms in {M}ercury's {N}orthern {S}mooth {P}lains: {A} new mechanical model of the lithosphere},
-  journal = {Icarus},
-  pages   = {115197},
+@MastersThesis{quiroga:numerical,
+  author  = {Quiroga, David},
+  title   = {Numerical Models of Lithosphere Removal in the {S}ierra {N}evada de {S}anta {M}arta, {C}olombia},
+  pages   = {178},
+  school  = {University of Alberta},
   year    = {2022},
-  issn    = {0019-1035},
-  doi     = {10.1016/j.icarus.2022.115197},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0019103522002962},
-  author  = {Xie Jingchun and Huang Chengli and Zhang Mian},
-  keywords = {Mercury, Thrust fault, Lithospheric model, Formation, Numerical simulations}
+  doi     = {10.7939/r3-6mk4-sj26}
 }
 
-@Article{fang.zhang.ea:causal,
-  title   = {The causal mechanism of the {S}angihe Forearc Thrust, {M}olucca {S}ea, northeast {I}ndonesia, from numerical simulation},
-  journal = {Journal of Asian Earth Sciences},
-  volume  = {237},
-  pages   = {105350},
+@Article{regazzoni.salvador.ea:cardiac,
+  doi     = {10.1016/j.jcp.2022.111083},
+  author  = {F. Regazzoni and M. Salvador and P.C. Africa and M. Fedele and L. Dede{\`{e}} and A. Quarteroni},
+  title   = {A cardiac electromechanical model coupled with a lumped-parameter model for closed-loop blood circulation},
+  journal = {Journal of Computational Physics},
+  volume  = {457},
+  pages   = {111083},
   year    = {2022},
-  issn    = {1367-9120},
-  doi     = {10.1016/j.jseaes.2022.105350},
-  url     = {https://www.sciencedirect.com/science/article/pii/S1367912022002814},
-  author  = {Gui Fang and Jian Zhang and Tianyao Hao and Miao Dong and Chenghao Jiang and Yubei He},
-  keywords = {Forearc collision, Sangihe Arc, Halmahera Arc, Forearc thrusting, Numerical modeling}
+  month   = may,
+  publisher = {Elsevier {BV}}
+}
+
+@Article{regazzoni.salvador.ea:machine,
+  doi     = {10.1016/j.cma.2022.114825},
+  title   = {A machine learning method for real-time numerical simulations of cardiac electromechanics},
+  author  = {Regazzoni, Francesco and Salvador, Matteo and Dede', Luca and Quarteroni, Alfio},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  volume  = {393},
+  pages   = {114825},
+  year    = {2022},
+  month   = apr,
+  publisher = {Elsevier}
+}
+
+@Article{root.sebera.ea:benchmark,
+  author  = {Root, B. C. and Sebera, J. and Szwillus, W. and Thieulot, C. and Martinec, Z. and Fullea, J.},
+  title   = {Benchmark forward gravity schemes: the gravity field of a realistic lithosphere model {WINTERC-G}},
+  journal = {Solid Earth},
+  volume  = {13},
+  year    = {2022},
+  number  = {5},
+  pages   = {849--873},
+  url     = {https://se.copernicus.org/articles/13/849/2022/},
+  doi     = {10.5194/se-13-849-2022}
+}
+
+@Article{roth.schroder.ea:neural,
+  author  = {Julian Roth and Max Schr{\"o}der and Thomas Wick},
+  title   = {Neural network guided adjoint computations in dual weighted residual error estimation},
+  journal = {SN Applied Sciences},
+  year    = {2022},
+  month   = jan,
+  day     = {31},
+  volume  = {4},
+  number  = {2},
+  pages   = {62},
+  abstract = {In this work, we are concerned with neural network guided goal-oriented a posteriori error estimation and adaptivity using the dual weighted residual method. The primal problem is solved using classical Galerkin finite elements. The adjoint problem is solved in strong form with a feedforward neural network using two or three hidden layers. The main objective of our approach is to explore alternatives for solving the adjoint problem with greater potential of a numerical cost reduction. The proposed algorithm is based on the general goal-oriented error estimation theorem including both linear and nonlinear stationary partial differential equations and goal functionals. Our developments are substantiated with some numerical experiments that include comparisons of neural network computed adjoints and classical finite element solutions of the adjoints. In the programming software, the open-source library deal.II is successfully coupled with LibTorch, the PyTorch C++
+            application programming interface.},
+  issn    = {2523-3971},
+  doi     = {10.1007/s42452-022-04938-9}
+}
+
+@Article{sabanskis.dadzis.ea:application,
+  doi     = {10.3390/cryst12020174},
+  year    = {2022},
+  month   = jan,
+  publisher = {{MDPI} {AG}},
+  volume  = {12},
+  number  = {2},
+  pages   = {174},
+  author  = {Andrejs Sabanskis and Kaspars Dadzis and Robert Menzel and J{\={a}}nis Virbulis},
+  title   = {Application of the {A}lexander{\textendash}{H}aasen Model for Thermally Stimulated Dislocation Generation in {FZ} Silicon Crystals},
+  journal = {Crystals}
+}
+
+@Article{salvador.regazzoni.ea:role,
+  doi     = {10.1016/j.compbiomed.2021.105203},
+  title   = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
+  author  = {Salvador, Matteo and Regazzoni, Francesco and Pagani, Stefano and Dede', Luca and Trayanova, Natalia and Quarteroni, Alfio},
+  journal = {Computers in Biology and Medicine},
+  volume  = {142},
+  pages   = {105203},
+  year    = {2022},
+  month   = mar,
+  publisher = {Elsevier}
+}
+
+@Article{salvador.regazzoni.ea:role*1,
+  doi     = {10.1016/j.compbiomed.2021.105203},
+  year    = {2022},
+  month   = mar,
+  publisher = {Elsevier {BV}},
+  volume  = {142},
+  pages   = {105203},
+  author  = {Matteo Salvador and Francesco Regazzoni and Stefano Pagani and Luca Ded{\`{e}} and Natalia Trayanova and Alfio Quarteroni},
+  title   = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
+  journal = {Computers in Biology and Medicine}
+}
+
+@Article{schussnig.pacheco.ea:efficient,
+  title   = {Efficient split-step schemes for fluid--structure interaction involving incompressible generalised {N}ewtonian flows},
+  journal = {Computers \& Structures},
+  volume  = {260},
+  pages   = {106718},
+  year    = {2022},
+  issn    = {0045-7949},
+  doi     = {10.1016/j.compstruc.2021.106718},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0045794921002406},
+  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
+}
+
+@Article{stein.comeau.ea:numerical,
+  title   = {Numerical study on the style of delamination},
+  journal = {Tectonophysics},
+  pages   = {229276},
+  year    = {2022},
+  issn    = {0040-1951},
+  doi     = {10.1016/j.tecto.2022.229276},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0040195122000701},
+  author  = {Claudia Stein and Matthew Comeau and Michael Becken and Ulrich Hansen},
+  keywords = {Numerical modelling delamination, Rayleigh-Taylor instability phase transition rheology}
+}
+
+@Article{tsagkari.connelly.ea:role,
+  doi     = {10.1038/s41522-022-00300-4},
+  year    = 2022,
+  month   = apr,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume  = {8},
+  number  = {1},
+  author  = {Erifyli Tsagkari and Stephanie Connelly and Zhaowei Liu and Andrew McBride and William T. Sloan},
+  title   = {The role of shear dynamics in biofilm formation},
+  journal = {npj Biofilms and Microbiomes}
+}
+
+@Article{vergara.stella.ea:computational,
+  author  = {Vergara, Christian and Stella, Simone and Maines, Massimiliano and Africa, Pasquale Claudio and Catanzariti, Domenico and Dematt\`{e}, Cristina and Centonze, Maurizio and Nobile, Fabio and Quarteroni, Alfio and Del Greco, Maurizio},
+  title   = {Computational electrophysiology of the coronary sinus branches based on electro-anatomical mapping for the prediction of the latest activated region},
+  journal = {Medical \& Biological Engineering \& Computing},
+  volume  = {60},
+  number  = {8},
+  pages   = {2307--2319},
+  year    = {2022},
+  month   = jun,
+  doi     = {10.1007/s11517-022-02610-3}
 }
 
 @MastersThesis{wik:high-performance,
@@ -611,14 +576,49 @@
   month   = jun
 }
 
-@InCollection{basava.mang.ea:adaptive,
-  doi     = {10.1007/978-3-030-92672-4_8},
+@Article{zha.lin.ea:effects,
+  author  = {Zha, Caicai and Lin, Jian and Zhou, Zhiyuan and Xu, Min and Zhang, Xubo},
+  title   = {Effects of Hotspot-Induced Long-Wavelength Mantle Melting Variations on Magmatic Segmentation at the {R}eykjanes Ridge: Insights From 3D Geodynamic Modeling},
+  journal = {Journal of Geophysical Research: Solid Earth},
+  volume  = {127},
+  number  = {3},
+  pages   = {e2021JB023244},
+  doi     = {10.1029/2021JB023244},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2021JB023244},
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021JB023244},
+  note    = {e2021JB023244 2021JB023244},
+  year    = {2022}
+}
+
+@Article{zhang.shahabad.ea:3-dimensional,
+  author  = {Zhang, Zhi-Dong and Shahabad, Shahriar Imani and Ibhadode, Osezua and Dibia, Chinedu Francis and Bonakdar, Ali and Toyserkani, Ehsan},
+  title   = {3-Dimensional Heat Transfer Modeling for Laser Powder Bed Fusion Additive Manufacturing Using Parallel Computing and Adaptive Mesh},
+  journal = {SSRN Electronic Journal},
   year    = {2022},
-  publisher = {Springer International Publishing},
-  pages   = {191--215},
-  author  = {Seshadri Basava and Katrin Mang and Mirjam Walloth and Thomas Wick and Winnifried Wollner},
-  title   = {Adaptive and Pressure-Robust Discretization of Incompressible Pressure-Driven Phase-Field Fracture},
-  booktitle = {Non-standard Discretisation Methods in Solid Mechanics}
+  url     = {https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4108005},
+  doi     = {10.2139/ssrn.4108005}
+}
+
+@Misc{zingaro.bucelli.ea:modeling,
+  doi     = {10.48550/ARXIV.2208.09435},
+  url     = {https://arxiv.org/abs/2208.09435},
+  author  = {Zingaro, Alberto and Bucelli, Michele and Fumagalli, Ivan and Dede', Luca and Quarteroni, Alfio},
+  keywords = {Numerical Analysis (math.NA), Fluid Dynamics (physics.flu-dyn), Medical Physics (physics.med-ph), Quantitative Methods (q-bio.QM), FOS: Mathematics, FOS: Mathematics, FOS: Physical sciences, FOS: Physical sciences, FOS: Biological sciences, FOS: Biological sciences, G.1; J.3, 65N30, 65M60, 65Z05, 76Z05, 76D05, 92C35},
+  title   = {Modeling isovolumetric phases in cardiac flows by an Augmented Resistive Immersed Implicit Surface Method},
+  publisher = {arXiv},
+  year    = {2022},
+  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+}
+
+@Article{zingaro.fumagalli.ea:geometric,
+  author  = {Zingaro, Alberto and Fumagalli, Ivan and Fedele, Marco and Africa, Pasquale Claudio and Dede', Luca and Quarteroni, Alfio and Corno, Antonio Francesco},
+  title   = {A geometric multiscale model for the numerical simulation of blood flow in the human left heart},
+  journal = {Discrete and Continuous Dynamical Systems - S},
+  volume  = {15},
+  number  = {8},
+  pages   = {2391--2427},
+  year    = {2022},
+  doi     = {10.3934/dcdss.2022052}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
Part of #389. Follow-up to #391.

This PR enables the `sort` feature of `bibtool`. In the previous PR, we only adjusted the citekeys and the general formatting. Now, we enable the default sorting mechanism, which is [sorting by the citekey](https://github.com/ge-ne/bibtool/blob/97fc3d04655c855ca2794c40303b12fee3fbd273/lib/default.rsc#L113).

I haven't checked if all entries are preserved. But a good indicator that we only move code around is that the number of additions equals the number of deletions (plus the two lines in the configuration file).