### PR TITLE
bibtool: translate iso characters to latex.

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -15,4 +15,7 @@ print.wide.equal = on
 % use braces instead of double quotes as delimiters
 resource braces
 
+% translate iso 8859/1 characters to latex
+resource iso2tex
+
 sort = on


### PR DESCRIPTION
Part of #389.

This patch lets bibtool automatically take care of non-ASCII characters according to this resource:
https://github.com/ge-ne/bibtool/blob/master/lib/iso2tex.rsc

We already check for these in the `latex` CI stage, but it would be nice to have another level to identify these characters and to automatically get rid of them.