### PR TITLE
use three letter month macros

### DIFF
--- a/publications-2001.bib
+++ b/publications-2001.bib
@@ -8,7 +8,7 @@
   volume  = {9},
   number  = {02},
   pages   = {575--591},
-  month   = {jun},
+  month   = jun,
   doi     = {10.1142/s0218396x01000668},
   publisher = {World Scientific Pub Co Pte Lt}
 }
@@ -21,7 +21,7 @@
   volume  = {23},
   number  = {3},
   pages   = {910--939},
-  month   = {jan},
+  month   = jan,
   doi     = {10.1137/s1064827599365501},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
@@ -33,7 +33,7 @@
   year    = {2001},
   volume  = {10},
   pages   = {1--102},
-  month   = {may},
+  month   = may,
   doi     = {10.1017/s0962492901000010},
   publisher = {Cambridge University Press ({CUP})}
 }
@@ -46,7 +46,7 @@
   volume  = {39},
   number  = {1},
   pages   = {264--285},
-  month   = {jan},
+  month   = jan,
   doi     = {10.1137/s0036142900371544},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -534,7 +534,7 @@
   volume  = {28},
   number  = {1},
   pages   = {111--132},
-  month   = {jan},
+  month   = jan,
   doi     = {10.1002/cnm.1487},
   publisher = {Wiley}
 }

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -9,7 +9,7 @@
   pages   = {062401},
   numpages = {12},
   year    = {2014},
-  month   = {Dec},
+  month   = dec,
   publisher = {American Physical Society},
   doi     = {10.1103/PhysRevE.90.062401},
   url     = {https://link.aps.org/doi/10.1103/PhysRevE.90.062401}
@@ -267,7 +267,7 @@
   year    = {2014},
   volume  = {277},
   pages   = {260--280},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1016/j.cma.2014.04.013},
   publisher = {Elsevier {BV}}
 }
@@ -930,7 +930,7 @@
   volume  = {27},
   number  = {2},
   pages   = {182--200},
-  month   = {sep},
+  month   = sep,
   doi     = {10.1002/ca.22313},
   publisher = {Wiley}
 }
@@ -1230,7 +1230,7 @@
   year    = {2014},
   volume  = {48},
   pages   = {23--37},
-  month   = {nov},
+  month   = nov,
   doi     = {10.1016/j.euromechsol.2014.03.007},
   publisher = {Elsevier {BV}}
 }

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -1306,7 +1306,7 @@
   year    = {2015},
   volume  = {50},
   pages   = {132--151},
-  month   = {mar},
+  month   = mar,
   doi     = {10.1016/j.euromechsol.2014.10.005},
   publisher = {Elsevier {BV}}
 }

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -57,7 +57,7 @@
   volume  = {69},
   number  = {3},
   pages   = {281--317},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1093/qjmam/hbw008},
   publisher = {Oxford University Press ({OUP})}
 }
@@ -133,7 +133,7 @@
   volume  = {38},
   number  = {5},
   pages   = {S78--S100},
-  month   = {jan},
+  month   = jan,
   issn    = {1064-8275},
   doi     = {10.1137/15M1026110},
   note    = {Unconfirmed citation},
@@ -198,7 +198,7 @@
   volume  = {37},
   number  = {3},
   pages   = {1245--1273},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1093/imanum/drw042},
   publisher = {Oxford University Press ({OUP})}
 }
@@ -266,7 +266,7 @@
   volume  = {38},
   number  = {5},
   pages   = {C471--C503},
-  month   = {jan},
+  month   = jan,
   issn    = {1064-8275},
   doi     = {10.1137/15M1040049},
   note    = {Unconfirmed citation},
@@ -347,7 +347,7 @@
   volume  = {38},
   number  = {2},
   pages   = {A668--A690},
-  month   = {jan},
+  month   = jan,
   issn    = {1064-8275},
   doi     = {10.1137/15M1032156},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
@@ -361,7 +361,7 @@
   volume  = {16},
   number  = {6},
   pages   = {D4016002},
-  month   = {dec},
+  month   = dec,
   issn    = {1532-3641},
   doi     = {10.1061/(ASCE)GM.1943-5622.0000558},
   publisher = {American Society of Civil Engineers ({ASCE})}
@@ -386,7 +386,7 @@
   volume  = {85},
   number  = {302},
   pages   = {2609--2638},
