### PR TITLE
Fix @misc entries.

### DIFF
--- a/jabref-template/listrefs.misc.layout
+++ b/jabref-template/listrefs.misc.layout
@@ -46,8 +46,8 @@
 
         -->
 
-    \begin{howpublished}  \howpublished\end{howpublished}<!--
-    -->\begin{publisher}, \format[HTMLChars]{\publisher}\end{publisher}<!--
+    \begin{howpublished}  \howpublished,\end{howpublished}<!--
+    -->\begin{publisher}  \format[HTMLChars]{\publisher}\end{publisher}<!--
       -->\begin{address}, \format[HTMLChars]{\address}\end{address}<!--
         -->\begin{pages}, pp. \format[FormatPagesForHTML]{\pages}\end{pages}<!--
          -->\begin{note}  (\format[HTMLChars]{\note})\end{note}<!--


### PR DESCRIPTION
See #397. There is no reason to start the second part of the output with a comma -- if the first part exists, make it end in a comma and if it doesn't, then the second just starts the line.

That approach isn't so easy for entries further down the list.

/rebuild