### PR TITLE
bibtool: use braces instead of double quotes as delimiters

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -9,4 +9,7 @@ print.line.length = 999
 print.use.tab = off
 print.wide.equal = on
 
+% use braces instead of double quotes as delimiters
+resource braces
+
 sort = on

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1901,13 +1901,13 @@
 }
 
 @Article{wang.rudraraju.ea:three,
-  title   = "A three dimensional field formulation, and isogeometric solutions to point and line defects using Toupin's theory of gradient elasticity at finite strains",
-  journal = "Journal of the Mechanics and Physics of Solids",
-  volume  = "94",
-  pages   = "336--361",
-  year    = "2016",
-  doi     = "10.1016/j.jmps.2016.03.028",
-  author  = "Z. Wang and S. Rudraraju and K. Garikipati"
+  title   = {A three dimensional field formulation, and isogeometric solutions to point and line defects using Toupin's theory of gradient elasticity at finite strains},
+  journal = {Journal of the Mechanics and Physics of Solids},
+  volume  = {94},
+  pages   = {336--361},
+  year    = {2016},
+  doi     = {10.1016/j.jmps.2016.03.028},
+  author  = {Z. Wang and S. Rudraraju and K. Garikipati}
 }
 
 @Article{white.castelletto.ea:block-partitioned,

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -187,15 +187,15 @@
 }
 
 @InProceedings{berselli.wells.ea:spatial,
-  author  = "Berselli, L. C. and Wells, D. and Xie, X. and Iliescu, T.",
-  editor  = "Salvetti, Maria Vittoria and Armenio, Vincenzo and Fr{\"o}hlich, Jochen and Geurts, Bernard J. and Kuerten, Hans",
-  title   = "Spatial Filtering for Reduced Order Modeling",
-  booktitle = "Direct and Large-Eddy Simulation XI",
-  year    = "2019",
-  publisher = "Springer International Publishing",
-  address = "Cham",
-  pages   = "151--157",
-  doi     = "10.1007/978-3-030-04915-7_21"
+  author  = {Berselli, L. C. and Wells, D. and Xie, X. and Iliescu, T.},
+  editor  = {Salvetti, Maria Vittoria and Armenio, Vincenzo and Fr{\"o}hlich, Jochen and Geurts, Bernard J. and Kuerten, Hans},
+  title   = {Spatial Filtering for Reduced Order Modeling},
+  booktitle = {Direct and Large-Eddy Simulation XI},
+  year    = {2019},
+  publisher = {Springer International Publishing},
+  address = {Cham},
+  pages   = {151--157},
+  doi     = {10.1007/978-3-030-04915-7_21}
 }
 
 @PhDThesis{bettendorf:optimum,
@@ -284,14 +284,14 @@
 
 @InProceedings{borregales.radu:higher,
   doi     = {10.1007/978-3-319-96415-7_49},
-  author  = "Borregales, Manuel and Radu, Florin Adrian",
-  editor  = "Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin",
-  title   = "Higher Order Space-Time Elements for a Non-linear Biot Model",
-  booktitle = "Numerical Mathematics and Advanced Applications ENUMATH 2017",
-  year    = "2019",
-  publisher = "Springer International Publishing",
-  address = "Cham",
-  pages   = "541--549"
+  author  = {Borregales, Manuel and Radu, Florin Adrian},
+  editor  = {Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin},
+  title   = {Higher Order Space-Time Elements for a Non-linear Biot Model},
+  booktitle = {Numerical Mathematics and Advanced Applications ENUMATH 2017},
+  year    = {2019},
+  publisher = {Springer International Publishing},
+  address = {Cham},
+  pages   = {541--549}
 }
 
 @InCollection{both.kocher:numerical,
@@ -628,14 +628,14 @@
 }
 
 @InProceedings{fan.wick.ea:phase-field,
-  author  = "Meng Fan and Thomas Wick and Yan Jin",
-  editor  = "Tobias Gleim and Stephan Lange",
-  title   = "A phase-field model for mixed-mode fracture",
-  booktitle = "8th GACM Colloquium on Computational Mechanics",
-  publisher = "Kassel University Press",
-  pages   = "51--54",
-  year    = "2019",
-  url     = "https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9"
+  author  = {Meng Fan and Thomas Wick and Yan Jin},
+  editor  = {Tobias Gleim and Stephan Lange},
+  title   = {A phase-field model for mixed-mode fracture},
+  booktitle = {8th GACM Colloquium on Computational Mechanics},
+  publisher = {Kassel University Press},
+  pages   = {51--54},
+  year    = {2019},
+  url     = {https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9}
 }
 
 @Article{fehn.kronbichler.ea:high-order,

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -72,16 +72,16 @@
 }
 
 @Article{assanelli.luoni.ea:tectono-metamorphic,
-  author  = "Assanelli, M. and Luoni, P. and Rebay, G. and Roda, M. and Spalla, M. I.",
-  title   = "Tectono-Metamorphic Evolution of Serpentinites from Lanzo Valleys Subduction Complex (Piemonte--Sesia-Lanzo Zone Boundary, Western Italian Alps)",
-  journal = "Minerals",
-  year    = "2020",
-  volume  = "10",
-  number  = "11",
-  pages   = "985",
-  issn    = "2075-163X",
-  doi     = "10.3390/min10110985",
-  url     = "https://www.mdpi.com/2075-163X/10/11/985"
+  author  = {Assanelli, M. and Luoni, P. and Rebay, G. and Roda, M. and Spalla, M. I.},
+  title   = {Tectono-Metamorphic Evolution of Serpentinites from Lanzo Valleys Subduction Complex (Piemonte--Sesia-Lanzo Zone Boundary, Western Italian Alps)},
+  journal = {Minerals},
+  year    = {2020},
+  volume  = {10},
+  number  = {11},
+  pages   = {985},
+  issn    = {2075-163X},
+  doi     = {10.3390/min10110985},
+  url     = {https://www.mdpi.com/2075-163X/10/11/985}
 }
 
 @Article{badia.martin.ea:generic,
@@ -255,15 +255,15 @@
 }
 
 @Article{endtmayer.langer.ea:multigoal-oriented,
-  title   = "Multigoal-oriented optimal control problems with nonlinear PDE constraints",
-  journal = "Computers {\&} Mathematics with Applications",
-  volume  = "79",
-  number  = "10",
-  pages   = "3001 - 3026",
-  year    = "2020",
-  issn    = "0898-1221",
-  doi     = "10.1016/j.camwa.2020.01.005",
-  author  = "B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner"
+  title   = {Multigoal-oriented optimal control problems with nonlinear PDE constraints},
+  journal = {Computers {\&} Mathematics with Applications},
+  volume  = {79},
+  number  = {10},
+  pages   = {3001 - 3026},
+  year    = {2020},
+  issn    = {0898-1221},
+  doi     = {10.1016/j.camwa.2020.01.005},
+  author  = {B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner}
 }
 
 @Article{endtmayer.langer.ea:two-side,
@@ -368,15 +368,15 @@
 }
 
 @Article{glerum.brune.ea:victoria,
-  author  = "Glerum, A. and Brune, S. and Stamps, D. S. and Strecker, M. R.",
-  title   = "Victoria continental microplate dynamics controlled by the lithospheric strength distribution of the East African Rift",
-  journal = "Nature Communications",
-  year    = "2020",
-  volume  = "11",
-  number  = "1",
-  issn    = "2041-1723",
-  doi     = "10.1038/s41467-020-16176-x",
-  url     = "http://www.nature.com/articles/s41467-020-16176-x"
+  author  = {Glerum, A. and Brune, S. and Stamps, D. S. and Strecker, M. R.},
+  title   = {Victoria continental microplate dynamics controlled by the lithospheric strength distribution of the East African Rift},
+  journal = {Nature Communications},
+  year    = {2020},
+  volume  = {11},
+  number  = {1},
+  issn    = {2041-1723},
+  doi     = {10.1038/s41467-020-16176-x},
+  url     = {http://www.nature.com/articles/s41467-020-16176-x}
 }
 
 @Article{grieshaber.mcbride.ea:convergence,
@@ -407,15 +407,15 @@
 }
 
 @Article{heister.wick:pfm-cracks,
-  title   = "pfm-cracks: A parallel-adaptive framework for phase-field fracture propagation",
-  journal = "Software Impacts",
-  volume  = "6",
-  pages   = "100045",
-  year    = "2020",
-  issn    = "2665-9638",
-  doi     = "10.1016/j.simpa.2020.100045",
-  url     = "http://www.sciencedirect.com/science/article/pii/S2665963820300361",
-  author  = "Timo Heister and Thomas Wick"
+  title   = {pfm-cracks: A parallel-adaptive framework for phase-field fracture propagation},
+  journal = {Software Impacts},
+  volume  = {6},
+  pages   = {100045},
+  year    = {2020},
+  issn    = {2665-9638},
+  doi     = {10.1016/j.simpa.2020.100045},
+  url     = {http://www.sciencedirect.com/science/article/pii/S2665963820300361},
+  author  = {Timo Heister and Thomas Wick}
 }
 
 @Article{heltai.lei:priori,
@@ -443,15 +443,15 @@
 }
 
 @Article{heyn.conrad.ea:core-mantle,
-  title   = "Core-mantle boundary topography and its relation to the viscosity structure of the lowermost mantle",
-  journal = "Earth and Planetary Science Letters",
-  volume  = "543",
-  pages   = "116358",
-  year    = "2020",
-  issn    = "0012-821X",
-  doi     = "10.1016/j.epsl.2020.116358",
-  url     = "http://www.sciencedirect.com/science/article/pii/S0012821X20303022",
-  author  = "Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes"
+  title   = {Core-mantle boundary topography and its relation to the viscosity structure of the lowermost mantle},
+  journal = {Earth and Planetary Science Letters},
+  volume  = {543},
+  pages   = {116358},
+  year    = {2020},
+  issn    = {0012-821X},
+  doi     = {10.1016/j.epsl.2020.116358},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0012821X20303022},
+  author  = {Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes}
 }
 
 @Article{heyn.conrad.ea:how,
@@ -467,15 +467,15 @@
 }
 
 @InBook{hoggard.austermann.ea:mantle,
-  author  = "Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon",
-  editor  = "H. Marquardt, M. Ballmer",
-  chapter = "Observational estimates of dynamic topography through space and time",
-  title   = "Mantle convection and surface expressions",
-  series  = "AGU Geophysical Monograph Series",
-  year    = "2021",
-  address = "Washington, D.C.",
-  publisher = "AGU",
-  doi     = "10.1002/9781119528609.ch15"
+  author  = {Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon},
+  editor  = {H. Marquardt, M. Ballmer},
+  chapter = {Observational estimates of dynamic topography through space and time},
+  title   = {Mantle convection and surface expressions},
+  series  = {AGU Geophysical Monograph Series},
+  year    = {2021},
+  address = {Washington, D.C.},
+  publisher = {AGU},
+  doi     = {10.1002/9781119528609.ch15}
 }
 
 @Article{jerg.austermuhl.ea:diffuse,
@@ -491,14 +491,14 @@
 }
 
 @Article{jodlbauer.langer.ea:matrix-free,
-  title   = "Matrix-free multigrid solvers for phase-field fracture problems",
-  journal = "Computer Methods in Applied Mechanics and Engineering",
-  volume  = "372",
-  pages   = "113431",
-  year    = "2020",
-  issn    = "0045-7825",
-  doi     = "10.1016/j.cma.2020.113431",
-  author  = "D. Jodlbauer and U. Langer and T. Wick"
+  title   = {Matrix-free multigrid solvers for phase-field fracture problems},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  volume  = {372},
+  pages   = {113431},
+  year    = {2020},
+  issn    = {0045-7825},
+  doi     = {10.1016/j.cma.2020.113431},
+  author  = {D. Jodlbauer and U. Langer and T. Wick}
 }
 
 @Article{jodlbauer.langer.ea:parallel,
@@ -696,14 +696,14 @@
 }
 
 @Article{naliboff.glerum.ea:development,
-  author  = "Naliboff, J.B. and Glerum, A. and Brune, S. and Peron-Pinvidic, G. and Wrona, T.",
-  title   = "Development of 3-D rift heterogeneity through fault network evolution",
-  journal = "Geophysical Research Letters",
-  year    = "2020",
-  volume  = "47",
-  number  = "e2019GL086611",
-  doi     = "10.1029/2019GL086611",
-  opturl  = "https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GL086611"
+  author  = {Naliboff, J.B. and Glerum, A. and Brune, S. and Peron-Pinvidic, G. and Wrona, T.},
+  title   = {Development of 3-D rift heterogeneity through fault network evolution},
+  journal = {Geophysical Research Letters},
+  year    = {2020},
+  volume  = {47},
+  number  = {e2019GL086611},
+  doi     = {10.1029/2019GL086611},
+  opturl  = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GL086611}
 }
 
 @Article{nayak.cojean.ea:evaluating,
@@ -920,14 +920,14 @@
 
 @Article{wheeler.wick.ea:ipacs--integrated-phase-field-advanced-crack-propagation-simulator--an-adaptive--parallel--physics-based-discretization-phase-field-framework-for-fracture-propagation-in-porous-media,
   title   = {{IPACS: Integrated Phase-Field Advanced Crack Propagation Simulator. An adaptive, parallel, physics-based-discretization phase-field framework for fracture propagation in porous media}},
-  journal = "Computer Methods in Applied Mechanics and Engineering",
-  volume  = "367",
-  pages   = "113124",
-  year    = "2020",
-  issn    = "0045-7825",
-  doi     = "10.1016/j.cma.2020.113124",
-  url     = "http://www.sciencedirect.com/science/article/pii/S0045782520303091",
-  author  = "Mary F. Wheeler and Thomas Wick and Sanghyun Lee"
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  volume  = {367},
+  pages   = {113124},
+  year    = {2020},
+  issn    = {0045-7825},
+  doi     = {10.1016/j.cma.2020.113124},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0045782520303091},
+  author  = {Mary F. Wheeler and Thomas Wick and Sanghyun Lee}
 }
 
 @Article{wick.wollner:optimization,
@@ -945,14 +945,14 @@
 }
 
 @Book{wick:multiphysics,
-  author  = "Thomas Wick",
-  title   = "Multiphysics Phase-Field Fracture: Modeling, Adaptive Discretizations, and Solvers",
-  year    = "2020",
-  publisher = "De Gruyter",
-  address = "Berlin, Boston",
-  isbn    = "978-3-11-049739-7",
-  doi     = "10.1515/9783110497397",
-  url     = "https://www.degruyter.com/view/title/523232"
+  author  = {Thomas Wick},
+  title   = {Multiphysics Phase-Field Fracture: Modeling, Adaptive Discretizations, and Solvers},
+  year    = {2020},
+  publisher = {De Gruyter},
+  address = {Berlin, Boston},
+  isbn    = {978-3-11-049739-7},
+  doi     = {10.1515/9783110497397},
+  url     = {https://www.degruyter.com/view/title/523232}
 }
 
 @Article{wilde.kramer.ea:semi-lagrangian-lattice-boltzmann-method-for-compressible-flows,

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -58,11 +58,11 @@
 }
 
 @Article{barrionuevo.liu.ea:influence,
-  author  = "Barrionuevo, M. and Liu, S. and Mescua, J. and Yagupsky, D. and Quinteros, J. and Giambiagi, L. and Sobolev, S. V. and Piceda, C. R. and Strecker, M. R.",
-  title   = "The influence of variations in crustal composition and lithospheric strength on the evolution of deformation processes in the southern Central Andes: insights from geodynamic models",
-  journal = "International Journal of Earth Sciences",
-  year    = "2021",
-  doi     = "10.1007/s00531-021-01982-5"
+  author  = {Barrionuevo, M. and Liu, S. and Mescua, J. and Yagupsky, D. and Quinteros, J. and Giambiagi, L. and Sobolev, S. V. and Piceda, C. R. and Strecker, M. R.},
+  title   = {The influence of variations in crustal composition and lithospheric strength on the evolution of deformation processes in the southern Central Andes: insights from geodynamic models},
+  journal = {International Journal of Earth Sciences},
+  year    = {2021},
+  doi     = {10.1007/s00531-021-01982-5}
 }
 
 @Article{beuchler.endtmayer.ea:goal,
@@ -583,7 +583,7 @@
 
 @Article{lee.saxena.ea:contributions-from-lithospheric-and-upper-mantle-heterogeneities-to-upper-crustal-seismicity-in-the-korean-peninsula,
   author  = {Lee, Sungho and Saxena, Arushi and Song, Jung-Hun and Rhie, Junkee and Choi, Eunseo},
-  title   = "{Contributions from lithospheric and upper-mantle heterogeneities to upper crustal seismicity in the {K}orean {P}eninsula}",
+  title   = {{Contributions from lithospheric and upper-mantle heterogeneities to upper crustal seismicity in the {K}orean {P}eninsula}},
   journal = {Geophysical Journal International},
   year    = {2021},
   month   = dec,
@@ -886,7 +886,7 @@
 
 @Article{saxena.choi.ea:seismicity-in-the-central-and-southeastern-united-states-due-to-upper-mantle-heterogeneities,
   author  = {Saxena, Arushi and Choi, Eunseo and Powell, Christine A and Aslam, Khurram S},
-  title   = "{Seismicity in the central and southeastern United States due to upper mantle heterogeneities}",
+  title   = {{Seismicity in the central and southeastern United States due to upper mantle heterogeneities}},
   journal = {Geophysical Journal International},
   volume  = {225},
   number  = {3},
@@ -999,12 +999,12 @@
 }
 
 @MastersThesis{withers:modelling,
-  author  = "Withers, Craig",
-  title   = "Modelling slab age and crustal thickness: numerical approaches to drivers of compressive stresses in the overriding plate in Andean style subduction zone systems",
-  year    = "2021",
-  publisher = "Durham University",
-  school  = "Durham theses",
-  opturl  = "http://etheses.dur.ac.uk/13836/"
+  author  = {Withers, Craig},
+  title   = {Modelling slab age and crustal thickness: numerical approaches to drivers of compressive stresses in the overriding plate in Andean style subduction zone systems},
+  year    = {2021},
+  publisher = {Durham University},
+  school  = {Durham theses},
+  opturl  = {http://etheses.dur.ac.uk/13836/}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -278,13 +278,13 @@
 }
 
 @MastersThesis{lorencio-abril:modelo,
-  author  = "Lorencio Abril, Jose Antonio",
-  title   = "Un modelo en elementos finitos para estudiar las deformaciones del tejido mamario",
-  school  = "Universidad de Murcia",
-  year    = "2022",
+  author  = {Lorencio Abril, Jose Antonio},
+  title   = {Un modelo en elementos finitos para estudiar las deformaciones del tejido mamario},
+  school  = {Universidad de Murcia},
+  year    = {2022},
   month   = jul,
-  url     = "https://github.com/Lorenc1o/University_Notes/blob/main/ComputerScience/TFG/TFG_FEM.pdf",
-  note    = "Bachelor's Thesis"
+  url     = {https://github.com/Lorenc1o/University_Notes/blob/main/ComputerScience/TFG/TFG_FEM.pdf},
+  note    = {Bachelor's Thesis}
 }
 
 @PhDThesis{mang:phase-field,


### PR DESCRIPTION
Part of #389.

This is just a cosmetic change to use braces as delimiters consistently in all bib files.