-  month   = {mar},
+  month   = mar,
   doi     = {10.1090/mcom/3093},
   publisher = {American Mathematical Society ({AMS})}
 }
@@ -407,7 +407,7 @@
   volume  = {43},
   number  = {1},
   pages   = {1--32},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1145/2835175},
   publisher = {Association for Computing Machinery ({ACM})}
 }
@@ -419,7 +419,7 @@
   year    = {2016},
   volume  = {308},
   pages   = {151--181},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1016/j.cma.2016.05.011},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}}
@@ -472,7 +472,7 @@
   booktitle = {46th {AIAA} Thermophysics Conference},
   year    = {2016},
   address = {Reston, Virginia},
-  month   = {jun},
+  month   = jun,
   publisher = {American Institute of Aeronautics and Astronautics},
   doi     = {10.2514/6.2016-3386},
   note    = {Unconfirmed citation}
@@ -497,7 +497,7 @@
   volume  = {433},
   number  = {1},
   pages   = {603--621},
-  month   = {jan},
+  month   = jan,
   doi     = {10.1016/j.jmaa.2015.07.054},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}},
@@ -523,7 +523,7 @@
   volume  = {58},
   number  = {1},
   pages   = {91--105},
-  month   = {apr},
+  month   = apr,
   issn    = {0178-7675},
   doi     = {10.1007/s00466-016-1283-1},
   publisher = {Springer Nature}
@@ -655,7 +655,7 @@
   volume  = {38},
   number  = {3},
   pages   = {C280--C306},
-  month   = {jan},
+  month   = jan,
   issn    = {1064-8275},
   doi     = {10.1137/15m1010798},
   note    = {Unconfirmed citation},
@@ -685,7 +685,7 @@
   title   = {Edge coloring in unstructured CFD codes},
   journal = {arxiv.org},
   year    = {2016},
-  month   = {jan},
+  month   = jan,
   archiveprefix = {arXiv},
   arxivid = {1601.07613},
   eprint  = {http://arxiv.org/abs/1601.07613v2},
@@ -944,7 +944,7 @@
   year    = {2016},
   volume  = {92},
   pages   = {313--344},
-  month   = {jul},
+  month   = jul,
   doi     = {10.1016/j.jmps.2016.04.004},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}}
@@ -1026,7 +1026,7 @@
   volume  = {32},
   number  = {2},
   pages   = {266--287},
-  month   = {oct},
+  month   = oct,
   doi     = {10.1177/1094342016671790},
   publisher = {{SAGE} Publications},
   url     = {https://mediatum.ub.tum.de/1272587}
@@ -1051,7 +1051,7 @@
   volume  = {437},
   number  = {1},
   pages   = {645--667},
-  month   = {may},
+  month   = may,
   doi     = {10.1016/j.jmaa.2016.01.022},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}},
@@ -1190,7 +1190,7 @@
   title   = {{Extending DUNE: The dune-xt modules}},
   journal = {arxiv.org},
   year    = {2016},
-  month   = {feb},
+  month   = feb,
   archiveprefix = {arXiv},
   arxivid = {1602.08991},
   eprint  = {1602.08991},
@@ -1304,7 +1304,7 @@
   volume  = {35},
   number  = {10},
   pages   = {2209--2217},
-  month   = {oct},
+  month   = oct,
   doi     = {10.1109/tmi.2016.2553156},
   publisher = {Institute of Electrical and Electronics Engineers ({IEEE})}
 }
@@ -1336,7 +1336,7 @@
   volume  = {23},
   number  = {5},
   pages   = {848--864},
-  month   = {jun},
+  month   = jun,
   doi     = {10.1002/nla.2057},
   note    = {Unconfirmed citation},
   publisher = {Wiley}
@@ -1350,7 +1350,7 @@
   volume  = {38},
   number  = {5},
   pages   = {S25--S47},
-  month   = {jan},
+  month   = jan,
   doi     = {10.1137/15m1021167},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
@@ -1361,7 +1361,7 @@
   booktitle = {2016 14th International Conference on Control, Automation, Robotics and Vision (ICARCV)},
   year    = {2016},
   pages   = {1--6},
-  month   = {nov},
+  month   = nov,
   publisher = {{IEEE}},
   doi     = {10.1109/icarcv.2016.7838769}
 }
@@ -1384,7 +1384,7 @@
   year    = {2016},
   volume  = {322},
   pages   = {345--364},
-  month   = {oct},
+  month   = oct,
   doi     = {10.1016/j.jcp.2016.06.017},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}}
@@ -1408,7 +1408,7 @@
   year    = {2016},
   volume  = {327},
   pages   = {1--18},
-  month   = {dec},
+  month   = dec,
   doi     = {10.1016/j.jcp.2016.09.037},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}}
@@ -1549,7 +1549,7 @@
   volume  = {108},
   number  = {11},
   pages   = {1307--1342},
-  month   = {jun},
+  month   = jun,
   doi     = {10.1002/nme.5254},
   publisher = {Wiley}
 }
@@ -1559,7 +1559,7 @@
   title   = {{A C$^{1}$-continuous finite element formulation for solving the Jeffery-Hamel boundary value problem}},
   journal = {arxiv.org},
   year    = {2016},
-  month   = {dec},
+  month   = dec,
   archiveprefix = {arXiv},
   arxivid = {1612.06312},
   eprint  = {1612.06312},
@@ -1593,7 +1593,7 @@
   volume  = {43},
   number  = {3},
   pages   = {1--27},
-  month   = {dec},
+  month   = dec,
   doi     = {10.1145/2998441},
   publisher = {Association for Computing Machinery ({ACM})},
   url     = {http://www.doc.ic.ac.uk/~lmitche1/08-06-PASC-firedrake.pdf}
@@ -1823,7 +1823,7 @@
   year    = {2016},
   volume  = {326},
   pages   = {544--568},
-  month   = {dec},
+  month   = dec,
   doi     = {10.1016/j.jcp.2016.09.003},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}}
@@ -1975,7 +1975,7 @@
   booktitle = {Advanced Science and Technology Letters},
   year    = {2016},
   volume  = {142},
-  month   = {dec},
+  month   = dec,
   publisher = {Science {\&} Engineering Research Support {soCiety}},
   doi     = {10.14257/astl.2016.142.08},
   url     = {https://www.researchgate.net/profile/Hao_Li192/publication/312344754_High_Order_Accurate_Curved-element_Implementation_in_OpenFOAM_for_Discontinuous_Galerkin_Method/links/590d26134585159781831faa/High-Order-Accurate-Curved-element-Implementation-in-OpenFOAM-for-Discontinuous-Galerkin-Method.pdf}
@@ -1997,7 +1997,7 @@
   volume  = {24},
   number  = {01},
   pages   = {1650003},
-  month   = {mar},
+  month   = mar,
   doi     = {10.1142/S2010132516500036},
   url     = {http://www.worldscientific.com/doi/abs/10.1142/S2010132516500036}
 }
@@ -2020,7 +2020,7 @@
   year    = {2016},
   volume  = {310},
   pages   = {252--277},
-  month   = {oct},
+  month   = oct,
   doi     = {10.1016/j.cma.2016.07.007},
   note    = {Unconfirmed citation},
   publisher = {Elsevier {BV}}
@@ -2064,7 +2064,7 @@
   title   = {{Effective Non-oscillatory Regularized L1 Finite Elements for Particle Transport Simulations}},
   journal = {arxiv.org},
   year    = {2016},
-  month   = {dec},
+  month   = dec,
   archiveprefix = {arXiv},
   arxivid = {1612.05581},
   eprint  = {1612.05581},
@@ -2096,7 +2096,7 @@
   title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
   author  = {Huang Zixuan},
   year    = {2016},
-  month   = {Jan},
+  month   = jan,
   school  = {National Taiwan University},
   doi     = {10.6342/NTU201602040},
   url     = {https://www.airitilibrary.com/Publication/alDetailedMesh?DocID=U0001-0508201623573200}

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -423,7 +423,7 @@
   volume  = {71},
   number  = {3},
   pages   = {1062--1093},
-  month   = {jan},
+  month   = jan,
   doi     = {10.1007/s10915-016-0339-x},
   publisher = {Springer Nature}
 }
@@ -494,7 +494,7 @@
   volume  = {4},
   number  = {1},
   pages   = {2213--7467},
-  month   = {dec},
+  month   = dec,
   doi     = {10.1186/s40323-017-0093-0},
   publisher = {Springer Nature}
 }
@@ -1048,7 +1048,7 @@
   title   = {{Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation}},
   booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})},
   year    = {2017},
-  month   = {may},
+  month   = may,
   publisher = {{IEEE}},
   doi     = {10.1109/ipdpsw.2017.160}
 }
@@ -1146,7 +1146,7 @@
   year    = {2017},
   volume  = {314},
   pages   = {40--60},
-  month   = {apr},
+  month   = apr,
   doi     = {10.1016/j.cam.2016.10.022},
   publisher = {Elsevier {BV}},
   url     = {https://pdfs.semanticscholar.org/02aa/832e109562d3201aaab220f0b6e3a4ddddbb.pdf}
@@ -1294,7 +1294,7 @@
   year    = {2017},
   volume  = {339},
   pages   = {126--145},
-  month   = {jun},
+  month   = jun,
   doi     = {10.1016/j.jcp.2017.03.014},
   publisher = {Elsevier {BV}}
 }
@@ -1810,7 +1810,7 @@
   year    = {2017},
   volume  = {309},
   pages   = {563--574},
-  month   = {jan},
+  month   = jan,
   doi     = {10.1016/j.cam.2016.02.056},
   publisher = {Elsevier {BV}},
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716301157}

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -74,7 +74,7 @@
   title   = {{A C1-mapping based on finite elements on quadrilateral and hexahedral meshes}},
   journal = {arxiv: 1810.02473},
   year    = {2018},
-  month   = {oct},
+  month   = oct,
   url     = {https://arxiv.org/abs/1810.02473}
 }
 
@@ -229,7 +229,7 @@
   publisher = {Springer Science and Business Media LLC},
   author  = {Bonito, Andrea and Borthagaray, Juan Pablo and Nochetto, Ricardo H. and Ot{\'a}rola, Enrique and Salgado, Abner J.},
   year    = {2018},
-  month   = {Mar},
+  month   = mar,
   pages   = {19--46}
 }
 
@@ -341,7 +341,7 @@
   volume  = {99},
   number  = {1-4},
   pages   = {833--843},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1007/s00170-018-2531-7},
   publisher = {Springer Nature America, Inc}
 }
@@ -353,7 +353,7 @@
   year    = {2018},
   volume  = {156},
   pages   = {143--153},
-  month   = {oct},
+  month   = oct,
   doi     = {10.1016/j.matdes.2018.06.037},
   publisher = {Elsevier {BV}}
 }
@@ -544,7 +544,7 @@
   journal = {Journal of Scientific Computing},
   year    = {2018},
   pages   = {1--24},
-  month   = {sep},
+  month   = sep,
   doi     = {10.1007/s10915-018-0841-4},
   publisher = {Springer Nature America, Inc},
   url     = {https://rdcu.be/725Z}
@@ -1328,7 +1328,7 @@
 @Article{jadamba.khan.ea:elliptic,
   url     = {http://www.ybook.co.jp/online2/oppafa/vol3/p309.html},
   year    = {2018},
-  month   = {Jan},
+  month   = jan,
   volume  = {3},
   number  = {2},
   author  = {Jadamba, B and Khan, A. A. and Kahler, R. and Sama, M.},
@@ -1371,7 +1371,7 @@
 @Article{k-gupta.keulen.ea:design,
   author  = {K. Gupta, Deepak and Keulen, Fred and Langelaar, Matthijs},
   year    = {2018},
-  month   = {11},
+  month   = nov,
   pages   = {},
   title   = {Design and analysis adaptivity in multi-resolution topology optimization},
   journal = {arXiv:1811.09821},
@@ -1412,7 +1412,7 @@
   title   = {An Overset Mesh Framework for the Hybridizable Discontinuous Galerkin Finite Element Method},
   school  = {Pennsylvania State University},
   year    = {2018},
-  month   = {1}
+  month   = jan
 }
 
 @Article{kaufl.grayver.ea:topographic,
@@ -1474,7 +1474,7 @@
 @InProceedings{koepf.soldner.ea:3d,
   author  = {Koepf, Johannes and Soldner, Dominic and Gotterbarm, Martin and Markl, Matthias and Mergheim, Julia and K{\"o}rner, Carolin},
   year    = {2018},
-  month   = {May},
+  month   = may,
   title   = {3D Grainstructure simulation in powder bed additive manufacturing},
   booktitle = {NAFEMS Konferenz 2018}
 }
@@ -1563,7 +1563,7 @@
   volume  = {37},
   number  = {12},
   pages   = {3123--3136},
-  month   = {January},
+  month   = jan,
   doi     = {10.1109/TCAD.2018.2789729}
 }
 
@@ -1692,7 +1692,7 @@
   title   = {High-Order Numerical Methods for 2D Parabolic Problems in Single and Composite Domains},
   journal = {Journal of Scientific Computing},
   year    = {2018},
-  month   = {Aug},
+  month   = aug,
   volume  = {76},
   number  = {2},
   pages   = {812--847},
@@ -1825,7 +1825,7 @@
   title   = {An efficient hybrid multigrid solver for high-order discontinuous Galerkin methods},
   school  = {Technical University of Munich},
   year    = {2018},
-  month   = {oct},
+  month   = oct,
   url     = {https://mediatum.ub.tum.de/node?id=1514962}
 }
 
@@ -1850,7 +1850,7 @@
   year    = {2018},
   volume  = {338},
   pages   = {657--691},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1016/j.cma.2017.12.022},
   publisher = {Elsevier {BV}}
 }
@@ -1927,7 +1927,7 @@
   year    = {2018},
   volume  = {464},
   pages   = {116--131},
-  month   = {oct},
+  month   = oct,
   doi     = {10.1016/j.jmmm.2018.02.094},
   publisher = {Elsevier {BV}}
 }
@@ -2031,7 +2031,7 @@
   title   = {A 3D adaptive boundary element method for potential flow with nonlinear Kutta condition},
   school  = {Politecnico di Milano},
   year    = {2018},
-  month   = {4},
+  month   = apr,
   url     = {https://www.politesi.polimi.it/handle/10589/140106}
 }
 
@@ -2052,7 +2052,7 @@
   title   = {Modeling Trace Gas Sensors with the Coupled Pressure-Temperature Equations},
   school  = {The University of Texas at Dallas},
   year    = {2018},
-  month   = {12},
+  month   = dec,
   url     = {https://hdl.handle.net/10735.1/6420}
 }
 
@@ -2063,7 +2063,7 @@
   year    = {2018},
   volume  = {2018},
   pages   = {1--10},
-  month   = {aug},
+  month   = aug,
   doi     = {10.1155/2018/4705472},
   publisher = {Hindawi Limited}
 }
@@ -2134,7 +2134,7 @@
   journal = {ACM Transactions on Graphics},
   author  = {Schneider, Teseo and Hu, Yixin and Dumas, Jeremie and Gao, Xifeng and Panozzo, Daniele and Zorin, Denis},
   year    = {2018},
-  month   = {Dec}
+  month   = dec
 }
 
 @MastersThesis{schneider:simulation,
@@ -2243,7 +2243,7 @@
   number  = 5,
   volume  = 24,
   year    = {2018},
-  month   = {6}
+  month   = jun
 }
 
 @PhDThesis{shovkun:coupled-chemo-mechanical-processes-in-reservoir-geomechanics,
@@ -2270,7 +2270,7 @@
   title   = {{Widespread volcanism in the Greenland-North Atlantic region explained by the Iceland plume}},
   journal = {Nature Geoscience},
   year    = 2018,
-  month   = {November},
+  month   = nov,
   doi     = {10.1038/s41561-018-0251-0}
 }
 
@@ -2343,7 +2343,7 @@
   doi     = {10.1007/s10237-017-0973-8},
   issn    = {16177940},
   journal = {Biomechanics and Modeling in Mechanobiology},
-  month   = {apr},
+  month   = apr,
   number  = {2},
   pages   = {479--497},
   pmid    = {29139052},
@@ -2410,7 +2410,7 @@
   volume  = {18},
   number  = {4},
   pages   = {753--776},
-  month   = {oct},
+  month   = oct,
   doi     = {10.1515/cmam-2017-0046},
   publisher = {Walter de Gruyter {GmbH}},
   url     = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf}


### PR DESCRIPTION
Part of #389.

With some help of bibtool and some additional sed routines, I brought all month entries into the recommended format in the [bibtex FAQ](https://ctan.org/pkg/bibtex?lang=en), Q13.

bibtool has a mechanism to force the three letter abbreviation, but it doesn't cover all possible cases, so I didn't add it to the configuration.