### PR TITLE
bibtool: sort order for fields.

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -25,4 +25,7 @@ resource improve
 % translate iso 8859/1 characters to latex
 resource iso2tex
 
+# sort order for fields
+resource sort_fld
+
 sort = on

--- a/publications-2001.bib
+++ b/publications-2001.bib
@@ -56,10 +56,10 @@
   title   = {Adaptive FE-Methods for Conservation Equations},
   booktitle = {Hyperbolic Problems: Theory, Numerics, Applications},
   year    = 2001,
-  number  = 141,
   series  = {ISNM International Series of Numerical Mathematics},
   pages   = {495--503},
   publisher = {Birkh\"{a}user, Basel},
+  number  = 141,
   doi     = {10.1007/978-3-0348-8372-6_3}
 }
 

--- a/publications-2002.bib
+++ b/publications-2002.bib
@@ -3,24 +3,24 @@
 @PhDThesis{2002:bangerth:adaptive,
   author  = {W. Bangerth},
   title   = {Adaptive Finite Element Methods for the Identification of Distributed Parameters in Partial Differential Equations},
-  year    = 2002,
-  school  = {University of Heidelberg}
+  school  = {University of Heidelberg},
+  year    = 2002
 }
 
 @MastersThesis{2002:benkler:numerical,
   author  = {S. Benkler},
   title   = {Numerical solution of the nonlinear Hartree equation.},
-  year    = 2002,
-  school  = {ETH Zurich, Switzerland}
+  school  = {ETH Zurich, Switzerland},
+  year    = 2002
 }
 
 @InProceedings{2002:cockburn.kanschat.ea:local,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {The local discontinuous Galerkin method in incompressible fluid flow},
-  booktitle = {Proceedings of the Fifth World Congress on Computational Mechanics (WCCM V)},
   editor  = {H.A. Mang and F.G. Rammerstorfer and J. Eberhardsteiner},
-  address = {Vienna University of Technology},
-  year    = 2002
+  booktitle = {Proceedings of the Fifth World Congress on Computational Mechanics (WCCM V)},
+  year    = 2002,
+  address = {Vienna University of Technology}
 }
 
 @Article{2002:cockburn.kanschat.ea:local*1,
@@ -47,8 +47,8 @@
 @PhDThesis{2002:hartmann:adaptive,
   author  = {R. Hartmann},
   title   = {Adaptive Finite Element Methods for the Compressible Euler Equations},
-  year    = 2002,
   school  = {University of Heidelberg},
+  year    = 2002,
   doi     = {10.11588/heidok.00002488}
 }
 

--- a/publications-2003.bib
+++ b/publications-2003.bib
@@ -3,8 +3,8 @@
 @PhDThesis{2003:achatz:adaptive,
   author  = {S. Achatz},
   title   = {Adaptive finite D\"{u}nngitter-Elemente h\"{o}herer Ordnung f\"{u}r elliptische partielle Differentialgleichungen mit variablen Koeffizienten},
-  year    = 2003,
-  school  = {TU Munich}
+  school  = {TU Munich},
+  year    = 2003
 }
 
 @Article{2003:bangerth.rannacher:adaptive,
@@ -25,15 +25,15 @@
 @PhDThesis{2003:calhoun-lopez:numerical,
   author  = {M. Calhoun-Lopez},
   title   = {Numerical solutions of hyperbolic conservation laws: Incorporating multi-resolution viscosity methods into the finite element framework},
-  year    = 2003,
-  school  = {Iowa State University}
+  school  = {Iowa State University},
+  year    = 2003
 }
 
 @PhDThesis{2003:carnes:adaptive,
   author  = {B. Carnes},
   title   = {Adaptive finite elements for nonlinear transport equations},
-  year    = 2003,
-  school  = {ICES, The University of Texas at Austin}
+  school  = {ICES, The University of Texas at Austin},
+  year    = 2003
 }
 
 @Article{2003:cockburn.kanschat.ea:ldg,
@@ -90,8 +90,8 @@
 @InProceedings{2003:hartmann.houston:goal-oriented,
   author  = {Hartmann, R. and Houston, P.},
   title   = {Goal-Oriented A Posteriori Error Estimation for Compressible Fluid Flows},
-  booktitle = {Numerical Mathematics and Advanced Applications},
   editor  = {Brezzi, Franco and Buffa, Annalisa and Corsaro, Stefania and Murli, Almerico},
+  booktitle = {Numerical Mathematics and Advanced Applications},
   year    = 2003,
   pages   = {775--784},
   doi     = {10.1007/978-88-470-2089-4_70}
@@ -100,8 +100,8 @@
 @InProceedings{2003:hartmann.houston:goal-oriented*1,
   author  = {Hartmann, Ralf and Houston, Paul},
   title   = {Goal-Oriented A Posteriori Error Estimation for Multiple Target Functionals},
-  booktitle = {Hyperbolic Problems: Theory, Numerics, Applications},
   editor  = {Hou, Thomas Y. and Tadmor, Eitan},
+  booktitle = {Hyperbolic Problems: Theory, Numerics, Applications},
   year    = 2003,
   pages   = {579--588},
   url     = {http://link.springer.com/chapter/10.1007/978-3-642-55711-8_54},

--- a/publications-2004.bib
+++ b/publications-2004.bib
@@ -55,8 +55,8 @@
 @MastersThesis{2004:frobel:tikhonov-regularisierung,
   author  = {C. Fr\"{o}bel},
   title   = {Tikhonov-Regularisierung zur Parameteridentifikation bei elliptischen und parabolischen Modellgleichungen.},
-  year    = 2004,
-  school  = {Universit\"{a}t Bremen, Germany}
+  school  = {Universit\"{a}t Bremen, Germany},
+  year    = 2004
 }
 
 @Article{2004:hasler.schneebeli.ea:mixed,

--- a/publications-2005.bib
+++ b/publications-2005.bib
@@ -81,8 +81,8 @@
 @PhDThesis{2005:joshi:adaptive,
   author  = {A. Joshi},
   title   = {Adaptive finite element methods for fluorescence enhanced optical tomography},
-  year    = 2005,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2005
 }
 
 @Article{2005:kanschat:block,
@@ -151,8 +151,8 @@
 @PhDThesis{2005:polner:galerkin,
   author  = {M. Polner},
   title   = {Galerkin least-squares stabilization operators for the Navier-Stokes equations, A unified approach},
-  year    = 2005,
-  school  = {University of Twente, The Netherlands}
+  school  = {University of Twente, The Netherlands},
+  year    = 2005
 }
 
 @Article{2005:schulz.echner.ea:development,

--- a/publications-2006.bib
+++ b/publications-2006.bib
@@ -3,8 +3,8 @@
 @MastersThesis{2006:allmaras:optimal,
   author  = {M. Allmaras},
   title   = {Optimal Design of Periodic Microstructures by the Inverse Homogenization Method},
-  year    = 2006,
-  school  = {Technical University Munich, Germany}
+  school  = {Technical University Munich, Germany},
+  year    = 2006
 }
 
 @Article{2006:antonic.vrdoljak:sequential,
@@ -19,11 +19,11 @@
 @TechReport{2006:bangtsson.lund:comparison,
   author  = {E. B\"{a}ngtsson and B. Lund},
   title   = {A comparison between two approaches to solve the equations of isostasy},
-  year    = 2006,
   institution = {Institute for Parallel Processing},
+  year    = 2006,
+  number  = {2006-03},
   address = {Bulgarian Academy of Sciences},
   series  = {BIS-21++ Report},
-  number  = {2006-03},
   url     = {http://bis-21pp.acad.bg/private/EricB-TRreport-final.pdf}
 }
 
@@ -127,8 +127,8 @@
 @PhDThesis{2006:heltai:finite,
   author  = {L. Heltai},
   title   = {The Finite Element Immersed Boundary Method},
-  year    = 2006,
-  school  = {Universit\`{a} di Pavia, Dipartimento di Matematica ``F. Casorati''}
+  school  = {Universit\`{a} di Pavia, Dipartimento di Matematica ``F. Casorati''},
+  year    = 2006
 }
 
 @Article{2006:hwang.pan.ea:influence,
@@ -153,9 +153,9 @@
   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
   title   = {Non-contact fluorescence optical tomography with scanning area illumination},
   booktitle = {3rd IEEE International Symposium on Biomedical Imaging: Nano to Macro, 2006.},
-  address = {Arlington, VA},
   year    = 2006,
   pages   = {582--585},
+  address = {Arlington, VA},
   url     = {http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=1624983},
   doi     = {10.1109/ISBI.2006.1624983}
 }
@@ -183,16 +183,16 @@
 @PhDThesis{2006:kayser-herold:least-squares,
   author  = {O. Kayser-Herold},
   title   = {Least-Squares Methods for the Solution of Fluid-Structure Interaction Problems},
-  year    = 2006,
   school  = {TU-Braunschweig, Germany},
+  year    = 2006,
   url     = {http://www.digibib.tu-bs.de/?docid=00000035}
 }
 
 @MastersThesis{2006:leicht:anisotropic,
   author  = {T. Leicht},
   title   = {Anisotropic Mesh Refinement for Discontinuous Galerkin Methods in Aerodynamic Flow Simulations},
-  year    = 2006,
   school  = {TU Dresden},
+  year    = 2006,
   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/publications/publications.html#supervised}
 }
 
@@ -207,8 +207,8 @@
 @PhDThesis{2006:oeltz:raum-zeit,
   author  = {D. Oeltz},
   title   = {Ein Raum-Zeit D\"{u}nngitterverfahren zur Diskretisierung parabolischer Differentialgleichungen},
-  year    = 2006,
-  school  = {University of Bonn, Germany}
+  school  = {University of Bonn, Germany},
+  year    = 2006
 }
 
 @Article{2006:schmidt:low-dimensional,

--- a/publications-2007.bib
+++ b/publications-2007.bib
@@ -21,8 +21,8 @@
 @PhDThesis{2007:antonietti:domain,
   author  = {P. F. Antonietti},
   title   = {Domain decomposition, spectral correctness and numerical testing of discontinuous Galerkin methods},
-  year    = 2007,
-  school  = {University of Pavia, Italy}
+  school  = {University of Pavia, Italy},
+  year    = 2007
 }
 
 @Article{2007:bangerth.hartmann.ea:deal,
@@ -169,15 +169,15 @@
 @MastersThesis{2007:hepperger:pod-basierter,
   author  = {P. Hepperger},
   title   = {Ein POD-basierter Ansatz zur numerischen L\"{o}sung eines Datenassimilationsproblems am Beispiel einer linearen Diffusions-Konvektions-Gleichung},
-  year    = 2007,
-  school  = {Technical University of Munich, Germany}
+  school  = {Technical University of Munich, Germany},
+  year    = 2007
 }
 
 @MastersThesis{2007:janssen:vergleich,
   author  = {B. Janssen and },
   title   = {Vergleich verschiedener Finite-Elemente-Approximationen zur numerischen L\"{o}sung der Plattengleichung},
-  year    = 2007,
-  school  = {University of Heidelberg, Germany}
+  school  = {University of Heidelberg, Germany},
+  year    = 2007
 }
 
 @Article{2007:joshi.bangerth.ea:molecular,
@@ -191,8 +191,8 @@
 @MastersThesis{2007:kamm:posteriori,
   author  = {C. D. Kamm},
   title   = {A posteriori error estimation in numerical methods for solving self-adjoint eigenvalue problems},
-  year    = 2007,
-  school  = {TU Berlin, Germany}
+  school  = {TU Berlin, Germany},
+  year    = 2007
 }
 
 @Article{2007:kayser-herold.matthies:unified,
@@ -225,8 +225,8 @@
 @PhDThesis{2007:nigro:discontinuous,
   author  = {A. Nigro},
   title   = {Discontinuous Galerkin Methods for inviscid low Mach number flows},
-  year    = 2007,
-  school  = {University of Calabria}
+  school  = {University of Calabria},
+  year    = 2007
 }
 
 @Article{2007:phillips.wheeler:coupling,
@@ -258,22 +258,22 @@
 @PhDThesis{2007:renda:discontinuous,
   author  = {S. M. Renda},
   title   = {Discontinuous Galerkin Methods for all speed flows},
-  year    = 2007,
-  school  = {University of Calabria}
+  school  = {University of Calabria},
+  year    = 2007
 }
 
 @MastersThesis{2007:rohe:residuale,
   author  = {L. R\"{o}he},
   title   = {Residuale Stabilisierung f\"{u}r Finite Elemente Verfahren bei inkompressiblen Str\"{o}mungen},
-  year    = 2007,
-  school  = {University of G\"{o}ttingen, Germany}
+  school  = {University of G\"{o}ttingen, Germany},
+  year    = 2007
 }
 
 @PhDThesis{2007:schmidt:systematic,
   author  = {M. Schmidt},
   title   = {Systematic discretization of input/output maps and other contributions to the control of distributed parameter systems},
-  year    = 2007,
-  school  = {TU Berlin, Germany}
+  school  = {TU Berlin, Germany},
+  year    = 2007
 }
 
 @Article{2007:schulz.schweiger.ea:applying,

--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -81,8 +81,8 @@
 @MastersThesis{2008:geiger:vergleich,
   author  = {M. Geiger},
   title   = {Vergleich dreier Zeitschrittverahren zur numerischen L\"{o}sung der akustischen Wellengleichung},
-  year    = 2008,
-  school  = {University of Heidelberg, Germany}
+  school  = {University of Heidelberg, Germany},
+  year    = 2008
 }
 
 @Article{2008:ghysels.samaey.ea:multi-scale,
@@ -147,8 +147,8 @@
 @MastersThesis{2008:heister:vorkonditionierunsstrategien,
   author  = {T. Heister},
   title   = {Vorkonditionierunsstrategien f\"{u}r das stabilisierte Oseen-Problem},
-  year    = 2008,
-  school  = {University of G\"{o}ttingen, Germany}
+  school  = {University of G\"{o}ttingen, Germany},
+  year    = 2008
 }
 
 @Article{2008:heltai:on,
@@ -200,17 +200,17 @@
 @PhDThesis{2008:khasina:mathematische,
   author  = {L. Khasina},
   title   = {Mathematische Behandlung von Mischungen elastoplastischer Substanzen},
-  year    = 2008,
-  school  = {University of Bonn, Germany}
+  school  = {University of Bonn, Germany},
+  year    = 2008
 }
 
 @InProceedings{2008:kronbichler.kreiss:hybrid,
   author  = {Martin Kronbichler and Gunilla Kreiss},
   title   = {A hybrid level-set {Cahn--Hilliard} model for two-phase flow},
-  journal = {Proceedings of the 1st European Conference on Microfluidics},
-  publisher = {La Soci\'{e}t\'{e} Hydrotechnique de France},
   year    = 2008,
   pages   = {59:1--10},
+  publisher = {La Soci\'{e}t\'{e} Hydrotechnique de France},
+  journal = {Proceedings of the 1st European Conference on Microfluidics},
   url     = {http://urn.kb.se/resolve?urn=urn:nbn:se:uu:diva-104899}
 }
 
@@ -226,8 +226,8 @@
 @MastersThesis{2008:lowe:stabilisierung,
   author  = {J. L\"{o}we},
   title   = {Stabilisierung durch lokale Projektion f\"{u}r inkompressible Str\"{o}mungsprobleme},
-  year    = 2008,
-  school  = {University of G\"{o}ttingen, Germany}
+  school  = {University of G\"{o}ttingen, Germany},
+  year    = 2008
 }
 
 @Article{2008:neytcheva.bangtsson:preconditioning,
@@ -249,8 +249,8 @@
 @MastersThesis{2008:schmid:theory,
   author  = {K. Schmid},
   title   = {Theory and numerics of a reconstruction algorithm for a problem from acoustic microscopy},
-  year    = 2008,
-  school  = {Technical University of Munich, Germany}
+  school  = {Technical University of Munich, Germany},
+  year    = 2008
 }
 
 @Article{2008:secanell.karan.ea:optimal,
@@ -282,8 +282,8 @@
 @MastersThesis{2008:wick:untersuchung,
   author  = {T. Wick},
   title   = {Untersuchung von Kopplungsmechanismen von Fluid-Struktur-Interaktion},
-  year    = 2008,
-  school  = {Universit\"{a}t Siegen, Germany}
+  school  = {Universit\"{a}t Siegen, Germany},
+  year    = 2008
 }
 
 @Article{2008:ziegler.brendel.ea:nonlinear,
@@ -297,8 +297,8 @@
 @PhDThesis{2008:ziegler:modeling,
   author  = {R. Ziegler},
   title   = {Modeling photon transport and reconstruction of optical properties for performance assessment of laser and fluorescence mammographs and analysis of clinical data},
-  year    = 2008,
-  school  = {Freie Universit\"{a}t Berlin}
+  school  = {Freie Universit\"{a}t Berlin},
+  year    = 2008
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2009.bib
+++ b/publications-2009.bib
@@ -35,8 +35,8 @@
 @MastersThesis{2009:bartle:shell,
   author  = {S. Bartle},
   title   = {Shell finite elements with applications in biomechanics},
-  year    = 2009,
-  school  = {University of Cape Town, South Africa}
+  school  = {University of Cape Town, South Africa},
+  year    = 2009
 }
 
 @Article{2009:bassi.bartolo.ea:discontinuous,
@@ -109,8 +109,8 @@
 @MastersThesis{2009:frohne:numerische,
   author  = {J. Frohne},
   title   = {Numerische L\"{o}sung des inversen W\"{a}rmeleitproblems in zwei Ortsdimensionen zur Identifizierung von Randbedingungen},
-  year    = 2009,
-  school  = {Universit\"{a}t Siegen, Germany}
+  school  = {Universit\"{a}t Siegen, Germany},
+  year    = 2009
 }
 
 @Article{2009:george.gupta.ea:empirical,
@@ -183,8 +183,8 @@
 @MastersThesis{2009:jung:mehrgitterverfahren,
   author  = {J. Jung},
   title   = {Mehrgitterverfahren f\"{u}r FE-Modelle 4. Ordnung},
-  year    = 2009,
-  school  = {Universit\"{a}t Siegen, Germany}
+  school  = {Universit\"{a}t Siegen, Germany},
+  year    = 2009
 }
 
 @Article{2009:kim.pasciak:computation,
@@ -199,15 +199,15 @@
 @PhDThesis{2009:kim:analysis,
   author  = {S. Kim},
   title   = {Analysis of a PML method applied to computation of resonances in open systems and acoustic scattering problems},
-  year    = 2009,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2009
 }
 
 @MastersThesis{2009:klein:modelladaptive,
   author  = {N. Klein},
   title   = {Modelladaptive FE-Techniken bei Elastizit\"{a}tsproblemen mit gro{\ss}en Verformungen},
-  year    = 2009,
-  school  = {Universit\"{a}t Siegen, Germany}
+  school  = {Universit\"{a}t Siegen, Germany},
+  year    = 2009
 }
 
 @Article{2009:kronbichler:numerical,
@@ -221,8 +221,8 @@
 @MastersThesis{2009:lorentzon:fluid-structure,
   author  = {J. Lorentzon},
   title   = {Fluid-structure interaction (FSI) case study of a cantilever using OpenFOAM and DEAL.II with application to VIV},
-  year    = 2009,
-  school  = {Lunds Institute of Technology, Sweden}
+  school  = {Lunds Institute of Technology, Sweden},
+  year    = 2009
 }
 
 @Article{2009:matthies.lube.ea:some,
@@ -236,8 +236,8 @@
 @MastersThesis{2009:mcmahon:modelling,
   author  = {A. M. McMahon},
   title   = {Modelling the Flow Behaviour of Gas Bubbles in a Bubble Column},
-  year    = 2009,
-  school  = {University of Cape Town, South Africa}
+  school  = {University of Cape Town, South Africa},
+  year    = 2009
 }
 
 @Article{2009:miller.costanzo:numerical,
@@ -292,8 +292,8 @@
 @MastersThesis{2009:raeini:fractured,
   author  = {A. Q. Raeini},
   title   = {Fractured reservoir simulation using finite element method with logarithmic shape functions (in Persian)},
-  year    = 2009,
-  school  = {Sharif University of Technology, Iran}
+  school  = {Sharif University of Technology, Iran},
+  year    = 2009
 }
 
 @Article{2009:ramay.vendelin:diffusion,
@@ -333,8 +333,8 @@
 @MastersThesis{2009:schroder:simulation,
   author  = {N. Schr\"{o}der},
   title   = {Simulation eines mikrofluidischen Kanals mit deal.II},
-  year    = 2009,
-  school  = {Universit\"{a}t Siegen, Germany}
+  school  = {Universit\"{a}t Siegen, Germany},
+  year    = 2009
 }
 
 @Article{2009:wang.bangerth.ea:three-dimensional,
@@ -349,29 +349,29 @@
 @PhDThesis{2009:wang:adaptive,
   author  = {Y. Wang},
   title   = {Adaptive mesh refinement solution techniques for the multigrid S$_{\textnormal{N}}$ transport equation using a higher-order discontinuous finite element method},
-  year    = 2009,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2009
 }
 
 @MastersThesis{2009:wanka:grundkonzepte,
   author  = {S. Wanka},
   title   = {Grundkonzepte zur Modelladaptivit\"{a}t bei Hindernisproblemen},
-  year    = 2009,
-  school  = {Universit\"{a}t Siegen, Germany}
+  school  = {Universit\"{a}t Siegen, Germany},
+  year    = 2009
 }
 
 @PhDThesis{2009:white:stabilized,
   author  = {J. White},
   title   = {Stabilized finite element methods for coupled flow and geomechanics},
-  year    = 2009,
-  school  = {Stanford University}
+  school  = {Stanford University},
+  year    = 2009
 }
 
 @PhDThesis{2009:willems:numerical,
   author  = {J. Willems},
   title   = {Numerical upscaling for multiscale flow problems - Analysis and Algorithms},
-  year    = 2009,
-  school  = {University of Kaiserslautern, Germany}
+  school  = {University of Kaiserslautern, Germany},
+  year    = 2009
 }
 
 @Article{2009:young.romero.ea:finite,

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -77,15 +77,15 @@
 @PhDThesis{2010:chueh:integrated,
   author  = {C. C. Chueh},
   title   = {Integrated adaptive numerical methods for transient two-phase flow in heterogeneous porous medi},
-  year    = 2010,
-  school  = {University of Victoria}
+  school  = {University of Victoria},
+  year    = 2010
 }
 
 @MastersThesis{2010:dally:fe-modelladaptivitat,
   author  = {T. Dally},
   title   = {FE-Modelladaptivit\"{a}t f\"{u}r P-Laplace},
-  year    = 2010,
-  school  = {Universit\"{a}t Siegen, Germany}
+  school  = {Universit\"{a}t Siegen, Germany},
+  year    = 2010
 }
 
 @Article{2010:freddi.fremond:collision,
@@ -337,8 +337,8 @@
 @InProceedings{2010:leicht.hartmann:error*1,
   author  = {Leicht, Tobias and Hartmann, Ralf},
   title   = {Error estimation and anisotropic mesh refinement for aerodynamic flow simulations},
-  booktitle = {Numerical Mathematics and Advanced Applications ENUMATH 2009},
   editor  = {Kreiss, Gunilla and L{\"o}tstedt, Per and M{\aa}lqvist, Axel and Neytcheva, Maya},
+  booktitle = {Numerical Mathematics and Advanced Applications ENUMATH 2009},
   year    = 2010,
   pages   = {579--587},
   doi     = {10.1007/978-3-642-11795-4_62}
@@ -349,10 +349,10 @@
   title   = {Optimal control of singularly perturbed advection-diffusion-reaction problems},
   journal = {Math. Model. Meths. Appl. Sc.},
   year    = 2010,
-  month   = mar,
   volume  = 20,
   number  = 3,
   pages   = {375--395},
+  month   = mar,
   doi     = {10.1142/S0218202510004271},
   comment = {Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G\"{o}ttingen, Germany}
 }
@@ -368,8 +368,8 @@
 @PhDThesis{2010:muehl:techniques,
   author  = {J. K. Muehl},
   title   = {Techniques for Interdisciplinary Validation by Visualization in Physiological Modeling Liver Radiofrequency Ablation},
-  year    = 2010,
   school  = {Graz University of Technology},
+  year    = 2010,
   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.419.3812&rep=rep1&type=pdf}
 }
 
@@ -384,8 +384,8 @@
 @MastersThesis{2010:neuen:multiscale,
   author  = {C. P. T. Neuen},
   title   = {A multiscale approach to the Poisson-Nernst-Planck equation},
-  year    = 2010,
-  school  = {University of Bonn, Germany}
+  school  = {University of Bonn, Germany},
+  year    = 2010
 }
 
 @Article{2010:nigro.bartolo.ea:discontinuous,
@@ -400,8 +400,8 @@
 @PhDThesis{2010:prill:diskontinuierliche,
   author  = {F. Prill},
   title   = {Diskontinuierliche Galerkin-Methoden und schnelle iterative L\"{o}ser zur Simulation kompressibler Str\"{o}mungen},
-  year    = 2010,
-  school  = {TU Hamburg-Harburg}
+  school  = {TU Hamburg-Harburg},
+  year    = 2010
 }
 
 @Article{2010:rapson.tapson:capturing,
@@ -449,8 +449,8 @@
 @PhDThesis{2010:salgado:approximation,
   author  = {A. J. Salgado},
   title   = {Approximation Techniques for Incompressible Flows with Heterogeneous Properties},
-  year    = 2010,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2010
 }
 
 @Article{2010:schulz.ale.ea:hybrid,
@@ -508,8 +508,8 @@
 @MastersThesis{2010:weiler:stromfunktionsformulierung,
   author  = {C. Weiler},
   title   = {Stromfunktionsformulierung der Navier-Stokes-Gleichungen und Methoden der Druckrekonstruktion},
-  year    = 2010,
-  school  = {University of Heidelberg, Germany}
+  school  = {University of Heidelberg, Germany},
+  year    = 2010
 }
 
 @Article{2010:young.armiento:strategies,
@@ -532,8 +532,8 @@
 @PhDThesis{2010:zhu:robust,
   author  = {L. Zhu},
   title   = {Robust a posteriori error estimation for discontinuous Galerkin methods for convection-diffusion equations},
-  year    = 2010,
-  school  = {University of British Columbia}
+  school  = {University of British Columbia},
+  year    = 2010
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2011.bib
+++ b/publications-2011.bib
@@ -20,8 +20,8 @@
 @PhDThesis{2011:allmaras:modeling,
   author  = {M. Allmaras},
   title   = {Modeling aspects and computational methods for some recent problems of tomographic imaging},
-  year    = 2011,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2011
 }
 
 @Article{2011:alouges.desimone.ea:numerical,
@@ -92,23 +92,23 @@
 @Article{2011:chandrasekaran.jayaraman.ea:msnfd,
   author  = {S. Chandrasekaran and K. R. Jayaraman and M. Gu and H. N. Mhaskar and J. Moffitt},
   title   = {MSNFD: A Higher Order Finite Difference Method for Solving Elliptic PDEs on scattered points (An Extended version of our paper submitted to ICCS 2011)},
-  note    = {Submitted},
   year    = 2011,
+  note    = {Submitted},
   url     = {http://scg.ece.ucsb.edu/msnpub.html}
 }
 
 @PhDThesis{2011:crestel:moving,
   author  = {B. Crestel},
   title   = {Moving meshes on general surfaces},
-  year    = 2011,
-  school  = {Simon Fraser University}
+  school  = {Simon Fraser University},
+  year    = 2011
 }
 
 @MastersThesis{2011:dobson:investigation,
   author  = {P. Dobson},
   title   = {Investigation of the polymer electrolyte membrane fuel cell catalyst layer microstructure },
-  year    = 2011,
   school  = {University of Alberta},
+  year    = 2011,
   url     = {https://era.library.ualberta.ca/public/datastream/get/uuid:30e76f20-e819-4c0e-b3e4-063dbdca6319/DS1/Dobson_Peter_Fall_2011.pdf}
 }
 
@@ -123,8 +123,8 @@
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {A variational approach to plasticity. Numerical experiments},
   booktitle = {Proceedings, Atti XX Congresso Nazionale AIMETA},
-  address = {Bologna, Italy},
-  year    = 2011
+  year    = 2011,
+  address = {Bologna, Italy}
 }
 
 @Article{2011:freddi.royer-carfagni:variational*1,
@@ -140,15 +140,15 @@
 @PhDThesis{2011:freyer:automatische,
   author  = {M. Freyer},
   title   = {Automatische Segmentierung anatomischer Strukturen in CT-Bildern eines hybriden FMT/XCT-Systems zur Verbesserung der optischen Bildgebung},
-  year    = 2011,
-  school  = {Ludwig-Maximilians-University Munich, Germany}
+  school  = {Ludwig-Maximilians-University Munich, Germany},
+  year    = 2011
 }
 
 @PhDThesis{2011:frohne:fem-simulation,
   author  = {J. Frohne},
   title   = {FEM-Simulation der Umformtechnik metallischer Oberfl\"{a}chen im Mikrokosmos},
-  year    = 2011,
-  school  = {University of Siegen, Germany}
+  school  = {University of Siegen, Germany},
+  year    = 2011
 }
 
 @Article{2011:george.gupta.ea:empirical,
@@ -196,8 +196,8 @@
 @PhDThesis{2011:heister:massively,
   author  = {T. Heister},
   title   = {A Massively Parallel Finite Element Framework with Application to Incompressible Flows},
-  year    = 2011,
-  school  = {University of G\"{o}ttingen, Germany}
+  school  = {University of G\"{o}ttingen, Germany},
+  year    = 2011
 }
 
 @Article{2011:hepperger:pricing,
@@ -272,8 +272,8 @@
 @MastersThesis{2011:johansson:implementation,
   author  = {N. Johansson},
   title   = {Implementation of a standard level set method for incompressible two-phase flow simulations},
-  year    = 2011,
-  school  = {Uppsala University, Uppsala, Sweden}
+  school  = {Uppsala University, Uppsala, Sweden},
+  year    = 2011
 }
 
 @Article{2011:joos.carraro.ea:detailed,
@@ -304,15 +304,15 @@
 @Article{2011:kronbichler.walker.ea:multiscale,
   author  = {M. Kronbichler and C. Walker and G. Kreiss and B. M\"{u}ller},
   title   = {Multiscale modeling of capillary-driven contact line dynamics},
-  note    = {Submitted},
-  year    = 2011
+  year    = 2011,
+  note    = {Submitted}
 }
 
 @PhDThesis{2011:kronbichler:computational,
   author  = {M. Kronbichler},
   title   = {Computational Techniques for Coupled Flow-Transport Problems},
-  year    = 2011,
-  school  = {Uppsala University, Uppsala, Sweden}
+  school  = {Uppsala University, Uppsala, Sweden},
+  year    = 2011
 }
 
 @Article{2011:layton.rohe.ea:explicitly,
@@ -358,8 +358,8 @@
 @PhDThesis{2011:lowe:finite-elemente-methode,
   author  = {J. L\"{o}we},
   title   = {Eine Finite-Elemente-Methode f\"{u}r nicht-isotherme inkompressible Str\"{o}mungsprobleme },
-  year    = 2011,
   school  = {Gottingen University},
+  year    = 2011,
   url     = {http://num.math.uni-goettingen.de/picap/pdf/E675.pdf}
 }
 
@@ -368,8 +368,8 @@
   title   = {Multi-scale modeling of localized heating caused by ion bombardment},
   journal = {Nuclear Instruments and Methods in Physics Research Section B: Beam Interactions with Materials and Atoms},
   year    = 2011,
-  url     = {http://www.sciencedirect.com/science/article/pii/S0168583X11000760},
-  note    = {In press}
+  note    = {In press},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0168583X11000760}
 }
 
 @Article{2011:nigro.renda.ea:discontinuous,
@@ -398,8 +398,8 @@
 @PhDThesis{2011:raghuram:higher,
   author  = {K. J. Raghuram},
   title   = {Higher Order Numerical Discretization on Scattered Grids},
-  year    = 2011,
-  school  = {University of California, Santa Barbara}
+  school  = {University of California, Santa Barbara},
+  year    = 2011
 }
 
 @Article{2011:richter.wick:fluid-structure,
@@ -414,8 +414,8 @@
 @MastersThesis{2011:riedlbauer:thermomechanical,
   author  = {D. Riedlbauer},
   title   = {Thermomechanical Modelling and Simulation of Electron Beam Melting},
-  year    = 2011,
-  school  = {Friedrich-Alexander-University, Erlangen-Nuremberg}
+  school  = {Friedrich-Alexander-University, Erlangen-Nuremberg},
+  year    = 2011
 }
 
 @Article{2011:rohe.lube:large-eddy,
@@ -439,8 +439,8 @@
   title   = {Preconditioners for state constrained optimal control problems with Moreau-Yosida penalty function},
   journal = {Numerical Linear Algebra with Applications},
   year    = 2011,
-  url     = {http://www.mpi-magdeburg.mpg.de/people/stollm/pub.html},
-  note    = {Submitted}
+  note    = {Submitted},
+  url     = {http://www.mpi-magdeburg.mpg.de/people/stollm/pub.html}
 }
 
 @Article{2011:white.borja:block-preconditioned,
@@ -455,8 +455,8 @@
 @PhDThesis{2011:wick:adaptive,
   author  = {T. Wick},
   title   = {Adaptive finite element simulation of fluid-structure interaction},
-  year    = 2011,
-  school  = {University of Heidelberg, Germany}
+  school  = {University of Heidelberg, Germany},
+  year    = 2011
 }
 
 @Article{2011:wick:fluid-structure,

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -3,24 +3,24 @@
 @PhDThesis{2012:adeniran:biophysically,
   author  = {I. Adeniran},
   title   = {Biophysically detailed modelling of the functional impact of gene mutations associated with the ``short QT syndrome''},
-  year    = 2012,
-  school  = {University of Manchester}
+  school  = {University of Manchester},
+  year    = 2012
 }
 
 @MastersThesis{2012:albring:optimal,
   author  = {T. A. Albring},
   title   = {Optimal Control of PDEs solved by Fixed Point Iterations using Algorithmic Differentiation},
   school  = {RWTH Aachen University},
-  note    = {Bachelor's thesis in Computational Engineering Science},
   year    = 2012,
+  note    = {Bachelor's thesis in Computational Engineering Science},
   url     = {http://www.mathcces.rwth-aachen.de/_media/5people/albring/thesis_bsc.pdf}
 }
 
 @PhDThesis{2012:alcalde:parallel,
   author  = {E. Romero Alcalde},
   title   = {Parallel implementation of Davidson-type methods for large-scale eigenvalue problems},
-  year    = 2012,
-  school  = {Universitat Politecnica de Valencia}
+  school  = {Universitat Politecnica de Valencia},
+  year    = 2012
 }
 
 @Article{2012:alexe.sandu:fully,
@@ -60,16 +60,16 @@
 @Article{2012:boehm.ulbrich:newton-cg,
   author  = {C. Boehm and M. Ulbrich},
   title   = {A Newton-CG method for full-waveform inversion in a coupled solid-fluid system},
-  note    = {Submitted},
   year    = 2012,
+  note    = {Submitted},
   url     = {http://www-m1.ma.tum.de/bin/view/Lehrstuhl/PublikationenUlbrich}
 }
 
 @PhDThesis{2012:boyanova:on,
   author  = {P. Boyanova},
   title   = {On Numerical Solution Methods for Block-Structured Discrete Systems},
-  year    = 2012,
-  school  = {University of Uppsala}
+  school  = {University of Uppsala},
+  year    = 2012
 }
 
 @Article{2012:braack.lube.ea:divergence,
@@ -83,8 +83,8 @@
 @PhDThesis{2012:burg:fully,
   author  = {M. B\"{u}rg},
   title   = {A Fully Automatic $hp$-Adaptive Refinement Strategy},
-  year    = 2012,
-  school  = {Karlsruhe Institute of Technology (KIT)}
+  school  = {Karlsruhe Institute of Technology (KIT)},
+  year    = 2012
 }
 
 @Article{2012:burg:residual-based,
@@ -99,16 +99,16 @@
 @Article{2012:cangiani.georgoulis.ea:discontinuous,
   author  = {A. Cangiani and E. Georgoulis and M. Jensen},
   title   = {Discontinuous Galerkin methods for mass transfer through semi-permeable membranes},
-  note    = {Submitted},
   year    = 2012,
+  note    = {Submitted},
   url     = {http://www2.le.ac.uk/departments/mathematics/extranet/staff-material/staff-profiles/eg64/publications}
 }
 
 @Article{2012:cangiani.georgoulis.ea:posteriori,
   author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
   title   = {An a posteriori error estimator for discontinuous Galerkin methods for non-stationary convection-diffusion problems},
-  note    = {Submitted},
-  year    = 2012
+  year    = 2012,
+  note    = {Submitted}
 }
 
 @Article{2012:carraro.joos.ea:3d,
@@ -134,8 +134,8 @@
 @PhDThesis{2012:chapman:on,
   author  = {J. Chapman},
   title   = {On Discontinuous Galerkin Methods for Singularly Perturbed and Incompressible Miscible Displacement Problems },
-  year    = 2012,
   school  = {Durham University},
+  year    = 2012,
   url     = {http://etheses.dur.ac.uk/5886/1/JRChapman_thesis_final.pdf?DDD21}
 }
 
@@ -166,13 +166,13 @@
 }
 
 @InProceedings{2012:efendiev.galvis.ea:robust*1,
-  doi     = {10.1007/978-3-642-29843-1_4},
-  year    = 2012,
-  publisher = {Springer Berlin Heidelberg},
-  pages   = {43--51},
   author  = {Yalchin Efendiev and Juan Galvis and Raytcho Lazarov and Joerg Willems},
   title   = {Robust Solvers for Symmetric Positive Definite Operators and Weighted Poincar{\'{e}} Inequalities},
   booktitle = {Large-Scale Scientific Computing LSSC 2011},
+  year    = 2012,
+  pages   = {43--51},
+  publisher = {Springer Berlin Heidelberg},
+  doi     = {10.1007/978-3-642-29843-1_4},
   editors = {I. Lirkov and S. Margenov and J. Wasniewski}
 }
 
@@ -194,15 +194,15 @@
 @MastersThesis{2012:fankhauser:hp-adaptive,
   author  = {T. Fankhauser},
   title   = {An hp-adaptive strategy based on smoothness estimation in 2d},
-  year    = 2012,
-  school  = {University of Bern, Switzerland}
+  school  = {University of Bern, Switzerland},
+  year    = 2012
 }
 
 @PhDThesis{2012:ferguson:brittle,
   author  = {L. Ferguson},
   title   = {Brittle fracture modeling with a surface tension excess property},
-  year    = 2012,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2012
 }
 
 @Article{2012:frisani.hassan:on,
@@ -224,20 +224,20 @@
 @MastersThesis{2012:hai:numerical,
   author  = {B. S. M. Ebna Hai},
   title   = {Numerical approximation of fluid structure interaction (FSI) problem and simplified model for the vertical vibrations of the aircraft wing},
-  year    = 2012,
   school  = {University of Hamburg, Germany and University of L'Aquila, Italy},
+  year    = 2012,
   isbn    = {978-3-659-30284-8},
   url     = {https://www.lap-publishing.com/catalog/details/store/gb/book/978-3-659-30284-8/numerical-approximation-of-fluid-structure-interaction-fsi-problem}
 }
 
 @InProceedings{2012:hartmann:higher-order,
-  doi     = {10.2514/6.2012-459},
+  author  = {Ralf Hartmann},
+  title   = {Higher-Order and Adaptive Discontinuous Galerkin Methods with Shock-Capturing Applied to Transonic Turbulent Delta Wing Flow},
+  booktitle = {50th {AIAA} Aerospace Sciences Meeting including the New Horizons Forum and Aerospace Exposition},
   year    = 2012,
   month   = nov,
   publisher = {American Institute of Aeronautics and Astronautics},
-  author  = {Ralf Hartmann},
-  title   = {Higher-Order and Adaptive Discontinuous Galerkin Methods with Shock-Capturing Applied to Transonic Turbulent Delta Wing Flow},
-  booktitle = {50th {AIAA} Aerospace Sciences Meeting including the New Horizons Forum and Aerospace Exposition}
+  doi     = {10.2514/6.2012-459}
 }
 
 @Article{2012:heltai.costanzo:variational,
@@ -307,30 +307,30 @@
   title   = {Representative Volume Element Size for Accurate Solid Oxide Fuel Cell Cathode Reconstructions from Focused Ion Beam Tomography Data},
   journal = {Electrochimica Acta},
   year    = 2012,
-  url     = {http://www.sciencedirect.com/science/article/pii/S001346861200761X},
-  note    = {In press}
+  note    = {In press},
+  url     = {http://www.sciencedirect.com/science/article/pii/S001346861200761X}
 }
 
 @PhDThesis{2012:joshi:model,
   author  = {S. Joshi},
   title   = {A model for the estimation of residual stresses in soft tissues},
-  year    = 2012,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2012
 }
 
 @PhDThesis{2012:kormann:efficient,
   author  = {K. Kormann},
   title   = {Efficient and Reliable Simulation of Quantum Molecular Dynamics},
-  year    = 2012,
   school  = {Uppsala University},
+  year    = 2012,
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A549981&dswid=6393}
 }
 
 @PhDThesis{2012:kormann:on,
   author  = {K. Kormann},
   title   = {On Numerical Solution Methods for Block-Structured Discrete Systems},
-  year    = 2012,
-  school  = {University of Uppsala}
+  school  = {University of Uppsala},
+  year    = 2012
 }
 
 @Article{2012:kormann:time-space,
@@ -344,8 +344,8 @@
 @PhDThesis{2012:kramer:cuda-based,
   author  = {S. Kramer},
   title   = {CUDA-based scientific computing tools and selected applications},
-  year    = 2012,
-  school  = {G\"{o}ttingen University, Germany}
+  school  = {G\"{o}ttingen University, Germany},
+  year    = 2012
 }
 
 @Article{2012:kronbichler.heister.ea:high,
@@ -358,23 +358,23 @@
 }
 
 @Article{2012:kronbichler.kormann:generic,
-  doi     = {10.1016/j.compfluid.2012.04.012},
-  url     = {https://doi.org/10.1016/j.compfluid.2012.04.012},
-  year    = 2012,
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = 63,
-  pages   = {135--147},
   author  = {Martin Kronbichler and Katharina Kormann},
   title   = {A generic interface for parallel cell-based finite element operator application},
-  journal = {Computers {\&} Fluids}
+  journal = {Computers {\&} Fluids},
+  year    = 2012,
+  volume  = 63,
+  pages   = {135--147},
+  month   = jun,
+  doi     = {10.1016/j.compfluid.2012.04.012},
+  url     = {https://doi.org/10.1016/j.compfluid.2012.04.012},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2012:kunkel:nonsmooth,
   author  = {M. Kunkel},
   title   = {Nonsmooth Newton Methods and Convergence of Discretized Optimal Control Problems subject to DAEs},
-  year    = 2012,
-  school  = {Universit\"{a}t der Bundeswehr M\"{u}nchen}
+  school  = {Universit\"{a}t der Bundeswehr M\"{u}nchen},
+  year    = 2012
 }
 
 @Article{2012:lowe.lube:projection-based,
@@ -397,8 +397,8 @@
 @MastersThesis{2012:moore:investigation,
   author  = {M. Moore},
   title   = {Investigation of the Double-Trap Intrinsic Kinetic Equation for the Oxygen Reduction Reaction and its implementation into a Membrane Electrode Assembly model},
-  year    = 2012,
   school  = {Department of Mechanical Engineering},
+  year    = 2012,
   url     = {https://era.library.ualberta.ca/public/view/item/uuid:79f8832e-b550-49fd-8160-9b055147ee6d/}
 }
 
@@ -432,24 +432,24 @@
 }
 
 @Article{2012:rapson.tapson.ea:unification,
-  doi     = {10.1121/1.3699238},
-  url     = {https://doi.org/10.1121/1.3699238},
+  author  = {Michael J. Rapson and Jonathan C. Tapson and David Karpul},
+  title   = {Unification and extension of monolithic state space and iterative cochlear models},
+  journal = {The Journal of the Acoustical Society of America},
   year    = 2012,
-  month   = may,
-  publisher = {Acoustical Society of America ({ASA})},
   volume  = 131,
   number  = 5,
   pages   = {3935--3952},
-  author  = {Michael J. Rapson and Jonathan C. Tapson and David Karpul},
-  title   = {Unification and extension of monolithic state space and iterative cochlear models},
-  journal = {The Journal of the Acoustical Society of America}
+  month   = may,
+  doi     = {10.1121/1.3699238},
+  url     = {https://doi.org/10.1121/1.3699238},
+  publisher = {Acoustical Society of America ({ASA})}
 }
 
 @PhDThesis{2012:rapson:extensible,
   author  = {Michael J. Rapson},
   title   = {An extensible computational cochlear modelling framework},
-  year    = 2012,
   school  = {University of Cape Town},
+  year    = 2012,
   url     = {http://hdl.handle.net/11427/5117}
 }
 
@@ -463,8 +463,8 @@
 @MastersThesis{2012:richardson:investigation,
   author  = {N. Richardson},
   title   = {An Investigation into Aspects of Rate-Independent Single Crystal Plasticity},
-  year    = 2012,
-  school  = {University of Cape Town, South Africa}
+  school  = {University of Cape Town, South Africa},
+  year    = 2012
 }
 
 @Article{2012:riedlbauer.mergheim.ea:macroscopic,
@@ -478,8 +478,8 @@
 @PhDThesis{2012:roy:numerical,
   author  = {S. Roy},
   title   = {Numerical simulation using the generalized immersed boundary method: An application to Hydrocephalus},
-  year    = 2012,
-  school  = {The Pennsylvania State University}
+  school  = {The Pennsylvania State University},
+  year    = 2012
 }
 
 @Article{2012:sauter:multiscale,
@@ -500,8 +500,8 @@
 @MastersThesis{2012:sheldon:comparison,
   author  = {J. Sheldon},
   title   = {A comparison of fluid-structure interaction coupling algorithms using the finite element method},
-  year    = 2012,
-  school  = {The Pennsylvania State University}
+  school  = {The Pennsylvania State University},
+  year    = 2012
 }
 
 @Article{2012:stoll.wathen:all-at-once,
@@ -596,8 +596,8 @@
 @PhDThesis{2012:worthen:inverse,
   author  = {J. A. Worthen},
   title   = {Inverse problems in mantle convection : models, algorithms, and applications },
-  year    = 2012,
   school  = {- University of Texas},
+  year    = 2012,
   url     = {http://repositories.lib.utexas.edu/handle/2152/19458}
 }
 

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -3,8 +3,8 @@
 @MastersThesis{2013:alam:fast,
   author  = {G. Alam},
   title   = {Fast iterative solution of large scale statistical inverse problems},
-  year    = 2013,
-  school  = {Stockholm University}
+  school  = {Stockholm University},
+  year    = 2013
 }
 
 @Article{2013:alouges.desimone.ea:optimally,
@@ -18,8 +18,8 @@
 @MastersThesis{2013:araujo-cabarcas:numerical,
   author  = {J. C. Araujo-Cabarcas},
   title   = {Numerical methods for glacial isostatic adjustment models},
-  year    = 2013,
-  school  = {Uppsala University, Uppsala, Sweden}
+  school  = {Uppsala University, Uppsala, Sweden},
+  year    = 2013
 }
 
 @Article{2013:argoul.ruocci.ea:improved,
@@ -32,8 +32,8 @@
 @MastersThesis{2013:arndt:augmented,
   author  = {D. Arndt},
   title   = {Augmented Taylor-Hood Elements for Incompressible Flow},
-  year    = 2013,
-  school  = {University of G\"{o}ttingen, Germany}
+  school  = {University of G\"{o}ttingen, Germany},
+  year    = 2013
 }
 
 @Article{2013:axelsson.boyanova.ea:numerical,
@@ -114,8 +114,8 @@
 @PhDThesis{2013:bramwell:discontinuous,
   author  = {J. A. Bramwell},
   title   = {A discontinuous Petrov-Galerkin method for seismic tomography problems},
-  year    = 2013,
-  school  = {University of Texas at Austin}
+  school  = {University of Texas at Austin},
+  year    = 2013
 }
 
 @Article{2013:burg:convergence,
@@ -163,8 +163,8 @@
 @MastersThesis{2013:devaud:adaptive,
   author  = {D. Devaud},
   title   = {Adaptive Methods for the Stokes System with Discontinuous Viscosities},
-  year    = 2013,
-  school  = {EPFL}
+  school  = {EPFL},
+  year    = 2013
 }
 
 @Article{2013:dohnal.dorfler:coupled,
@@ -179,15 +179,15 @@
 @MastersThesis{2013:donev:time,
   author  = {I. Donev},
   title   = {Time Dependent Finite Element Simulations of a Generalized Oldroyd-B Fluid},
-  year    = 2013,
-  school  = {University of Cape Town}
+  school  = {University of Cape Town},
+  year    = 2013
 }
 
 @MastersThesis{2013:dugan:dynamic,
   author  = {K. Dugan},
   title   = {Dynamic adaptive multimesh refinement for coupled physics applicable to nuclear engineering},
-  year    = 2013,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2013
 }
 
 @Article{2013:efendiev.galvis.ea:multiscale,
@@ -238,15 +238,15 @@
 @PhDThesis{2013:gimbel:modelling,
   author  = {F. Gimbel},
   title   = {Modelling and numerical simulation of contact and lubrication},
-  year    = 2013,
-  school  = {University of Siegen, Germany}
+  school  = {University of Siegen, Germany},
+  year    = 2013
 }
 
 @MastersThesis{2013:giuliani:hybrid,
   author  = {N. Giuliani},
   title   = {An hybrid boundary element method for free surface flows},
-  year    = 2013,
   school  = {Politecnico di Milano},
+  year    = 2013,
   url     = {https://www.politesi.polimi.it/handle/10589/81430}
 }
 
@@ -346,8 +346,8 @@
 @PhDThesis{2013:klein:consistent,
   author  = {N. Klein},
   title   = {Consistent FE-Analysis of elliptic Variational Inequalities},
-  year    = 2013,
-  school  = {University of Siegen, Germany}
+  school  = {University of Siegen, Germany},
+  year    = 2013
 }
 
 @Article{2013:kramer:cuda-based,
@@ -370,8 +370,8 @@
 @PhDThesis{2013:kruger:regularization-based,
   author  = {T. Kr\"{u}ger},
   title   = {Regularization-based fictitious domain methods},
-  year    = 2013,
-  school  = {University of Siegen, Germany}
+  school  = {University of Siegen, Germany},
+  year    = 2013
 }
 
 @Article{2013:kumar.noorden.ea:ale-based,
@@ -401,8 +401,8 @@
 @MastersThesis{2013:lim:numerical,
   author  = {S. H. Lim},
   title   = {Numerical Simulation of Two-phase Heat Flow and Transient Partial Melting in the Lower Crust with Adaptive Mesh Refinement},
-  year    = 2013,
   school  = {University of Michigan, Ann Arbor},
+  year    = 2013,
   note    = {Undergraduate honors thesis}
 }
 
@@ -461,8 +461,8 @@
 @MastersThesis{2013:povall:single,
   author  = {T. Povall},
   title   = {Single Crystal Plasticity at Finite Strains: A Computational Investigation of Hardening Relations},
-  year    = 2013,
-  school  = {University of Cape Town}
+  school  = {University of Cape Town},
+  year    = 2013
 }
 
 @Article{2013:redlund.cheng:implementation,
@@ -491,8 +491,8 @@
 @Article{2013:richter.wick:on,
   author  = {T. Richter and T. Wick},
   title   = {On time discretizations of fluid-structure interactions},
-  note    = {Submitted},
-  year    = 2013
+  year    = 2013,
+  note    = {Submitted}
 }
 
 @Article{2013:richter.wick:optimal,
@@ -506,15 +506,15 @@
 @Article{2013:richter.wick:solid,
   author  = {T. Richter and T. Wick},
   title   = {Solid growth and clogging in fluid-structure interaction computed in ALE and fully Eulerian coordinates},
-  note    = {Submitted},
-  year    = 2013
+  year    = 2013,
+  note    = {Submitted}
 }
 
 @PhDThesis{2013:roberts:discontinuous,
   author  = {N. V. Roberts},
   title   = {A discontinuous Petrov-Galerkin methodology for incompressible flow problems},
-  year    = 2013,
   school  = {University of Texas at Austin},
+  year    = 2013,
   url     = {http://repositories.lib.utexas.edu/handle/2152/21174}
 }
 
@@ -579,8 +579,8 @@
 @MastersThesis{2013:siehr:stabilisierungsmethoden,
   author  = {P. Siehr},
   title   = {Stabilisierungsmethoden f\"{u}r die Stokes-Gleichungen},
-  year    = 2013,
   school  = {University of Heidelberg, Germany},
+  year    = 2013,
   note    = {Bachelor thesis}
 }
 
@@ -612,15 +612,15 @@
 @MastersThesis{2013:sutton:numerical,
   author  = {O. Sutton},
   title   = {Numerical methods for reaction diffusion systems arising in Mathematical Biology},
-  year    = 2013,
-  school  = {University of Leicester}
+  school  = {University of Leicester},
+  year    = 2013
 }
 
 @MastersThesis{2013:tong:exactly,
   author  = {Q. Tong},
   title   = {An exactly divergence-free finite element method for non-isothermal flow problems},
-  year    = 2013,
-  school  = {University of British Columbia}
+  school  = {University of British Columbia},
+  year    = 2013
 }
 
 @Article{2013:tran:partitioned,
@@ -635,8 +635,8 @@
   author  = {N. Vakulin and R. Shaw and T. Livingston},
   title   = {ELEC 490, final report: High performance computing with GPUs},
   school  = {Queen's University},
-  note    = {Semester project for ELEC 490, final report},
-  year    = 2013
+  year    = 2013,
+  note    = {Semester project for ELEC 490, final report}
 }
 
 @Article{2013:wallraff.leicht.ea:numerical,

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -1,27 +1,27 @@
 % Encoding: US-ASCII
 
 @Article{2014:abaimov.cusumano:nucleation,
-  title   = {Nucleation phenomena in an annealed damage model: Statistics of times to failure},
   author  = {Abaimov, S. G. and Cusumano, J. P.},
+  title   = {Nucleation phenomena in an annealed damage model: Statistics of times to failure},
   journal = {Phys. Rev. E},
-  volume  = 90,
-  issue   = 6,
-  pages   = 062401,
-  numpages = 12,
   year    = 2014,
+  volume  = 90,
+  pages   = 062401,
   month   = dec,
+  issue   = 6,
+  numpages = 12,
   publisher = {American Physical Society},
   doi     = {10.1103/PhysRevE.90.062401},
   url     = {https://link.aps.org/doi/10.1103/PhysRevE.90.062401}
 }
 
 @Book{2014:adeniran:modelling,
-  doi     = {10.1007/978-3-319-07200-5},
-  url     = {https://doi.org/10.1007/978-3-319-07200-5},
-  year    = 2014,
-  publisher = {Springer International Publishing},
   author  = {Ismail Adeniran},
-  title   = {Modelling the Short {QT} Syndrome Gene Mutations}
+  title   = {Modelling the Short {QT} Syndrome Gene Mutations},
+  publisher = {Springer International Publishing},
+  year    = 2014,
+  doi     = {10.1007/978-3-319-07200-5},
+  url     = {https://doi.org/10.1007/978-3-319-07200-5}
 }
 
 @Article{2014:adler.atherton.ea:energy,
@@ -49,17 +49,17 @@
 }
 
 @Article{2014:albert.schwarz:dynamics,
-  doi     = {10.1016/j.bpj.2014.04.036},
-  url     = {https://doi.org/10.1016/j.bpj.2014.04.036},
+  author  = {Philipp~J. Albert and Ulrich~S. Schwarz},
+  title   = {Dynamics of Cell Shape and Forces on Micropatterned Substrates Predicted by a Cellular Potts Model},
+  journal = {Biophysical Journal},
   year    = 2014,
-  month   = jun,
-  publisher = {Elsevier {BV}},
   volume  = 106,
   number  = 11,
   pages   = {2340--2352},
-  author  = {Philipp~J. Albert and Ulrich~S. Schwarz},
-  title   = {Dynamics of Cell Shape and Forces on Micropatterned Substrates Predicted by a Cellular Potts Model},
-  journal = {Biophysical Journal}
+  month   = jun,
+  doi     = {10.1016/j.bpj.2014.04.036},
+  url     = {https://doi.org/10.1016/j.bpj.2014.04.036},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2014:alexe.sandu:space-time,
@@ -117,8 +117,8 @@
 @PhDThesis{2014:bhaiya:open-source,
   author  = {M. Bhaiya},
   title   = {An open-source two-phase non-isothermal mathematical model of a polymer electrolyte membrane fuel cell},
-  year    = 2014,
-  school  = {University of Alberta, Edmonton}
+  school  = {University of Alberta, Edmonton},
+  year    = 2014
 }
 
 @Article{2014:bonito.glowinski:on,
@@ -151,8 +151,8 @@
 @PhDThesis{2014:brauss:implementation,
   author  = {K. D. Brauss},
   title   = {An implementation of the finite element method for the velocity-current magnetohydrodynamics equations},
-  year    = 2014,
-  school  = {University of Texas at Austin}
+  school  = {University of Texas at Austin},
+  year    = 2014
 }
 
 @Article{2014:cangiani.chapman.ea:on,
@@ -183,8 +183,8 @@
 @PhDThesis{2014:cattoglio:multigrid,
   author  = {F. Cattoglio},
   title   = {Multigrid preconditioning techniques for saddle point problems with highly variable coefficients},
-  year    = 2014,
-  school  = {Politecnico di Milano}
+  school  = {Politecnico di Milano},
+  year    = 2014
 }
 
 @Article{2014:chueh.bertei.ea:effective,
@@ -256,15 +256,15 @@
 }
 
 @InProceedings{2014:ebna-hai.bause:finite-element-model-based-structural-health-monitoring-shm-systems-for-composite-material-under-fluid-structure-interaction-fsi-effect,
-  title   = {{Finite Element Model-Based Structural Health Monitoring (SHM) Systems for Composite Material under Fluid-Structure Interaction (FSI) Effect}},
   author  = {Ebna Hai, Bhuiyan Shameem Mahmood and Bause, Markus},
-  url     = {https://hal.inria.fr/hal-01021185},
-  booktitle = {{EWSHM - 7th European Workshop on Structural Health Monitoring}},
-  address = {Nantes, France},
-  organization = {{IFFSTTAR, Inria, Universit{\'e} de Nantes}},
+  title   = {{Finite Element Model-Based Structural Health Monitoring (SHM) Systems for Composite Material under Fluid-Structure Interaction (FSI) Effect}},
   editor  = {Le Cam and Vincent and Mevel and Laurent and Schoefs and Franck},
+  booktitle = {{EWSHM - 7th European Workshop on Structural Health Monitoring}},
   year    = 2014,
+  address = {Nantes, France},
   month   = jul,
+  organization = {{IFFSTTAR, Inria, Universit{\'e} de Nantes}},
+  url     = {https://hal.inria.fr/hal-01021185},
   pdf     = {https://hal.inria.fr/hal-01021185/file/0389.pdf},
   hal_id  = {hal-01021185},
   hal_version = {v1}
@@ -330,17 +330,17 @@
 @MastersThesis{2014:fraters:thermo-mechanically,
   author  = {M. Fraters},
   title   = {Thermo-mechanically coupled subduction modelling with ASPECT},
-  year    = 2014,
-  school  = {Utrecht University}
+  school  = {Utrecht University},
+  year    = 2014
 }
 
 @MastersThesis{2014:fraters:thermo-mechanically-coupled-subduction-modelling-with-aspect,
   author  = {Fraters, Menno},
-  number  = {August},
-  school  = {Utrecht University},
   title   = {{Thermo-mechanically coupled subduction modelling with ASPECT}},
-  url     = {https://dspace.library.uu.nl/handle/1874/297347},
-  year    = 2014
+  school  = {Utrecht University},
+  year    = 2014,
+  number  = {August},
+  url     = {https://dspace.library.uu.nl/handle/1874/297347}
 }
 
 @Article{2014:freddi.royer-carfagni:plastic,
@@ -362,25 +362,25 @@
 }
 
 @InCollection{2014:frei.richter.ea:eulerian,
-  doi     = {10.1007/978-3-319-10705-9_74},
-  year    = 2014,
-  month   = oct,
-  publisher = {Springer International Publishing},
-  pages   = {745--753},
   author  = {Stefan Frei and Thomas Richter and Thomas Wick},
   title   = {Eulerian Techniques for Fluid-Structure Interactions: Part I --- Modeling and Simulation},
-  booktitle = {Numerical Mathematics and Advanced Applications - ENUMATH 2013}
+  booktitle = {Numerical Mathematics and Advanced Applications - ENUMATH 2013},
+  publisher = {Springer International Publishing},
+  year    = 2014,
+  pages   = {745--753},
+  month   = oct,
+  doi     = {10.1007/978-3-319-10705-9_74}
 }
 
 @InCollection{2014:frei.richter.ea:eulerian*1,
-  doi     = {10.1007/978-3-319-10705-9_75},
-  year    = 2014,
-  month   = oct,
-  publisher = {Springer International Publishing},
-  pages   = {755--762},
   author  = {Stefan Frei and Thomas Richter and Thomas Wick},
   title   = {Eulerian Techniques for Fluid-Structure Interactions: Part {II} --- Applications},
-  booktitle = {Numerical Mathematics and Advanced Applications - ENUMATH 2013}
+  booktitle = {Numerical Mathematics and Advanced Applications - ENUMATH 2013},
+  publisher = {Springer International Publishing},
+  year    = 2014,
+  pages   = {755--762},
+  month   = oct,
+  doi     = {10.1007/978-3-319-10705-9_75}
 }
 
 @Article{2014:frei.richter.ea:solid,
@@ -467,25 +467,25 @@
 }
 
 @InProceedings{2014:hai.bause:adaptive,
-  doi     = {10.1115/fedsm2014-21379},
-  url     = {https://doi.org/10.1115/fedsm2014-21379},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Adaptive Finite Elements Simulation Methods and Applications for Monolithic Fluid-Structure Interaction ({FSI}) Problem},
+  booktitle = {Volume 1B, Symposia: Fluid Machinery; Fluid-Structure Interaction and Flow-Induced Noise in Industrial Applications; Flow Applications in Aerospace; Flow Manipulation and Active Control: Theory, Experiments and Implementation; Multiscale Methods for Multiphase Flow; Noninvasive Measurements in Single and Multiphase Flows},
   year    = 2014,
   month   = dec,
   publisher = {American Society of Mechanical Engineers},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Adaptive Finite Elements Simulation Methods and Applications for Monolithic Fluid-Structure Interaction ({FSI}) Problem},
-  booktitle = {Volume 1B, Symposia: Fluid Machinery; Fluid-Structure Interaction and Flow-Induced Noise in Industrial Applications; Flow Applications in Aerospace; Flow Manipulation and Active Control: Theory, Experiments and Implementation; Multiscale Methods for Multiphase Flow; Noninvasive Measurements in Single and Multiphase Flows}
+  doi     = {10.1115/fedsm2014-21379},
+  url     = {https://doi.org/10.1115/fedsm2014-21379}
 }
 
 @InProceedings{2014:hai.bause:finite,
-  doi     = {10.1115/gt2014-26314},
-  url     = {https://doi.org/10.1115/gt2014-26314},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Finite Element Approximation of Wave Propagation in Composite Material With Asymptotic Homogenization},
+  booktitle = {Volume 7A: Structures and Dynamics},
   year    = 2014,
   month   = sep,
   publisher = {American Society of Mechanical Engineers},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Finite Element Approximation of Wave Propagation in Composite Material With Asymptotic Homogenization},
-  booktitle = {Volume 7A: Structures and Dynamics}
+  doi     = {10.1115/gt2014-26314},
+  url     = {https://doi.org/10.1115/gt2014-26314}
 }
 
 @Article{2014:hale.kerfriden.ea:parallel,
@@ -620,8 +620,8 @@
 @PhDThesis{2014:krehel:aggregation,
   author  = {O. Krehel},
   title   = {Aggregation and fragmentation in reaction-diffusion systems posed in heterogeneous domains},
-  year    = 2014,
   school  = {Friedrich Alexander University ErlangenNuremberg, Germany Oct},
+  year    = 2014,
   url     = {http://alexandria.tue.nl/extra2/780944.pdf}
 }
 
@@ -635,8 +635,8 @@
 @PhDThesis{2014:leonard:mathematical,
   author  = {K. Leonard},
   title   = {Mathematical and Computational Modelling of Tissue Engineered Bone in a Hydrostatic Bioreactor},
-  year    = 2014,
-  school  = {University of Oxford}
+  school  = {University of Oxford},
+  year    = 2014
 }
 
 @Article{2014:liebenstein.sandfeld.ea:higher,
@@ -684,15 +684,15 @@
 @MastersThesis{2014:merten:entwicklung,
   author  = {J. Y. Merten},
   title   = {Entwicklung eines adaptiven Finite-Elemente-Verfahrens f\"{u}r ein Lithium-Ionen-Akkumulator Modell},
-  year    = 2014,
-  school  = {University of Heidelberg}
+  school  = {University of Heidelberg},
+  year    = 2014
 }
 
 @PhDThesis{2014:metcalfe:adaptive,
   author  = {S. A. Metcalfe},
   title   = {Adaptive discontinuous Galerkin methods for nonlinear parabolic problems},
-  year    = 2014,
   school  = {University of Leicester},
+  year    = 2014,
   url     = {http://arXiv.org/abs/1504.02646}
 }
 
@@ -724,8 +724,8 @@
 @MastersThesis{2014:muller:explicit,
   author  = {C. M\"{u}ller},
   title   = {An explicit formulation of the hybridizable discontinuous Galerkin method for the acoustic wave equation},
-  year    = 2014,
-  school  = {Technische Universit\"{a}t M\"{u}nchen}
+  school  = {Technische Universit\"{a}t M\"{u}nchen},
+  year    = 2014
 }
 
 @Article{2014:nama.huang.ea:investigation,
@@ -766,8 +766,8 @@
 @PhDThesis{2014:otarola:pde,
   author  = {Enrique Otarola},
   title   = {A {PDE} approach to numerical fractional diffusion},
-  year    = 2014,
   school  = {University of Maryland},
+  year    = 2014,
   url     = {http://hdl.handle.net/1903/15317}
 }
 
@@ -805,8 +805,8 @@
 @PhDThesis{2014:phillips:fast,
   author  = {E. G. Phillips},
   title   = {Fast Solvers and Uncertainty Quantification for Models of Magnetohydrodynamics},
-  year    = 2014,
-  school  = {University of Maryland}
+  school  = {University of Maryland},
+  year    = 2014
 }
 
 @Article{2014:povall.mcbride.ea:finite,
@@ -820,8 +820,8 @@
 
 @PhDThesis{2014:quinquis:a-numerical-study-of-subduction-zone-dynamics-using-linear-viscous-to-thermo-mechanical-model-setups-including-dehydration-processes,
   author  = {Quinquis, M.},
-  school  = {Charles University},
   title   = {{A numerical study of subduction zone dynamics using linear viscous to thermo-mechanical model setups including (de)hydration processes}},
+  school  = {Charles University},
   year    = 2014,
   url     = {http://hdl.handle.net/20.500.11956/66505}
 }
@@ -835,17 +835,17 @@
 }
 
 @Article{2014:rapson.hamilton.ea:on,
-  doi     = {10.1121/1.4883382},
-  url     = {https://doi.org/10.1121/1.4883382},
+  author  = {Michael J. Rapson and Tara J. Hamilton and Jonathan C. Tapson},
+  title   = {On the fluid-structure interaction in the cochlea},
+  journal = {The Journal of the Acoustical Society of America},
   year    = 2014,
-  month   = jul,
-  publisher = {Acoustical Society of America ({ASA})},
   volume  = 136,
   number  = 1,
   pages   = {284--300},
-  author  = {Michael J. Rapson and Tara J. Hamilton and Jonathan C. Tapson},
-  title   = {On the fluid-structure interaction in the cochlea},
-  journal = {The Journal of the Acoustical Society of America}
+  month   = jul,
+  doi     = {10.1121/1.4883382},
+  url     = {https://doi.org/10.1121/1.4883382},
+  publisher = {Acoustical Society of America ({ASA})}
 }
 
 @Article{2014:reinhardt.scacchi.ea:microrheology,
@@ -933,8 +933,8 @@
 @PhDThesis{2014:schmidt:direct,
   author  = {A. Schmidt},
   title   = {Direct Metods for PDE-Constrained Optimization Using Derivative-Extended POD Reduced-Order Models },
-  year    = 2014,
   school  = {University of Heidelberg},
+  year    = 2014,
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/17780/}
 }
 
@@ -966,8 +966,8 @@
 @PhDThesis{2014:soine:reconstruction,
   author  = {J. R. D. Soin\'{e}},
   title   = {Reconstruction and Simulation of Cellular Traction Forces},
-  year    = 2014,
-  school  = {University of Heidelberg}
+  school  = {University of Heidelberg},
+  year    = 2014
 }
 
 @Article{2014:stapf.garbe:learning-based,
@@ -1041,9 +1041,9 @@
 @InProceedings{2014:walter.saxena.ea:on,
   author  = {B. Walter and P. Saxena and J.-P. V. Pelteret and J. Kaschta and D. Schubert and P. Steinmann},
   title   = {On The Preparation, Characterisation, Modelling And Simulation Of Magneto-Sensitive Elastomers},
+  editor  = {Schroder, J. and Lupascu, D. C. and Keip, M.-A. and Brands D.},
   booktitle = {Proceedings of the Second Seminar on the Mechanics of Multifunctional Materials},
   year    = 2014,
-  editor  = {Schroder, J. and Lupascu, D. C. and Keip, M.-A. and Brands D.},
   volume  = 12,
   pages   = {103--106},
   address = {Bad Honnef, Germany}
@@ -1052,22 +1052,22 @@
 @PhDThesis{2014:wang:parallel,
   author  = {K. Wang},
   title   = {Parallel Markov Chain Monte Carlo Methods for Large Scale Inverse Problems},
-  year    = 2014,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2014
 }
 
 @PhDThesis{2014:wang:regularizing,
   author  = {F. Wang},
   title   = {Regularizing Inverse Problems},
-  year    = 2014,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2014
 }
 
 @PhDThesis{2014:weiler:optimum,
   author  = {C. Weiler},
   title   = {Optimum Experimental Design for the Identification of Gaussian Disorder Mobility Parameters in Charge Transport Models of Organic Semiconductors},
-  year    = 2014,
-  school  = {University of Heidelberg, Germany}
+  school  = {University of Heidelberg, Germany},
+  year    = 2014
 }
 
 @Article{2014:weinbub.rupp.ea:highly,
@@ -1164,8 +1164,8 @@
 @PhDThesis{2014:zhang:spn,
   author  = {Y. Zhang},
   title   = {SP$_{\textnormal{N}}$ Model Error and Iterative Solution Techniques},
-  year    = 2014,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2014
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -19,8 +19,8 @@
 @PhDThesis{2015:alrashed:parallel,
   author  = {F. S. Alrashed},
   title   = {Parallel multiphase Navier-Stokes solver},
-  year    = 2015,
   school  = {Texas A\&M University},
+  year    = 2015,
   url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf}
 }
 
@@ -106,23 +106,23 @@
 @MastersThesis{2015:bardelloni:high,
   author  = {M. Bardelloni},
   title   = {High performance programming paradigms applied to computational fluid dynamic simulations},
-  year    = 2015,
   school  = {SISSA},
+  year    = 2015,
   url     = {http://urania.sissa.it/xmlui/handle/1963/35161}
 }
 
 @Article{2015:bartels.bonito.ea:bilayer,
-  doi     = {10.1002/cpa.21626},
-  url     = {https://doi.org/10.1002/cpa.21626},
+  author  = {S\"{o}ren Bartels and Andrea Bonito and Ricardo H. Nochetto},
+  title   = {Bilayer Plates: Model Reduction, $\Gamma$-Convergent Finite Element Approximation, and Discrete Gradient Flow},
+  journal = {Communications on Pure and Applied Mathematics},
   year    = 2015,
-  month   = dec,
-  publisher = {Wiley},
   volume  = 70,
   number  = 3,
   pages   = {547--589},
-  author  = {S\"{o}ren Bartels and Andrea Bonito and Ricardo H. Nochetto},
-  title   = {Bilayer Plates: Model Reduction, $\Gamma$-Convergent Finite Element Approximation, and Discrete Gradient Flow},
-  journal = {Communications on Pure and Applied Mathematics}
+  month   = dec,
+  doi     = {10.1002/cpa.21626},
+  url     = {https://doi.org/10.1002/cpa.21626},
+  publisher = {Wiley}
 }
 
 @Article{2015:bartels.nochetto.ea:total,
@@ -145,8 +145,8 @@
 @MastersThesis{2015:bercovici:experimental,
   author  = {B. Bercovici},
   title   = {Experimental and numerical validation of ion extractor grids},
-  year    = 2015,
   school  = {University of Illinois at Urbana-Champaign},
+  year    = 2015,
   url     = {http://hdl.handle.net/2142/72822}
 }
 
@@ -312,23 +312,23 @@
 @PhDThesis{2015:dallmann:finite,
   author  = {H. Dallmann},
   title   = {Finite element methods with local projection stabilization for thermally coupled incompressible flow},
-  year    = 2015,
-  school  = {University of G\"{o}ttingen, Germany}
+  school  = {University of G\"{o}ttingen, Germany},
+  year    = 2015
 }
 
 @PhDThesis{2015:dannberg:dynamics,
   author  = {J. Dannberg},
   title   = {Dynamics of mantle plumes: Linking scales and coupling physics},
-  year    = 2015,
   school  = {Potsdam University, Germany},
+  year    = 2015,
   url     = {https://publishup.uni-potsdam.de/opus4-ubp/frontdoor/index/index/docId/9102}
 }
 
 @MastersThesis{2015:davidsson:orbital-free,
   author  = {J. Davidsson},
   title   = {Orbital-free Density-Functional Theory in a Finite Element Basis},
-  year    = 2015,
   school  = {Department of Physics, Chemistry and Biology Linkopings universitet, SE-581 83 Linkoping, Sweden},
+  year    = 2015,
   url     = {http://www.diva-portal.org/smash/get/diva2:864857/FULLTEXT01.pdf}
 }
 
@@ -377,8 +377,8 @@
 @PhDThesis{2015:emerson:advanced,
   author  = {D. B. Emerson},
   title   = {Advanced discretizations and multigrid methods for liquid crystal configurations},
-  year    = 2015,
   school  = {Tufts University},
+  year    = 2015,
   url     = {http://webhosting.math.tufts.edu/dbemerson/PHD_thesis.pdf}
 }
 
@@ -402,16 +402,16 @@
 @MastersThesis{2015:farouq:performance,
   author  = {S. Farouq},
   title   = {Performance comparisons of preconditioned iterative methods for problems arising in PDE-constrained optimization},
-  year    = 2015,
   school  = {Uppsala University},
+  year    = 2015,
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A815563&dswid=5325}
 }
 
 @MastersThesis{2015:fehn:discontinuous,
   author  = {N. Fehn},
   title   = {A Discontinuous Galerkin Approach for the Unsteady Incompressible Navier--Stokes Equations},
-  year    = 2015,
-  school  = {Technische Universit\"{a}t M\"{u}nchen}
+  school  = {Technische Universit\"{a}t M\"{u}nchen},
+  year    = 2015
 }
 
 @Article{2015:ferguson.muddamallappa.ea:numerical,
@@ -453,16 +453,16 @@
 @PhDThesis{2015:fu:magnetic,
   author  = {R. R. Fu},
   title   = {Magnetic fields in the early solar system},
-  year    = 2015,
   school  = {Massachusetts Institute of Technology},
+  year    = 2015,
   url     = {http://hdl.handle.net/1721.1/101348}
 }
 
 @MastersThesis{2015:furst:parallel,
   author  = {E. Furst},
   title   = {Parallel Preconditioners for Finite Element Computations},
-  year    = 2015,
   school  = {Saint John's University},
+  year    = 2015,
   note    = {Honors thesis},
   url     = {http://digitalcommons.csbsju.edu/cgi/viewcontent.cgi?article=1065&context=honors_theses}
 }
@@ -470,8 +470,8 @@
 @PhDThesis{2015:gerecht:adaptive,
   author  = {D. Gerecht},
   title   = {Adaptive Finite Element Simulation of Coupled PDE/ODE Systems Modeling Intercellular Signaling},
-  year    = 2015,
-  school  = {University of Heidelberg, Germany}
+  school  = {University of Heidelberg, Germany},
+  year    = 2015
 }
 
 @Article{2015:giavaras.boateng:transient,
@@ -518,24 +518,24 @@
 }
 
 @Article{2015:goll.rannacher.ea:damped,
-  doi     = {10.21314/jcf.2015.301},
-  url     = {https://doi.org/10.21314/jcf.2015.301},
+  author  = {Christian Goll and Wolf Rannacher and Winnifried Woolner},
+  title   = {The damped {Crank--Nicolson} time-marching scheme for the adaptive solution of the {Black--Scholes} equation},
+  journal = {The Journal of Computational Finance},
   year    = 2015,
-  month   = jun,
-  publisher = {Infopro Digital Services Limited},
   volume  = 18,
   number  = 4,
   pages   = {1--37},
-  author  = {Christian Goll and Wolf Rannacher and Winnifried Woolner},
-  title   = {The damped {Crank--Nicolson} time-marching scheme for the adaptive solution of the {Black--Scholes} equation},
-  journal = {The Journal of Computational Finance}
+  month   = jun,
+  doi     = {10.21314/jcf.2015.301},
+  url     = {https://doi.org/10.21314/jcf.2015.301},
+  publisher = {Infopro Digital Services Limited}
 }
 
 @PhDThesis{2015:gong:formation,
   author  = {J. Gong},
   title   = {Formation of Physical Sedimentary Structure in the Presence of Microbial Communities},
-  year    = 2015,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2015
 }
 
 @Article{2015:grayver.kolev:large-scale,
@@ -568,14 +568,14 @@
 }
 
 @InProceedings{2015:hai.bause:adaptive,
-  doi     = {10.1115/imece2015-53265},
-  url     = {https://doi.org/10.1115/imece2015-53265},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Adaptive Multigrid Methods for Extended Fluid-Structure Interaction ({eXFSI}) Problem: Part I --- Mathematical Modelling},
+  booktitle = {Volume 7B: Fluids Engineering Systems and Technologies},
   year    = 2015,
   month   = nov,
   publisher = {American Society of Mechanical Engineers},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Adaptive Multigrid Methods for Extended Fluid-Structure Interaction ({eXFSI}) Problem: Part I --- Mathematical Modelling},
-  booktitle = {Volume 7B: Fluids Engineering Systems and Technologies}
+  doi     = {10.1115/imece2015-53265},
+  url     = {https://doi.org/10.1115/imece2015-53265}
 }
 
 @Article{2015:harting.marciniak-czochra.ea:stable,
@@ -607,8 +607,8 @@
 @MastersThesis{2015:heilmann:magneto-statics,
   author  = {D. Heilmann},
   title   = {Magneto-statics in multi-material media},
-  year    = 2015,
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+  year    = 2015,
   note    = {Bachelor thesis}
 }
 
@@ -639,8 +639,8 @@
 @PhDThesis{2015:janka:sequential,
   author  = {D. Janka},
   title   = {Sequential quadratic programming with indefinite Hessian approximations for nonlinear optimum experimental design for parameter estimation in differential--algebraic equations},
-  year    = 2015,
-  school  = {University of Heidelberg, Germany}
+  school  = {University of Heidelberg, Germany},
+  year    = 2015
 }
 
 @Article{2015:jean-baptiste.lofstead.ea:delta,
@@ -702,8 +702,8 @@
 @PhDThesis{2015:kocher:variational,
   author  = {U. K\"{o}cher},
   title   = {Variational Space-Time Methods for the Elastic Wave Equation and the Diffusion Equation},
-  year    = 2015,
   school  = {Department of Mechanical Engineering of the Helmut-Schmidt-University, University of the German Federal Armed Forces Hamburg},
+  year    = 2015,
   url     = {http://nbn-resolving.de/urn:nbn:de:gbv:705-opus-31129}
 }
 
@@ -752,15 +752,15 @@
 @Article{2015:lee.wheeler.ea:3d,
   author  = {S. Lee and M. F. Wheeler and T. Wick},
   title   = {3D Fluid Filled Fracture Propagation in Porous Media using Phase Field and Adaptive Finite Elements},
-  note    = {Submitted},
-  year    = 2015
+  year    = 2015,
+  note    = {Submitted}
 }
 
 @MastersThesis{2015:lemenager:numerical,
   author  = {A. Lemenager},
   title   = {Numerical modelling of the Sydney Basin using temperature dependent thermal conductivity measurements},
-  year    = 2015,
-  school  = {Macquarie University}
+  school  = {Macquarie University},
+  year    = 2015
 }
 
 @Article{2015:li.hartmann:adjoint-based,
@@ -783,16 +783,16 @@
 @MastersThesis{2015:ljungkvist:techniques,
   author  = {K. Ljungkvist},
   title   = {Techniques for finite element methods on modern processors},
-  year    = 2015,
   school  = {University of Uppsala, Sweden},
+  year    = 2015,
   note    = {IT licentiate thesis}
 }
 
 @PhDThesis{2015:londero:cut-cell,
   author  = {A. A. Londero},
   title   = {A Cut-Cell Implementation of the Finite Element Method in deal.ii},
-  year    = 2015,
   school  = {Uppsala University, Aug},
+  year    = 2015,
   url     = {http://www.diva-portal.org/smash/get/diva2:858026/FULLTEXT01.pdf}
 }
 
@@ -806,8 +806,8 @@
 @PhDThesis{2015:maier:duality-based,
   author  = {M. Maier},
   title   = {Duality-based adaptivity of model and discretization in multiscale finite-element methods},
-  year    = 2015,
-  school  = {Heidelberg University, Germany}
+  school  = {Heidelberg University, Germany},
+  year    = 2015
 }
 
 @Article{2015:mallikarjunaiah.walton:on,
@@ -837,51 +837,51 @@
 }
 
 @Article{2015:mikelic.wheeler.ea:phase-field,
-  doi     = {10.1137/140967118},
-  url     = {http://epubs.siam.org/doi/abs/10.1137/140967118},
+  author  = {Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
+  title   = {A Phase-Field Method for Propagating Fluid-Filled Fractures Coupled to a Surrounding Porous Medium},
+  journal = {Multiscale Modeling \& Simulation},
   year    = 2015,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 13,
   number  = 1,
   pages   = {367--398},
-  author  = {Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
-  title   = {A Phase-Field Method for Propagating Fluid-Filled Fractures Coupled to a Surrounding Porous Medium},
-  journal = {Multiscale Modeling \& Simulation}
+  doi     = {10.1137/140967118},
+  url     = {http://epubs.siam.org/doi/abs/10.1137/140967118},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2015:mikelic.wheeler.ea:phase-field*1,
-  doi     = {10.1007/s10596-015-9532-5},
-  url     = {http://link.springer.com/article/10.1007%2Fs10596-015-9532-5},
+  author  = {A. Mikeli{\'{c}} and M. F. Wheeler and T. Wick},
+  title   = {Phase-field modeling of a fluid-driven fracture in a poroelastic medium},
+  journal = {Computational Geosciences},
   year    = 2015,
-  month   = nov,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 19,
   number  = 6,
   pages   = {1171--1195},
-  author  = {A. Mikeli{\'{c}} and M. F. Wheeler and T. Wick},
-  title   = {Phase-field modeling of a fluid-driven fracture in a poroelastic medium},
-  journal = {Computational Geosciences}
+  month   = nov,
+  doi     = {10.1007/s10596-015-9532-5},
+  url     = {http://link.springer.com/article/10.1007%2Fs10596-015-9532-5},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2015:mikelic.wheeler.ea:quasi-static,
-  doi     = {10.1088/0951-7715/28/5/1371},
-  url     = {https://doi.org/10.1088/0951-7715/28/5/1371},
+  author  = {Andro Mikeli{\'{c}} and Mary F Wheeler and Thomas Wick},
+  title   = {A quasi-static phase-field approach to pressurized fractures},
+  journal = {Nonlinearity},
   year    = 2015,
-  month   = apr,
-  publisher = {{IOP} Publishing},
   volume  = 28,
   number  = 5,
   pages   = {1371--1399},
-  author  = {Andro Mikeli{\'{c}} and Mary F Wheeler and Thomas Wick},
-  title   = {A quasi-static phase-field approach to pressurized fractures},
-  journal = {Nonlinearity}
+  month   = apr,
+  doi     = {10.1088/0951-7715/28/5/1371},
+  url     = {https://doi.org/10.1088/0951-7715/28/5/1371},
+  publisher = {{IOP} Publishing}
 }
 
 @MastersThesis{2015:mital:enriched,
   author  = {P. Mital},
   title   = {The Enriched Galerkin Method for Linear Elasticity and Phase Field Fracture Propagation},
-  year    = 2015,
   school  = {UT Austin},
+  year    = 2015,
   url     = {http://hdl.handle.net/2152/34222}
 }
 
@@ -906,8 +906,8 @@
   title   = {A PDE Approach to Numerical Fractional Diffusion},
   journal = {arXiv:1508.04382},
   year    = 2015,
-  url     = {http://arxiv.org/abs/1508.04382},
-  note    = {Final version appeared in the Proceedings of the ICIAM, 2015}
+  note    = {Final version appeared in the Proceedings of the ICIAM, 2015},
+  url     = {http://arxiv.org/abs/1508.04382}
 }
 
 @Article{2015:nochetto.otarola.ea:pde*1,
@@ -915,10 +915,10 @@
   title   = {A PDE Approach to Fractional Diffusion in General Domains: A Priori Error Analysis},
   journal = {Foundations of Computational Mathematics},
   year    = 2015,
-  month   = jun,
   volume  = 15,
   number  = 3,
   pages   = {733--791},
+  month   = jun,
   url     = {http://link.springer.com/article/10.1007/s10208-014-9208-x},
   doi     = {10.1007/s10208-014-9208-x}
 }
@@ -962,8 +962,8 @@
 @PhDThesis{2015:peyre:methode,
   author  = {G. Peyre},
   title   = {Methode EF et hyperreduction de modele: vers des calculs massifs a l'echelle micro},
-  year    = 2015,
   school  = {Ecole Nationale Superieure des Mines de Paris},
+  year    = 2015,
   url     = {https://hal.archives-ouvertes.fr/tel-01247931/}
 }
 
@@ -1030,13 +1030,13 @@
 @Article{2015:roy.heltai.ea:benchmarking,
   author  = {Saswati Roy and Luca Heltai and Francesco Costanzo},
   title   = {Benchmarking the immersed finite element method for fluid-structure interaction problems},
-  doi     = {10.1016/j.camwa.2015.03.012},
-  url     = {https://doi.org/10.1016/j.camwa.2015.03.012},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2015,
   volume  = 69,
   number  = 10,
   pages   = {1167--1188},
-  journal = {Computers {\&} Mathematics with Applications}
+  doi     = {10.1016/j.camwa.2015.03.012},
+  url     = {https://doi.org/10.1016/j.camwa.2015.03.012}
 }
 
 @Article{2015:salgado:convergence,
@@ -1081,8 +1081,8 @@
 @PhDThesis{2015:schoenawa:higher-order,
   author  = {S. Schoenawa},
   title   = {Higher-order discontinuous Galerkin discretizations of two-equation models of turbulence},
-  year    = 2015,
-  school  = {TU Braunschweig, Germany}
+  school  = {TU Braunschweig, Germany},
+  year    = 2015
 }
 
 @Article{2015:shyer.huycke.ea:bending,
@@ -1130,8 +1130,8 @@
 @MastersThesis{2015:tezzele:isogeometric,
   author  = {M. Tezzele},
   title   = {Isogeometric analysis in HPC: object oriented design and open source massively parallel implementation},
-  year    = 2015,
-  school  = {University of Milan}
+  school  = {University of Milan},
+  year    = 2015
 }
 
 @Article{2015:thurley.gerecht.ea:three-dimensional,
@@ -1228,8 +1228,8 @@
 @PhDThesis{2015:wallraff:investigation,
   author  = {M. Wallraff},
   title   = {An investigation of multigrid algorithms for a higher order Discontinuous Galerkin RANS solver},
-  year    = 2015,
-  school  = {TU Braunschweig, Germany}
+  school  = {TU Braunschweig, Germany},
+  year    = 2015
 }
 
 @Article{2015:wells.wang.ea:regularized,
@@ -1303,8 +1303,8 @@
 @MastersThesis{2015:zelst:mantle,
   author  = {I. van Zelst},
   title   = {Mantle dynamics on Venus: insights from numerical modelling},
-  year    = 2015,
   school  = {University of Utrecht, The Netherlands},
+  year    = 2015,
   url     = {http://dspace.library.uu.nl/bitstream/handle/1874/316227/Iris_van_Zelst_final_master_thesis.pdf}
 }
 

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -38,8 +38,8 @@
 @PhDThesis{2016:arndt:stabilized,
   author  = {D. Arndt},
   title   = {Stabilized Finite Element Methods for Coupled Incompressible Flow},
-  year    = 2016,
-  school  = {Georg-August-Universit\"{a}t G\"{o}ttingen, Germany}
+  school  = {Georg-August-Universit\"{a}t G\"{o}ttingen, Germany},
+  year    = 2016
 }
 
 @Article{2016:assier.poon.ea:spectral-study-of-the-laplace-beltrami-operator-arising-in-the-problem-of-acoustic-wave-scattering-by-a-quarter-plane,
@@ -68,8 +68,8 @@
 @MastersThesis{2016:balen:multi-component,
   author  = {C. A. Balen},
   title   = {A Multi-Component Mass Transport Model for Polymer Electrolyte Fuel Cells},
-  year    = 2016,
   school  = {University of Alberta, Australia},
+  year    = 2016,
   url     = {http://www.esdlab.mece.ualberta.ca/pdfs/Balen_Chad_A_201607_MSc.pdf}
 }
 
@@ -120,9 +120,9 @@
   number  = 5,
   pages   = {S78--S100},
   month   = jan,
+  note    = {Unconfirmed citation},
   issn    = {1064-8275},
   doi     = {10.1137/15M1026110},
-  note    = {Unconfirmed citation},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
@@ -139,17 +139,17 @@
 @MastersThesis{2016:beez:funktionsinterpolation,
   author  = {C. Beez},
   title   = {Funktionsinterpolation: Alternativen zu EIM/DEIM},
-  year    = 2016,
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+  year    = 2016,
   note    = {Project thesis}
 }
 
 @MastersThesis{2016:blom:state,
   author  = {Blom, C. A. H.},
-  school  = {Utrecht University, Netherlands},
   title   = {State of the art numerical subduction modelling with {ASPECT}; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls},
-  url     = {https://studenttheses.uu.nl/handle/20.500.12932/25682},
-  year    = 2016
+  school  = {Utrecht University, Netherlands},
+  year    = 2016,
+  url     = {https://studenttheses.uu.nl/handle/20.500.12932/25682}
 }
 
 @Article{2016:bonito.demlow:convergence,
@@ -238,17 +238,17 @@
   number  = 5,
   pages   = {C471--C503},
   month   = jan,
+  note    = {Unconfirmed citation},
   issn    = {1064-8275},
   doi     = {10.1137/15M1040049},
-  note    = {Unconfirmed citation},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @MastersThesis{2016:bystricky:using,
   author  = {L. Bystricky},
   title   = {Using deal.ii to solve problems in computational fluid dynamics},
-  year    = 2016,
   school  = {The Florida State University},
+  year    = 2016,
   url     = {http://search.proquest.com/docview/1806862661/previewPDF/E6506DE2A6364AD3PQ/1?accountid=7082}
 }
 
@@ -298,8 +298,8 @@
 }
 
 @Manual{2016:chen.ladenheim.ea:the-manchester-thermal-analyzer,
-  title   = {{The Manchester Thermal Analyzer}},
   author  = {Chen, Yi-Chung and Ladenheim, Scott and Mihajlovi{\'{c}}, Milan and Pavlidis, Vasilis},
+  title   = {{The Manchester Thermal Analyzer}},
   year    = 2016,
   url     = {https://pdfs.semanticscholar.org/853e/b3362f9d2670680f21dc7ed280e745fa6a9f.pdf}
 }
@@ -358,8 +358,8 @@
 @PhDThesis{2016:cox:adaptive,
   author  = {S. Cox},
   title   = {Adaptive large-scale mantle convection simulations},
-  year    = 2016,
-  school  = {University of Leicester}
+  school  = {University of Leicester},
+  year    = 2016
 }
 
 @Article{2016:cruz.ramos:general,
@@ -383,8 +383,8 @@
   volume  = 308,
   pages   = {151--181},
   month   = aug,
-  doi     = {10.1016/j.cma.2016.05.011},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.cma.2016.05.011},
   publisher = {Elsevier {BV}}
 }
 
@@ -410,10 +410,10 @@
 
 @PhDThesis{2016:dannberg:dynamics-of-mantle-plumes--linking-scales-and-coupling-physics,
   author  = {Dannberg, J.},
-  school  = {Potsdam University},
   title   = {{Dynamics of Mantle Plumes: Linking Scales and Coupling Physics}},
-  url     = {https://nbn-resolving.org/urn:nbn:de:kobv:517-opus4-91024},
-  year    = 2016
+  school  = {Potsdam University},
+  year    = 2016,
+  url     = {https://nbn-resolving.org/urn:nbn:de:kobv:517-opus4-91024}
 }
 
 @Article{2016:davydov.young.ea:on,
@@ -433,8 +433,8 @@
   address = {Reston, Virginia},
   month   = jun,
   publisher = {American Institute of Aeronautics and Astronautics},
-  doi     = {10.2514/6.2016-3386},
-  note    = {Unconfirmed citation}
+  note    = {Unconfirmed citation},
+  doi     = {10.2514/6.2016-3386}
 }
 
 @Article{2016:ellam.zabaras.ea:bayesian,
@@ -456,8 +456,8 @@
   number  = 1,
   pages   = {603--621},
   month   = jan,
-  doi     = {10.1016/j.jmaa.2015.07.054},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.jmaa.2015.07.054},
   publisher = {Elsevier {BV}},
   url     = {https://www.sciencedirect.com/science/article/pii/S0022247X15007003}
 }
@@ -516,16 +516,16 @@
 }
 
 @Article{2016:frei.richter.ea:long-term,
-  doi     = {10.1016/j.jcp.2016.06.015},
-  url     = {https://doi.org/10.1016/j.jcp.2016.06.015},
-  year    = 2016,
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = 321,
-  pages   = {874--891},
   author  = {S. Frei and T. Richter and T. Wick},
   title   = {Long-term simulation of large deformation, mechano-chemical fluid-structure interactions in {ALE} and fully Eulerian coordinates},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2016,
+  volume  = 321,
+  pages   = {874--891},
+  month   = sep,
+  doi     = {10.1016/j.jcp.2016.06.015},
+  url     = {https://doi.org/10.1016/j.jcp.2016.06.015},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2016:frei:eulerian,
@@ -564,8 +564,8 @@
 }
 
 @Misc{2016:gassmoeller.heien.ea:flexible,
-  title   = {Flexible and scalable particle-in-cell methods for massively parallel computations},
   author  = {R. Gassmoeller and E. Heien and E. G. Puckett and W. Bangerth},
+  title   = {Flexible and scalable particle-in-cell methods for massively parallel computations},
   year    = 2016,
   eprint  = {1612.03369},
   archiveprefix = {arXiv},
@@ -582,8 +582,8 @@
 }
 
 @Misc{2016:gersbacher:implementation,
-  title   = {Implementation of $hp$-adaptive discontinuous finite element methods in Dune-Fem},
   author  = {Christoph Gersbacher},
+  title   = {Implementation of $hp$-adaptive discontinuous finite element methods in Dune-Fem},
   year    = 2016,
   eprint  = {1604.07242},
   archiveprefix = {arXiv},
@@ -599,9 +599,9 @@
   number  = 3,
   pages   = {C280--C306},
   month   = jan,
+  note    = {Unconfirmed citation},
   issn    = {1064-8275},
   doi     = {10.1137/15m1010798},
-  note    = {Unconfirmed citation},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
@@ -660,28 +660,28 @@
 @MastersThesis{2016:hamann:linear,
   author  = {T. Hamann},
   title   = {A linear finite element model of the biceps brachii skeletal muscle},
-  year    = 2016,
-  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
+  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+  year    = 2016
 }
 
 @Article{2016:harmon.gamba.ea:numerical,
-  doi     = {10.1016/j.jcp.2016.08.026},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303825},
-  year    = 2016,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 327,
-  pages   = {140--167},
   author  = {Michael Harmon and Irene M. Gamba and Kui Ren},
   title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical ({PEC}) solar cells},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2016,
+  volume  = 327,
+  pages   = {140--167},
+  month   = dec,
+  doi     = {10.1016/j.jcp.2016.08.026},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303825},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2016:harmon:numerical,
   author  = {M. Harmon},
   title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
-  year    = 2016,
-  school  = {University of Texas at Austin}
+  school  = {University of Texas at Austin},
+  year    = 2016
 }
 
 @Article{2016:harting:reaction-diffusion-ode,
@@ -728,31 +728,31 @@
 }
 
 @Article{2016:jiang.rudraraju.ea:multiphysics,
-  doi     = {10.1021/acs.jpcc.6b09775},
-  url     = {https://doi.org/10.1021/acs.jpcc.6b09775},
+  author  = {Tonghu Jiang and Shiva Rudraraju and Anindya Roy and Anton Van der Ven and Krishna Garikipati and Michael L. Falk},
+  title   = {Multiphysics Simulations of Lithiation-Induced Stress in $Li_{1+x}Ti_2O_4$ Electrode Particles},
+  journal = {The Journal of Physical Chemistry C},
   year    = 2016,
-  month   = dec,
-  publisher = {American Chemical Society ({ACS})},
   volume  = 120,
   number  = 49,
   pages   = {27871--27881},
-  author  = {Tonghu Jiang and Shiva Rudraraju and Anindya Roy and Anton Van der Ven and Krishna Garikipati and Michael L. Falk},
-  title   = {Multiphysics Simulations of Lithiation-Induced Stress in $Li_{1+x}Ti_2O_4$ Electrode Particles},
-  journal = {The Journal of Physical Chemistry C}
+  month   = dec,
+  doi     = {10.1021/acs.jpcc.6b09775},
+  url     = {https://doi.org/10.1021/acs.jpcc.6b09775},
+  publisher = {American Chemical Society ({ACS})}
 }
 
 @MastersThesis{2016:jodlbauer:robust,
   author  = {D. Jodlbauer},
   title   = {Robust Preconditioners for Fluid-Structure-Interaction Problems},
-  year    = 2016,
-  school  = {Johannes Kepler University Linz, Austria}
+  school  = {Johannes Kepler University Linz, Austria},
+  year    = 2016
 }
 
 @Book{2016:john:finite,
+  author  = {Volker John},
   title   = {Finite Element Methods for Incompressible Flow Problems},
   publisher = {Springer International Publishing},
   year    = 2016,
-  author  = {Volker John},
   doi     = {10.1007/978-3-319-45750-5},
   url     = {https://link.springer.com/content/pdf/10.1007/978-3-319-45750-5.pdf}
 }
@@ -773,8 +773,8 @@
 @MastersThesis{2016:kahler:on,
   author  = {R. Kahler},
   title   = {On Identification of Nonlinear Parameters in PDEs},
-  year    = 2016,
   school  = {Rochester Institute of Technology},
+  year    = 2016,
   url     = {http://scholarworks.rit.edu/theses/9018/}
 }
 
@@ -786,17 +786,17 @@
 }
 
 @Article{2016:kanschat.lorca:weakly,
-  doi     = {10.1515/cmam-2016-0023},
-  url     = {https://doi.org/10.1515/cmam-2016-0023},
+  author  = {Guido Kanschat and Jos{\'{e}} Pablo Lucero Lorca},
+  title   = {A Weakly Penalized Discontinuous Galerkin Method for Radiation in Dense, Scattering Media},
+  journal = {Computational Methods in Applied Mathematics},
   year    = 2016,
-  month   = jan,
-  publisher = {Walter de Gruyter {GmbH}},
   volume  = 16,
   number  = 4,
   pages   = {563--577},
-  author  = {Guido Kanschat and Jos{\'{e}} Pablo Lucero Lorca},
-  title   = {A Weakly Penalized Discontinuous Galerkin Method for Radiation in Dense, Scattering Media},
-  journal = {Computational Methods in Applied Mathematics}
+  month   = jan,
+  doi     = {10.1515/cmam-2016-0023},
+  url     = {https://doi.org/10.1515/cmam-2016-0023},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @Article{2016:kanschat.mao:multiplicative,
@@ -848,16 +848,16 @@
   volume  = 92,
   pages   = {313--344},
   month   = jul,
-  doi     = {10.1016/j.jmps.2016.04.004},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.jmps.2016.04.004},
   publisher = {Elsevier {BV}}
 }
 
 @Book{2016:klinsmann:effects,
+  author  = {Klinsmann, Markus},
   title   = {The Effects of Internal Stress and Lithium Transport on Fracture in Storage Materials in Lithium-Ion Batteries},
   publisher = {KIT Scientific Publishing},
   year    = 2016,
-  author  = {Klinsmann, Markus},
   volume  = 54,
   series  = {Schriftenreihe des Instituts fuer Angewandte Materialien, Karlsruher Institut f\"{u}r Technologie},
   isbn    = 9783731504559,
@@ -885,17 +885,17 @@
 }
 
 @Article{2016:kormann:time-space,
-  doi     = {10.4208/cicp.101214.021015a},
-  url     = {https://doi.org/10.4208/cicp.101214.021015a},
+  author  = {Katharina Kormann},
+  title   = {A Time-Space Adaptive Method for the Schr\"{o}dinger Equation},
+  journal = {Communications in Computational Physics},
   year    = 2016,
-  month   = jun,
-  publisher = {Global Science Press},
   volume  = 20,
   number  = 1,
   pages   = {60--85},
-  author  = {Katharina Kormann},
-  title   = {A Time-Space Adaptive Method for the Schr\"{o}dinger Equation},
-  journal = {Communications in Computational Physics}
+  month   = jun,
+  doi     = {10.4208/cicp.101214.021015a},
+  url     = {https://doi.org/10.4208/cicp.101214.021015a},
+  publisher = {Global Science Press}
 }
 
 @MastersThesis{2016:kottapalli:numerical-prediction-of-flow-induced-vibrations-in-nuclear-reactors-through-pressure-fluctuation-modeling,
@@ -950,8 +950,8 @@
   number  = 1,
   pages   = {645--667},
   month   = may,
-  doi     = {10.1016/j.jmaa.2016.01.022},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.jmaa.2016.01.022},
   publisher = {Elsevier {BV}},
   url     = {https://www.sciencedirect.com/science/article/pii/S0022247X16000470}
 }
@@ -959,17 +959,17 @@
 @MastersThesis{2016:kufner:entwurf,
   author  = {M. Kufner},
   title   = {Entwurf und Implementierung eines Perfectly Matched Layer f\"{u}r die lineare Akustik},
-  year    = 2016,
-  school  = {Technical University of Munich}
+  school  = {Technical University of Munich},
+  year    = 2016
 }
 
 @MastersThesis{2016:kumar:investigation,
   author  = {Kumar, Pankaj},
   title   = {{I}nvestigation of density in {B}uoyancy {F}lows using {CFD} code {J}u{F}ire},
   school  = {Bergische Universit{\"a}t Wuppertal},
+  year    = 2016,
   reportid = {FZJ-2016-05448},
   pages   = {xv, 63 p.},
-  year    = 2016,
   url     = {https://juser.fz-juelich.de/record/819869}
 }
 
@@ -1012,30 +1012,30 @@
 }
 
 @Article{2016:lee.mikelic.ea:phase-field,
-  doi     = {10.1016/j.cma.2016.02.008},
-  url     = {https://doi.org/10.1016/j.cma.2016.02.008},
-  year    = 2016,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 312,
-  pages   = {509--541},
   author  = {Sanghyun Lee and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
   title   = {Phase-field modeling of proppant-filled fractures in a poroelastic medium},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2016,
+  volume  = 312,
+  pages   = {509--541},
+  month   = dec,
+  doi     = {10.1016/j.cma.2016.02.008},
+  url     = {https://doi.org/10.1016/j.cma.2016.02.008},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2016:lee.reber.ea:investigation,
-  doi     = {10.1002/2016gl069979},
-  url     = {https://doi.org/10.1002/2016gl069979},
+  author  = {Sanghyun Lee and Jacqueline E. Reber and Nicholas W. Hayman and Mary F. Wheeler},
+  title   = {Investigation of wing crack formation with a combined phase-field and experimental approach},
+  journal = {Geophysical Research Letters},
   year    = 2016,
-  month   = aug,
-  publisher = {American Geophysical Union ({AGU})},
   volume  = 43,
   number  = 15,
   pages   = {7946--7952},
-  author  = {Sanghyun Lee and Jacqueline E. Reber and Nicholas W. Hayman and Mary F. Wheeler},
-  title   = {Investigation of wing crack formation with a combined phase-field and experimental approach},
-  journal = {Geophysical Research Letters}
+  month   = aug,
+  doi     = {10.1002/2016gl069979},
+  url     = {https://doi.org/10.1002/2016gl069979},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2016:lee.salgado:stability,
@@ -1062,8 +1062,8 @@
 @MastersThesis{2016:legat:advancement,
   author  = {S. Legat},
   title   = {Advancement of a semi-explicit discontinuous Galerkin approach for simulation of turbulent incompressible flow},
-  year    = 2016,
-  school  = {Technical University of Munich}
+  school  = {Technical University of Munich},
+  year    = 2016
 }
 
 @Article{2016:leibner.milk.ea:extending-dune--the-dune-xt-modules,
@@ -1112,11 +1112,11 @@
 @InProceedings{2016:lofstead.jean-baptiste.ea:delta,
   author  = {Lofstead, Jay and Jean-Baptiste, Gregory and Oldfield, Ron},
   title   = {Delta: Data Reduction for Integrated Application Workflows and Data Storage},
+  editor  = {Taufer, M. and Mohr, B. and Kunkel, J.},
   booktitle = {ISC High Performance 2016: High Performance Computing},
   year    = 2016,
-  editor  = {Taufer, M. and Mohr, B. and Kunkel, J.},
-  volume  = 9945,
   series  = {Lecture Notes in Computer Science},
+  volume  = 9945,
   pages   = {142--152},
   publisher = {Springer International Publishing},
   doi     = {10.1007/978-3-319-46079-6_11},
@@ -1132,8 +1132,8 @@
   volume  = 11,
   number  = 5,
   pages   = {4--32},
-  doi     = {10.1051/mmnp/201611502},
   note    = {Unconfirmed citation},
+  doi     = {10.1051/mmnp/201611502},
   editor  = {A. Morozov and M. Ptashnyk and V. Volpert},
   publisher = {{EDP} Sciences}
 }
@@ -1149,17 +1149,17 @@
 }
 
 @Article{2016:maier.bardelloni.ea:linearoperator-a,
-  doi     = {10.1016/j.camwa.2016.04.024},
-  url     = {https://doi.org/10.1016/j.camwa.2016.04.024},
+  author  = {Matthias Maier and Mauro Bardelloni and Luca Heltai},
+  title   = {{LinearOperator}---A generic, high-level expression syntax for linear algebra},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2016,
-  month   = jul,
-  publisher = {Elsevier {BV}},
   volume  = 72,
   number  = 1,
   pages   = {1--24},
-  author  = {Matthias Maier and Mauro Bardelloni and Luca Heltai},
-  title   = {{LinearOperator}---A generic, high-level expression syntax for linear algebra},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = jul,
+  doi     = {10.1016/j.camwa.2016.04.024},
+  url     = {https://doi.org/10.1016/j.camwa.2016.04.024},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2016:maier.rannacher:duality-based,
@@ -1211,8 +1211,8 @@
   number  = 5,
   pages   = {848--864},
   month   = jun,
-  doi     = {10.1002/nla.2057},
   note    = {Unconfirmed citation},
+  doi     = {10.1002/nla.2057},
   publisher = {Wiley}
 }
 
@@ -1257,8 +1257,8 @@
   volume  = 322,
   pages   = {345--364},
   month   = oct,
-  doi     = {10.1016/j.jcp.2016.06.017},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.jcp.2016.06.017},
   publisher = {Elsevier {BV}}
 }
 
@@ -1277,8 +1277,8 @@
   volume  = 327,
   pages   = {1--18},
   month   = dec,
-  doi     = {10.1016/j.jcp.2016.09.037},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.jcp.2016.09.037},
   publisher = {Elsevier {BV}}
 }
 
@@ -1345,8 +1345,8 @@
 @MastersThesis{2016:narayanan:parallel,
   author  = {R. K. Narayanan},
   title   = {Parallel particle-in-cell performance optimization: a case study of electrospray simulation},
-  year    = 2016,
   school  = {The Pennsylvania State University, University Park},
+  year    = 2016,
   url     = {https://etda.libraries.psu.edu/files/final_submissions/11560}
 }
 
@@ -1371,17 +1371,17 @@
 }
 
 @Article{2016:oswald.poy.ea:lehmann,
-  doi     = {10.1080/02678292.2016.1255363},
-  url     = {https://doi.org/10.1080/02678292.2016.1255363},
+  author  = {P. Oswald and G. Poy and A. Dequidt},
+  title   = {Lehmann rotation of twisted bipolar cholesteric droplets: role of Leslie, Akopyan and Zel'dovich thermomechanical coupling terms of nematodynamics},
+  journal = {Liquid Crystals},
   year    = 2016,
-  month   = nov,
-  publisher = {Informa {UK} Limited},
   volume  = 44,
   number  = 6,
   pages   = {969--988},
-  author  = {P. Oswald and G. Poy and A. Dequidt},
-  title   = {Lehmann rotation of twisted bipolar cholesteric droplets: role of Leslie, Akopyan and Zel'dovich thermomechanical coupling terms of nematodynamics},
-  journal = {Liquid Crystals}
+  month   = nov,
+  doi     = {10.1080/02678292.2016.1255363},
+  url     = {https://doi.org/10.1080/02678292.2016.1255363},
+  publisher = {Informa {UK} Limited}
 }
 
 @Article{2016:owen.barnes:ground-state,
@@ -1424,8 +1424,8 @@
 @PhDThesis{2016:quezada-de-luna:high-order,
   author  = {M. {Quezada de Luna}},
   title   = {High-order and maximum principle preserving (MPP) techniques for solving conservation laws with applications on multiphase flow},
-  year    = 2016,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2016
 }
 
 @MastersThesis{2016:rahman:posteriori,
@@ -1462,8 +1462,8 @@
 @MastersThesis{2016:roberge:computational,
   author  = {J. R. Roberge},
   title   = {Computational Design of Ceramic Bone Scaffolds Fabricated Via Direct Ink Writing},
-  year    = 2016,
   school  = {University of Connecticut, Connecticut},
+  year    = 2016,
   url     = {http://digitalcommons.uconn.edu/gs_theses/989/}
 }
 
@@ -1509,8 +1509,8 @@
   volume  = 14,
   number  = 4,
   pages   = {415--438},
-  doi     = {10.1615/intjmultcompeng.2016017040},
   note    = {Unconfirmed citation},
+  doi     = {10.1615/intjmultcompeng.2016017040},
   publisher = {Begell House}
 }
 
@@ -1518,10 +1518,10 @@
   author  = {Salmoiraghi, F and Ballarin, F and Corsi, G and Mola, A and Tezzele, M},
   title   = {Advances in geometrical parametrization and reduced order models and methods for computational fluid dynamics problems in applied sciences and engineering},
   booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
-  organization = {Institute of Structural Analysis and Antiseismic Research School of Civil Engineering National Technical University of Athens (NTUA) Greece},
   year    = 2016,
   volume  = 1,
   pages   = {1013--1031},
+  organization = {Institute of Structural Analysis and Antiseismic Research School of Civil Engineering National Technical University of Athens (NTUA) Greece},
   url     = {http://preprints.sissa.it/xmlui/handle/1963/35179},
   doi     = {10.7712/100016.1867.8680}
 }
@@ -1583,8 +1583,8 @@
 @PhDThesis{2016:sheldon:hybridizable,
   author  = {J. Sheldon},
   title   = {A hybridizable discontinuous Galerkin method for modeling fluid-structure interaction.},
-  year    = 2016,
-  school  = {The Pennsylvania State University}
+  school  = {The Pennsylvania State University},
+  year    = 2016
 }
 
 @MastersThesis{2016:siehr:das-newton-verfahren-zur-berechnung-variationeller-eigenwertprobleme,
@@ -1595,17 +1595,17 @@
 }
 
 @Article{2016:soine.hersch.ea:measuring,
-  doi     = {10.1098/rsfs.2016.0024},
-  url     = {https://doi.org/10.1098/rsfs.2016.0024},
+  author  = {J{\'{e}}r{\^{o}}me R. D. Soin{\'{e}} and Nils Hersch and Georg Dreissen and Nico Hampe and Bernd Hoffmann and Rudolf Merkel and Ulrich S. Schwarz},
+  title   = {Measuring cellular traction forces on non-planar substrates},
+  journal = {Interface Focus},
   year    = 2016,
-  month   = oct,
-  publisher = {The Royal Society},
   volume  = 6,
   number  = 5,
   pages   = 20160024,
-  author  = {J{\'{e}}r{\^{o}}me R. D. Soin{\'{e}} and Nils Hersch and Georg Dreissen and Nico Hampe and Bernd Hoffmann and Rudolf Merkel and Ulrich S. Schwarz},
-  title   = {Measuring cellular traction forces on non-planar substrates},
-  journal = {Interface Focus}
+  month   = oct,
+  doi     = {10.1098/rsfs.2016.0024},
+  url     = {https://doi.org/10.1098/rsfs.2016.0024},
+  publisher = {The Royal Society}
 }
 
 @InProceedings{2016:stegmann.yang:development-of-a-discontinuous-galerkin-time-domain-solver-on-a-staggered-grid-for-pan-spectral-single-scattering-analysis,
@@ -1615,8 +1615,8 @@
   year    = 2016,
   organization = {Optical Society of America},
   publisher = {{OSA}},
-  doi     = {10.1364/fts.2016.jw4a.29},
-  note    = {Unconfirmed citation}
+  note    = {Unconfirmed citation},
+  doi     = {10.1364/fts.2016.jw4a.29}
 }
 
 @PhDThesis{2016:stegmann:light,
@@ -1660,8 +1660,8 @@
   volume  = 326,
   pages   = {544--568},
   month   = dec,
-  doi     = {10.1016/j.jcp.2016.09.003},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.jcp.2016.09.003},
   publisher = {Elsevier {BV}}
 }
 
@@ -1674,16 +1674,16 @@
 }
 
 @Article{2016:vidal-ferrandiz.fayez.ea:moving,
-  doi     = {10.1016/j.cam.2015.03.040},
-  url     = {https://doi.org/10.1016/j.cam.2015.03.040},
-  year    = 2016,
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = 291,
-  pages   = {197--208},
   author  = {A. Vidal-Ferr{\`{a}}ndiz and R. Fayez and D. Ginestar and G. Verd{\'{u}}},
   title   = {Moving meshes to solve the time-dependent neutron diffusion equation in hexagonal geometry},
-  journal = {Journal of Computational and Applied Mathematics}
+  journal = {Journal of Computational and Applied Mathematics},
+  year    = 2016,
+  volume  = 291,
+  pages   = {197--208},
+  month   = jan,
+  doi     = {10.1016/j.cam.2015.03.040},
+  url     = {https://doi.org/10.1016/j.cam.2015.03.040},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2016:vidal-ferrandiz.gonzalez-pintor.ea:use,
@@ -1697,15 +1697,15 @@
 }
 
 @InProceedings{2016:voll.stollenwerk.ea:computing,
-  doi     = {10.1117/12.2220292},
-  url     = {http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=2505859},
+  author  = {Annika V\"{o}ll and Jochen Stollenwerk and Peter Loosen},
+  title   = {Computing specific intensity distributions for laser material processing by solving an inverse heat conduction problem},
+  editor  = {Friedhelm Dorsch and Stefan Kaierle},
+  booktitle = {High-Power Laser Materials Processing: Lasers, Beam Delivery, Diagnostics, and Applications V},
   year    = 2016,
   month   = mar,
   publisher = {{SPIE}},
-  author  = {Annika V\"{o}ll and Jochen Stollenwerk and Peter Loosen},
-  editor  = {Friedhelm Dorsch and Stefan Kaierle},
-  title   = {Computing specific intensity distributions for laser material processing by solving an inverse heat conduction problem},
-  booktitle = {High-Power Laser Materials Processing: Lasers, Beam Delivery, Diagnostics, and Applications V}
+  doi     = {10.1117/12.2220292},
+  url     = {http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=2505859}
 }
 
 @Article{2016:wacker.arndt.ea:nodal-based,
@@ -1719,13 +1719,13 @@
 }
 
 @Article{2016:wang.rudraraju.ea:three,
+  author  = {Z. Wang and S. Rudraraju and K. Garikipati},
   title   = {A three dimensional field formulation, and isogeometric solutions to point and line defects using Toupin's theory of gradient elasticity at finite strains},
   journal = {Journal of the Mechanics and Physics of Solids},
+  year    = 2016,
   volume  = 94,
   pages   = {336--361},
-  year    = 2016,
-  doi     = {10.1016/j.jmps.2016.03.028},
-  author  = {Z. Wang and S. Rudraraju and K. Garikipati}
+  doi     = {10.1016/j.jmps.2016.03.028}
 }
 
 @Article{2016:white.castelletto.ea:block-partitioned,
@@ -1748,26 +1748,26 @@
 }
 
 @InProceedings{2016:wick:coupling,
-  doi     = {10.1007/978-3-319-39929-4_38},
-  year    = 2016,
-  publisher = {Springer International Publishing},
-  pages   = {401--409},
   author  = {Thomas Wick},
   title   = {Coupling Fluid-Structure Interaction with Phase-Field Fracture: Modeling and a Numerical Example},
   booktitle = {Numerical Mathematics and Advanced Applications ENUMATH 2015},
-  series  = {Lecture Notes in Computational Science and Engineering}
+  year    = 2016,
+  series  = {Lecture Notes in Computational Science and Engineering},
+  pages   = {401--409},
+  publisher = {Springer International Publishing},
+  doi     = {10.1007/978-3-319-39929-4_38}
 }
 
 @Article{2016:wick:coupling*1,
-  doi     = {10.1016/j.jcp.2016.09.024},
-  year    = 2016,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 327,
-  pages   = {67--96},
   author  = {Thomas Wick},
   title   = {Coupling fluid-structure interaction with phase-field fracture},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2016,
+  volume  = 327,
+  pages   = {67--96},
+  month   = dec,
+  doi     = {10.1016/j.jcp.2016.09.024},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2016:wick:goal,
@@ -1803,8 +1803,8 @@
 @PhDThesis{2016:yang:continuous,
   author  = {Y. Yang},
   title   = {Continuous finite element approximation of hyperbolic systems},
-  year    = 2016,
   school  = {Texas A\&M University},
+  year    = 2016,
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/157976}
 }
 
@@ -1838,8 +1838,8 @@
   volume  = 310,
   pages   = {252--277},
   month   = oct,
-  doi     = {10.1016/j.cma.2016.07.007},
   note    = {Unconfirmed citation},
+  doi     = {10.1016/j.cma.2016.07.007},
   publisher = {Elsevier {BV}}
 }
 
@@ -1900,11 +1900,11 @@
 }
 
 @MastersThesis{2016:zixuan:computational,
-  title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
   author  = {Huang Zixuan},
+  title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
+  school  = {National Taiwan University},
   year    = 2016,
   month   = jan,
-  school  = {National Taiwan University},
   doi     = {10.6342/NTU201602040},
   url     = {https://www.airitilibrary.com/Publication/alDetailedMesh?DocID=U0001-0508201623573200}
 }

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -19,17 +19,17 @@
 }
 
 @Article{2017:aizinger.kosik.ea:anisotropic,
-  doi     = {10.1002/fld.4360},
-  url     = {https://doi.org/10.1002/fld.4360},
+  author  = {Vadym Aizinger and Adam Kos{\'{i}}k and Dmitri Kuzmin and Balthasar Reuter},
+  title   = {Anisotropic slope limiting for discontinuous Galerkin methods},
+  journal = {International Journal for Numerical Methods in Fluids},
   year    = 2017,
-  month   = jan,
-  publisher = {Wiley},
   volume  = 84,
   number  = 9,
   pages   = {543--565},
-  author  = {Vadym Aizinger and Adam Kos{\'{i}}k and Dmitri Kuzmin and Balthasar Reuter},
-  title   = {Anisotropic slope limiting for discontinuous Galerkin methods},
-  journal = {International Journal for Numerical Methods in Fluids}
+  month   = jan,
+  doi     = {10.1002/fld.4360},
+  url     = {https://doi.org/10.1002/fld.4360},
+  publisher = {Wiley}
 }
 
 @Article{2017:almani.lee.ea:multirate,
@@ -40,17 +40,17 @@
 }
 
 @Article{2017:almeida-konzen.azevedo.ea:numerical,
-  doi     = {10.5540/tema.2017.018.02.0287},
-  url     = {https://doi.org/10.5540/tema.2017.018.02.0287},
+  author  = {Pedro Henrique de Almeida Konzen and F S Azevedo and E Sauter and P R A Zingano},
+  title   = {Numerical Simulations with the Galerkin Least Squares Finite Element Method for the Burgers' Equation on the Real Line},
+  journal = {{TEMA} (S{\~{a}}o Carlos)},
   year    = 2017,
-  month   = aug,
-  publisher = {Brazilian Society for Computational and Applied Mathematics ({SBMAC})},
   volume  = 18,
   number  = 2,
   pages   = 0287,
-  author  = {Pedro Henrique de Almeida Konzen and F S Azevedo and E Sauter and P R A Zingano},
-  title   = {Numerical Simulations with the Galerkin Least Squares Finite Element Method for the Burgers' Equation on the Real Line},
-  journal = {{TEMA} (S{\~{a}}o Carlos)}
+  month   = aug,
+  doi     = {10.5540/tema.2017.018.02.0287},
+  url     = {https://doi.org/10.5540/tema.2017.018.02.0287},
+  publisher = {Brazilian Society for Computational and Applied Mathematics ({SBMAC})}
 }
 
 @MastersThesis{2017:alzetta:core,
@@ -62,40 +62,40 @@
 }
 
 @Article{2017:araujo.engstrom:on,
-  doi     = {10.1016/j.camwa.2017.07.020},
-  url     = {https://doi.org/10.1016/j.camwa.2017.07.020},
+  author  = {Ara\'{u}jo, Juan C. and Engstr\"{o}m, Christian},
+  title   = {On spurious solutions in finite element approximations of resonances in open systems},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2017,
-  month   = nov,
-  publisher = {Elsevier {BV}},
   volume  = 74,
   number  = 10,
   pages   = {2385--2402},
-  author  = {Ara\'{u}jo, Juan C. and Engstr\"{o}m, Christian},
-  title   = {On spurious solutions in finite element approximations of resonances in open systems},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = nov,
+  doi     = {10.1016/j.camwa.2017.07.020},
+  url     = {https://doi.org/10.1016/j.camwa.2017.07.020},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:arbogast.hesse.ea:mixed,
-  doi     = {10.1137/16m1091095},
-  url     = {http://epubs.siam.org/doi/abs/10.1137/16M1091095},
+  author  = {Todd Arbogast and Marc A. Hesse and Abraham L. Taicher},
+  title   = {Mixed Methods for Two-Phase Darcy--Stokes Mixtures of Partially Melted Materials with Regions of Zero Porosity},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2017,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 39,
   number  = 2,
   pages   = {B375--B402},
-  author  = {Todd Arbogast and Marc A. Hesse and Abraham L. Taicher},
-  title   = {Mixed Methods for Two-Phase Darcy--Stokes Mixtures of Partially Melted Materials with Regions of Zero Porosity},
-  journal = {{SIAM} Journal on Scientific Computing}
+  month   = jan,
+  doi     = {10.1137/16m1091095},
+  url     = {http://epubs.siam.org/doi/abs/10.1137/16M1091095},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @InProceedings{2017:aristotelous.papanicolaou:numerical,
-  doi     = {10.1063/1.5007418},
-  url     = {https://doi.org/10.1063/1.5007418},
-  year    = 2017,
-  booktitle = {AIP Conference Proceedings, volume 1895},
   author  = {A. C. Aristotelous and N. C. Papanicolaou},
-  title   = {A numerical study of biofilm growth in a microgravity environment}
+  title   = {A numerical study of biofilm growth in a microgravity environment},
+  booktitle = {AIP Conference Proceedings, volume 1895},
+  year    = 2017,
+  doi     = {10.1063/1.5007418},
+  url     = {https://doi.org/10.1063/1.5007418}
 }
 
 @Article{2017:arndt.bangerth.ea:deal-ii,
@@ -120,16 +120,16 @@
 }
 
 @Article{2017:avila.meister.ea:adaptive,
-  doi     = {10.1016/j.apnum.2017.06.013},
-  url     = {https://doi.org/10.1016/j.apnum.2017.06.013},
-  year    = 2017,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 121,
-  pages   = {149--169},
   author  = {A.I. {\'{A}}vila and A. Meister and M. Steigemann},
   title   = {An adaptive Galerkin method for the time-dependent complex Schr\"{o}dinger equation},
-  journal = {Applied Numerical Mathematics}
+  journal = {Applied Numerical Mathematics},
+  year    = 2017,
+  volume  = 121,
+  pages   = {149--169},
+  month   = nov,
+  doi     = {10.1016/j.apnum.2017.06.013},
+  url     = {https://doi.org/10.1016/j.apnum.2017.06.013},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:axelsson.farouq.ea:preconditioner,
@@ -143,8 +143,8 @@
 }
 
 @Misc{2017:badia.martin.ea:fempar,
-  title   = {FEMPAR: An object-oriented parallel finite element framework},
   author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
+  title   = {FEMPAR: An object-oriented parallel finite element framework},
   year    = 2017,
   eprint  = {1708.01773},
   archiveprefix = {arXiv},
@@ -161,17 +161,17 @@
 }
 
 @Article{2017:ballani.kressner.ea:multilevel,
-  doi     = {10.1007/s40072-017-0092-7},
-  url     = {https://doi.org/10.1007/s40072-017-0092-7},
+  author  = {Jonas Ballani and Daniel Kressner and Michael D. Peters},
+  title   = {Multilevel tensor approximation of {PDEs} with random data},
+  journal = {Stochastics and Partial Differential Equations: Analysis and Computations},
   year    = 2017,
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 5,
   number  = 3,
   pages   = {400--427},
-  author  = {Jonas Ballani and Daniel Kressner and Michael D. Peters},
-  title   = {Multilevel tensor approximation of {PDEs} with random data},
-  journal = {Stochastics and Partial Differential Equations: Analysis and Computations}
+  month   = feb,
+  doi     = {10.1007/s40072-017-0092-7},
+  url     = {https://doi.org/10.1007/s40072-017-0092-7},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2017:basak.levitas:interfacial,
@@ -205,8 +205,8 @@
 }
 
 @PhDThesis{2017:beams:high-order-hybrid-methods-using-greens-functions-and-finite-elements,
-  title   = {{High-order hybrid methods using Green's functions and finite elements}},
   author  = {Beams, Natalie N},
+  title   = {{High-order hybrid methods using Green's functions and finite elements}},
   school  = {University of Illinois at Urbana-Champaign},
   year    = 2017,
   url     = {https://www.ideals.illinois.edu/bitstream/handle/2142/98387/BEAMS-DISSERTATION-2017.pdf?sequence=1}
@@ -220,8 +220,8 @@
 }
 
 @Misc{2017:berselli.wells.ea:spatial,
-  title   = {Spatial Filtering for Reduced Order Modeling},
   author  = {L. C. Berselli and D. Wells and X. Xie and T. Iliescu},
+  title   = {Spatial Filtering for Reduced Order Modeling},
   year    = 2017,
   eprint  = {1707.04133},
   archiveprefix = {arXiv},
@@ -242,9 +242,9 @@
   author  = {Boltersdorf, Jana},
   title   = {{A}usarbeitung und {V}ergleich verschiedener {G}itterverfeinerungsstrategien hinsichtlich der parallelen {P}erformance eines {B}randsimulationsprogramms mit adaptiver {G}itterverfeinerung},
   school  = {Fachhochschule Aachen},
+  year    = 2017,
   reportid = {FZJ-2018-00798},
   pages   = {63 p.},
-  year    = 2017,
   url     = {https://juser.fz-juelich.de/record/842585}
 }
 
@@ -266,8 +266,8 @@
 }
 
 @Misc{2017:bonito.demlow.ea:priori,
-  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace-Beltrami Operator},
   author  = {Andrea Bonito and Alan Demlow and Justin Owen},
+  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace-Beltrami Operator},
   year    = 2017,
   eprint  = {1801.00197},
   archiveprefix = {arXiv},
@@ -275,10 +275,10 @@
 }
 
 @PhDThesis{2017:brand:forces-and-flow-of-contractile-networks,
-  title   = {{Forces and Flow of Contractile Networks}},
   author  = {Brand, Christoph Alexander},
-  year    = 2017,
+  title   = {{Forces and Flow of Contractile Networks}},
   school  = {Heidelberg University},
+  year    = 2017,
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20233/1/thesis20151207.pdf},
   doi     = {10.11588/heidok.00020233}
 }
@@ -286,8 +286,8 @@
 @MastersThesis{2017:brauer:reduced-order,
   author  = {P. Br\"{a}uer},
   title   = {Reduced-Order modeling for transient thermoelasticity with moving sources using global-local bases},
-  year    = 2017,
-  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
+  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+  year    = 2017
 }
 
 @Article{2017:bredow.steinberger.ea:how,
@@ -300,16 +300,16 @@
 }
 
 @Article{2017:brisard:reconstructing,
-  doi     = {10.1002/nme.5263},
+  author  = {S{\'{e}}bastien Brisard},
+  title   = {Reconstructing displacements from the solution to the periodic Lippmann-Schwinger equation discretized on a uniform grid},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2017,
-  month   = jan,
-  publisher = {Wiley},
   volume  = 109,
   number  = 4,
   pages   = {459--486},
-  author  = {S{\'{e}}bastien Brisard},
-  title   = {Reconstructing displacements from the solution to the periodic Lippmann-Schwinger equation discretized on a uniform grid},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = jan,
+  doi     = {10.1002/nme.5263},
+  publisher = {Wiley}
 }
 
 @Article{2017:bucci.swamy.ea:modeling,
@@ -321,31 +321,31 @@
 }
 
 @Article{2017:burger.kenettinkara.ea:approximate,
-  doi     = {10.1016/j.camwa.2017.06.019},
-  url     = {https://doi.org/10.1016/j.camwa.2017.06.019},
+  author  = {Raimund B\"{u}rger and Sudarshan Kumar Kenettinkara and David Zor{\'{i}}o},
+  title   = {Approximate Lax-Wendroff discontinuous Galerkin methods for hyperbolic conservation laws},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2017,
-  month   = sep,
-  publisher = {Elsevier {BV}},
   volume  = 74,
   number  = 6,
   pages   = {1288--1310},
-  author  = {Raimund B\"{u}rger and Sudarshan Kumar Kenettinkara and David Zor{\'{i}}o},
-  title   = {Approximate Lax-Wendroff discontinuous Galerkin methods for hyperbolic conservation laws},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = sep,
+  doi     = {10.1016/j.camwa.2017.06.019},
+  url     = {https://doi.org/10.1016/j.camwa.2017.06.019},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:cajuhi.sanavia.ea:phase-field,
-  doi     = {10.1007/s00466-017-1459-3},
-  url     = {https://doi.org/10.1007/s00466-017-1459-3},
+  author  = {T. Cajuhi and L. Sanavia and L. De Lorenzis},
+  title   = {Phase-field modeling of fracture in variably saturated porous media},
+  journal = {Computational Mechanics},
   year    = 2017,
-  month   = aug,
-  publisher = {Springer Nature},
   volume  = 61,
   number  = 3,
   pages   = {299--318},
-  author  = {T. Cajuhi and L. Sanavia and L. De Lorenzis},
-  title   = {Phase-field modeling of fracture in variably saturated porous media},
-  journal = {Computational Mechanics}
+  month   = aug,
+  doi     = {10.1007/s00466-017-1459-3},
+  url     = {https://doi.org/10.1007/s00466-017-1459-3},
+  publisher = {Springer Nature}
 }
 
 @Article{2017:carraro.goll:goal-oriented,
@@ -381,8 +381,8 @@
 }
 
 @Misc{2017:charnyi.heister.ea:efficient,
-  title   = {Efficient discretizations for the EMAC formulation of the incompressible Navier-Stokes equations},
   author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
+  title   = {Efficient discretizations for the EMAC formulation of the incompressible Navier-Stokes equations},
   year    = 2017,
   eprint  = {1712.00857},
   archiveprefix = {arXiv},
@@ -402,37 +402,37 @@
 @PhDThesis{2017:chu:application,
   author  = {H.-C. Chu},
   title   = {Application of the fictitious domain method to flow problems with complex geometries},
-  year    = 2017,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2017
 }
 
 @PhDThesis{2017:cox:adaptive-large-scale-mantle-convection-simulations,
-  title   = {{Adaptive large-scale mantle convection simulations}},
   author  = {Cox, S. P.},
-  year    = 2017,
+  title   = {{Adaptive large-scale mantle convection simulations}},
   school  = {University of Leicester},
+  year    = 2017,
   url     = {https://lra.le.ac.uk/handle/2381/39571}
 }
 
 @Article{2017:dannberg.eilon.ea:importance,
-  doi     = {10.1002/2017gc006944},
-  url     = {https://doi.org/10.1002/2017gc006944},
+  author  = {J. Dannberg and Z. Eilon and Ulrich Faul and Rene Gassm\"{o}ller and Pritwiraj Moulik and Robert Myhill},
+  title   = {The importance of grain size to mantle dynamics and seismological observations},
+  journal = {Geochemistry, Geophysics, Geosystems},
   year    = 2017,
-  month   = aug,
-  publisher = {American Geophysical Union ({AGU})},
   volume  = 18,
   number  = 8,
   pages   = {3034--3061},
-  author  = {J. Dannberg and Z. Eilon and Ulrich Faul and Rene Gassm\"{o}ller and Pritwiraj Moulik and Robert Myhill},
-  title   = {The importance of grain size to mantle dynamics and seismological observations},
-  journal = {Geochemistry, Geophysics, Geosystems}
+  month   = aug,
+  doi     = {10.1002/2017gc006944},
+  url     = {https://doi.org/10.1002/2017gc006944},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @MastersThesis{2017:david:multi-patch,
   author  = {K. David},
   title   = {Multi-patch Discontinuous Galerkin Isogeometric Analysis for Porous Media Flow},
-  year    = 2017,
   school  = {Delft University of Technology, Delft, Netherlands },
+  year    = 2017,
   url     = {http://repository.tudelft.nl/islandora/object/uuid:85dfa311-2926-4390-a91b-876141e607e0/datastream/OBJ/view}
 }
 
@@ -450,17 +450,17 @@
 }
 
 @Article{2017:deolmi.dahmen.ea:effective,
-  doi     = {10.4208/cicp.oa-2016-0015},
-  url     = {https://doi.org/10.4208/cicp.oa-2016-0015},
+  author  = {Giulia Deolmi and Wolfgang Dahmen and Siegfried M\"{u}ller},
+  title   = {Effective Boundary Conditions: A General Strategy and Application to Compressible Flows Over Rough Boundaries},
+  journal = {Communications in Computational Physics},
   year    = 2017,
-  month   = feb,
-  publisher = {Global Science Press},
   volume  = 21,
   number  = 2,
   pages   = {358--400},
-  author  = {Giulia Deolmi and Wolfgang Dahmen and Siegfried M\"{u}ller},
-  title   = {Effective Boundary Conditions: A General Strategy and Application to Compressible Flows Over Rough Boundaries},
-  journal = {Communications in Computational Physics}
+  month   = feb,
+  doi     = {10.4208/cicp.oa-2016-0015},
+  url     = {https://doi.org/10.4208/cicp.oa-2016-0015},
+  publisher = {Global Science Press}
 }
 
 @Article{2017:dewitt.solomon.ea:misfit-driven,
@@ -474,17 +474,17 @@
 }
 
 @Article{2017:dhillon.milinkovitch.ea:bifurcation,
-  doi     = {10.1007/s11538-017-0255-8},
-  url     = {https://doi.org/10.1007/s11538-017-0255-8},
+  author  = {Daljit Singh J. Dhillon and Michel C. Milinkovitch and Matthias Zwicker},
+  title   = {Bifurcation Analysis of Reaction Diffusion Systems on Arbitrary Surfaces},
+  journal = {Bulletin of Mathematical Biology},
   year    = 2017,
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 79,
   number  = 4,
   pages   = {788--827},
-  author  = {Daljit Singh J. Dhillon and Michel C. Milinkovitch and Matthias Zwicker},
-  title   = {Bifurcation Analysis of Reaction Diffusion Systems on Arbitrary Surfaces},
-  journal = {Bulletin of Mathematical Biology}
+  month   = feb,
+  doi     = {10.1007/s11538-017-0255-8},
+  url     = {https://doi.org/10.1007/s11538-017-0255-8},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2017:diehl:review,
@@ -500,14 +500,14 @@
 @MastersThesis{2017:dockhorn:turbulence,
   author  = {T. Dockhorn},
   title   = {Turbulence modeling for large eddy simulation of incompressible flows using high-order discontinuous Galerkin methods},
-  year    = 2017,
   school  = {Technical University of Munich},
+  year    = 2017,
   note    = {Bachelor's thesis}
 }
 
 @Misc{2017:emerson:posteriori,
-  title   = {A Posteriori Error Estimators for the Frank-Oseen Model of Liquid Crystals},
   author  = {D. B. Emerson},
+  title   = {A Posteriori Error Estimators for the Frank-Oseen Model of Liquid Crystals},
   year    = 2017,
   eprint  = {1709.06157},
   archiveprefix = {arXiv},
@@ -515,16 +515,16 @@
 }
 
 @Article{2017:endtmayer.wick:partition-of-unity,
-  doi     = {10.1515/cmam-2017-0001},
-  url     = {https://doi.org/10.1515/cmam-2017-0001},
-  year    = 2017,
-  month   = jan,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = 17,
-  number  = 4,
   author  = {Bernhard Endtmayer and Thomas Wick},
   title   = {A Partition-of-Unity Dual-Weighted Residual Approach for Multi-Objective Goal Functional Error Estimation Applied to Elliptic Problems},
-  journal = {Computational Methods in Applied Mathematics}
+  journal = {Computational Methods in Applied Mathematics},
+  year    = 2017,
+  volume  = 17,
+  number  = 4,
+  month   = jan,
+  doi     = {10.1515/cmam-2017-0001},
+  url     = {https://doi.org/10.1515/cmam-2017-0001},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @Article{2017:ervin.lee.ea:nonlinear,
@@ -557,29 +557,29 @@
 }
 
 @Article{2017:fu.ermakov.ea:interior,
-  doi     = {10.1016/j.epsl.2017.07.053},
-  url     = {https://doi.org/10.1016/j.epsl.2017.07.053},
-  year    = 2017,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 476,
-  pages   = {153--164},
   author  = {Roger R. Fu and Anton I. Ermakov and Simone Marchi and Julie C. Castillo-Rogez and Carol A. Raymond and Bradford H. Hager and Maria T. Zuber and Scott D. King and Michael T. Bland and Maria Cristina De Sanctis and Frank Preusker and Ryan S. Park and Christopher T. Russell},
   title   = {The interior structure of Ceres as revealed by surface topography},
-  journal = {Earth and Planetary Science Letters}
+  journal = {Earth and Planetary Science Letters},
+  year    = 2017,
+  volume  = 476,
+  pages   = {153--164},
+  month   = oct,
+  doi     = {10.1016/j.epsl.2017.07.053},
+  url     = {https://doi.org/10.1016/j.epsl.2017.07.053},
+  publisher = {Elsevier {BV}}
 }
 
 @MastersThesis{2017:fuchs:hermite-artige,
   author  = {A. Fuchs},
   title   = {Hermite-artige Basisfunktionen f\"{u}r diskontinuierliche Galerkin-Verfahren hoher Ordnung},
-  year    = 2017,
   school  = {Technical University of Munich},
+  year    = 2017,
   note    = {Bachelor's thesis}
 }
 
 @Misc{2017:galiano.velasco:on,
-  title   = {On a cross-diffusion system arising in image denosing},
   author  = {Gonzalo Galiano and Juli{\'a}n Velasco},
+  title   = {On a cross-diffusion system arising in image denosing},
   year    = 2017,
   eprint  = {1703.02487},
   archiveprefix = {arXiv},
@@ -595,52 +595,52 @@
 }
 
 @PhDThesis{2017:gallego-valencia:on-runge-kutta-discontinuous-galerkin-methods-for-compressible-euler-equations-and-the-ideal-magneto-hydrodynamical-model,
-  title   = {{On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamical model}},
   author  = {J. P. {Gallego Valencia}},
-  year    = 2017,
+  title   = {{On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamical model}},
   school  = {University of W{\"u}rzburg},
+  year    = 2017,
   url     = {https://www.researchgate.net/profile/Juan_Gallego-Valencia/publication/317093976_On_Runge-Kutta_discontinuous_Galerkin_methods_for_compressible_Euler_equations_and_the_ideal_magneto-hydrodynamical_model/links/592978060f7e9b9979a686c2/On-Runge-Kutta-discontinuous-Galerkin-methods-for-compressible-Euler-equations-and-the-ideal-magneto-hydrodynamical-model.pdf}
 }
 
 @Article{2017:ganesan:microstructural-response-of-magnesium-alloys--3d-crystal-plasticity-and-experimental-validation,
-  title   = {{Microstructural Response of Magnesium Alloys: 3D Crystal Plasticity and Experimental Validation}},
   author  = {Ganesan, S},
+  title   = {{Microstructural Response of Magnesium Alloys: 3D Crystal Plasticity and Experimental Validation}},
   year    = 2017,
   school  = {University of Michigan},
   url     = {http://www-personal.umich.edu/~veeras/papers/sriramthesis.pdf}
 }
 
 @Article{2017:garikipati:perspectives,
-  doi     = {10.1016/j.jmps.2016.11.013},
-  url     = {https://doi.org/10.1016/j.jmps.2016.11.013},
-  year    = 2017,
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = 99,
-  pages   = {192--210},
   author  = {Krishna Garikipati},
   title   = {Perspectives on the mathematics of biological patterning and morphogenesis},
-  journal = {Journal of the Mechanics and Physics of Solids}
+  journal = {Journal of the Mechanics and Physics of Solids},
+  year    = 2017,
+  volume  = 99,
+  pages   = {192--210},
+  month   = feb,
+  doi     = {10.1016/j.jmps.2016.11.013},
+  url     = {https://doi.org/10.1016/j.jmps.2016.11.013},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2017:ghesmati:residual,
   author  = {A. Ghesmati},
   title   = {Residual and goal-oriented h- and hp-adaptive finite element; application for elliptic and saddle point problems},
-  year    = 2017,
-  school  = {Texas A\&M University}
+  school  = {Texas A\&M University},
+  year    = 2017
 }
 
 @Article{2017:ghorashi.lahmer.ea:stochastic,
-  doi     = {10.1016/j.enggeo.2016.07.012},
-  url     = {https://doi.org/10.1016/j.enggeo.2016.07.012},
-  year    = 2017,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 225,
-  pages   = {103--113},
   author  = {S.Sh. Ghorashi and T. Lahmer and A.S. Bagherzadeh and G. Zi and T. Rabczuk},
   title   = {A stochastic computational method based on goal-oriented error estimation for heterogeneous geological materials},
-  journal = {Engineering Geology}
+  journal = {Engineering Geology},
+  year    = 2017,
+  volume  = 225,
+  pages   = {103--113},
+  month   = jul,
+  doi     = {10.1016/j.enggeo.2016.07.012},
+  url     = {https://doi.org/10.1016/j.enggeo.2016.07.012},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:ghorashi.rabczuk:goal-oriented,
@@ -654,8 +654,8 @@
 }
 
 @PhDThesis{2017:giuliani:modelling-fluid-structure-interaction-problems-using-boundary-element-method,
-  title   = {{Modelling Fluid Structure Interaction problems using Boundary Element Method}},
   author  = {Giuliani, N},
+  title   = {{Modelling Fluid Structure Interaction problems using Boundary Element Method}},
   school  = {Scuola Internazionale Superiore di Studi Avanzati - Trieste},
   year    = 2017,
   url     = {https://iris.sissa.it/handle/20.500.11767/57293}
@@ -664,16 +664,16 @@
 @Article{2017:glerum.thieulot.ea:implementing,
   author  = {A. Glerum and C. Thieulot and M. Fraters and C. Blom and W. Spakman},
   title   = {Implementing nonlinear viscoplasticity in ASPECT: benchmarking and applications to 3D subduction modeling},
-  note    = {Submitted},
   year    = 2017,
+  note    = {Submitted},
   url     = {https://www.solid-earth-discuss.net/se-2017-9/}
 }
 
 @MastersThesis{2017:goering:implicit-explicit,
   author  = {C. Goering},
   title   = {Implicit-explicit Runge-Kutta methods for acoustics with the hybridizable discontinuous Galerkin method},
-  year    = 2017,
-  school  = {Technical University of Munich}
+  school  = {Technical University of Munich},
+  year    = 2017
 }
 
 @Article{2017:goering:slope,
@@ -684,33 +684,33 @@
 }
 
 @Article{2017:goll.wick.ea:dopelib,
-  doi     = {10.11588/ANS.2017.2.11815},
-  url     = {http://journals.ub.uni-heidelberg.de/index.php/ans/article/view/11815},
   author  = {Goll, Christian and Wick, Thomas and Wollner, Winnifried},
-  language = {en},
   title   = {{DOpElib}: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving {PDEs} and Optimization Problems with {PDEs}},
   journal = {Archive of Numerical Software},
+  year    = 2017,
   volume  = {Vol 5},
   pages   = {No 2 (2017)},
-  publisher = {Archive of Numerical Software},
-  year    = 2017
+  doi     = {10.11588/ANS.2017.2.11815},
+  url     = {http://journals.ub.uni-heidelberg.de/index.php/ans/article/view/11815},
+  language = {en},
+  publisher = {Archive of Numerical Software}
 }
 
 @Article{2017:grohs.hiptmair.ea:tensor-product,
-  doi     = {10.5802/smai-jcm.26},
-  url     = {https://doi.org/10.5802/smai-jcm.26},
-  year    = 2017,
-  publisher = {Cellule {MathDoc}/{CEDRAM}},
-  volume  = 3,
-  pages   = {219--248},
   author  = {Philipp Grohs and Ralf Hiptmair and Simon Pintarelli},
   title   = {Tensor-Product Discretization for the Spatially Inhomogeneous and Transient Boltzmann Equation in Two Dimensions},
-  journal = {{SMAI} Journal of Computational Mathematics}
+  journal = {{SMAI} Journal of Computational Mathematics},
+  year    = 2017,
+  volume  = 3,
+  pages   = {219--248},
+  doi     = {10.5802/smai-jcm.26},
+  url     = {https://doi.org/10.5802/smai-jcm.26},
+  publisher = {Cellule {MathDoc}/{CEDRAM}}
 }
 
 @PhDThesis{2017:grove:discretizations,
-  title   = {Discretizations \& Efficient Linear Solvers for Problems Related to Fluid Flow},
   author  = {Ryan R. Grove},
+  title   = {Discretizations \& Efficient Linear Solvers for Problems Related to Fluid Flow},
   school  = {Clemson University},
   year    = 2017,
   url     = {https://tigerprints.clemson.edu/all_dissertations/1985/}
@@ -727,17 +727,17 @@
 }
 
 @Article{2017:guermond.popov.ea:invariant,
-  doi     = {10.1137/16m1063034},
-  url     = {https://doi.org/10.1137/16m1063034},
+  author  = {Jean-Luc Guermond and Bojan Popov and Laura Saavedra and Yong Yang},
+  title   = {Invariant Domains Preserving Arbitrary Lagrangian Eulerian Approximation of Hyperbolic Systems with Continuous Finite Elements},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2017,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 39,
   number  = 2,
   pages   = {A385--A414},
-  author  = {Jean-Luc Guermond and Bojan Popov and Laura Saavedra and Yong Yang},
-  title   = {Invariant Domains Preserving Arbitrary Lagrangian Eulerian Approximation of Hyperbolic Systems with Continuous Finite Elements},
-  journal = {{SIAM} Journal on Scientific Computing}
+  month   = jan,
+  doi     = {10.1137/16m1063034},
+  url     = {https://doi.org/10.1137/16m1063034},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2017:gupta.veen.ea:bounds,
@@ -745,8 +745,8 @@
   title   = {Bounds for decoupled design and analysis discretizations in topology optimization},
   journal = {International Journal for Numerical Methods in Engineering},
   year    = 2017,
-  url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5455/full},
-  note    = {In press}
+  note    = {In press},
+  url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5455/full}
 }
 
 @Article{2017:hai.bause:finite,
@@ -766,22 +766,22 @@
 @PhDThesis{2017:hai:finite,
   author  = {B. S. M. Ebna Hai},
   title   = {Finite Element Approximation of Ultrasonic Wave Propagation under Fluid-Structure Interaction for Structural Health Monitoring Systems},
-  year    = 2017,
-  school  = {Helmut Schmidt University-University of the Federal Armed Forces Hambur, Germany}
+  school  = {Helmut Schmidt University-University of the Federal Armed Forces Hambur, Germany},
+  year    = 2017
 }
 
 @MastersThesis{2017:haider:numerical,
   author  = {S. Haider},
   title   = {Numerical analysis and comparison of high performance incompressible Navier Stokes equations solvers based on the discontinuous Galerkin Method},
-  year    = 2017,
-  school  = {Technical University of Munich}
+  school  = {Technical University of Munich},
+  year    = 2017
 }
 
 @MastersThesis{2017:hanowski:numerical,
   author  = {C. Hanowski},
   title   = {Numerical Homogenisation of Magneto-Active Materials},
-  year    = 2017,
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+  year    = 2017,
   note    = {Project thesis}
 }
 
@@ -807,46 +807,46 @@
 }
 
 @InCollection{2017:hinze.kunkel.ea:model,
-  doi     = {10.1007/978-3-319-07236-4_1},
-  url     = {https://doi.org/10.1007/978-3-319-07236-4_1},
-  year    = 2017,
-  publisher = {Springer International Publishing},
-  pages   = {1--37},
   author  = {Michael Hinze and Martin Kunkel and Ulrich Matthes and Morten Vierling},
   title   = {Model Order Reduction of Integrated Circuits in Electrical Networks},
-  booktitle = {Mathematics in Industry}
+  booktitle = {Mathematics in Industry},
+  publisher = {Springer International Publishing},
+  year    = 2017,
+  pages   = {1--37},
+  doi     = {10.1007/978-3-319-07236-4_1},
+  url     = {https://doi.org/10.1007/978-3-319-07236-4_1}
 }
 
 @PhDThesis{2017:holmgren:modelling-of-moving-contact-lines-in-two-phase-flows,
-  title   = {{Modelling of Moving Contact Lines in Two-Phase Flows}},
   author  = {Holmgren, H},
-  year    = 2017,
+  title   = {{Modelling of Moving Contact Lines in Two-Phase Flows}},
   school  = {Uppsala University},
+  year    = 2017,
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2:1139929}
 }
 
 @InProceedings{2017:horak.straub.ea:epicyclic,
-  title   = {Epicyclic oscillations of thick relativistic disks},
   author  = {J. Hor{\'a}k and O. Straub and E. {\v{S}}r{\'a}mkov{\'a} and K. Goluchov{\'{a}} and G. T{\"{o}}r{\"{o}}k},
-  booktitle = {Proceedings of RAGtime 2015/2016/2017, Opava, Czech Republic},
+  title   = {Epicyclic oscillations of thick relativistic disks},
   editor  = {Z. Stuchl{\'i}k, G. Tor{\"o}k and V. Karas},
-  pages   = {47--59},
+  booktitle = {Proceedings of RAGtime 2015/2016/2017, Opava, Czech Republic},
   year    = 2017,
+  pages   = {47--59},
   url     = {http://proceedings.physics.cz/images/proc17/hor2.pdf}
 }
 
 @Article{2017:hwang.fish.ea:software,
-  doi     = {10.1002/2016ea000225},
-  url     = {https://doi.org/10.1002/2016ea000225},
+  author  = {Lorraine Hwang and Allison Fish and Laura Soito and MacKenzie Smith and Louise H. Kellogg},
+  title   = {Software and the Scientist: Coding and Citation Practices in Geodynamics},
+  journal = {Earth and Space Science},
   year    = 2017,
-  month   = nov,
-  publisher = {American Geophysical Union ({AGU})},
   volume  = 4,
   number  = 11,
   pages   = {670--680},
-  author  = {Lorraine Hwang and Allison Fish and Laura Soito and MacKenzie Smith and Louise H. Kellogg},
-  title   = {Software and the Scientist: Coding and Citation Practices in Geodynamics},
-  journal = {Earth and Space Science}
+  month   = nov,
+  doi     = {10.1002/2016ea000225},
+  url     = {https://doi.org/10.1002/2016ea000225},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2017:jansen.sohrabi.ea:hulk,
@@ -867,16 +867,16 @@
 }
 
 @PhDThesis{2017:joos:microstructural-characterisation--modelling-and-simulation-of-solid-oxide-fuel-cell-cathodes,
-  title   = {{Microstructural Characterisation, Modelling and Simulation of Solid Oxide Fuel Cell Cathodes}},
   author  = {Joos, J},
-  year    = 2017,
+  title   = {{Microstructural Characterisation, Modelling and Simulation of Solid Oxide Fuel Cell Cathodes}},
   school  = {Karlsruhe Institute of Technology},
+  year    = 2017,
   url     = {https://publikationen.bibliothek.kit.edu/1000064791/4189242}
 }
 
 @Misc{2017:joshi.chatterjee:a-posteriori,
-  title   = {A-posteriori diffusion analysis of higher-order numerical schemes for application to propagating linear waves},
   author  = {S. M. Joshi and A. Chatterjee},
+  title   = {A-posteriori diffusion analysis of higher-order numerical schemes for application to propagating linear waves},
   year    = 2017,
   eprint  = {1707.05026},
   archiveprefix = {arXiv},
@@ -902,17 +902,17 @@
 }
 
 @Article{2017:karban.dolezel:fully,
-  doi     = {10.1007/s00202-017-0629-9},
-  url     = {https://doi.org/10.1007/s00202-017-0629-9},
+  author  = {Pavel Karban and Ivo Dole{\v{z}}el},
+  title   = {Fully adaptive higher-order finite element analysis of fast transient phenomena on overhead lines},
+  journal = {Electrical Engineering},
   year    = 2017,
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 99,
   number  = 4,
   pages   = {1255--1261},
-  author  = {Pavel Karban and Ivo Dole{\v{z}}el},
-  title   = {Fully adaptive higher-order finite element analysis of fast transient phenomena on overhead lines},
-  journal = {Electrical Engineering}
+  month   = aug,
+  doi     = {10.1007/s00202-017-0629-9},
+  url     = {https://doi.org/10.1007/s00202-017-0629-9},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2017:karrecha.abbassi.ea:self-consistent,
@@ -925,17 +925,17 @@
 }
 
 @Article{2017:kauffman.sheldon.ea:overset,
-  doi     = {10.1002/nme.5512},
-  url     = {https://doi.org/10.1002/nme.5512},
+  author  = {Justin A. Kauffman and Jason P. Sheldon and Scott T. Miller},
+  title   = {Overset meshing coupled with hybridizable discontinuous Galerkin finite elements},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2017,
-  month   = mar,
-  publisher = {Wiley},
   volume  = 112,
   number  = 5,
   pages   = {403--433},
-  author  = {Justin A. Kauffman and Jason P. Sheldon and Scott T. Miller},
-  title   = {Overset meshing coupled with hybridizable discontinuous Galerkin finite elements},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = mar,
+  doi     = {10.1002/nme.5512},
+  url     = {https://doi.org/10.1002/nme.5512},
+  publisher = {Wiley}
 }
 
 @InProceedings{2017:kodanganallur-narayanan:parallel-particle-in-cell-performance-optimization--a-case-study-of-electrospray-simulation,
@@ -949,31 +949,31 @@
 }
 
 @InProceedings{2017:korous.karban.ea:distributed,
-  title   = {Distributed Implicit Discontinuous Galerkin {MHD} Solver},
   author  = {Korous, L and Karban, P and Skala, J},
+  title   = {Distributed Implicit Discontinuous Galerkin {MHD} Solver},
   booktitle = {Proceedings of the 2017 CompuMag conference},
   year    = 2017,
   url     = {http://www.compumag.org/CMAG2017/[PD-A7-13]_492.pdf}
 }
 
 @Article{2017:kramer.kullmer.ea:semi-lagrangian,
-  doi     = {10.1103/physreve.95.023305},
-  url     = {https://doi.org/10.1103/physreve.95.023305},
-  year    = 2017,
-  month   = feb,
-  publisher = {American Physical Society ({APS})},
-  volume  = 95,
-  number  = 2,
   author  = {Andreas Kr\"{a}mer and Knut K\"{u}llmer and Dirk Reith and Wolfgang Joppich and Holger Foysi},
   title   = {Semi-Lagrangian off-lattice Boltzmann method for weakly compressible flows},
-  journal = {Physical Review E}
+  journal = {Physical Review E},
+  year    = 2017,
+  volume  = 95,
+  number  = 2,
+  month   = feb,
+  doi     = {10.1103/physreve.95.023305},
+  url     = {https://doi.org/10.1103/physreve.95.023305},
+  publisher = {American Physical Society ({APS})}
 }
 
 @PhDThesis{2017:kramer:lattice-boltzmann-methoden,
   author  = {Andreas Kr{\"a}mer},
   title   = {Lattice-{B}oltzmann-{M}ethoden zur {S}imulation inkompressibler {W}irbelstr{\"o}mungen},
-  year    = 2017,
   school  = {Universit{\"a}t Siegen},
+  year    = 2017,
   url     = {https://dspace.ub.uni-siegen.de/handle/ubsi/1237}
 }
 
@@ -1004,16 +1004,16 @@
 }
 
 @Article{2017:kynch.ledger:resolving,
-  doi     = {10.1016/j.compstruc.2016.05.021},
-  url     = {https://doi.org/10.1016/j.compstruc.2016.05.021},
-  year    = 2017,
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = 181,
-  pages   = {41--54},
   author  = {R.M. Kynch and P.D. Ledger},
   title   = {Resolving the sign conflict problem for hp-hexahedral N{\'{e}}d{\'{e}}lec elements with application to eddy current problems},
-  journal = {Computers {\&} Structures}
+  journal = {Computers {\&} Structures},
+  year    = 2017,
+  volume  = 181,
+  pages   = {41--54},
+  month   = mar,
+  doi     = {10.1016/j.compstruc.2016.05.021},
+  url     = {https://doi.org/10.1016/j.compstruc.2016.05.021},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:lee.wheeler.ea:initialization,
@@ -1059,19 +1059,19 @@
 }
 
 @InProceedings{2017:li.ren.ea:practical,
-  doi     = {10.1109/cit.2017.22},
-  url     = {https://doi.org/10.1109/cit.2017.22},
+  author  = {Hao Li and Xiaoguang Ren and Yufei Lin and Yuhua Tang and Shuai Ye},
+  title   = {Practical Performance Models for High-Order {CFD} Simulation},
+  booktitle = {2017 {IEEE} International Conference on Computer and Information Technology ({CIT})},
   year    = 2017,
   month   = aug,
   publisher = {{IEEE}},
-  author  = {Hao Li and Xiaoguang Ren and Yufei Lin and Yuhua Tang and Shuai Ye},
-  title   = {Practical Performance Models for High-Order {CFD} Simulation},
-  booktitle = {2017 {IEEE} International Conference on Computer and Information Technology ({CIT})}
+  doi     = {10.1109/cit.2017.22},
+  url     = {https://doi.org/10.1109/cit.2017.22}
 }
 
 @Misc{2017:licht.maier:flux,
-  title   = {Flux Reconstruction for Goal-Oriented A Posteriori Error Estimation},
   author  = {Martin Licht and Matthias Maier},
+  title   = {Flux Reconstruction for Goal-Oriented A Posteriori Error Estimation},
   year    = 2017,
   eprint  = {1707.09659},
   archiveprefix = {arXiv},
@@ -1081,92 +1081,92 @@
 @MastersThesis{2017:lin:high,
   author  = {S. Lin},
   title   = {High Performance Techniques Applied in Partial Differential Equations Library},
-  year    = 2017,
   school  = {St. Johns University},
+  year    = 2017,
   note    = {Honors thesis}
 }
 
 @Article{2017:liu.foo.ea:3d,
-  doi     = {10.1016/j.camss.2017.07.005},
-  url     = {https://doi.org/10.1016/j.camss.2017.07.005},
+  author  = {Jun Liu and Choon Chiang Foo and Zhi-Qian Zhang},
+  title   = {A 3D multi-field element for simulating the electromechanical coupling behavior of dielectric elastomers},
+  journal = {Acta Mechanica Solida Sinica},
   year    = 2017,
-  month   = aug,
-  publisher = {Springer Nature},
   volume  = 30,
   number  = 4,
   pages   = {374--389},
-  author  = {Jun Liu and Choon Chiang Foo and Zhi-Qian Zhang},
-  title   = {A 3D multi-field element for simulating the electromechanical coupling behavior of dielectric elastomers},
-  journal = {Acta Mechanica Solida Sinica}
+  month   = aug,
+  doi     = {10.1016/j.camss.2017.07.005},
+  url     = {https://doi.org/10.1016/j.camss.2017.07.005},
+  publisher = {Springer Nature}
 }
 
 @Article{2017:liu.liang:prevalence,
-  doi     = {10.1126/sciadv.1701872},
-  url     = {https://doi.org/10.1126/sciadv.1701872},
+  author  = {Boda Liu and Yan Liang},
+  title   = {The prevalence of kilometer-scale heterogeneity in the source region of {MORB} upper mantle},
+  journal = {Science Advances},
   year    = 2017,
-  month   = nov,
-  publisher = {American Association for the Advancement of Science ({AAAS})},
   volume  = 3,
   number  = 11,
   pages   = {e1701872},
-  author  = {Boda Liu and Yan Liang},
-  title   = {The prevalence of kilometer-scale heterogeneity in the source region of {MORB} upper mantle},
-  journal = {Science Advances}
+  month   = nov,
+  doi     = {10.1126/sciadv.1701872},
+  url     = {https://doi.org/10.1126/sciadv.1701872},
+  publisher = {American Association for the Advancement of Science ({AAAS})}
 }
 
 @TechReport{2017:ljungkvist.kronbichler:multigrid-for-matrix-free-finite-element-computations-on-graphics-processors,
-  title   = {{Multigrid for matrix-free finite element computations on graphics processors}},
   author  = {Ljungkvist, K and Kronbichler, M},
+  title   = {{Multigrid for matrix-free finite element computations on graphics processors}},
   institution = {Uppsala University},
-  number  = {2017-006},
   year    = 2017,
+  number  = {2017-006},
   url     = {https://pdfs.semanticscholar.org/924a/734d1e402f8b562e18c28a681baeaf10e34a.pdf}
 }
 
 @PhDThesis{2017:ljungkvist:finite,
   author  = {K. Ljungkvist},
   title   = {Finite element computations on multicore and graphics processors},
-  year    = 2017,
-  school  = {University of Uppsala, Sweden}
+  school  = {University of Uppsala, Sweden},
+  year    = 2017
 }
 
 @InProceedings{2017:ljungkvist:matrix-free,
   author  = {Ljungkvist, Karl},
   title   = {Matrix-free Finite-element Computations on Graphics Processors with Adaptively Refined Unstructured Meshes},
   booktitle = {Proceedings of the 25th High Performance Computing Symposium},
-  series  = {HPC '17},
   year    = 2017,
+  series  = {HPC '17},
+  pages   = {1:1--1:12},
+  address = {San Diego, CA, USA},
+  publisher = {Society for Computer Simulation International},
   isbn    = {978-1-5108-3822-2},
   location = {Virginia Beach, Virginia},
-  pages   = {1:1--1:12},
   articleno = 1,
   numpages = 12,
   url     = {http://dl.acm.org/citation.cfm?id=3108096.3108097},
-  acmid   = 3108097,
-  publisher = {Society for Computer Simulation International},
-  address = {San Diego, CA, USA}
+  acmid   = 3108097
 }
 
 @Article{2017:lovelace.demos.ea:numerically,
-  doi     = {10.1088/1361-6382/aa9ccc},
-  url     = {https://doi.org/10.1088/1361-6382/aa9ccc},
+  author  = {Geoffrey Lovelace and Nicholas Demos and Haroon Khan},
+  title   = {Numerically modeling Brownian thermal noise in amorphous and crystalline thin coatings},
+  journal = {Classical and Quantum Gravity},
   year    = 2017,
-  month   = dec,
-  publisher = {{IOP} Publishing},
   volume  = 35,
   number  = 2,
   pages   = 025017,
-  author  = {Geoffrey Lovelace and Nicholas Demos and Haroon Khan},
-  title   = {Numerically modeling Brownian thermal noise in amorphous and crystalline thin coatings},
-  journal = {Classical and Quantum Gravity}
+  month   = dec,
+  doi     = {10.1088/1361-6382/aa9ccc},
+  url     = {https://doi.org/10.1088/1361-6382/aa9ccc},
+  publisher = {{IOP} Publishing}
 }
 
 @InProceedings{2017:luo.zhao:numerical-simulation-of-temperature-fields-in-powder-bed-fusion-process-by-using-hybrid-heat-source-model,
-  title   = {{Numerical simulation of temperature fields in powder bed fusion process by using hybrid heat source model}},
   author  = {Luo, Z and Zhao, YF},
-  journal = {sffsymposium.engr.utexas.edu},
-  year    = 2017,
+  title   = {{Numerical simulation of temperature fields in powder bed fusion process by using hybrid heat source model}},
   booktitle = {Proceedings of the 28th Annual International Solid Freeform Fabrication Symposium: An Additive Manufacturing conference},
+  year    = 2017,
+  journal = {sffsymposium.engr.utexas.edu},
   url     = {https://sffsymposium.engr.utexas.edu/sites/default/files/2017/Manuscripts/NumericalSimulationofTemperatureFieldsinPowd.pdf}
 }
 
@@ -1183,8 +1183,8 @@
 }
 
 @Misc{2017:maier.margetis.ea:generation,
-  title   = {Generation of surface plasmon-polaritons by edge effects},
   author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
+  title   = {Generation of surface plasmon-polaritons by edge effects},
   year    = 2017,
   eprint  = {1702.00848},
   archiveprefix = {arXiv},
@@ -1192,22 +1192,22 @@
 }
 
 @Article{2017:maier.nemilentsau.ea:ultracompact,
-  doi     = {10.1021/acsphotonics.7b01094},
-  url     = {https://doi.org/10.1021/acsphotonics.7b01094},
+  author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
+  title   = {Ultracompact Amplitude Modulator by Coupling Hyperbolic Polaritons over a Graphene-Covered Gap},
+  journal = {{ACS} Photonics},
   year    = 2017,
-  month   = dec,
-  publisher = {American Chemical Society ({ACS})},
   volume  = 5,
   number  = 2,
   pages   = {544--551},
-  author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
-  title   = {Ultracompact Amplitude Modulator by Coupling Hyperbolic Polaritons over a Graphene-Covered Gap},
-  journal = {{ACS} Photonics}
+  month   = dec,
+  doi     = {10.1021/acsphotonics.7b01094},
+  url     = {https://doi.org/10.1021/acsphotonics.7b01094},
+  publisher = {American Chemical Society ({ACS})}
 }
 
 @Misc{2017:marojevic.goklu.ea:life,
-  title   = {Life time of topological coherent modes of a Bose--Einstein condensate in a gravito optical surface trap},
   author  = {{\v{Z}}elimir Marojevi{\'c} and Ertan G{\"o}kl{\"u} and Hannes Uecker and Claus L{\"a}mmerzahl},
+  title   = {Life time of topological coherent modes of a Bose--Einstein condensate in a gravito optical surface trap},
   year    = 2017,
   eprint  = {1708.04443},
   archiveprefix = {arXiv},
@@ -1215,64 +1215,64 @@
 }
 
 @Article{2017:mcgovern.kollet.ea:novel,
-  doi     = {10.1007/s10596-017-9643-2},
-  url     = {https://doi.org/10.1007/s10596-017-9643-2},
+  author  = {Sean McGovern and Stefan Kollet and Claudius M. B\"{u}rger and Ronnie L. Schwede and Olaf G. Podlaha},
+  title   = {Novel basin modelling concept for simulating deformation from mechanical compaction using level sets},
+  journal = {Computational Geosciences},
   year    = 2017,
-  month   = apr,
-  publisher = {Springer Nature},
   volume  = 21,
   number  = {5-6},
   pages   = {835--848},
-  author  = {Sean McGovern and Stefan Kollet and Claudius M. B\"{u}rger and Ronnie L. Schwede and Olaf G. Podlaha},
-  title   = {Novel basin modelling concept for simulating deformation from mechanical compaction using level sets},
-  journal = {Computational Geosciences}
+  month   = apr,
+  doi     = {10.1007/s10596-017-9643-2},
+  url     = {https://doi.org/10.1007/s10596-017-9643-2},
+  publisher = {Springer Nature}
 }
 
 @Article{2017:mehnert.pelteret.ea:numerical,
-  doi     = {10.1177/1081286517729867},
-  url     = {https://doi.org/10.1177/1081286517729867},
+  author  = {Markus Mehnert and Jean-Paul Pelteret and Paul Steinmann},
+  title   = {Numerical modelling of nonlinear thermo-electro-elasticity},
+  journal = {Mathematics and Mechanics of Solids},
   year    = 2017,
-  month   = sep,
-  publisher = {{SAGE} Publications},
   volume  = 22,
   number  = 11,
   pages   = {2196--2213},
-  author  = {Markus Mehnert and Jean-Paul Pelteret and Paul Steinmann},
-  title   = {Numerical modelling of nonlinear thermo-electro-elasticity},
-  journal = {Mathematics and Mechanics of Solids}
+  month   = sep,
+  doi     = {10.1177/1081286517729867},
+  url     = {https://doi.org/10.1177/1081286517729867},
+  publisher = {{SAGE} Publications}
 }
 
 @MastersThesis{2017:mentler:high,
   author  = {M. Mentler},
   title   = {High performance implementation of one-field elasticity using the deal.II Finite Element library},
-  year    = 2017,
-  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
+  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
+  year    = 2017
 }
 
 @Article{2017:mohebujjaman.rebholz:efficient,
-  doi     = {10.1515/cmam-2016-0033},
-  url     = {https://doi.org/10.1515/cmam-2016-0033},
-  year    = 2017,
-  month   = jan,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = 17,
-  number  = 1,
   author  = {Muhammad Mohebujjaman and Leo G. Rebholz},
   title   = {An Efficient Algorithm for Computation of {MHD} Flow Ensembles},
-  journal = {Computational Methods in Applied Mathematics}
+  journal = {Computational Methods in Applied Mathematics},
+  year    = 2017,
+  volume  = 17,
+  number  = 1,
+  month   = jan,
+  doi     = {10.1515/cmam-2016-0033},
+  url     = {https://doi.org/10.1515/cmam-2016-0033},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @TechReport{2017:mohebujjaman:c-parallel-implementation-of-incompressible-viscous-time-dependent-nse-simulation-using-projection-method-in-dealii,
-  title   = {{C++ parallel implementation of incompressible viscous time-dependent NSE simulation using projection method in Dealii}},
   author  = {Mohebujjaman, M},
+  title   = {{C++ parallel implementation of incompressible viscous time-dependent NSE simulation using projection method in Dealii}},
   institution = {Virginia Tech},
   year    = 2017,
   url     = {http://mmohebu.people.clemson.edu/PDFDocuments/project_HPC_Projection_Method_NSE.pdf}
 }
 
 @PhDThesis{2017:mohebujjaman:efficient,
-  title   = {Efficient Numerical Methods for Magnetohydrodynamic Flow},
   author  = {Muhammad Mohebujjaman},
+  title   = {Efficient Numerical Methods for Magnetohydrodynamic Flow},
   school  = {Clemson University},
   year    = 2017,
   url     = {https://tigerprints.clemson.edu/all_dissertations/2027/}
@@ -1280,9 +1280,9 @@
 
 @TechReport{2017:mohebujjaman:high-order,
   author  = {Mohebujjaman, M.},
-  year    = 2017,
   title   = {High-order efficient algorithms for computation of {MHD} flow ensemble},
   institution = {Virginia Tech},
+  year    = 2017,
   url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/publication/327449710_HIGH_ORDER_EFFICIENT_ALGORITHM_FOR_COMPUTATION_OF_MHD_FLOW_ENSEMBLE/links/5b903a08a6fdcce8a4c3548d/HIGH-ORDER-EFFICIENT-ALGORITHM-FOR-COMPUTATION-OF-MHD-FLOW-ENSEMBLE.pdf}
 }
 
@@ -1297,25 +1297,25 @@
 }
 
 @PhDThesis{2017:monavari:continuum,
-  title   = {Continuum Dislocation Kinematics},
   author  = {Mehran Monavari},
+  title   = {Continuum Dislocation Kinematics},
   school  = {Friedrich-Alexander-Universit{\"a}t Erlangen-N{\"u}rnberg},
   year    = 2017,
   url     = {https://opus4.kobv.de/opus4-fau/frontdoor/deliver/index/docId/8685/file/MehranMonavariDissertation.pdf}
 }
 
 @Article{2017:na.sun.ea:effects,
-  doi     = {10.1002/2016jb013374},
-  url     = {https://doi.org/10.1002/2016jb013374},
+  author  = {SeonHong Na and WaiChing Sun and Mathew D. Ingraham and Hongkyu Yoon},
+  title   = {Effects of spatial heterogeneity and material anisotropy on the fracture pattern and macroscopic effective toughness of Mancos Shale in Brazilian tests},
+  journal = {Journal of Geophysical Research: Solid Earth},
   year    = 2017,
-  month   = aug,
-  publisher = {American Geophysical Union ({AGU})},
   volume  = 122,
   number  = 8,
   pages   = {6202--6230},
-  author  = {SeonHong Na and WaiChing Sun and Mathew D. Ingraham and Hongkyu Yoon},
-  title   = {Effects of spatial heterogeneity and material anisotropy on the fracture pattern and macroscopic effective toughness of Mancos Shale in Brazilian tests},
-  journal = {Journal of Geophysical Research: Solid Earth}
+  month   = aug,
+  doi     = {10.1002/2016jb013374},
+  url     = {https://doi.org/10.1002/2016jb013374},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2017:na.sun:computational,
@@ -1329,14 +1329,14 @@
 }
 
 @InProceedings{2017:narayanan.madduri:parallel,
-  doi     = {10.1109/ipdpsw.2017.160},
-  url     = {https://doi.org/10.1109/ipdpsw.2017.160},
+  author  = {Ramachandran Kodanganallur Narayanan and Kamesh Madduri},
+  title   = {Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation},
+  booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})},
   year    = 2017,
   month   = may,
   publisher = {{IEEE}},
-  author  = {Ramachandran Kodanganallur Narayanan and Kamesh Madduri},
-  title   = {Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation},
-  booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})}
+  doi     = {10.1109/ipdpsw.2017.160},
+  url     = {https://doi.org/10.1109/ipdpsw.2017.160}
 }
 
 @Article{2017:odster.wheeler.ea:postprocessing,
@@ -1350,37 +1350,37 @@
 }
 
 @Article{2017:oneill.marchi.ea:impact-driven,
-  doi     = {10.1038/ngeo3029},
-  title   = {Impact-driven subduction on the {H}adean {E}arth},
   author  = {O'Neill, C. and Marchi, S. and Zhang, S. and Bottke, W.},
+  title   = {Impact-driven subduction on the {H}adean {E}arth},
   journal = {Nature Geoscience},
+  year    = 2017,
   volume  = 10,
   number  = 10,
   pages   = 793,
-  year    = 2017,
+  doi     = {10.1038/ngeo3029},
   publisher = {Nature Publishing Group}
 }
 
 @PhDThesis{2017:patty:an-energy-formulation-of-surface-tension-or-willmore-force-for-two-phase-flow,
-  title   = {{An Energy Formulation of Surface Tension or Willmore Force For Two-Phase Flow}},
   author  = {Patty, S.},
+  title   = {{An Energy Formulation of Surface Tension or Willmore Force For Two-Phase Flow}},
   school  = {Texas A\&M University},
   year    = 2017,
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/165987}
 }
 
 @Article{2017:porcelli.simoncini.ea:preconditioning,
-  doi     = {10.1016/j.camwa.2017.04.033},
-  url     = {https://doi.org/10.1016/j.camwa.2017.04.033},
+  author  = {Margherita Porcelli and Valeria Simoncini and Martin Stoll},
+  title   = {Preconditioning {PDE}-constrained optimization with L1-sparsity and control constraints},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2017,
-  month   = sep,
-  publisher = {Elsevier {BV}},
   volume  = 74,
   number  = 5,
   pages   = {1059--1075},
-  author  = {Margherita Porcelli and Valeria Simoncini and Martin Stoll},
-  title   = {Preconditioning {PDE}-constrained optimization with L1-sparsity and control constraints},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = sep,
+  doi     = {10.1016/j.camwa.2017.04.033},
+  url     = {https://doi.org/10.1016/j.camwa.2017.04.033},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:poy.bunel.ea:role,
@@ -1392,24 +1392,24 @@
 }
 
 @Article{2017:pratik-rai:adjoint-based,
-  doi     = {10.13140/RG.2.2.23244.10884},
-  url     = {http://rgdoi.net/10.13140/RG.2.2.23244.10884},
   author  = {{Pratik Rai}},
   title   = {Adjoint-based error estimation and mesh adaptivity for stationary fluid-structure interaction},
-  publisher = {Unpublished},
-  year    = 2017
+  year    = 2017,
+  doi     = {10.13140/RG.2.2.23244.10884},
+  url     = {http://rgdoi.net/10.13140/RG.2.2.23244.10884},
+  publisher = {Unpublished}
 }
 
 @PhDThesis{2017:quinelato:mixed,
   author  = {T. O. Quinelato},
   title   = {Mixed Hybrid Finite Element Methods in Elasticity and Poroelasticity},
-  year    = 2017,
-  school  = {Laborat\'{o}rio Nacional de Computa\c{c}\~{a}o Cient\'{i}fica, Brazil}
+  school  = {Laborat\'{o}rio Nacional de Computa\c{c}\~{a}o Cient\'{i}fica, Brazil},
+  year    = 2017
 }
 
 @PhDThesis{2017:ramirez:time-dependent,
-  title   = {Time-dependent {S}tokes-{D}arcy Flow with Deposition},
   author  = {Javier Ruiz Ramirez},
+  title   = {Time-dependent {S}tokes-{D}arcy Flow with Deposition},
   school  = {Clemson University},
   year    = 2017,
   url     = {https://tigerprints.clemson.edu/all_dissertations/1968/}
@@ -1442,8 +1442,8 @@
 }
 
 @Misc{2017:riviere.kanschat:finite,
-  title   = {A finite element method with strong mass conservation for Biot's linear consolidation model},
   author  = {Beatrice Riviere and Guido Kanschat},
+  title   = {A finite element method with strong mass conservation for Biot's linear consolidation model},
   year    = 2017,
   eprint  = {1712.07468},
   archiveprefix = {arXiv},
@@ -1451,17 +1451,17 @@
 }
 
 @Article{2017:roland.tjardes.ea:personalized,
-  doi     = {10.1002/pamm.201710078},
-  url     = {https://doi.org/10.1002/pamm.201710078},
+  author  = {Michael Roland and Thorsten Tjardes and Bertil Bouillon and Stefan Diebels},
+  title   = {Personalized simulation of a bone-implant-system during a step forward},
+  journal = {{PAMM}},
   year    = 2017,
-  month   = dec,
-  publisher = {Wiley},
   volume  = 17,
   number  = 1,
   pages   = {217--218},
-  author  = {Michael Roland and Thorsten Tjardes and Bertil Bouillon and Stefan Diebels},
-  title   = {Personalized simulation of a bone-implant-system during a step forward},
-  journal = {{PAMM}}
+  month   = dec,
+  doi     = {10.1002/pamm.201710078},
+  url     = {https://doi.org/10.1002/pamm.201710078},
+  publisher = {Wiley}
 }
 
 @Article{2017:rose.buffett.ea:stability,
@@ -1485,32 +1485,32 @@
 }
 
 @InCollection{2017:russ.pacini:empirically-derived,
-  doi     = {10.1007/978-3-319-54735-0_8},
-  url     = {https://doi.org/10.1007/978-3-319-54735-0_8},
-  year    = 2017,
-  publisher = {Springer International Publishing},
-  pages   = {71--82},
   author  = {Jonathan B. Russ and Benjamin R. Pacini},
   title   = {Empirically-Derived, Constitutive Damping Model for Cellular Silicone},
-  booktitle = {Shock {\&} Vibration, Aircraft/Aerospace, Energy Harvesting, Acoustics {\&} Optics, Volume 9}
+  booktitle = {Shock {\&} Vibration, Aircraft/Aerospace, Energy Harvesting, Acoustics {\&} Optics, Volume 9},
+  publisher = {Springer International Publishing},
+  year    = 2017,
+  pages   = {71--82},
+  doi     = {10.1007/978-3-319-54735-0_8},
+  url     = {https://doi.org/10.1007/978-3-319-54735-0_8}
 }
 
 @PhDThesis{2017:sabawi:adaptive-discontinuous-galerkin-methods-for-interface-problems,
-  title   = {{Adaptive discontinuous Galerkin methods for interface problems}},
   author  = {Sabawi, YA},
-  year    = 2017,
+  title   = {{Adaptive discontinuous Galerkin methods for interface problems}},
   school  = {University of Leicester},
+  year    = 2017,
   url     = {http://hdl.handle.net/2381/39386}
 }
 
 @InProceedings{2017:santos.azeredo-coutinho:continuous,
-  doi     = {10.20906/cps/cilamce2017-0712},
-  url     = {https://doi.org/10.20906/cps/cilamce2017-0712},
-  year    = 2017,
-  publisher = {{ABMEC} Brazilian Association of Computational Methods in Engineering},
   author  = {T{\'{u}}lio Ligneul Santos and Alvaro Luiz Gayoso de Azeredo Coutinho},
   title   = {A continuous finite element approach to the well-balanced shallow water equations},
-  booktitle = {Proceedings of the {XXXVIII} Iberian Latin American Congress on Computational Methods in Engineering}
+  booktitle = {Proceedings of the {XXXVIII} Iberian Latin American Congress on Computational Methods in Engineering},
+  year    = 2017,
+  publisher = {{ABMEC} Brazilian Association of Computational Methods in Engineering},
+  doi     = {10.20906/cps/cilamce2017-0712},
+  url     = {https://doi.org/10.20906/cps/cilamce2017-0712}
 }
 
 @Article{2017:schoeder.kronbichler.ea:photoacoustic,
@@ -1533,59 +1533,59 @@
 }
 
 @Article{2017:seydel.schuster:identifying,
-  doi     = {10.1088/1361-6420/aa8d91},
-  url     = {https://doi.org/10.1088/1361-6420/aa8d91},
+  author  = {Julia Seydel and Thomas Schuster},
+  title   = {Identifying the stored energy of a hyperelastic structure by using an attenuated Landweber method},
+  journal = {Inverse Problems},
   year    = 2017,
-  month   = nov,
-  publisher = {{IOP} Publishing},
   volume  = 33,
   number  = 12,
   pages   = 124004,
-  author  = {Julia Seydel and Thomas Schuster},
-  title   = {Identifying the stored energy of a hyperelastic structure by using an attenuated Landweber method},
-  journal = {Inverse Problems}
+  month   = nov,
+  doi     = {10.1088/1361-6420/aa8d91},
+  url     = {https://doi.org/10.1088/1361-6420/aa8d91},
+  publisher = {{IOP} Publishing}
 }
 
 @PhDThesis{2017:seydel:identifikation-der-verzerrungsenergiedichte-hyperelastischer-materialien-aus-zeitabhangigen-randmessungen,
-  title   = {{Identifikation der Verzerrungsenergiedichte hyperelastischer Materialien aus zeitabh{\"{a}}ngigen Randmessungen}},
   author  = {Seydel, J.},
-  year    = 2017,
+  title   = {{Identifikation der Verzerrungsenergiedichte hyperelastischer Materialien aus zeitabh{\"{a}}ngigen Randmessungen}},
   school  = {Universit{\"a}t des Saarlandes},
+  year    = 2017,
   url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/26795},
   doi     = {10.22028/D291-26782}
 }
 
 @PhDThesis{2017:shakir:multilevel-schwarz-methods-for-incompressible-flow-problems,
-  title   = {{Multilevel Schwarz Methods for Incompressible Flow Problems}},
   author  = {Shakir, N.},
-  year    = 2017,
+  title   = {{Multilevel Schwarz Methods for Incompressible Flow Problems}},
   school  = {Heidelberg University},
+  year    = 2017,
   doi     = {10.11588/heidok.00023210},
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/23210}
 }
 
 @TechReport{2017:song.west.ea:munition-penetration-depth-prediction,
-  title   = {{Munition Penetration Depth Prediction}},
   author  = {Song, A. S. and West, B. A. and Taylor, O. D. S. and O'Connor, D. T.},
-  year    = 2017,
-  url     = {http://www.dtic.mil/get-tr-doc/pdf?AD=AD1039187},
+  title   = {{Munition Penetration Depth Prediction}},
   institution = {US Army Corps of Engineers},
-  number  = {SERDP SEED Project MR 2629}
+  year    = 2017,
+  number  = {SERDP SEED Project MR 2629},
+  url     = {http://www.dtic.mil/get-tr-doc/pdf?AD=AD1039187}
 }
 
 @MastersThesis{2017:strom:preconditioned,
   author  = {A. Str\"{o}m},
   title   = {Preconditioned iterative methods for PDE-constrained optimization problems with pointwise state constraints},
-  year    = 2017,
   school  = {Uppsala University, Sweden},
+  year    = 2017,
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A1081649&dswid=292}
 }
 
 @PhDThesis{2017:sutton:virtual-element-methods,
-  title   = {{Virtual Element Methods}},
   author  = {Sutton, O. J.},
-  year    = 2017,
+  title   = {{Virtual Element Methods}},
   school  = {University of Leicester},
+  year    = 2017,
   url     = {https://lra.le.ac.uk/handle/2381/39955}
 }
 
@@ -1600,39 +1600,39 @@
 }
 
 @PhDThesis{2017:teichert:mathematical-framework-and-numerical-methods-for-the-modeling-of-mechanochemistry-in-multi-phase-materials,
-  title   = {{Mathematical Framework and Numerical Methods for the Modeling of Mechanochemistry in Multi-Phase Materials}},
   author  = {Teichert, Gregory},
-  url     = {http://hdl.handle.net/2027.42/138690},
+  title   = {{Mathematical Framework and Numerical Methods for the Modeling of Mechanochemistry in Multi-Phase Materials}},
+  school  = {University of Michigan},
   year    = 2017,
-  school  = {University of Michigan}
+  url     = {http://hdl.handle.net/2027.42/138690}
 }
 
 @Article{2017:thieulot:analytical,
-  doi     = {10.5194/se-8-1181-2017},
-  url     = {https://doi.org/10.5194/se-8-1181-2017},
+  author  = {Cedric Thieulot},
+  title   = {Analytical solution for viscous incompressible Stokes flow in a spherical shell},
+  journal = {Solid Earth},
   year    = 2017,
-  month   = nov,
-  publisher = {Copernicus {GmbH}},
   volume  = 8,
   number  = 6,
   pages   = {1181--1191},
-  author  = {Cedric Thieulot},
-  title   = {Analytical solution for viscous incompressible Stokes flow in a spherical shell},
-  journal = {Solid Earth}
+  month   = nov,
+  doi     = {10.5194/se-8-1181-2017},
+  url     = {https://doi.org/10.5194/se-8-1181-2017},
+  publisher = {Copernicus {GmbH}}
 }
 
 @Article{2017:toulopoulos.wick:numerical,
-  doi     = {10.1137/16m1067792},
-  url     = {https://doi.org/10.1137/16m1067792},
+  author  = {Ioannis Toulopoulos and Thomas Wick},
+  title   = {Numerical Methods for Power-Law Diffusion Problems},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2017,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 39,
   number  = 3,
   pages   = {A681--A710},
-  author  = {Ioannis Toulopoulos and Thomas Wick},
-  title   = {Numerical Methods for Power-Law Diffusion Problems},
-  journal = {{SIAM} Journal on Scientific Computing}
+  month   = jan,
+  doi     = {10.1137/16m1067792},
+  url     = {https://doi.org/10.1137/16m1067792},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2017:verner.garikipati:computational,
@@ -1659,8 +1659,8 @@
 @PhDThesis{2017:villiers:patient-specific,
   author  = {A. M. De Villiers},
   title   = {A patient-specific FSI model for vascular access in haemodialysis},
-  year    = 2017,
   school  = {University of Cape Town},
+  year    = 2017,
   url     = {http://hdl.handle.net/11427/24441}
 }
 
@@ -1673,8 +1673,8 @@
 }
 
 @Misc{2017:wells.banks:using,
-  title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates},
   author  = {David Wells and Jeffrey Banks},
+  title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates},
   year    = 2017,
   eprint  = {1711.05922},
   archiveprefix = {arXiv},
@@ -1682,8 +1682,8 @@
 }
 
 @Misc{2017:welper:h,
-  title   = {$h$ and $hp$-adaptive Interpolation by Transformed Snapshots for Parametric and Stochastic Hyperbolic PDEs},
   author  = {G. Welper},
+  title   = {$h$ and $hp$-adaptive Interpolation by Transformed Snapshots for Parametric and Stochastic Hyperbolic PDEs},
   year    = 2017,
   eprint  = {1710.11481},
   archiveprefix = {arXiv},
@@ -1691,42 +1691,42 @@
 }
 
 @InCollection{2017:wick:coupling,
-  doi     = {10.1515/9783110494259-009},
-  year    = 2017,
-  month   = nov,
-  publisher = {De Gruyter},
-  pages   = {329--366},
   author  = {Thomas Wick},
-  editor  = {Stefan Frei and B\"{a}rbel Holm and Thomas Richter and Thomas Wick and Huidong Yang},
   title   = {Coupling fluid-structure interaction with phase-field fracture: Algorithmic details},
-  booktitle = {Fluid-Structure Interaction}
+  editor  = {Stefan Frei and B\"{a}rbel Holm and Thomas Richter and Thomas Wick and Huidong Yang},
+  booktitle = {Fluid-Structure Interaction},
+  publisher = {De Gruyter},
+  year    = 2017,
+  pages   = {329--366},
+  month   = nov,
+  doi     = {10.1515/9783110494259-009}
 }
 
 @Article{2017:wick:error-oriented,
-  doi     = {10.1137/16m1063873},
-  url     = {https://doi.org/10.1137/16m1063873},
+  author  = {Thomas Wick},
+  title   = {An Error-Oriented {Newton}/Inexact Augmented {Lagrangian} Approach for Fully Monolithic Phase-Field Fracture Propagation},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2017,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 39,
   number  = 4,
   pages   = {B589--B617},
-  author  = {Thomas Wick},
-  title   = {An Error-Oriented {Newton}/Inexact Augmented {Lagrangian} Approach for Fully Monolithic Phase-Field Fracture Propagation},
-  journal = {{SIAM} Journal on Scientific Computing}
+  month   = jan,
+  doi     = {10.1137/16m1063873},
+  url     = {https://doi.org/10.1137/16m1063873},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2017:wick:modified,
-  doi     = {10.1016/j.cma.2017.07.026},
-  url     = {https://doi.org/10.1016/j.cma.2017.07.026},
-  year    = 2017,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 325,
-  pages   = {577--611},
   author  = {Thomas Wick},
   title   = {Modified {Newton} methods for solving fully monolithic phase-field quasi-static brittle fracture propagation},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2017,
+  volume  = 325,
+  pages   = {577--611},
+  month   = oct,
+  doi     = {10.1016/j.cma.2017.07.026},
+  url     = {https://doi.org/10.1016/j.cma.2017.07.026},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:wilmers.mcbride.ea:interface,
@@ -1739,87 +1739,87 @@
 }
 
 @PhDThesis{2017:wilmers:multiphysically,
+  author  = {Wilmers, Jana},
+  title   = {Multiphysically coupled modelling of polymer-based materials},
+  year    = 2017,
   doi     = {10.15480/882.1438},
   url     = {https://tubdok.tub.tuhh.de/handle/11420/1441},
-  author  = {Wilmers, Jana},
   language = {en},
-  title   = {Multiphysically coupled modelling of polymer-based materials},
-  publisher = {TUHH Universit\"{a}tsbibliothek},
-  year    = 2017
+  publisher = {TUHH Universit\"{a}tsbibliothek}
 }
 
 @TechReport{2017:yoon:multiscale,
+  author  = {Yoon, H},
   title   = {Multiscale Characterization of Structural, Compositional, and Textural Heterogeneity of Nano-porous Geomaterials},
   institution = {Sandia National Laboratory},
-  author  = {Yoon, H},
   year    = 2017,
   url     = {http://prod.sandia.gov/techlib/access-control.cgi/2017/1710273.pdf}
 }
 
 @Article{2017:yu.cheng.ea:residual-based,
-  doi     = {10.1016/j.compfluid.2017.08.016},
-  url     = {https://doi.org/10.1016/j.compfluid.2017.08.016},
-  year    = 2017,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 156,
-  pages   = {470--484},
   author  = {Shengjiao Yu and Jian Cheng and Huiqiang Yue and Tiegang Liu},
   title   = {A residual-based h-adaptive reconstructed discontinuous Galerkin method for the compressible Euler equations on unstructured grids},
-  journal = {Computers {\&} Fluids}
+  journal = {Computers {\&} Fluids},
+  year    = 2017,
+  volume  = 156,
+  pages   = {470--484},
+  month   = oct,
+  doi     = {10.1016/j.compfluid.2017.08.016},
+  url     = {https://doi.org/10.1016/j.compfluid.2017.08.016},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:zhang.gain.ea:stress-based,
-  doi     = {10.1016/j.cma.2017.06.025},
-  url     = {https://doi.org/10.1016/j.cma.2017.06.025},
-  year    = 2017,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 325,
-  pages   = {1--21},
   author  = {Shanglong Zhang and Arun L. Gain and Juli{\'{a}}n A. Norato},
   title   = {Stress-based topology optimization with discrete geometric components},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2017,
+  volume  = 325,
+  pages   = {1--21},
+  month   = oct,
+  doi     = {10.1016/j.cma.2017.06.025},
+  url     = {https://doi.org/10.1016/j.cma.2017.06.025},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2017:zhang.norato:optimal,
-  doi     = {10.1115/1.4036999},
-  url     = {https://doi.org/10.1115/1.4036999},
-  year    = 2017,
-  month   = jun,
-  publisher = {{ASME} International},
-  volume  = 139,
-  number  = 8,
   author  = {Shanglong Zhang and Juli{\'{a}}n A. Norato},
   title   = {Optimal Design of Panel Reinforcements With Ribs Made of Plates},
-  journal = {Journal of Mechanical Design}
+  journal = {Journal of Mechanical Design},
+  year    = 2017,
+  volume  = 139,
+  number  = 8,
+  month   = jun,
+  doi     = {10.1115/1.4036999},
+  url     = {https://doi.org/10.1115/1.4036999},
+  publisher = {{ASME} International}
 }
 
 @Article{2017:zheng.mcclarren.ea:accurate,
-  doi     = {10.1080/00295639.2017.1407592},
-  url     = {https://doi.org/10.1080/00295639.2017.1407592},
+  author  = {Weixiong Zheng and Ryan G. McClarren and Jim E. Morel},
+  title   = {An Accurate Globally Conservative Subdomain Discontinuous Least-Squares Scheme for Solving Neutron Transport Problems},
+  journal = {Nuclear Science and Engineering},
   year    = 2017,
-  month   = dec,
-  publisher = {Informa {UK} Limited},
   volume  = 189,
   number  = 3,
   pages   = {259--271},
-  author  = {Weixiong Zheng and Ryan G. McClarren and Jim E. Morel},
-  title   = {An Accurate Globally Conservative Subdomain Discontinuous Least-Squares Scheme for Solving Neutron Transport Problems},
-  journal = {Nuclear Science and Engineering}
+  month   = dec,
+  doi     = {10.1080/00295639.2017.1407592},
+  url     = {https://doi.org/10.1080/00295639.2017.1407592},
+  publisher = {Informa {UK} Limited}
 }
 
 @Article{2017:zheng.mcclarren:accurate,
-  doi     = {10.1016/j.pnucene.2017.06.001},
-  url     = {https://doi.org/10.1016/j.pnucene.2017.06.001},
-  year    = 2017,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 101,
-  pages   = {394--400},
   author  = {Weixiong Zheng and Ryan G. McClarren},
   title   = {Accurate least-squares $P_N$ scaling based on problem optical thickness for solving neutron transport problems},
-  journal = {Progress in Nuclear Energy}
+  journal = {Progress in Nuclear Energy},
+  year    = 2017,
+  volume  = 101,
+  pages   = {394--400},
+  month   = nov,
+  doi     = {10.1016/j.pnucene.2017.06.001},
+  url     = {https://doi.org/10.1016/j.pnucene.2017.06.001},
+  publisher = {Elsevier {BV}}
 }
 
 @InProceedings{2017:zheng.mcclarren:continuous-discontinuous,

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -13,22 +13,22 @@
 @PhDThesis{2018:aggul:high,
   author  = {Aggul, Mustafa},
   title   = {High Accuracy Methods and Regularization Techniques for Fluid Flows and Fluid-Fluid interactions},
+  year    = 2018,
   url     = {https://digitalcommons.mtu.edu/etdr/642/},
-  publisher = {Michigan Tech},
-  year    = 2018
+  publisher = {Michigan Tech}
 }
 
 @PhDThesis{2018:alhazmi:exploring-mechanisms-for-pattern-formation-through-coupled-bulk-surface-pdes,
   author  = {Alhazmi, M.},
   title   = {{Exploring mechanisms for pattern formation through coupled bulk-surface PDEs}},
+  school  = {University of Sussex},
   year    = 2018,
-  url     = {http://sro.sussex.ac.uk/id/eprint/78232/},
-  school  = {University of Sussex}
+  url     = {http://sro.sussex.ac.uk/id/eprint/78232/}
 }
 
 @Article{2018:alzetta.arndt.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.0},
   author  = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
+  title   = {The \texttt{deal.II} Library, Version 9.0},
   journal = {Journal of Numerical Mathematics},
   year    = 2018,
   volume  = 26,
@@ -47,8 +47,8 @@
 }
 
 @Misc{2018:arbogast.tao:direct,
-  title   = {Direct Serendipity and Mixed Finite Elements on Convex Quadrilaterals},
   author  = {Todd Arbogast and Zhen Tao},
+  title   = {Direct Serendipity and Mixed Finite Elements on Convex Quadrilaterals},
   year    = 2018,
   eprint  = {1809.02192},
   archiveprefix = {arXiv},
@@ -65,8 +65,8 @@
 }
 
 @Misc{2018:arndt.kanschat:c1-mapping,
-  title   = {A C1-mapping based on finite elements on quadrilateral and hexahedral meshes},
   author  = {Daniel Arndt and Guido Kanschat},
+  title   = {A C1-mapping based on finite elements on quadrilateral and hexahedral meshes},
   year    = 2018,
   eprint  = {1810.02473},
   archiveprefix = {arXiv},
@@ -74,77 +74,77 @@
 }
 
 @Article{2018:axelsson.neytcheva.ea:efficient,
-  doi     = {10.1515/jnma-2017-0047},
-  url     = {https://doi.org/10.1515/jnma-2017-0047},
+  author  = {Owe Axelsson and Maya Neytcheva and Anders Str\"{o}m},
+  title   = {An efficient preconditioning method for state box-constrained optimal control problems},
+  journal = {Journal of Numerical Mathematics},
   year    = 2018,
-  month   = dec,
-  publisher = {Walter de Gruyter {GmbH}},
   volume  = 26,
   number  = 4,
   pages   = {185--207},
-  author  = {Owe Axelsson and Maya Neytcheva and Anders Str\"{o}m},
-  title   = {An efficient preconditioning method for state box-constrained optimal control problems},
-  journal = {Journal of Numerical Mathematics}
+  month   = dec,
+  doi     = {10.1515/jnma-2017-0047},
+  url     = {https://doi.org/10.1515/jnma-2017-0047},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @InCollection{2018:babaei.levitas:phase,
-  doi     = {10.1007/978-3-319-76968-4_26},
-  url     = {https://doi.org/10.1007/978-3-319-76968-4_26},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {167--170},
   author  = {H. Babaei and V. I. Levitas},
   title   = {Phase Field Study of Lattice Instability and Nanostructure Evolution in Silicon During Phase Transformation Under Complex Loading},
-  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
+  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {167--170},
+  doi     = {10.1007/978-3-319-76968-4_26},
+  url     = {https://doi.org/10.1007/978-3-319-76968-4_26}
 }
 
 @Article{2018:babaei.levitas:phase-field,
-  doi     = {10.1016/j.ijplas.2018.04.006},
-  url     = {https://doi.org/10.1016/j.ijplas.2018.04.006},
-  year    = 2018,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 107,
-  pages   = {223--245},
   author  = {Hamed Babaei and Valery I. Levitas},
   title   = {Phase-field approach for stress- and temperature-induced phase transformations that satisfies lattice instability conditions. Part 2. simulations of phase transformations Si I$\leftrightarrow$ Si {II}},
-  journal = {International Journal of Plasticity}
+  journal = {International Journal of Plasticity},
+  year    = 2018,
+  volume  = 107,
+  pages   = {223--245},
+  month   = aug,
+  doi     = {10.1016/j.ijplas.2018.04.006},
+  url     = {https://doi.org/10.1016/j.ijplas.2018.04.006},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:badnava.msekh.ea:h-adaptive,
+  author  = {Hojjat Badnava and Mohammed A. Msekh and Elahe Etemadi and Timon Rabczuk},
   title   = {An h-adaptive thermo-mechanical phase field model for fracture},
   journal = {Finite Elements in Analysis and Design},
+  year    = 2018,
   volume  = 138,
   pages   = {31--47},
-  year    = 2018,
   issn    = {0168-874X},
   doi     = {https://doi.org/10.1016/j.finel.2017.09.003},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0168874X17303347},
-  author  = {Hojjat Badnava and Mohammed A. Msekh and Elahe Etemadi and Timon Rabczuk}
+  url     = {http://www.sciencedirect.com/science/article/pii/S0168874X17303347}
 }
 
 @InCollection{2018:basak.levitas:nanoscale,
-  doi     = {10.1007/978-3-319-76968-4_25},
-  url     = {https://doi.org/10.1007/978-3-319-76968-4_25},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {161--165},
   author  = {Anup Basak and Valery I. Levitas},
   title   = {Nanoscale Phase Field Modeling and Simulations of Martensitic Phase Transformations and Twinning at Finite Strains},
-  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
+  booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {161--165},
+  doi     = {10.1007/978-3-319-76968-4_25},
+  url     = {https://doi.org/10.1007/978-3-319-76968-4_25}
 }
 
 @Article{2018:basak.levitas:nanoscale*1,
-  doi     = {10.1016/j.jmps.2018.01.014},
-  url     = {https://doi.org/10.1016/j.jmps.2018.01.014},
-  year    = 2018,
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = 113,
-  pages   = {162--196},
   author  = {Anup Basak and Valery I. Levitas},
   title   = {Nanoscale multiphase phase field approach for stress- and temperature-induced martensitic phase transformations with interfacial stresses at finite strains},
-  journal = {Journal of the Mechanics and Physics of Solids}
+  journal = {Journal of the Mechanics and Physics of Solids},
+  year    = 2018,
+  volume  = 113,
+  pages   = {162--196},
+  month   = apr,
+  doi     = {10.1016/j.jmps.2018.01.014},
+  url     = {https://doi.org/10.1016/j.jmps.2018.01.014},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:basak.levitas:phase,
@@ -159,67 +159,67 @@
 @Article{2018:bause.kocher.ea:post-processed,
   author  = {M. Bause and U. K\"{o}cher and F. A. Radu and F. Schieweck},
   title   = {Post-processed Galerkin approximation of improved order for wave equations},
-  note    = {Submitted},
-  year    = 2018
+  year    = 2018,
+  note    = {Submitted}
 }
 
 @Article{2018:beams.klockner.ea:high-order,
-  doi     = {10.1016/j.jcp.2018.08.032},
-  url     = {https://doi.org/10.1016/j.jcp.2018.08.032},
-  year    = 2018,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 375,
-  pages   = {1295--1313},
   author  = {Natalie N. Beams and Andreas Kl\"{o}ckner and Luke N. Olson},
   title   = {High-order finite element--integral equation coupling on embedded meshes},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2018,
+  volume  = 375,
+  pages   = {1295--1313},
+  month   = dec,
+  doi     = {10.1016/j.jcp.2018.08.032},
+  url     = {https://doi.org/10.1016/j.jcp.2018.08.032},
+  publisher = {Elsevier {BV}}
 }
 
 @InBook{2018:boffi.gastaldi.ea:distributed,
   author  = {Boffi, Daniele and Gastaldi, Lucia and Heltai, Luca},
   editor  = {Boffi, Daniele and Pavarino, Luca F. and Rozza, Gianluigi and Scacchi, Simone and Vergara, Christian},
   title   = {A Distributed Lagrange Formulation of the Finite Element Immersed Boundary Method for Fluids Interacting with Compressible Solids},
-  booktitle = {Mathematical and Numerical Modeling of the Cardiovascular System and Applications},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  address = {Cham},
   pages   = {1--21},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  address = {Cham},
+  booktitle = {Mathematical and Numerical Modeling of the Cardiovascular System and Applications},
   doi     = {10.1007/978-3-319-96649-6}
 }
 
 @Article{2018:bonito.borthagaray.ea:numerical,
+  author  = {Bonito, Andrea and Borthagaray, Juan Pablo and Nochetto, Ricardo H. and Ot{\'a}rola, Enrique and Salgado, Abner J.},
   title   = {Numerical methods for fractional diffusion},
+  journal = {Computing and Visualization in Science},
+  year    = 2018,
   volume  = 19,
+  number  = {5-6},
+  pages   = {19--46},
+  month   = mar,
   issn    = {1433-0369},
   url     = {http://dx.doi.org/10.1007/s00791-018-0289-y},
   doi     = {10.1007/s00791-018-0289-y},
-  number  = {5-6},
-  journal = {Computing and Visualization in Science},
-  publisher = {Springer Science and Business Media LLC},
-  author  = {Bonito, Andrea and Borthagaray, Juan Pablo and Nochetto, Ricardo H. and Ot{\'a}rola, Enrique and Salgado, Abner J.},
-  year    = 2018,
-  month   = mar,
-  pages   = {19--46}
+  publisher = {Springer Science and Business Media LLC}
 }
 
 @Article{2018:bonito.demlow.ea:priori,
-  doi     = {10.1137/17m1163311},
-  url     = {https://doi.org/10.1137/17m1163311},
+  author  = {Andrea Bonito and Alan Demlow and Justin Owen},
+  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace--Beltrami Operator},
+  journal = {{SIAM} Journal on Numerical Analysis},
   year    = 2018,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 56,
   number  = 5,
   pages   = {2963--2988},
-  author  = {Andrea Bonito and Alan Demlow and Justin Owen},
-  title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace--Beltrami Operator},
-  journal = {{SIAM} Journal on Numerical Analysis}
+  month   = jan,
+  doi     = {10.1137/17m1163311},
+  url     = {https://doi.org/10.1137/17m1163311},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Misc{2018:bonito.girault.ea:finite,
-  title   = {Finite Element Approximation of a Strain-Limiting Elastic Model},
   author  = {Andrea Bonito and Vivette Girault and Endre Suli},
+  title   = {Finite Element Approximation of a Strain-Limiting Elastic Model},
   year    = 2018,
   eprint  = {1805.04006},
   archiveprefix = {arXiv},
@@ -227,8 +227,8 @@
 }
 
 @Misc{2018:bonito.lei.ea:finite,
-  title   = {Finite element approximation of an obstacle problem for a class of integro-differential operators},
   author  = {Andrea Bonito and Wenyu Lei and Abner J. Salgado},
+  title   = {Finite element approximation of an obstacle problem for a class of integro-differential operators},
   year    = 2018,
   eprint  = {1808.01576},
   archiveprefix = {arXiv},
@@ -248,42 +248,42 @@
 }
 
 @Article{2018:brauss.meir:on,
-  doi     = {10.1016/j.apnum.2018.01.014},
-  year    = 2018,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 133,
-  pages   = {130--143},
   author  = {K.D. Brauss and A.J. Meir},
   title   = {On a parallel, 3-dimensional, finite element solver for viscous, resistive, stationary magnetohydrodynamics equations: {V}elocity--current formulation},
-  journal = {Applied Numerical Mathematics}
+  journal = {Applied Numerical Mathematics},
+  year    = 2018,
+  volume  = 133,
+  pages   = {130--143},
+  month   = nov,
+  doi     = {10.1016/j.apnum.2018.01.014},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:bredow.steinberger:variable,
-  doi     = {10.1002/2017gl075822},
-  url     = {https://doi.org/10.1002/2017gl075822},
+  author  = {Eva Bredow and Bernhard Steinberger},
+  title   = {Variable Melt Production Rate of the {K}erguelen {HotSpot} Due To Long-Term Plume-Ridge Interaction},
+  journal = {Geophysical Research Letters},
   year    = 2018,
-  month   = jan,
-  publisher = {American Geophysical Union ({AGU})},
   volume  = 45,
   number  = 1,
   pages   = {126--136},
-  author  = {Eva Bredow and Bernhard Steinberger},
-  title   = {Variable Melt Production Rate of the {K}erguelen {HotSpot} Due To Long-Term Plume-Ridge Interaction},
-  journal = {Geophysical Research Letters}
+  month   = jan,
+  doi     = {10.1002/2017gl075822},
+  url     = {https://doi.org/10.1002/2017gl075822},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2018:bruchhauser.schwegler.ea:dual,
-  title   = {Dual weighted residual based error control for nonstationary convection-dominated equations: potential or ballast?},
   author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
+  title   = {Dual weighted residual based error control for nonstationary convection-dominated equations: potential or ballast?},
   journal = {arXiv:1812.06810},
   year    = 2018,
   url     = {https://arxiv.org/abs/1812.06810}
 }
 
 @Misc{2018:bruchhauser.schwegler.ea:numerical,
-  title   = {Numerical study of goal-oriented error control for stabilized finite element methods},
   author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
+  title   = {Numerical study of goal-oriented error control for stabilized finite element methods},
   year    = 2018,
   eprint  = {1803.10643},
   archiveprefix = {arXiv},
@@ -328,21 +328,21 @@
 }
 
 @Article{2018:bunger.richter.ea:deterministic,
-  doi     = {10.1088/1757-899x/304/1/012004},
-  url     = {https://doi.org/10.1088/1757-899x/304/1/012004},
-  year    = 2018,
-  month   = jan,
-  publisher = {{IOP} Publishing},
-  volume  = 304,
-  pages   = 012004,
   author  = {J B\"{u}nger and S Richter and M Torrilhon},
   title   = {A deterministic model of electron transport for electron probe microanalysis},
-  journal = {{IOP} Conference Series: Materials Science and Engineering}
+  journal = {{IOP} Conference Series: Materials Science and Engineering},
+  year    = 2018,
+  volume  = 304,
+  pages   = 012004,
+  month   = jan,
+  doi     = {10.1088/1757-899x/304/1/012004},
+  url     = {https://doi.org/10.1088/1757-899x/304/1/012004},
+  publisher = {{IOP} Publishing}
 }
 
 @Misc{2018:burstedde:parallel,
-  title   = {Parallel tree algorithms for AMR and non-standard data access},
   author  = {Carsten Burstedde},
+  title   = {Parallel tree algorithms for AMR and non-standard data access},
   year    = 2018,
   eprint  = {1803.08432},
   archiveprefix = {arXiv},
@@ -350,88 +350,88 @@
 }
 
 @Article{2018:bzowski.rauch.ea:application,
+  author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk},
   title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
   journal = {Procedia Manufacturing},
+  year    = 2018,
   volume  = 15,
   pages   = {1847--1855},
-  year    = 2018,
   note    = {Proceedings of the 17th International Conference on Metal Forming METAL FORMING 2018 September 16 -- 19, 2018, Loisir Hotel Toyohashi, Toyohashi, Japan},
   doi     = {https://doi.org/10.1016/j.promfg.2018.07.205},
-  url     = {http://www.sciencedirect.com/science/article/pii/S2351978918308977},
-  author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk}
+  url     = {http://www.sciencedirect.com/science/article/pii/S2351978918308977}
 }
 
 @Article{2018:caen.schutz.ea:high-throughput,
-  doi     = {10.1038/s41378-018-0033-2},
-  url     = {https://doi.org/10.1038/s41378-018-0033-2},
-  year    = 2018,
-  month   = oct,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 4,
-  number  = 1,
   author  = {Ouriel Caen and Simon Sch\"{u}tz and M. S. Suryateja Jammalamadaka and J{\'{e}}r{\'{e}}my Vrignon and Philippe Nizard and Tobias M. Schneider and Jean-Christophe Baret and Val{\'{e}}rie Taly},
   title   = {High-throughput multiplexed fluorescence-activated droplet sorting},
-  journal = {Microsystems {\&} Nanoengineering}
+  journal = {Microsystems {\&} Nanoengineering},
+  year    = 2018,
+  volume  = 4,
+  number  = 1,
+  month   = oct,
+  doi     = {10.1038/s41378-018-0033-2},
+  url     = {https://doi.org/10.1038/s41378-018-0033-2},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:cangiani.georgoulis.ea:adaptive,
-  doi     = {10.1090/mcom/3322},
-  url     = {https://doi.org/10.1090/mcom/3322},
+  author  = {Andrea Cangiani and Emmanuil H. Georgoulis and Younis A. Sabawi},
+  title   = {Adaptive discontinuous Galerkin methods for elliptic interface problems},
+  journal = {Mathematics of Computation},
   year    = 2018,
-  month   = feb,
-  publisher = {American Mathematical Society ({AMS})},
   volume  = 87,
   number  = 314,
   pages   = {2675--2707},
-  author  = {Andrea Cangiani and Emmanuil H. Georgoulis and Younis A. Sabawi},
-  title   = {Adaptive discontinuous Galerkin methods for elliptic interface problems},
-  journal = {Mathematics of Computation}
+  month   = feb,
+  doi     = {10.1090/mcom/3322},
+  url     = {https://doi.org/10.1090/mcom/3322},
+  publisher = {American Mathematical Society ({AMS})}
 }
 
 @Article{2018:cangiani.georgoulis.ea:revealing,
-  doi     = {10.1098/rspa.2017.0608},
-  url     = {https://doi.org/10.1098/rspa.2017.0608},
+  author  = {A. Cangiani and E. H. Georgoulis and A. Yu. Morozov and O. J. Sutton},
+  title   = {Revealing new dynamical patterns in a reaction-diffusion model with cyclic competition via a novel computational framework},
+  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences},
   year    = 2018,
-  month   = may,
-  publisher = {The Royal Society},
   volume  = 474,
   number  = 2213,
   pages   = 20170608,
-  author  = {A. Cangiani and E. H. Georgoulis and A. Yu. Morozov and O. J. Sutton},
-  title   = {Revealing new dynamical patterns in a reaction-diffusion model with cyclic competition via a novel computational framework},
-  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
+  month   = may,
+  doi     = {10.1098/rspa.2017.0608},
+  url     = {https://doi.org/10.1098/rspa.2017.0608},
+  publisher = {The Royal Society}
 }
 
 @Article{2018:carraro.dorsam.ea:adaptive,
-  doi     = {10.1007/s10957-018-1242-4},
-  url     = {https://doi.org/10.1007/s10957-018-1242-4},
+  author  = {Thomas Carraro and Simon D\"{o}rsam and Stefan Frei and Daniel Schwarz},
+  title   = {An Adaptive Newton Algorithm for Optimal Control Problems with Application to Optimal Electrode Design},
+  journal = {Journal of Optimization Theory and Applications},
   year    = 2018,
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 177,
   number  = 2,
   pages   = {498--534},
-  author  = {Thomas Carraro and Simon D\"{o}rsam and Stefan Frei and Daniel Schwarz},
-  title   = {An Adaptive Newton Algorithm for Optimal Control Problems with Application to Optimal Electrode Design},
-  journal = {Journal of Optimization Theory and Applications}
+  month   = feb,
+  doi     = {10.1007/s10957-018-1242-4},
+  url     = {https://doi.org/10.1007/s10957-018-1242-4},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:carraro.marusic-paloka.ea:effective,
-  doi     = {10.1016/j.nonrwa.2018.04.008},
-  url     = {https://doi.org/10.1016/j.nonrwa.2018.04.008},
-  year    = 2018,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 44,
-  pages   = {149--172},
   author  = {Thomas Carraro and Eduard Maru{\v{s}}i{\'{c}}-Paloka and Andro Mikeli{\'{c}}},
   title   = {Effective pressure boundary condition for the filtration through porous medium via homogenization},
-  journal = {Nonlinear Analysis: Real World Applications}
+  journal = {Nonlinear Analysis: Real World Applications},
+  year    = 2018,
+  volume  = 44,
+  pages   = {149--172},
+  month   = dec,
+  doi     = {10.1016/j.nonrwa.2018.04.008},
+  url     = {https://doi.org/10.1016/j.nonrwa.2018.04.008},
+  publisher = {Elsevier {BV}}
 }
 
 @Misc{2018:carraro.wetterauer.ea:level-set,
-  title   = {A level-set approach for a multi-scale cancer invasion model},
   author  = {Thomas Carraro and Sven E. Wetterauer and Ana Victoria Ponce Bobadilla and Dumitru Trucu},
+  title   = {A level-set approach for a multi-scale cancer invasion model},
   year    = 2018,
   eprint  = {1805.07485},
   archiveprefix = {arXiv},
@@ -439,38 +439,38 @@
 }
 
 @Article{2018:carreno.vidal-ferrandiz.ea:block,
-  doi     = {10.1016/j.anucene.2018.08.010},
-  url     = {https://doi.org/10.1016/j.anucene.2018.08.010},
-  year    = 2018,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 121,
-  pages   = {513--524},
   author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
   title   = {Block hybrid multilevel method to compute the dominant $\lambda$-modes of the neutron diffusion equation},
-  journal = {Annals of Nuclear Energy}
+  journal = {Annals of Nuclear Energy},
+  year    = 2018,
+  volume  = 121,
+  pages   = {513--524},
+  month   = nov,
+  doi     = {10.1016/j.anucene.2018.08.010},
+  url     = {https://doi.org/10.1016/j.anucene.2018.08.010},
+  publisher = {Elsevier {BV}}
 }
 
 @InCollection{2018:carreno.vidal-ferrandiz.ea:solution,
-  doi     = {10.1007/978-3-319-93701-4_67},
-  url     = {https://doi.org/10.1007/978-3-319-93701-4_67},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {846--855},
   author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
   title   = {The Solution of the Lambda Modes Problem Using Block Iterative Eigensolvers},
-  booktitle = {Lecture Notes in Computer Science}
+  booktitle = {Lecture Notes in Computer Science},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {846--855},
+  doi     = {10.1007/978-3-319-93701-4_67},
+  url     = {https://doi.org/10.1007/978-3-319-93701-4_67}
 }
 
 @InProceedings{2018:castelletto.ferronato.ea:fully-implicit,
-  doi     = {10.3997/2214-4609.201802132},
-  url     = {https://doi.org/10.3997/2214-4609.201802132},
+  author  = {N. Castelletto and M. Ferronato and A. Franceschini and R.R. Settgast and J.A. White},
+  title   = {Fully-Implicit Solvers For Coupled Poromechanics Of Fractured Reservoirs},
+  booktitle = {{ECMOR} {XVI} - 16th European Conference on the Mathematics of Oil Recovery},
   year    = 2018,
   month   = sep,
   publisher = {{EAGE} Publications {BV}},
-  author  = {N. Castelletto and M. Ferronato and A. Franceschini and R.R. Settgast and J.A. White},
-  title   = {Fully-Implicit Solvers For Coupled Poromechanics Of Fractured Reservoirs},
-  booktitle = {{ECMOR} {XVI} - 16th European Conference on the Mathematics of Oil Recovery}
+  doi     = {10.3997/2214-4609.201802132},
+  url     = {https://doi.org/10.3997/2214-4609.201802132}
 }
 
 @InProceedings{2018:chandrashekar.gallego-valencia.ea:a-runge-kutta-discontinuous-galerkin-scheme-for-the-ideal-magnetohydrodynamical-model,
@@ -478,8 +478,8 @@
   title   = {{A Runge-Kutta Discontinuous Galerkin Scheme for the Ideal Magnetohydrodynamical Model}},
   booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
   year    = 2018,
-  volume  = 236,
   series  = {Springer Proceedings in Mathematics \& Statistics},
+  volume  = 236,
   pages   = {335--344},
   publisher = {Springer International Publishing},
   doi     = {10.1007/978-3-319-91545-6_27},
@@ -500,17 +500,17 @@
 }
 
 @Article{2018:chang.fabien.ea:comparative,
-  doi     = {10.1137/18m1172260},
-  url     = {https://doi.org/10.1137/18m1172260},
+  author  = {Justin Chang and Maurice S. Fabien and Matthew G. Knepley and Richard T. Mills},
+  title   = {Comparative Study of Finite Element Methods Using the Time-Accuracy-Size({TAS}) Spectrum Analysis},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2018,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 40,
   number  = 6,
   pages   = {C779--C802},
-  author  = {Justin Chang and Maurice S. Fabien and Matthew G. Knepley and Richard T. Mills},
-  title   = {Comparative Study of Finite Element Methods Using the Time-Accuracy-Size({TAS}) Spectrum Analysis},
-  journal = {{SIAM} Journal on Scientific Computing}
+  month   = jan,
+  doi     = {10.1137/18m1172260},
+  url     = {https://doi.org/10.1137/18m1172260},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2018:charnyi.heister.ea:efficient,
@@ -518,128 +518,128 @@
   title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier-Stokes equations},
   journal = {Applied Numerical Mathematics},
   year    = 2018,
+  note    = {in press},
   doi     = {10.1016/j.apnum.2018.11.013},
-  url     = {https://arxiv.org/abs/1712.00857},
-  note    = {in press}
+  url     = {https://arxiv.org/abs/1712.00857}
 }
 
 @PhDThesis{2018:charnyi:emac,
-  title   = {The {EMAC} scheme for Navier-Stokes simulations, and application to flow past bluff bodies},
   author  = {Sergey Charnyi},
+  title   = {The {EMAC} scheme for Navier-Stokes simulations, and application to flow past bluff bodies},
   school  = {Clemson University},
   year    = 2018,
   url     = {https://tigerprints.clemson.edu/all_dissertations/2243/}
 }
 
 @Article{2018:cheng.yue.ea:analysis,
-  doi     = {10.1016/j.jcp.2018.02.031},
-  url     = {https://doi.org/10.1016/j.jcp.2018.02.031},
-  year    = 2018,
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = 362,
-  pages   = {305--326},
   author  = {Jian Cheng and Huiqiang Yue and Shengjiao Yu and Tiegang Liu},
   title   = {Analysis and development of adjoint-based h-adaptive direct discontinuous Galerkin method for the compressible Navier--Stokes equations},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2018,
+  volume  = 362,
+  pages   = {305--326},
+  month   = jun,
+  doi     = {10.1016/j.jcp.2018.02.031},
+  url     = {https://doi.org/10.1016/j.jcp.2018.02.031},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:cheng:direct,
-  doi     = {10.4208/aamm.oa-2017-0060},
-  url     = {https://doi.org/10.4208/aamm.oa-2017-0060},
+  author  = {Jian Cheng},
+  title   = {A Direct Discontinuous Galerkin Method with Interface Correction for the Compressible Navier-Stokes Equations on Unstructured Grids},
+  journal = {Advances in Applied Mathematics and Mechanics},
   year    = 2018,
-  month   = jun,
-  publisher = {Global Science Press},
   volume  = 10,
   number  = 1,
   pages   = {1--21},
-  author  = {Jian Cheng},
-  title   = {A Direct Discontinuous Galerkin Method with Interface Correction for the Compressible Navier-Stokes Equations on Unstructured Grids},
-  journal = {Advances in Applied Mathematics and Mechanics}
+  month   = jun,
+  doi     = {10.4208/aamm.oa-2017-0060},
+  url     = {https://doi.org/10.4208/aamm.oa-2017-0060},
+  publisher = {Global Science Press}
 }
 
 @InCollection{2018:choo.lee:enriched,
-  doi     = {10.1007/978-3-319-97112-4_69},
-  url     = {https://doi.org/10.1007/978-3-319-97112-4_69},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {312--315},
   author  = {Jinhyun Choo and Sanghyun Lee},
   title   = {Enriched Galerkin Finite Element Method for Locally Mass Conservative Simulation of Coupled Hydromechanical Problems},
-  booktitle = {Springer Series in Geomechanics and Geoengineering}
+  booktitle = {Springer Series in Geomechanics and Geoengineering},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {312--315},
+  doi     = {10.1007/978-3-319-97112-4_69},
+  url     = {https://doi.org/10.1007/978-3-319-97112-4_69}
 }
 
 @Article{2018:choo.lee:enriched*1,
-  doi     = {10.1016/j.cma.2018.06.022},
-  url     = {https://doi.org/10.1016/j.cma.2018.06.022},
-  year    = 2018,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 341,
-  pages   = {311--332},
   author  = {Jinhyun Choo and Sanghyun Lee},
   title   = {Enriched Galerkin finite elements for coupled poromechanics with local mass conservation},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2018,
+  volume  = 341,
+  pages   = {311--332},
+  month   = nov,
+  doi     = {10.1016/j.cma.2018.06.022},
+  url     = {https://doi.org/10.1016/j.cma.2018.06.022},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:choo.sun:coupled,
-  doi     = {10.1016/j.cma.2017.10.009},
-  url     = {https://doi.org/10.1016/j.cma.2017.10.009},
-  year    = 2018,
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = 330,
-  pages   = {1--32},
   author  = {Jinhyun Choo and Waiching Sun},
   title   = {Coupled phase-field and plasticity modeling of geological materials: From brittle fracture to ductile flow},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2018,
+  volume  = 330,
+  pages   = {1--32},
+  month   = mar,
+  doi     = {10.1016/j.cma.2017.10.009},
+  url     = {https://doi.org/10.1016/j.cma.2017.10.009},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:choo.sun:cracking,
-  doi     = {10.1016/j.cma.2018.01.044},
-  url     = {https://doi.org/10.1016/j.cma.2018.01.044},
-  year    = 2018,
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = 335,
-  pages   = {347--379},
   author  = {Jinhyun Choo and WaiChing Sun},
   title   = {Cracking and damage from crystallization in pores: Coupled chemo-hydro-mechanics and phase-field modeling},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2018,
+  volume  = 335,
+  pages   = {347--379},
+  month   = jun,
+  doi     = {10.1016/j.cma.2018.01.044},
+  url     = {https://doi.org/10.1016/j.cma.2018.01.044},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:choo:large,
-  doi     = {10.1002/nme.5915},
-  url     = {https://doi.org/10.1002/nme.5915},
+  author  = {Jinhyun Choo},
+  title   = {Large deformation poromechanics with local mass conservation: An enriched Galerkin finite element framework},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2018,
-  month   = aug,
-  publisher = {Wiley},
   volume  = 116,
   number  = 1,
   pages   = {66--90},
-  author  = {Jinhyun Choo},
-  title   = {Large deformation poromechanics with local mass conservation: An enriched Galerkin finite element framework},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = aug,
+  doi     = {10.1002/nme.5915},
+  url     = {https://doi.org/10.1002/nme.5915},
+  publisher = {Wiley}
 }
 
 @MastersThesis{2018:cinatl:finite,
-  title   = {Finite Element Discretizations for Linear Elasticity},
   author  = {Emma Cinatl},
+  title   = {Finite Element Discretizations for Linear Elasticity},
   school  = {Clemson University},
   year    = 2018,
   url     = {https://tigerprints.clemson.edu/all_theses/2977/}
 }
 
 @InCollection{2018:dang.do.ea:fractured,
-  doi     = {10.1007/978-981-13-2306-5_15},
-  url     = {https://doi.org/10.1007/978-981-13-2306-5_15},
-  year    = 2018,
-  month   = sep,
-  publisher = {Springer Singapore},
-  pages   = {123--129},
   author  = {Hong-Lam Dang and Duc-Phi Do and Dashnor Hoxha},
   title   = {Fractured Reservoirs Modeling by Embedded Fracture Continuum Approach: Field-Scale Applications},
-  booktitle = {Lecture Notes in Civil Engineering}
+  booktitle = {Lecture Notes in Civil Engineering},
+  publisher = {Springer Singapore},
+  year    = 2018,
+  pages   = {123--129},
+  month   = sep,
+  doi     = {10.1007/978-981-13-2306-5_15},
+  url     = {https://doi.org/10.1007/978-981-13-2306-5_15}
 }
 
 @PhDThesis{2018:dang:hydro-mechanical,
@@ -652,24 +652,24 @@
 
 @Article{2018:dannberg.gassmoller:chemical,
   author  = {Dannberg, Juliane and Gassm{\"{o}}ller, Rene},
+  title   = {Chemical trends in ocean islands explained by plume-slab interaction},
   journal = {Proceedings of the National Academy of Sciences},
+  year    = 2018,
+  volume  = 115,
   number  = 17,
   pages   = {4351--4356},
   publisher = {National Acad Sciences},
-  title   = {Chemical trends in ocean islands explained by plume-slab interaction},
-  volume  = 115,
-  year    = 2018,
   doi     = {10.1073/pnas.1714125115}
 }
 
 @Article{2018:davydov.heister.ea:matrix-free,
-  title   = {Matrix-Free Locally Adaptive Finite Element Solution of Density-Functional Theory With Nonorthogonal Orbitals and Multigrid Preconditioning},
   author  = {Davydov, Denis and Heister, Timo and Kronbichler, Martin and Steinmann, Paul},
+  title   = {Matrix-Free Locally Adaptive Finite Element Solution of Density-Functional Theory With Nonorthogonal Orbitals and Multigrid Preconditioning},
   journal = {physica status solidi (b)},
+  year    = 2018,
   volume  = 255,
   number  = 9,
   pages   = 1800069,
-  year    = 2018,
   publisher = {Wiley Online Library},
   doi     = {10.1002/pssb.201800069}
 }
@@ -686,8 +686,8 @@
   title   = {{Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface}},
   booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
   year    = 2018,
-  volume  = 236,
   series  = {Springer Proceedings in Mathematics \& Statistics},
+  volume  = 236,
   pages   = {473--485},
   publisher = {Springer International Publishing},
   doi     = {10.1007/978-3-319-91545-6_36},
@@ -695,111 +695,111 @@
 }
 
 @Article{2018:deolmi.muller:two-step,
-  doi     = {10.1016/j.matcom.2018.02.008},
-  url     = {https://doi.org/10.1016/j.matcom.2018.02.008},
-  year    = 2018,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 150,
-  pages   = {49--65},
   author  = {G. Deolmi and S. M\"{u}ller},
   title   = {A two-step model order reduction method to simulate a compressible flow over an extended rough surface},
-  journal = {Mathematics and Computers in Simulation}
+  journal = {Mathematics and Computers in Simulation},
+  year    = 2018,
+  volume  = 150,
+  pages   = {49--65},
+  month   = aug,
+  doi     = {10.1016/j.matcom.2018.02.008},
+  url     = {https://doi.org/10.1016/j.matcom.2018.02.008},
+  publisher = {Elsevier {BV}}
 }
 
 @MastersThesis{2018:dommaraju:partition,
   author  = {N. Dommaraju},
   title   = {Partition of unity finite element method with overlapping enrichment domains},
-  year    = 2018,
-  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
-}
-
-@Article{2018:dorschner.chikatamarla.ea:fluid-structure,
-  doi     = {10.1103/physreve.97.023305},
-  url     = {https://doi.org/10.1103/physreve.97.023305},
-  year    = 2018,
-  month   = feb,
-  publisher = {American Physical Society ({APS})},
-  volume  = 97,
-  number  = 2,
-  author  = {B. Dorschner and S. S. Chikatamarla and I. V. Karlin},
-  title   = {Fluid-structure interaction with the entropic lattice Boltzmann method},
-  journal = {Physical Review E}
-}
-
-@PhDThesis{2018:dorschner:entropic,
-  doi     = {10.3929/ETHZ-B-000278644},
-  url     = {http://hdl.handle.net/20.500.11850/278644},
-  author  = {Dorschner, Benedikt},
-  title   = {Entropic Lattice Boltzmann Method for Complex Flows},
-  school  = {ETH Zurich},
+  school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg},
   year    = 2018
 }
 
-@Article{2018:duijn.mikelic.ea:monolithic,
-  doi     = {10.1177/1081286518801050},
-  url     = {https://doi.org/10.1177/1081286518801050},
+@Article{2018:dorschner.chikatamarla.ea:fluid-structure,
+  author  = {B. Dorschner and S. S. Chikatamarla and I. V. Karlin},
+  title   = {Fluid-structure interaction with the entropic lattice Boltzmann method},
+  journal = {Physical Review E},
   year    = 2018,
-  month   = oct,
-  publisher = {{SAGE} Publications},
+  volume  = 97,
+  number  = 2,
+  month   = feb,
+  doi     = {10.1103/physreve.97.023305},
+  url     = {https://doi.org/10.1103/physreve.97.023305},
+  publisher = {American Physical Society ({APS})}
+}
+
+@PhDThesis{2018:dorschner:entropic,
+  author  = {Dorschner, Benedikt},
+  title   = {Entropic Lattice Boltzmann Method for Complex Flows},
+  school  = {ETH Zurich},
+  year    = 2018,
+  doi     = {10.3929/ETHZ-B-000278644},
+  url     = {http://hdl.handle.net/20.500.11850/278644}
+}
+
+@Article{2018:duijn.mikelic.ea:monolithic,
+  author  = {CJ van Duijn and Andro Mikeli{\'{c}} and Thomas Wick},
+  title   = {A monolithic phase-field model of a fluid-driven fracture in a nonlinear poroelastic medium},
+  journal = {Mathematics and Mechanics of Solids},
+  year    = 2018,
   volume  = 24,
   number  = 5,
   pages   = {1530--1555},
-  author  = {CJ van Duijn and Andro Mikeli{\'{c}} and Thomas Wick},
-  title   = {A monolithic phase-field model of a fluid-driven fracture in a nonlinear poroelastic medium},
-  journal = {Mathematics and Mechanics of Solids}
+  month   = oct,
+  doi     = {10.1177/1081286518801050},
+  url     = {https://doi.org/10.1177/1081286518801050},
+  publisher = {{SAGE} Publications}
 }
 
 @Article{2018:dunkelberger.metaferia.ea:theoretical,
-  doi     = {10.1021/acs.jpcb.8b07638},
-  url     = {https://doi.org/10.1021/acs.jpcb.8b07638},
+  author  = {Emily B. Dunkelberger and Belhu Metaferia and Troy Cellmer and Eric R. Henry},
+  title   = {Theoretical Simulation of Red Cell Sickling Upon Deoxygenation Based on the Physical Chemistry of Sickle Hemoglobin Fiber Formation},
+  journal = {The Journal of Physical Chemistry B},
   year    = 2018,
-  month   = sep,
-  publisher = {American Chemical Society ({ACS})},
   volume  = 122,
   number  = 49,
   pages   = {11579--11590},
-  author  = {Emily B. Dunkelberger and Belhu Metaferia and Troy Cellmer and Eric R. Henry},
-  title   = {Theoretical Simulation of Red Cell Sickling Upon Deoxygenation Based on the Physical Chemistry of Sickle Hemoglobin Fiber Formation},
-  journal = {The Journal of Physical Chemistry B}
+  month   = sep,
+  doi     = {10.1021/acs.jpcb.8b07638},
+  url     = {https://doi.org/10.1021/acs.jpcb.8b07638},
+  publisher = {American Chemical Society ({ACS})}
 }
 
 @Article{2018:ellam:bayesian,
-  doi     = {10.25560/70367},
-  url     = {http://spiral.imperial.ac.uk/handle/10044/1/70367},
   author  = {Ellam, Louis},
   title   = {Bayesian approaches to modelling physical and socio-economic systems},
-  publisher = {Imperial College London},
   year    = 2018,
+  doi     = {10.25560/70367},
+  url     = {http://spiral.imperial.ac.uk/handle/10044/1/70367},
+  publisher = {Imperial College London},
   copyright = {Creative Commons Attribution NonCommercial Licence}
 }
 
 @MastersThesis{2018:ellowitz:dynamics-of-magma-recharge-and-mixing-at-mount-hood-volcano--oregon--insights-from-enclave-bearing-lavas,
   author  = {Ellowitz, Molly},
-  doi     = {10.15760/etd.6429},
-  school  = {Portland State University},
   title   = {{Dynamics of Magma Recharge and Mixing at Mount Hood Volcano, Oregon -- Insights from Enclave-bearing Lavas}},
+  school  = {Portland State University},
+  year    = 2018,
   type    = {Master Thesis},
-  url     = {https://archives.pdx.edu/ds/psu/26513},
-  year    = 2018
+  doi     = {10.15760/etd.6429},
+  url     = {https://archives.pdx.edu/ds/psu/26513}
 }
 
 @Article{2018:emerson.farrell.ea:computing,
-  doi     = {10.1080/02678292.2017.1365385},
-  url     = {https://doi.org/10.1080/02678292.2017.1365385},
+  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
+  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
+  journal = {Liquid Crystals},
   year    = 2018,
-  publisher = {Informa {UK} Limited},
   volume  = 45,
   number  = 3,
   pages   = {341--350},
-  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
-  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
-  journal = {Liquid Crystals}
+  doi     = {10.1080/02678292.2017.1365385},
+  url     = {https://doi.org/10.1080/02678292.2017.1365385},
+  publisher = {Informa {UK} Limited}
 }
 
 @Misc{2018:emerson:error,
-  title   = {Error Estimators and Marking Strategies for Electrically Coupled Liquid Crystal Systems},
   author  = {D. B. Emerson},
+  title   = {Error Estimators and Marking Strategies for Electrically Coupled Liquid Crystal Systems},
   year    = 2018,
   eprint  = {1806.06248},
   archiveprefix = {arXiv},
@@ -807,75 +807,75 @@
 }
 
 @Article{2018:endtmayer.langer.ea:multiple,
-  doi     = {10.1002/pamm.201800048},
-  url     = {https://doi.org/10.1002/pamm.201800048},
-  year    = 2018,
-  month   = dec,
-  publisher = {Wiley},
-  volume  = 18,
-  number  = 1,
   author  = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
   title   = {Multiple goal-oriented error estimates applied to 3d non-linear problems},
-  journal = {{PAMM}}
+  journal = {{PAMM}},
+  year    = 2018,
+  volume  = 18,
+  number  = 1,
+  month   = dec,
+  doi     = {10.1002/pamm.201800048},
+  url     = {https://doi.org/10.1002/pamm.201800048},
+  publisher = {Wiley}
 }
 
 @InCollection{2018:evgrafov:discontinuous,
-  doi     = {10.1007/978-3-319-97773-7_24},
-  url     = {https://doi.org/10.1007/978-3-319-97773-7_24},
-  year    = 2018,
-  month   = sep,
-  publisher = {Springer International Publishing},
-  pages   = {260--271},
   author  = {Anton Evgrafov},
   title   = {Discontinuous Petrov-Galerkin Methods for Topology Optimization},
-  booktitle = {{EngOpt} 2018 Proceedings of the 6th International Conference on Engineering Optimization}
+  booktitle = {{EngOpt} 2018 Proceedings of the 6th International Conference on Engineering Optimization},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {260--271},
+  month   = sep,
+  doi     = {10.1007/978-3-319-97773-7_24},
+  url     = {https://doi.org/10.1007/978-3-319-97773-7_24}
 }
 
 @Article{2018:failer.wick:adaptive,
-  doi     = {10.1016/j.jcp.2018.04.021},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0021999118302377},
-  year    = 2018,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 366,
-  pages   = {448--477},
   author  = {Lukas Failer and Thomas Wick},
   title   = {Adaptive time-step control for nonlinear fluid--structure interaction},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2018,
+  volume  = 366,
+  pages   = {448--477},
+  month   = aug,
+  doi     = {10.1016/j.jcp.2018.04.021},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0021999118302377},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:fehn.wall.ea:efficiency,
-  title   = {Efficiency of high-performance discontinuous Galerkin spectral element methods for under-resolved turbulent incompressible flows},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
+  title   = {Efficiency of high-performance discontinuous Galerkin spectral element methods for under-resolved turbulent incompressible flows},
   journal = {International Journal for Numerical Methods in Fluids},
+  year    = 2018,
   volume  = 88,
   number  = 1,
   pages   = {32--54},
-  year    = 2018,
   publisher = {Wiley Online Library},
   url     = {https://doi.org/10.1002/fld.4511},
   doi     = {10.1002/fld.4511}
 }
 
 @Article{2018:fehn.wall.ea:robust,
-  title   = {Robust and efficient discontinuous Galerkin methods for under-resolved turbulent incompressible flows},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
+  title   = {Robust and efficient discontinuous Galerkin methods for under-resolved turbulent incompressible flows},
   journal = {Journal of Computational Physics},
+  year    = 2018,
   volume  = 372,
   pages   = {667--693},
-  year    = 2018,
   publisher = {Elsevier},
   url     = {https://doi.org/10.1016/j.jcp.2018.06.037},
   doi     = {10.1016/j.jcp.2018.06.037}
 }
 
 @PhDThesis{2018:ferrandiz:development,
+  author  = {Antoni Vidal Ferr{\`{a}}ndiz},
+  title   = {Development of a finite element method for neutron transport equation approximations},
+  year    = 2018,
   doi     = {10.4995/thesis/10251/98522},
   url     = {https://doi.org/10.4995/thesis/10251/98522},
-  year    = 2018,
-  publisher = {Universitat Politecnica de Valencia},
-  author  = {Antoni Vidal Ferr{\`{a}}ndiz},
-  title   = {Development of a finite element method for neutron transport equation approximations}
+  publisher = {Universitat Politecnica de Valencia}
 }
 
 @Article{2018:freddi.sacco.ea:enriched,
@@ -889,8 +889,8 @@
 }
 
 @Misc{2018:frei.richter.ea:on,
-  title   = {On the implementation of a locally modified finite element method for interface problems in deal.II},
   author  = {Stefan Frei and Thomas Richter and Thomas Wick},
+  title   = {On the implementation of a locally modified finite element method for interface problems in deal.II},
   year    = 2018,
   eprint  = {1806.00999},
   archiveprefix = {arXiv},
@@ -898,117 +898,117 @@
 }
 
 @Article{2018:freund.kim.ea:field,
-  doi     = {10.1016/j.jnnfm.2018.03.013},
-  url     = {https://doi.org/10.1016/j.jnnfm.2018.03.013},
-  year    = 2018,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 257,
-  pages   = {71--82},
   author  = {J.B. Freund and J. Kim and R.H. Ewoldt},
   title   = {Field sensitivity of flow predictions to rheological parameters},
-  journal = {Journal of Non-Newtonian Fluid Mechanics}
+  journal = {Journal of Non-Newtonian Fluid Mechanics},
+  year    = 2018,
+  volume  = 257,
+  pages   = {71--82},
+  month   = jul,
+  doi     = {10.1016/j.jnnfm.2018.03.013},
+  url     = {https://doi.org/10.1016/j.jnnfm.2018.03.013},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:galiano.velasco:on,
-  doi     = {10.1016/j.camwa.2018.05.035},
-  url     = {https://doi.org/10.1016/j.camwa.2018.05.035},
+  author  = {Gonzalo Galiano and Juli{\'{a}}n Velasco},
+  title   = {On a cross-diffusion system arising in image denoising},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2018,
-  month   = sep,
-  publisher = {Elsevier {BV}},
   volume  = 76,
   number  = 5,
   pages   = {984--996},
-  author  = {Gonzalo Galiano and Juli{\'{a}}n Velasco},
-  title   = {On a cross-diffusion system arising in image denoising},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = sep,
+  doi     = {10.1016/j.camwa.2018.05.035},
+  url     = {https://doi.org/10.1016/j.camwa.2018.05.035},
+  publisher = {Elsevier {BV}}
 }
 
 @InCollection{2018:gantner.herrmann.ea:multilevel,
-  doi     = {10.1007/978-3-319-72456-0_18},
-  url     = {https://doi.org/10.1007/978-3-319-72456-0_18},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {373--405},
   author  = {Robert N. Gantner and Lukas Herrmann and Christoph Schwab},
   title   = {Multilevel {QMC} with Product Weights for Affine-Parametric, Elliptic {PDEs}},
-  booktitle = {Contemporary Computational Mathematics - A Celebration of the 80th Birthday of Ian Sloan}
+  booktitle = {Contemporary Computational Mathematics - A Celebration of the 80th Birthday of Ian Sloan},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {373--405},
+  doi     = {10.1007/978-3-319-72456-0_18},
+  url     = {https://doi.org/10.1007/978-3-319-72456-0_18}
 }
 
 @Article{2018:gassmoller.lokavarapu.ea:flexible,
-  doi     = {10.1029/2018gc007508},
-  url     = {https://doi.org/10.1029/2018gc007508},
+  author  = {Rene Gassm\"{o}ller and Harsha Lokavarapu and Eric Heien and Elbridge Gerry Puckett and Wolfgang Bangerth},
+  title   = {Flexible and Scalable Particle-in-Cell Methods With Adaptive Mesh Refinement for Geodynamic Computations},
+  journal = {Geochemistry, Geophysics, Geosystems},
   year    = 2018,
-  month   = sep,
-  publisher = {American Geophysical Union ({AGU})},
   volume  = 19,
   number  = 9,
   pages   = {3596--3604},
-  author  = {Rene Gassm\"{o}ller and Harsha Lokavarapu and Eric Heien and Elbridge Gerry Puckett and Wolfgang Bangerth},
-  title   = {Flexible and Scalable Particle-in-Cell Methods With Adaptive Mesh Refinement for Geodynamic Computations},
-  journal = {Geochemistry, Geophysics, Geosystems}
+  month   = sep,
+  doi     = {10.1029/2018gc007508},
+  url     = {https://doi.org/10.1029/2018gc007508},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2018:ge.holmgren.ea:effective,
-  doi     = {10.1103/physrevfluids.3.054201},
-  url     = {https://doi.org/10.1103/physrevfluids.3.054201},
-  year    = 2018,
-  month   = may,
-  publisher = {American Physical Society ({APS})},
-  volume  = 3,
-  number  = 5,
   author  = {Zhouyang Ge and Hanna Holmgren and Martin Kronbichler and Luca Brandt and Gunilla Kreiss},
   title   = {Effective slip over partially filled microcavities and its possible failure},
-  journal = {Physical Review Fluids}
+  journal = {Physical Review Fluids},
+  year    = 2018,
+  volume  = 3,
+  number  = 5,
+  month   = may,
+  doi     = {10.1103/physrevfluids.3.054201},
+  url     = {https://doi.org/10.1103/physrevfluids.3.054201},
+  publisher = {American Physical Society ({APS})}
 }
 
 @PhDThesis{2018:ghesmati:residual-and-goal-oriented-h-and-hp-adaptive-finite-element--application-for-elliptic-and-saddle-point-problems,
   author  = {Ghesmati, Arezou},
   title   = {{Residual and Goal-Oriented h-and hp-adaptive Finite Element; Application for Elliptic and Saddle Point Problems}},
+  year    = 2018,
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/173289},
-  publisher = {Texas A\&M University},
-  year    = 2018
+  publisher = {Texas A\&M University}
 }
 
 @Article{2018:giuliani.heltai.ea:predicting,
-  doi     = {10.1089/soro.2017.0099},
-  url     = {https://doi.org/10.1089/soro.2017.0099},
+  author  = {Nicola Giuliani and Luca Heltai and Antonio DeSimone},
+  title   = {Predicting and Optimizing Microswimmer Performance from the Hydrodynamics of Its Components: The Relevance of Interactions},
+  journal = {Soft Robotics},
   year    = 2018,
-  month   = aug,
-  publisher = {Mary Ann Liebert Inc},
   volume  = 5,
   number  = 4,
   pages   = {410--424},
-  author  = {Nicola Giuliani and Luca Heltai and Antonio DeSimone},
-  title   = {Predicting and Optimizing Microswimmer Performance from the Hydrodynamics of Its Components: The Relevance of Interactions},
-  journal = {Soft Robotics}
+  month   = aug,
+  doi     = {10.1089/soro.2017.0099},
+  url     = {https://doi.org/10.1089/soro.2017.0099},
+  publisher = {Mary Ann Liebert Inc}
 }
 
 @Article{2018:giuliani.mola.ea:-bem,
-  doi     = {10.1016/j.advengsoft.2018.03.008},
-  url     = {https://doi.org/10.1016/j.advengsoft.2018.03.008},
-  year    = 2018,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 121,
-  pages   = {39--58},
   author  = {Nicola Giuliani and Andrea Mola and Luca Heltai},
   title   = {$\pi$-{BEM}: A flexible parallel implementation for adaptive, geometry aware, and high order boundary element methods},
-  journal = {Advances in Engineering Software}
+  journal = {Advances in Engineering Software},
+  year    = 2018,
+  volume  = 121,
+  pages   = {39--58},
+  month   = jul,
+  doi     = {10.1016/j.advengsoft.2018.03.008},
+  url     = {https://doi.org/10.1016/j.advengsoft.2018.03.008},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:glerum.thieulot.ea:nonlinear,
-  doi     = {10.5194/se-9-267-2018},
-  url     = {https://doi.org/10.5194/se-9-267-2018},
+  author  = {Anne Glerum and Cedric Thieulot and Menno Fraters and Constantijn Blom and Wim Spakman},
+  title   = {Nonlinear viscoplasticity in {ASPECT}: benchmarking and applications to subduction},
+  journal = {Solid Earth},
   year    = 2018,
-  month   = mar,
-  publisher = {Copernicus {GmbH}},
   volume  = 9,
   number  = 2,
   pages   = {267--294},
-  author  = {Anne Glerum and Cedric Thieulot and Menno Fraters and Constantijn Blom and Wim Spakman},
-  title   = {Nonlinear viscoplasticity in {ASPECT}: benchmarking and applications to subduction},
-  journal = {Solid Earth}
+  month   = mar,
+  doi     = {10.5194/se-9-267-2018},
+  url     = {https://doi.org/10.5194/se-9-267-2018},
+  publisher = {Copernicus {GmbH}}
 }
 
 @Article{2018:goll.wick.ea:dopelib,
@@ -1021,58 +1021,58 @@
 }
 
 @Article{2018:gong.chen.ea:fast,
-  title   = {Fast simulations of a large number of crystals growth in centimeter-scale during alloy solidification via nonlinearly preconditioned quantitative phase-field formula},
   author  = {Tong Zhao Gong and Yun Chen and Yan Fei Cao and Xiu Hong Kang and Dian Zhong Li},
-  doi     = {10.1016/j.commatsci.2018.02.003},
-  url     = {https://doi.org/10.1016/j.commatsci.2018.02.003},
+  title   = {Fast simulations of a large number of crystals growth in centimeter-scale during alloy solidification via nonlinearly preconditioned quantitative phase-field formula},
+  journal = {Computational Materials Science},
   year    = 2018,
-  month   = may,
-  publisher = {Elsevier {BV}},
   volume  = 147,
   pages   = {338--352},
-  journal = {Computational Materials Science}
+  month   = may,
+  doi     = {10.1016/j.commatsci.2018.02.003},
+  url     = {https://doi.org/10.1016/j.commatsci.2018.02.003},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:gonzalez-valverde.garcia-aznar:mechanical,
-  doi     = {10.1016/j.cma.2018.03.036},
-  url     = {https://doi.org/10.1016/j.cma.2018.03.036},
-  year    = 2018,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 337,
-  pages   = {246--262},
   author  = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
   title   = {Mechanical modeling of collective cell migration: An agent-based and continuum material approach},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2018,
+  volume  = 337,
+  pages   = {246--262},
+  month   = aug,
+  doi     = {10.1016/j.cma.2018.03.036},
+  url     = {https://doi.org/10.1016/j.cma.2018.03.036},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2018:greene:a-bayesian-approach-to-spike-sorting-of-neural-data-via-source-localization,
   author  = {Greene, P},
   title   = {{A Bayesian Approach to Spike Sorting of Neural Data via Source Localization}},
+  year    = 2018,
   url     = {https://repository.arizona.edu/handle/10150/628404},
-  publisher = {University of Arizona},
-  year    = 2018
+  publisher = {University of Arizona}
 }
 
 @Article{2018:guermond.nazarov.ea:second-order,
-  doi     = {10.1137/17m1149961},
-  url     = {https://doi.org/10.1137/17m1149961},
+  author  = {Jean-Luc Guermond and Murtazo Nazarov and Bojan Popov and Ignacio Tomas},
+  title   = {Second-Order Invariant Domain Preserving Approximation of the Euler Equations Using Convex Limiting},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2018,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 40,
   number  = 5,
   pages   = {A3211--A3239},
-  author  = {Jean-Luc Guermond and Murtazo Nazarov and Bojan Popov and Ignacio Tomas},
-  title   = {Second-Order Invariant Domain Preserving Approximation of the Euler Equations Using Convex Limiting},
-  journal = {{SIAM} Journal on Scientific Computing}
+  month   = jan,
+  doi     = {10.1137/17m1149961},
+  url     = {https://doi.org/10.1137/17m1149961},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @TechReport{2018:gulevich.gulevich:user-guide-for-mitmojco-1-2-microscopic-tunneling-model-for-josephson-contacts-mitmojco-1-2,
   author  = {Gulevich, Dmitry R and Gulevich, Dmitry R},
   title   = {{User Guide for MiTMoJCo 1.2 (Microscopic Tunneling Model for Josephson Contacts) MiTMoJCo 1.2}},
-  url     = {https://github.com/drgulevich/mitmojco},
-  year    = 2018
+  year    = 2018,
+  url     = {https://github.com/drgulevich/mitmojco}
 }
 
 @Article{2018:gulevich.koshelets.ea:bridging,
@@ -1084,8 +1084,8 @@
 }
 
 @Misc{2018:gulevich:mitmojco,
-  title   = {MiTMoJCo: Microscopic Tunneling Model for Josephson Contacts},
   author  = {Dmitry R. Gulevich},
+  title   = {MiTMoJCo: Microscopic Tunneling Model for Josephson Contacts},
   year    = 2018,
   eprint  = {1809.04706},
   archiveprefix = {arXiv},
@@ -1100,223 +1100,223 @@
 }
 
 @InCollection{2018:gulpak.wernsing.ea:compensation,
-  doi     = {10.1007/978-3-319-57120-1_12},
-  url     = {https://doi.org/10.1007/978-3-319-57120-1_12},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {251--288},
   author  = {M. Gulpak and H. Wernsing and J. S\"{o}lter and C. B\"{u}skens},
   title   = {Compensation Strategies for Thermal Effects in Dry Milling},
-  booktitle = {Lecture Notes in Production Engineering}
+  booktitle = {Lecture Notes in Production Engineering},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {251--288},
+  doi     = {10.1007/978-3-319-57120-1_12},
+  url     = {https://doi.org/10.1007/978-3-319-57120-1_12}
 }
 
 @Article{2018:guo.song.ea:pressure,
-  doi     = {10.1016/j.petrol.2017.12.038},
-  url     = {https://doi.org/10.1016/j.petrol.2017.12.038},
-  year    = 2018,
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = 163,
-  pages   = {1--15},
   author  = {Xuyang Guo and Hongqing Song and Kan Wu and John Killough},
   title   = {Pressure characteristics and performance of multi-stage fractured horizontal well in shale gas reservoirs with coupled flow and geomechanics},
-  journal = {Journal of Petroleum Science and Engineering}
+  journal = {Journal of Petroleum Science and Engineering},
+  year    = 2018,
+  volume  = 163,
+  pages   = {1--15},
+  month   = apr,
+  doi     = {10.1016/j.petrol.2017.12.038},
+  url     = {https://doi.org/10.1016/j.petrol.2017.12.038},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:guo.wu.ea:investigation,
-  doi     = {10.2118/189974-pa},
-  url     = {https://doi.org/10.2118/189974-pa},
+  author  = {Xuyang Guo and Kan Wu and John Killough},
+  title   = {Investigation of Production-Induced Stress Changes for Infill-Well Stimulation in Eagle Ford Shale},
+  journal = {{SPE} Journal},
   year    = 2018,
-  month   = aug,
-  publisher = {Society of Petroleum Engineers ({SPE})},
   volume  = 23,
   number  = 04,
   pages   = {1372--1388},
-  author  = {Xuyang Guo and Kan Wu and John Killough},
-  title   = {Investigation of Production-Induced Stress Changes for Infill-Well Stimulation in Eagle Ford Shale},
-  journal = {{SPE} Journal}
+  month   = aug,
+  doi     = {10.2118/189974-pa},
+  url     = {https://doi.org/10.2118/189974-pa},
+  publisher = {Society of Petroleum Engineers ({SPE})}
 }
 
 @InProceedings{2018:guo.wu.ea:understanding,
-  doi     = {10.15530/urtec-2018-2874464},
-  url     = {https://doi.org/10.15530/urtec-2018-2874464},
-  year    = 2018,
-  publisher = {American Association of Petroleum Geologists},
   author  = {Xuyang Guo and Kan Wu and John Killough and Jizhou Tang},
   title   = {Understanding the Mechanism of Interwell Fracturing Interference Based on Reservoir-Geomechanics-Fracturing Modeling in Eagle Ford Shale},
-  booktitle = {Proceedings of the 6th Unconventional Resources Technology Conference}
+  booktitle = {Proceedings of the 6th Unconventional Resources Technology Conference},
+  year    = 2018,
+  publisher = {American Association of Petroleum Geologists},
+  doi     = {10.15530/urtec-2018-2874464},
+  url     = {https://doi.org/10.15530/urtec-2018-2874464}
 }
 
 @PhDThesis{2018:guo:a-study-of-interwell-interference-and-well-performance-in-unconventional-reservoirs-based-on-coupled-flow-and-geomechanics-modeling-with-improved,
   author  = {Guo, X.},
   title   = {{A Study of Interwell Interference and Well Performance in Unconventional Reservoirs Based on Coupled Flow and Geomechanics Modeling with Improved}},
+  year    = 2018,
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/173772},
-  publisher = {Texas A\&M University},
-  year    = 2018
+  publisher = {Texas A\&M University}
 }
 
 @Article{2018:gupta.langelaar.ea:qr-patterns,
-  doi     = {10.1007/s00158-018-2048-6},
-  url     = {https://doi.org/10.1007/s00158-018-2048-6},
+  author  = {Deepak K. Gupta and Matthijs Langelaar and Fred van Keulen},
+  title   = {{QR}-patterns: artefacts in multiresolution topology optimization},
+  journal = {Structural and Multidisciplinary Optimization},
   year    = 2018,
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 58,
   number  = 4,
   pages   = {1335--1350},
-  author  = {Deepak K. Gupta and Matthijs Langelaar and Fred van Keulen},
-  title   = {{QR}-patterns: artefacts in multiresolution topology optimization},
-  journal = {Structural and Multidisciplinary Optimization}
+  month   = aug,
+  doi     = {10.1007/s00158-018-2048-6},
+  url     = {https://doi.org/10.1007/s00158-018-2048-6},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:ha.choo.ea:liquid,
-  doi     = {10.1007/s00603-018-1542-x},
-  url     = {https://doi.org/10.1007/s00603-018-1542-x},
+  author  = {Seong Jun Ha and Jinhyun Choo and Tae Sup Yun},
+  title   = {Liquid {CO}2 Fracturing: Effect of Fluid Permeation on the Breakdown Pressure and Cracking Behavior},
+  journal = {Rock Mechanics and Rock Engineering},
   year    = 2018,
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 51,
   number  = 11,
   pages   = {3407--3420},
-  author  = {Seong Jun Ha and Jinhyun Choo and Tae Sup Yun},
-  title   = {Liquid {CO}2 Fracturing: Effect of Fluid Permeation on the Breakdown Pressure and Cracking Behavior},
-  journal = {Rock Mechanics and Rock Engineering}
+  month   = jul,
+  doi     = {10.1007/s00603-018-1542-x},
+  url     = {https://doi.org/10.1007/s00603-018-1542-x},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @InProceedings{2018:hai.bause:mathematical-modelling-of-structural-health-monitoring-systems--coupling-fluid-structure-interaction-with-wave-propagation-,
   author  = {Hai, BSME and Bause, M},
   title   = {{Mathematical Modelling of Structural Health Monitoring Systems: Coupling Fluid-Structure Interaction with Wave Propagation.}},
-  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/filePaper/p1848.pdf},
-  year    = 2018
+  year    = 2018,
+  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/filePaper/p1848.pdf}
 }
 
 @InProceedings{2018:hai.bause:numerical,
-  doi     = {10.1115/imece2018-87448},
-  url     = {https://doi.org/10.1115/imece2018-87448},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Numerical Modeling and Approximation of the Coupling Lamb Wave Propagation With Fluid-Structure Interaction Problem},
+  booktitle = {Volume 9: Mechanics of Solids, Structures, and Fluids},
   year    = 2018,
   month   = nov,
   publisher = {American Society of Mechanical Engineers},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Numerical Modeling and Approximation of the Coupling Lamb Wave Propagation With Fluid-Structure Interaction Problem},
-  booktitle = {Volume 9: Mechanics of Solids, Structures, and Fluids}
+  doi     = {10.1115/imece2018-87448},
+  url     = {https://doi.org/10.1115/imece2018-87448}
 }
 
 @Article{2018:heister.wick:parallel,
-  title   = {Parallel solution, adaptivity, computational convergence, and open-source code of 2d and 3d pressurized phase-field fracture problems},
   author  = {Timo Heister and Thomas Wick},
+  title   = {Parallel solution, adaptivity, computational convergence, and open-source code of 2d and 3d pressurized phase-field fracture problems},
   journal = {Proc. Appl. Math. Mech.},
   year    = 2018,
+  volume  = 18,
   number  = 1,
   pages   = {e201800353},
-  volume  = 18,
   doi     = {10.1002/pamm.201800353}
 }
 
 @TechReport{2018:hochbruck.kohler:on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-methods-on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-problems,
   author  = {Hochbruck, Marlis and K{\"{o}}hler, Jonas},
   title   = {{On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type methods On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type problems}},
-  url     = {https://www.waves.kit.edu/downloads/CRC1173_Preprint_2017-34.pdf},
-  year    = 2018
+  year    = 2018,
+  url     = {https://www.waves.kit.edu/downloads/CRC1173_Preprint_2017-34.pdf}
 }
 
 @PhDThesis{2018:huang:hybrid-analog-digital-co-processing-for-scientific-computation,
   author  = {Huang, Y.},
   title   = {{Hybrid Analog-Digital Co-Processing for Scientific Computation}},
+  year    = 2018,
   url     = {https://academiccommons.columbia.edu/doi/10.7916/D8V711TR},
-  publisher = {Columbia University},
-  year    = 2018
+  publisher = {Columbia University}
 }
 
 @Article{2018:ilio.dorschner.ea:simulation,
-  doi     = {10.1017/jfm.2018.413},
-  url     = {https://www.researchgate.net/publication/325069808_Simulation_of_turbulent_flows_with_the_entropic_multi-relaxation_time_lattice_Boltzmann_method_on_body-fitted_meshes},
-  year    = 2018,
-  month   = jun,
-  publisher = {Cambridge University Press ({CUP})},
-  volume  = 849,
-  pages   = {35--56},
   author  = {G. Di Ilio and B. Dorschner and G. Bella and S. Succi and I. V. Karlin},
   title   = {Simulation of turbulent flows with the entropic multirelaxation time lattice Boltzmann method on body-fitted meshes},
-  journal = {Journal of Fluid Mechanics}
+  journal = {Journal of Fluid Mechanics},
+  year    = 2018,
+  volume  = 849,
+  pages   = {35--56},
+  month   = jun,
+  doi     = {10.1017/jfm.2018.413},
+  url     = {https://www.researchgate.net/publication/325069808_Simulation_of_turbulent_flows_with_the_entropic_multi-relaxation_time_lattice_Boltzmann_method_on_body-fitted_meshes},
+  publisher = {Cambridge University Press ({CUP})}
 }
 
 @Article{2018:jadamba.khan.ea:elliptic,
-  url     = {http://www.ybook.co.jp/online2/oppafa/vol3/p309.html},
-  year    = 2018,
-  month   = jan,
-  volume  = 3,
-  number  = 2,
   author  = {Jadamba, B and Khan, A. A. and Kahler, R. and Sama, M.},
   title   = {Elliptic Inverse Problems of Identifying Nonlinear Parameters},
-  journal = {Pure and Applied Functional Analysis}
+  journal = {Pure and Applied Functional Analysis},
+  year    = 2018,
+  volume  = 3,
+  number  = 2,
+  month   = jan,
+  url     = {http://www.ybook.co.jp/online2/oppafa/vol3/p309.html}
 }
 
 @PhDThesis{2018:jansen:modeling-heat-and-fluid-flow-in-discrete-fracture-networks,
   author  = {Jansen, G.},
   title   = {{Modeling heat and fluid flow in discrete fracture networks}},
+  year    = 2018,
   url     = {https://doc.rero.ch/record/328092},
-  publisher = {Universit\'{e} de Neuch\^{a}tel},
-  year    = 2018
+  publisher = {Universit\'{e} de Neuch\^{a}tel}
 }
 
 @Article{2018:jithin-jith:acousto-elastic,
+  author  = {{Jithin Jith}},
+  title   = {Acousto-Elastic Interactions in High-Pressure Centrifugal Compressors},
+  year    = 2018,
   doi     = {10.13140/RG.2.2.30755.14885},
   url     = {http://rgdoi.net/10.13140/RG.2.2.30755.14885},
-  author  = {{Jithin Jith}},
   language = {en},
-  title   = {Acousto-Elastic Interactions in High-Pressure Centrifugal Compressors},
-  publisher = {Unpublished},
-  year    = 2018
+  publisher = {Unpublished}
 }
 
 @Article{2018:jodlbauer.langer.ea:parallel,
-  doi     = {10.1002/nme.5970},
-  url     = {https://doi.org/10.1002/nme.5970},
+  author  = {D. Jodlbauer and U. Langer and T. Wick},
+  title   = {Parallel block-preconditioned monolithic solvers for fluid-structure interaction problems},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2018,
-  month   = oct,
-  publisher = {Wiley},
   volume  = 117,
   number  = 6,
   pages   = {623--643},
-  author  = {D. Jodlbauer and U. Langer and T. Wick},
-  title   = {Parallel block-preconditioned monolithic solvers for fluid-structure interaction problems},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = oct,
+  doi     = {10.1002/nme.5970},
+  url     = {https://doi.org/10.1002/nme.5970},
+  publisher = {Wiley}
 }
 
 @Article{2018:k-gupta.keulen.ea:design,
   author  = {K. Gupta, Deepak and Keulen, Fred and Langelaar, Matthijs},
-  year    = 2018,
-  month   = nov,
   title   = {Design and analysis adaptivity in multi-resolution topology optimization},
   journal = {arXiv:1811.09821},
+  year    = 2018,
+  month   = nov,
   url     = {https://arxiv.org/abs/1811.09821}
 }
 
 @Article{2018:kanschat.riviere:finite,
-  doi     = {10.1007/s10915-018-0843-2},
-  url     = {https://doi.org/10.1007/s10915-018-0843-2},
+  author  = {Guido Kanschat and Beatrice Riviere},
+  title   = {A Finite Element Method with Strong Mass Conservation for Biot's Linear Consolidation Model},
+  journal = {Journal of Scientific Computing},
   year    = 2018,
-  month   = oct,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 77,
   number  = 3,
   pages   = {1762--1779},
-  author  = {Guido Kanschat and Beatrice Riviere},
-  title   = {A Finite Element Method with Strong Mass Conservation for Biot's Linear Consolidation Model},
-  journal = {Journal of Scientific Computing}
+  month   = oct,
+  doi     = {10.1007/s10915-018-0843-2},
+  url     = {https://doi.org/10.1007/s10915-018-0843-2},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:karban.kropik.ea:bayes,
-  doi     = {10.1016/j.amc.2017.07.043},
-  url     = {https://doi.org/10.1016/j.amc.2017.07.043},
-  year    = 2018,
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = 319,
-  pages   = {681--692},
   author  = {Pavel Karban and Petr Krop{\'{i}}k and V{\'{a}}clav Kotlan and Ivo Dole{\v{z}}el},
   title   = {Bayes approach to solving T.E.A.M. benchmark problems 22 and 25 and its comparison with other optimization techniques},
-  journal = {Applied Mathematics and Computation}
+  journal = {Applied Mathematics and Computation},
+  year    = 2018,
+  volume  = 319,
+  pages   = {681--692},
+  month   = feb,
+  doi     = {10.1016/j.amc.2017.07.043},
+  url     = {https://doi.org/10.1016/j.amc.2017.07.043},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2018:kauffman:overset,
@@ -1328,28 +1328,28 @@
 }
 
 @Article{2018:kaufl.grayver.ea:topographic,
-  title   = {Topographic distortions of magnetotelluric transfer functions: a high-resolution 3-D modelling study using real elevation data},
   author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Kuvshinov, Alexey V},
+  title   = {Topographic distortions of magnetotelluric transfer functions: a high-resolution 3-D modelling study using real elevation data},
   journal = {Geophysical Journal International},
+  year    = 2018,
   volume  = 215,
   number  = 3,
   pages   = {1943--1961},
-  year    = 2018,
   publisher = {Oxford University Press},
   doi     = {10.1093/gji/ggy375}
 }
 
 @Article{2018:kazemi.vaziri.ea:topology,
-  doi     = {10.1115/1.4040624},
-  url     = {https://doi.org/10.1115/1.4040624},
-  year    = 2018,
-  month   = sep,
-  publisher = {{ASME} International},
-  volume  = 140,
-  number  = 11,
   author  = {Hesaneh Kazemi and Ashkan Vaziri and Juli{\'{a}}n A. Norato},
   title   = {Topology Optimization of Structures Made of Discrete Geometric Components With Different Materials},
-  journal = {Journal of Mechanical Design}
+  journal = {Journal of Mechanical Design},
+  year    = 2018,
+  volume  = 140,
+  number  = 11,
+  month   = sep,
+  doi     = {10.1115/1.4040624},
+  url     = {https://doi.org/10.1115/1.4040624},
+  publisher = {{ASME} International}
 }
 
 @PhDThesis{2018:khattatov:efficient,
@@ -1361,8 +1361,8 @@
 }
 
 @Misc{2018:kocher.bause:mixed,
-  title   = {A mixed discontinuous-continuous Galerkin time discretisation for Biot's system},
   author  = {Uwe K{\"o}cher and Markus Bause},
+  title   = {A mixed discontinuous-continuous Galerkin time discretisation for Biot's system},
   year    = 2018,
   eprint  = {1805.00771},
   archiveprefix = {arXiv},
@@ -1371,20 +1371,20 @@
 
 @InProceedings{2018:koepf.soldner.ea:3d,
   author  = {Koepf, Johannes and Soldner, Dominic and Gotterbarm, Martin and Markl, Matthias and Mergheim, Julia and K{\"o}rner, Carolin},
-  year    = 2018,
-  month   = may,
   title   = {3D Grainstructure simulation in powder bed additive manufacturing},
-  booktitle = {NAFEMS Konferenz 2018}
+  booktitle = {NAFEMS Konferenz 2018},
+  year    = 2018,
+  month   = may
 }
 
 @Article{2018:krank.kronbichler.ea:direct,
-  title   = {Direct Numerical Simulation of Flow over Periodic Hills up to Re$_{\textnormal{H}}$ = 10,595},
   author  = {Krank, Benjamin and Kronbichler, Martin and Wall, Wolfgang A},
+  title   = {Direct Numerical Simulation of Flow over Periodic Hills up to Re$_{\textnormal{H}}$ = 10,595},
   journal = {Flow, Turbulence, and Combustion},
+  year    = 2018,
   volume  = 101,
   number  = 2,
   pages   = {521--551},
-  year    = 2018,
   publisher = {Springer},
   url     = {https://doi.org/10.1007/s10494-018-9941-3},
   doi     = {10.1007/s10494-018-9941-3}
@@ -1403,26 +1403,26 @@
 }
 
 @InProceedings{2018:kronbichler.allalen:efficient,
-  doi     = {10.1007/978-3-319-99654-7_7},
-  url     = {https://doi.org/10.1007/978-3-319-99654-7_7},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {89--110},
   author  = {Martin Kronbichler and Momme Allalen},
   title   = {Efficient High-Order Discontinuous Galerkin Finite Elements with Matrix-Free Implementations},
-  booktitle = {Advances and New Trends in Environmental Informatics},
   editor  = {Bungartz, Hans-Joachim and Kranzlm\"uller, Dieter and Weinberg, Volker and Weism\"uller, Jens and Wohlgemuth, Volker},
-  series  = {Progress in {IS}}
+  booktitle = {Advances and New Trends in Environmental Informatics},
+  year    = 2018,
+  series  = {Progress in {IS}},
+  pages   = {89--110},
+  publisher = {Springer International Publishing},
+  doi     = {10.1007/978-3-319-99654-7_7},
+  url     = {https://doi.org/10.1007/978-3-319-99654-7_7}
 }
 
 @Article{2018:kronbichler.diagne.ea:fast,
   author  = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
   title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
   journal = {The International Journal of High Performance Computing Applications},
+  year    = 2018,
   volume  = 32,
   number  = 2,
   pages   = {266--287},
-  year    = 2018,
   doi     = {10.1177/1094342016671790},
   url     = {https://doi.org/10.1177/1094342016671790},
   eprint  = { https://doi.org/10.1177/1094342016671790 }
@@ -1433,9 +1433,9 @@
   title   = {A new high-order discontinuous Galerkin solver for {DNS} and {LES} of turbulent incompressible flow},
   editor  = {Andreas Dillmann and Gerd Heller and Ewald Kr\"amer and Claus Wagner and Stephan Bansmer and Rolf Radespiel and Richard Semaan},
   booktitle = {New Results in Numerical and Experimental Fluid Mechanics},
+  year    = 2018,
   series  = {Notes on Numerical Fluid Mechanics and Multidisciplinary Design},
   volume  = 136,
-  year    = 2018,
   pages   = {467--477},
   url     = {https://doi.org/10.1007/978-3-319-64519-3_42},
   doi     = {10.1007/978-3-319-64519-3_42}
@@ -1445,10 +1445,10 @@
   author  = {Kronbichler, Martin and Wall, Wolfgang A.},
   title   = {A Performance Comparison of Continuous and Discontinuous Galerkin Methods with Fast Multigrid Solvers},
   journal = {SIAM Journal on Scientific Computing},
+  year    = 2018,
   volume  = 40,
   number  = 5,
   pages   = {A3423--A3448},
-  year    = 2018,
   doi     = {10.1137/16M110455X},
   url     = { https://doi.org/10.1137/16M110455X}
 }
@@ -1466,84 +1466,84 @@
 }
 
 @Article{2018:lambe.czekanski:density,
-  doi     = {10.1002/nme.5843},
+  author  = {Andrew B. Lambe and Aleksander Czekanski},
+  title   = {A density field parametrization for topology optimization using {B}ernstein elements},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2018,
-  month   = jun,
-  publisher = {Wiley},
   volume  = 115,
   number  = 10,
   pages   = {1266--1286},
-  author  = {Andrew B. Lambe and Aleksander Czekanski},
-  title   = {A density field parametrization for topology optimization using {B}ernstein elements},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = jun,
+  doi     = {10.1002/nme.5843},
+  publisher = {Wiley}
 }
 
 @Article{2018:lambe.czekanski:topology,
-  doi     = {10.1002/nme.5617},
-  url     = {https://doi.org/10.1002/nme.5617},
+  author  = {Andrew B. Lambe and Aleksander Czekanski},
+  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2018,
-  month   = jan,
-  publisher = {Wiley},
   volume  = 113,
   number  = 3,
   pages   = {357--373},
-  author  = {Andrew B. Lambe and Aleksander Czekanski},
-  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = jan,
+  doi     = {10.1002/nme.5617},
+  url     = {https://doi.org/10.1002/nme.5617},
+  publisher = {Wiley}
 }
 
 @Article{2018:lee.mikelic.ea:phase-field,
-  doi     = {10.1137/17m1145239},
-  url     = {https://doi.org/10.1137/17m1145239},
+  author  = {Sanghyun Lee and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
+  title   = {Phase-Field Modeling of Two Phase Fluid Filled Fractures in a Poroelastic Medium},
+  journal = {Multiscale Modeling {\&} Simulation},
   year    = 2018,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 16,
   number  = 4,
   pages   = {1542--1580},
-  author  = {Sanghyun Lee and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
-  title   = {Phase-Field Modeling of Two Phase Fluid Filled Fractures in a Poroelastic Medium},
-  journal = {Multiscale Modeling {\&} Simulation}
+  month   = jan,
+  doi     = {10.1137/17m1145239},
+  url     = {https://doi.org/10.1137/17m1145239},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2018:lee.min.ea:optimal,
-  doi     = {10.1007/s10596-018-9728-6},
-  url     = {https://doi.org/10.1007/s10596-018-9728-6},
+  author  = {Sanghyun Lee and Baehyun Min and Mary F. Wheeler},
+  title   = {Optimal design of hydraulic fracturing in porous media using the phase field fracture model coupled with genetic algorithm},
+  journal = {Computational Geosciences},
   year    = 2018,
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 22,
   number  = 3,
   pages   = {833--849},
-  author  = {Sanghyun Lee and Baehyun Min and Mary F. Wheeler},
-  title   = {Optimal design of hydraulic fracturing in porous media using the phase field fracture model coupled with genetic algorithm},
-  journal = {Computational Geosciences}
+  month   = feb,
+  doi     = {10.1007/s10596-018-9728-6},
+  url     = {https://doi.org/10.1007/s10596-018-9728-6},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:lee.wheeler:enriched,
-  doi     = {10.1016/j.jcp.2018.03.031},
-  url     = {https://doi.org/10.1016/j.jcp.2018.03.031},
-  year    = 2018,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 367,
-  pages   = {65--86},
   author  = {Sanghyun Lee and Mary F. Wheeler},
   title   = {Enriched Galerkin methods for two-phase flow in porous media with capillary pressure},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2018,
+  volume  = 367,
+  pages   = {65--86},
+  month   = aug,
+  doi     = {10.1016/j.jcp.2018.03.031},
+  url     = {https://doi.org/10.1016/j.jcp.2018.03.031},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:lemenager.oneill.ea:effect,
-  doi     = {10.1186/s40517-018-0092-5},
-  url     = {https://doi.org/10.1186/s40517-018-0092-5},
-  year    = 2018,
-  month   = may,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 6,
-  number  = 1,
   author  = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang and Morgan Evans},
   title   = {The effect of temperature-dependent thermal conductivity on the geothermal structure of the Sydney Basin},
-  journal = {Geothermal Energy}
+  journal = {Geothermal Energy},
+  year    = 2018,
+  volume  = 6,
+  number  = 1,
+  month   = may,
+  doi     = {10.1186/s40517-018-0092-5},
+  url     = {https://doi.org/10.1186/s40517-018-0092-5},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @MastersThesis{2018:lin:stabilized,
@@ -1555,17 +1555,17 @@
 }
 
 @Article{2018:liu.reina:dynamic,
-  doi     = {10.1007/s00466-018-1662-x},
-  url     = {https://doi.org/10.1007/s00466-018-1662-x},
+  author  = {Chenchen Liu and Celia Reina},
+  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
+  journal = {Computational Mechanics},
   year    = 2018,
-  month   = dec,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 64,
   number  = 1,
   pages   = {147--161},
-  author  = {Chenchen Liu and Celia Reina},
-  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
-  journal = {Computational Mechanics}
+  month   = dec,
+  doi     = {10.1007/s00466-018-1662-x},
+  url     = {https://doi.org/10.1007/s00466-018-1662-x},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:liu.yin:unconditionally,
@@ -1579,8 +1579,8 @@
 @PhDThesis{2018:lucero-lorca:multilevel-schwarz-methods-for-multigroup-radiation-transport-problems,
   author  = {Jose Pablo {Lucero Lorca}},
   title   = {{Multilevel Schwarz methods for multigroup radiation transport problems}},
-  year    = 2018,
   school  = {Heidelberg University},
+  year    = 2018,
   url     = {https://archiv.ub.uni-heidelberg.de/volltextserver/25216/},
   doi     = {10.11588/heidok.00025216}
 }
@@ -1590,29 +1590,29 @@
   title   = {High-Order Numerical Methods for 2D Parabolic Problems in Single and Composite Domains},
   journal = {Journal of Scientific Computing},
   year    = 2018,
-  month   = aug,
   volume  = 76,
   number  = 2,
   pages   = {812--847},
+  month   = aug,
   issn    = {1573-7691},
   doi     = {10.1007/s10915-017-0637-y},
   url     = {https://doi.org/10.1007/s10915-017-0637-y}
 }
 
 @InProceedings{2018:luo.zhao:finite,
-  doi     = {10.1115/detc2018-85701},
-  url     = {https://doi.org/10.1115/detc2018-85701},
+  author  = {Zhibo Luo and Yaoyao Fiona Zhao},
+  title   = {Finite Element Thermal Analysis of Melt Pool in Selective Laser Melting Process},
+  booktitle = {38th Computers and Information in Engineering Conference, Volume 1A},
   year    = 2018,
   month   = aug,
   publisher = {American Society of Mechanical Engineers},
-  author  = {Zhibo Luo and Yaoyao Fiona Zhao},
-  title   = {Finite Element Thermal Analysis of Melt Pool in Selective Laser Melting Process},
-  booktitle = {38th Computers and Information in Engineering Conference, Volume 1A}
+  doi     = {10.1115/detc2018-85701},
+  url     = {https://doi.org/10.1115/detc2018-85701}
 }
 
 @Misc{2018:maday.marcati:regularity,
-  title   = {Regularity and $hp$ discontinuous {G}alerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
   author  = {Yvon Maday and Carlo Marcati},
+  title   = {Regularity and $hp$ discontinuous {G}alerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
   year    = 2018,
   eprint  = {1810.09010},
   archiveprefix = {arXiv},
@@ -1629,8 +1629,8 @@
 }
 
 @Misc{2018:maier.mattheakis.ea:homogenization,
-  title   = {Homogenization of plasmonic crystals: Seeking the epsilon-near-zero effect},
   author  = {Matthias Maier and Marios Mattheakis and Efthimios Kaxiras and Mitchell Luskin and Dionisios Margetis},
+  title   = {Homogenization of plasmonic crystals: Seeking the epsilon-near-zero effect},
   year    = 2018,
   eprint  = {1809.08276},
   archiveprefix = {arXiv},
@@ -1639,27 +1639,27 @@
 
 @Article{2018:maier.nemilentsau.ea:ultracompact,
   author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
-  doi     = {10.1021/acsphotonics.7b01094},
+  title   = {Ultracompact amplitude modulator by coupling hyperbolic polaritons over a graphene-covered gap},
   journal = {ACS Photonics},
+  year    = 2018,
+  volume  = 5,
   number  = 2,
   pages   = {544--551},
-  title   = {Ultracompact amplitude modulator by coupling hyperbolic polaritons over a graphene-covered gap},
-  volume  = 5,
-  year    = 2018
+  doi     = {10.1021/acsphotonics.7b01094}
 }
 
 @Article{2018:maier.rannacher:duality-based,
-  doi     = {10.1137/16m1105670},
-  url     = {https://doi.org/10.1137/16m1105670},
+  author  = {Matthias Maier and Rolf Rannacher},
+  title   = {A Duality-Based Optimization Approach for Model Adaptivity in Heterogeneous Multiscale Problems},
+  journal = {Multiscale Modeling {\&} Simulation},
   year    = 2018,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 16,
   number  = 1,
   pages   = {412--428},
-  author  = {Matthias Maier and Rolf Rannacher},
-  title   = {A Duality-Based Optimization Approach for Model Adaptivity in Heterogeneous Multiscale Problems},
-  journal = {Multiscale Modeling {\&} Simulation}
+  month   = jan,
+  doi     = {10.1137/16m1105670},
+  url     = {https://doi.org/10.1137/16m1105670},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @PhDThesis{2018:marcati:discontinuous,
@@ -1673,43 +1673,43 @@
 @PhDThesis{2018:massoudi:numerical-algorithms-for-the-linear-quadratic-optimal-control-of-well-posed-linear-systems,
   author  = {Massoudi, A},
   title   = {{Numerical Algorithms for the Linear-Quadratic Optimal Control of Well-Posed Linear Systems}},
+  year    = 2018,
   publisher = {Universit\"{a}t Hamburg},
-  url     = {https://ediss.sub.uni-hamburg.de/volltexte/2018/9055/},
-  year    = 2018
+  url     = {https://ediss.sub.uni-hamburg.de/volltexte/2018/9055/}
 }
 
 @InProceedings{2018:mehnert.hossain.ea:a-thermo-electro-viscoelastic-material-model-for-the-simulation-of-vhb-4905,
   author  = {Mehnert, M and Hossain, M and Steinmann, P},
-  journal = {congress.cimne.com},
   title   = {{A THERMO-ELECTRO-VISCOELASTIC MATERIAL MODEL FOR THE SIMULATION OF VHB 4905}},
-  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a839.pdf},
-  year    = 2018
+  year    = 2018,
+  journal = {congress.cimne.com},
+  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a839.pdf}
 }
 
 @Article{2018:mehnert.hossain.ea:numerical,
-  doi     = {10.1016/j.ijnonlinmec.2018.08.016},
-  url     = {https://doi.org/10.1016/j.ijnonlinmec.2018.08.016},
-  year    = 2018,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 106,
-  pages   = {13--24},
   author  = {Markus Mehnert and Mokarram Hossain and Paul Steinmann},
   title   = {Numerical modeling of thermo-electro-viscoelasticity with field-dependent material parameters},
-  journal = {International Journal of Non-Linear Mechanics}
+  journal = {International Journal of Non-Linear Mechanics},
+  year    = 2018,
+  volume  = 106,
+  pages   = {13--24},
+  month   = nov,
+  doi     = {10.1016/j.ijnonlinmec.2018.08.016},
+  url     = {https://doi.org/10.1016/j.ijnonlinmec.2018.08.016},
+  publisher = {Elsevier {BV}}
 }
 
 @TechReport{2018:mohebujjaman:high,
-  year    = 2018,
   author  = {Mohebujjaman, Muhammad},
-  institution = {Virginia Tech University},
   title   = {High order efficient algorithm for computation of {MHD} flow ensemble},
+  institution = {Virginia Tech University},
+  year    = 2018,
   url     = {https://mohebujjaman.github.io/Second_order_ensembleMHD_Mohebujjaman.pdf}
 }
 
 @Misc{2018:mohebujjaman:second,
-  title   = {Second order ensemble simulation for {MHD} flow in Els{\"a}sser variable with noisy input data},
   author  = {Muhammad Mohebujjaman},
+  title   = {Second order ensemble simulation for {MHD} flow in Els{\"a}sser variable with noisy input data},
   year    = 2018,
   eprint  = {1803.06980},
   archiveprefix = {arXiv},
@@ -1726,17 +1726,17 @@
 }
 
 @Article{2018:murphy.venkataraman.ea:parameter,
-  doi     = {10.1142/s1793524518500535},
-  url     = {https://doi.org/10.1142/s1793524518500535},
+  author  = {Laura Murphy and Chandrasekhar Venkataraman and Anotida Madzvamuse},
+  title   = {Parameter identification through mode isolation for reaction-diffusion systems on arbitrary geometries},
+  journal = {International Journal of Biomathematics},
   year    = 2018,
-  month   = may,
-  publisher = {World Scientific Pub Co Pte Lt},
   volume  = 11,
   number  = 04,
   pages   = 1850053,
-  author  = {Laura Murphy and Chandrasekhar Venkataraman and Anotida Madzvamuse},
-  title   = {Parameter identification through mode isolation for reaction-diffusion systems on arbitrary geometries},
-  journal = {International Journal of Biomathematics}
+  month   = may,
+  doi     = {10.1142/s1793524518500535},
+  url     = {https://doi.org/10.1142/s1793524518500535},
+  publisher = {World Scientific Pub Co Pte Lt}
 }
 
 @Article{2018:na.sun:computational,
@@ -1754,34 +1754,34 @@
 @PhDThesis{2018:na:multiscale-thermo-hydro-mechanical-chemical-coupling-effects-for-fluid-infiltrating-crystalline-solids-and-geomaterials--theory--implementation--and-validation,
   author  = {Na, S. H.},
   title   = {{Multiscale thermo-hydro-mechanical-chemical coupling effects for fluid-infiltrating crystalline solids and geomaterials: theory, implementation, and validation}},
+  year    = 2018,
   url     = {https://academiccommons.columbia.edu/doi/10.7916/D8P85VM9},
-  publisher = {Columbia University},
-  year    = 2018
+  publisher = {Columbia University}
 }
 
 @Article{2018:neitzel.wick.ea:optimal,
   author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
   title   = {An Optimal Control Problem Governed by a Regularized Phase-field Fracture Propagation Model. {P}art {I}{I} {T}he Regularization Limit},
   journal = {SIAM Journal on Control and Optimization},
+  year    = 2018,
   volume  = 55,
   number  = 4,
   pages   = 18,
-  year    = 2018,
   doi     = {10.1137/16M1062375}
 }
 
 @Article{2018:neitzel.wollner:priori,
-  doi     = {10.1007/s00211-017-0906-6},
-  url     = {https://doi.org/10.1007/s00211-017-0906-6},
+  author  = {I. Neitzel and W. Wollner},
+  title   = {A priori $L^2$ -discretization error estimates for the state in elliptic optimization problems with pointwise inequality state constraints},
+  journal = {Numerische Mathematik},
   year    = 2018,
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 138,
   number  = 2,
   pages   = {273--299},
-  author  = {I. Neitzel and W. Wollner},
-  title   = {A priori $L^2$ -discretization error estimates for the state in elliptic optimization problems with pointwise inequality state constraints},
-  journal = {Numerische Mathematik}
+  month   = jul,
+  doi     = {10.1007/s00211-017-0906-6},
+  url     = {https://doi.org/10.1007/s00211-017-0906-6},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:odster.kvamsdal.ea:simple,
@@ -1792,32 +1792,32 @@
 }
 
 @Article{2018:oneill.turner.ea:inception,
-  doi     = {10.1098/rsta.2017.0414},
-  title   = {The inception of plate tectonics: a record of failure},
   author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
+  title   = {The inception of plate tectonics: a record of failure},
   journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+  year    = 2018,
   volume  = 376,
   number  = 2132,
   pages   = 20170414,
-  year    = 2018,
+  doi     = {10.1098/rsta.2017.0414},
   publisher = {The Royal Society Publishing}
 }
 
 @Article{2018:oneill.zhang:lateral,
-  doi     = {10.1029/2018JB015698},
-  title   = {Lateral Mixing Processes in the {H}adean},
   author  = {O'Neill, C. J. and Zhang, S.},
+  title   = {Lateral Mixing Processes in the {H}adean},
   journal = {Journal of Geophysical Research: Solid Earth},
+  year    = 2018,
   volume  = 123,
   number  = 8,
   pages   = {7074--7089},
-  year    = 2018,
+  doi     = {10.1029/2018JB015698},
   publisher = {Wiley Online Library}
 }
 
 @Misc{2018:pearson.porcelli.ea:interior,
-  title   = {Interior Point Methods and Preconditioning for PDE-Constrained Optimization Problems Involving Sparsity Terms},
   author  = {John W. Pearson and Margherita Porcelli and Martin Stoll},
+  title   = {Interior Point Methods and Preconditioning for PDE-Constrained Optimization Problems Involving Sparsity Terms},
   year    = 2018,
   eprint  = {1806.05896},
   archiveprefix = {arXiv},
@@ -1837,89 +1837,89 @@
 }
 
 @Article{2018:puckett.turcotte.ea:new,
-  doi     = {10.1016/j.pepi.2017.10.004},
-  url     = {https://doi.org/10.1016/j.pepi.2017.10.004},
-  year    = 2018,
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = 276,
-  pages   = {10--35},
   author  = {Elbridge Gerry Puckett and Donald L. Turcotte and Ying He and Harsha Lokavarapu and Jonathan M. Robey and Louise H. Kellogg},
   title   = {New numerical approaches for modeling thermochemical convection in a compositionally stratified fluid},
-  journal = {Physics of the Earth and Planetary Interiors}
+  journal = {Physics of the Earth and Planetary Interiors},
+  year    = 2018,
+  volume  = 276,
+  pages   = {10--35},
+  month   = mar,
+  doi     = {10.1016/j.pepi.2017.10.004},
+  url     = {https://doi.org/10.1016/j.pepi.2017.10.004},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:qiao.bai.ea:blended,
-  doi     = {10.1051/jnwpu/20183610057},
-  url     = {https://doi.org/10.1051/jnwpu/20183610057},
+  author  = {Lei Qiao and Junqiang Bai and Yasong Qiu and Jun Hua and Jiakuan Xu},
+  title   = {A Blended Continuation Method for Solving Steady Inviscid Flow},
+  journal = {Xibei Gongye Daxue Xuebao/Journal of Northwestern Polytechnical University},
   year    = 2018,
-  month   = feb,
-  publisher = {{EDP} Sciences},
   volume  = 36,
   number  = 1,
   pages   = {57--65},
-  author  = {Lei Qiao and Junqiang Bai and Yasong Qiu and Jun Hua and Jiakuan Xu},
-  title   = {A Blended Continuation Method for Solving Steady Inviscid Flow},
-  journal = {Xibei Gongye Daxue Xuebao/Journal of Northwestern Polytechnical University}
+  month   = feb,
+  doi     = {10.1051/jnwpu/20183610057},
+  url     = {https://doi.org/10.1051/jnwpu/20183610057},
+  publisher = {{EDP} Sciences}
 }
 
 @Article{2018:roberge.norato:computational,
   author  = {Jeffrey Roberge and Juli{\'{a}}n Norato},
   title   = {Computational design of curvilinear bone scaffolds fabricated via direct ink writing},
-  doi     = {10.1016/j.cad.2017.09.003},
-  url     = {https://doi.org/10.1016/j.cad.2017.09.003},
+  journal = {Computer-Aided Design},
   year    = 2018,
   volume  = 95,
   pages   = {1--13},
-  journal = {Computer-Aided Design}
+  doi     = {10.1016/j.cad.2017.09.003},
+  url     = {https://doi.org/10.1016/j.cad.2017.09.003}
 }
 
 @Article{2018:rom.muller:effective,
-  doi     = {10.1016/j.triboint.2018.04.011},
-  url     = {https://doi.org/10.1016/j.triboint.2018.04.011},
-  year    = 2018,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 124,
-  pages   = {247--258},
   author  = {Michael Rom and Siegfried M\"{u}ller},
   title   = {An effective Navier-Stokes model for the simulation of textured surface lubrication},
-  journal = {Tribology International}
+  journal = {Tribology International},
+  year    = 2018,
+  volume  = 124,
+  pages   = {247--258},
+  month   = aug,
+  doi     = {10.1016/j.triboint.2018.04.011},
+  url     = {https://doi.org/10.1016/j.triboint.2018.04.011},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:ross.ryan.ea:size,
-  doi     = {10.1093/icb/icy021},
-  url     = {https://doi.org/10.1093/icb/icy021},
+  author  = {Stephanie A Ross and David S Ryan and Sebastian Dominguez and Nilima Nigam and James M Wakeling},
+  title   = {Size, History-Dependent, Activation and Three-Dimensional Effects on the Work and Power Produced During Cyclic Muscle Contractions},
+  journal = {Integrative and Comparative Biology},
   year    = 2018,
-  month   = may,
-  publisher = {Oxford University Press ({OUP})},
   volume  = 58,
   number  = 2,
   pages   = {232--250},
-  author  = {Stephanie A Ross and David S Ryan and Sebastian Dominguez and Nilima Nigam and James M Wakeling},
-  title   = {Size, History-Dependent, Activation and Three-Dimensional Effects on the Work and Power Produced During Cyclic Muscle Contractions},
-  journal = {Integrative and Comparative Biology}
+  month   = may,
+  doi     = {10.1093/icb/icy021},
+  url     = {https://doi.org/10.1093/icb/icy021},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @PhDThesis{2018:sabawi:discontinuous,
   author  = {Sabawi, Mohammad},
   title   = {Discontinuous Galerkin timestepping for nonlinear parabolic problems},
+  year    = 2018,
   url     = {https://www.researchgate.net/publication/327546550},
-  publisher = {University of Leicester},
-  year    = 2018
+  publisher = {University of Leicester}
 }
 
 @Article{2018:sabharwal.gostick.ea:virtual,
-  doi     = {10.1149/2.0921807jes},
-  url     = {https://doi.org/10.1149/2.0921807jes},
+  author  = {Mayank Sabharwal and Jeff T. Gostick and Marc Secanell},
+  title   = {Virtual Liquid Water Intrusion in Fuel Cell Gas Diffusion Media},
+  journal = {Journal of The Electrochemical Society},
   year    = 2018,
-  publisher = {The Electrochemical Society},
   volume  = 165,
   number  = 7,
   pages   = {F553--F563},
-  author  = {Mayank Sabharwal and Jeff T. Gostick and Marc Secanell},
-  title   = {Virtual Liquid Water Intrusion in Fuel Cell Gas Diffusion Media},
-  journal = {Journal of The Electrochemical Society}
+  doi     = {10.1149/2.0921807jes},
+  url     = {https://doi.org/10.1149/2.0921807jes},
+  publisher = {The Electrochemical Society}
 }
 
 @PhDThesis{2018:sacco:3d,
@@ -1935,10 +1935,10 @@
   author  = {Safin, Artur and Minkoff, Susan E. and Zweck, John},
   title   = {A preconditioned finite element solution of the coupled pressure-temperature equations used to model trace gas sensors},
   journal = {SIAM Journal on Scientific Computing},
+  year    = 2018,
   volume  = 40,
   number  = 5,
   pages   = {B1470--B1493},
-  year    = 2018,
   doi     = {10.1137/17M1145823},
   url     = {https://doi.org/10.1137/17M1145823}
 }
@@ -1965,41 +1965,41 @@
 }
 
 @Article{2018:samrock.grayver.ea:magnetotelluric,
-  title   = {Magnetotelluric image of transcrustal magmatic system beneath the {Tulu Moye} geothermal prospect in the {Ethiopian Rift}},
   author  = {Samrock, Friedemann and Grayver, Alexander V and Eysteinsson, Hjalmar and Saar, Martin O},
+  title   = {Magnetotelluric image of transcrustal magmatic system beneath the {Tulu Moye} geothermal prospect in the {Ethiopian Rift}},
   journal = {Geophysical Research Letters},
+  year    = 2018,
   volume  = 45,
   number  = 23,
   pages   = {12847--12855},
-  year    = 2018,
   publisher = {Wiley Online Library},
   doi     = {10.1029/2018GL080333}
 }
 
 @Article{2018:sarna.torrilhon:entropy,
-  doi     = {10.1016/j.jcp.2018.04.050},
-  year    = 2018,
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = 369,
-  pages   = {16--44},
   author  = {Neeraj Sarna and Manuel Torrilhon},
   title   = {Entropy stable {H}ermite approximation of the linearised {B}oltzmann equation for inflow and outflow boundaries},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2018,
+  volume  = 369,
+  pages   = {16--44},
+  month   = sep,
+  doi     = {10.1016/j.jcp.2018.04.050},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:sartori.giuliani.ea:deal2lkit,
-  doi     = {10.1016/j.softx.2018.09.004},
-  url     = {https://linkinghub.elsevier.com/retrieve/pii/S2352711018302048},
-  year    = 2018,
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  issn    = 23527110,
-  volume  = 7,
-  pages   = {318--327},
   author  = {Alberto Sartori and Nicola Giuliani and Mauro Bardelloni and Luca Heltai},
   title   = {deal2lkit: A toolkit library for high performance programming in deal.{II}},
-  journal = {{SoftwareX}}
+  journal = {{SoftwareX}},
+  year    = 2018,
+  volume  = 7,
+  pages   = {318--327},
+  month   = jan,
+  doi     = {10.1016/j.softx.2018.09.004},
+  url     = {https://linkinghub.elsevier.com/retrieve/pii/S2352711018302048},
+  publisher = {Elsevier {BV}},
+  issn    = 23527110
 }
 
 @Article{2018:scacchi.brader:local,
@@ -2014,12 +2014,12 @@
 }
 
 @Article{2018:schneider.hu.ea:decoupling,
-  title   = {Decoupling Simulation Accuracy from Mesh Quality},
-  url     = {http://par.nsf.gov/biblio/10080686},
-  journal = {ACM Transactions on Graphics},
   author  = {Schneider, Teseo and Hu, Yixin and Dumas, Jeremie and Gao, Xifeng and Panozzo, Daniele and Zorin, Denis},
+  title   = {Decoupling Simulation Accuracy from Mesh Quality},
+  journal = {ACM Transactions on Graphics},
   year    = 2018,
-  month   = dec
+  month   = dec,
+  url     = {http://par.nsf.gov/biblio/10080686}
 }
 
 @MastersThesis{2018:schneider:simulation,
@@ -2031,25 +2031,25 @@
 }
 
 @Article{2018:schoeder.kormann.ea:efficient,
-  title   = {Efficient explicit time stepping of high order discontinuous {G}alerkin schemes for waves},
   author  = {Schoeder, Svenja and Kormann, Katharina and Wall, Wolfgang A and Kronbichler, Martin},
+  title   = {Efficient explicit time stepping of high order discontinuous {G}alerkin schemes for waves},
   journal = {SIAM Journal on Scientific Computing},
+  year    = 2018,
   volume  = 40,
   number  = 6,
   pages   = {C803--C826},
-  year    = 2018,
   publisher = {SIAM},
   url     = {http://www.siam.org/journals/sisc/40-6/M118539.html},
   doi     = {10.1137/18M1185399}
 }
 
 @Article{2018:schoeder.kronbichler.ea:arbitrary,
-  title   = {Arbitrary high-order explicit hybridizable discontinuous {G}alerkin methods for the acoustic wave equation},
   author  = {Schoeder, Svenja and Kronbichler, Martin and Wall, Wolfgang A},
+  title   = {Arbitrary high-order explicit hybridizable discontinuous {G}alerkin methods for the acoustic wave equation},
   journal = {Journal of Scientific Computing},
+  year    = 2018,
   volume  = 76,
   pages   = {969--1006},
-  year    = 2018,
   publisher = {Springer},
   url     = {https://doi.org/10.1007/s10915-018-0649-2},
   doi     = {10.1007/s10915-018-0649-2}
@@ -2067,23 +2067,23 @@
 }
 
 @InCollection{2018:schuster.schopfer:damage,
-  doi     = {10.1007/978-3-319-49715-0_16},
-  url     = {https://doi.org/10.1007/978-3-319-49715-0_16},
-  year    = 2018,
-  publisher = {Springer International Publishing},
-  pages   = {373--397},
   author  = {T. Schuster and F. Sch\"{o}pfer},
   title   = {Damage Identification by Dynamic Load Monitoring},
-  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites}
+  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites},
+  publisher = {Springer International Publishing},
+  year    = 2018,
+  pages   = {373--397},
+  doi     = {10.1007/978-3-319-49715-0_16},
+  url     = {https://doi.org/10.1007/978-3-319-49715-0_16}
 }
 
 @Article{2018:schutz:3d,
-  title   = {3D Boundary Element Simulation of Droplet Dynamics in Microchannels: How Droplets Squeeze Through Constrictions and Move in Electric Fields},
   author  = {Sch\"{u}tz, Simon Sebastian},
+  title   = {3D Boundary Element Simulation of Droplet Dynamics in Microchannels: How Droplets Squeeze Through Constrictions and Move in Electric Fields},
+  year    = 2018,
+  pages   = 156,
   publisher = {EPFL},
   address = {Lausanne},
-  pages   = 156,
-  year    = 2018,
   url     = {http://infoscience.epfl.ch/record/255307},
   doi     = {10.5075/epfl-thesis-8621}
 }
@@ -2099,54 +2099,54 @@
 @PhDThesis{2018:shannon:hybridized-discontinuous-galerkin-methods-for-magnetohydrodynamics,
   author  = {Shannon, S. J.},
   title   = {{Hybridized discontinuous Galerkin methods for magnetohydrodynamics}},
+  year    = 2018,
   url     = {https://repositories.lib.utexas.edu/handle/2152/75763},
-  publisher = {University of Texas},
-  year    = 2018
+  publisher = {University of Texas}
 }
 
 @Article{2018:sharma.kanschat:contraction,
-  doi     = {10.1515/jnma-2016-1132},
-  url     = {https://doi.org/10.1515/jnma-2016-1132},
+  author  = {Natasha Sharma and Guido Kanschat},
+  title   = {A contraction property of an adaptive divergence-conforming discontinuous Galerkin method for the Stokes problem},
+  journal = {Journal of Numerical Mathematics},
   year    = 2018,
-  month   = dec,
-  publisher = {Walter de Gruyter {GmbH}},
   volume  = 26,
   number  = 4,
   pages   = {209--232},
-  author  = {Natasha Sharma and Guido Kanschat},
-  title   = {A contraction property of an adaptive divergence-conforming discontinuous Galerkin method for the Stokes problem},
-  journal = {Journal of Numerical Mathematics}
+  month   = dec,
+  doi     = {10.1515/jnma-2016-1132},
+  url     = {https://doi.org/10.1515/jnma-2016-1132},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @Article{2018:sheldon.miller.ea:improved,
-  title   = {An Improved Formulation for Hybridizable Discontinuous Galerkin Fluid-Structure Interaction Modeling with Reduced Computational Expense},
   author  = {Sheldon, Jason P. and Miller, Scott T. and Pitt, Jonathan S.},
-  doi     = {10.4208/cicp.OA-2017-0114},
+  title   = {An Improved Formulation for Hybridizable Discontinuous Galerkin Fluid-Structure Interaction Modeling with Reduced Computational Expense},
   journal = {Communications in Computational Physics},
-  issn    = {1815-2406},
-  number  = 5,
-  volume  = 24,
   year    = 2018,
-  month   = jun
+  volume  = 24,
+  number  = 5,
+  month   = jun,
+  doi     = {10.4208/cicp.OA-2017-0114},
+  issn    = {1815-2406}
 }
 
 @PhDThesis{2018:shovkun:coupled-chemo-mechanical-processes-in-reservoir-geomechanics,
   author  = {Shovkun, I},
   title   = {{Coupled chemo-mechanical processes in reservoir geomechanics}},
+  year    = 2018,
   url     = {https://repositories.lib.utexas.edu/handle/2152/72439},
-  publisher = {University of Texas at Austin},
-  year    = 2018
+  publisher = {University of Texas at Austin}
 }
 
 @InProceedings{2018:smolyanov.karban:optimal,
-  doi     = {10.1109/elektro.2018.8398325},
-  url     = {https://doi.org/10.1109/elektro.2018.8398325},
+  author  = {Ivan A. Smolyanov and Pavel Karban},
+  title   = {Optimal design of {MHD} pump},
+  booktitle = {2018 {ELEKTRO}},
   year    = 2018,
   month   = may,
   publisher = {{IEEE}},
-  author  = {Ivan A. Smolyanov and Pavel Karban},
-  title   = {Optimal design of {MHD} pump},
-  booktitle = {2018 {ELEKTRO}}
+  doi     = {10.1109/elektro.2018.8398325},
+  url     = {https://doi.org/10.1109/elektro.2018.8398325}
 }
 
 @Article{2018:steinberger.bredow.ea:widespread-volcanism-in-the-greenland-north-atlantic-region-explained-by-the-iceland-plume,
@@ -2162,128 +2162,128 @@
   author  = {Sticko, Simon},
   title   = {High Order Cut Finite Element Methods for Wave Equations},
   school  = {Uppsala University},
+  year    = 2018,
   series  = {Digital Comprehensive Summaries of Uppsala Dissertations from the Faculty of Science and Technology},
   issn    = {1651-6214},
   number  = 1656,
   isbn    = {978-91-513-0300-0},
-  year    = 2018,
   url     = {http://urn.kb.se/resolve?urn=urn%3Anbn%3Ase%3Auu%3Adiva-347439}
 }
 
 @Article{2018:tezzele.salmoiraghi.ea:dimension,
-  doi     = {10.1186/s40323-018-0118-3},
-  url     = {https://doi.org/10.1186/s40323-018-0118-3},
-  year    = 2018,
-  month   = sep,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 5,
-  number  = 1,
   author  = {Marco Tezzele and Filippo Salmoiraghi and Andrea Mola and Gianluigi Rozza},
   title   = {Dimension reduction in heterogeneous parametric spaces with application to naval engineering shape design problems},
-  journal = {Advanced Modeling and Simulation in Engineering Sciences}
+  journal = {Advanced Modeling and Simulation in Engineering Sciences},
+  year    = 2018,
+  volume  = 5,
+  number  = 1,
+  month   = sep,
+  doi     = {10.1186/s40323-018-0118-3},
+  url     = {https://doi.org/10.1186/s40323-018-0118-3},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2018:truster:deip,
-  doi     = {10.1016/j.softx.2018.05.002},
-  url     = {https://doi.org/10.1016/j.softx.2018.05.002},
-  year    = 2018,
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = 7,
-  pages   = {162--170},
   author  = {Timothy J. Truster},
   title   = {{DEIP}, discontinuous element insertion Program---Mesh generation for interfacial finite element modeling},
-  journal = {{SoftwareX}}
+  journal = {{SoftwareX}},
+  year    = 2018,
+  volume  = 7,
+  pages   = {162--170},
+  month   = jan,
+  doi     = {10.1016/j.softx.2018.05.002},
+  url     = {https://doi.org/10.1016/j.softx.2018.05.002},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:verner.garikipati:computational,
-  doi     = {10.1016/j.eml.2017.11.003},
-  url     = {https://doi.org/10.1016/j.eml.2017.11.003},
-  year    = 2018,
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = 18,
-  pages   = {58--69},
   author  = {S. N. Verner and K. Garikipati},
   title   = {A computational study of the mechanisms of growth-driven folding patterns on shells, with application to the developing brain},
-  journal = {Extreme Mechanics Letters}
+  journal = {Extreme Mechanics Letters},
+  year    = 2018,
+  volume  = 18,
+  pages   = {58--69},
+  month   = jan,
+  doi     = {10.1016/j.eml.2017.11.003},
+  url     = {https://doi.org/10.1016/j.eml.2017.11.003},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:veske.kyritsakis.ea:dynamic,
-  doi     = {10.1016/j.jcp.2018.04.031},
-  url     = {https://doi.org/10.1016/j.jcp.2018.04.031},
-  year    = 2018,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 367,
-  pages   = {279--294},
   author  = {Mihkel Veske and Andreas Kyritsakis and Kristjan Eimre and Vahur Zadin and Alvo Aabloo and Flyura Djurabekova},
   title   = {Dynamic coupling of a finite element solver to large-scale atomistic simulations},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2018,
+  volume  = 367,
+  pages   = {279--294},
+  month   = aug,
+  doi     = {10.1016/j.jcp.2018.04.031},
+  url     = {https://doi.org/10.1016/j.jcp.2018.04.031},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:villiers.mcbride.ea:a-validated-patient-specific-fsi-model-for-vascular-access-in-haemodialysis,
   author  = {de Villiers, A. M. and McBride, A. T. and Reddy, B. D. and Franz, T. and Spottiswoode, B. S.},
-  doi     = {10.1007/s10237-017-0973-8},
-  issn    = 16177940,
+  title   = {{A validated patient-specific FSI model for vascular access in haemodialysis}},
   journal = {Biomechanics and Modeling in Mechanobiology},
-  month   = apr,
+  year    = 2018,
+  volume  = 17,
   number  = 2,
   pages   = {479--497},
+  month   = apr,
+  doi     = {10.1007/s10237-017-0973-8},
+  issn    = 16177940,
   pmid    = 29139052,
-  publisher = {Springer Verlag},
-  title   = {{A validated patient-specific FSI model for vascular access in haemodialysis}},
-  volume  = 17,
-  year    = 2018
+  publisher = {Springer Verlag}
 }
 
 @MastersThesis{2018:vundla:numerical,
   author  = {Vundla, Nkosilathi},
   title   = {Numerical modelling of the Oldroyd-B fluid},
-  url     = {http://hdl.handle.net/11427/30996},
+  school  = {University of Cape Town},
   year    = 2018,
   month   = nov,
-  school  = {University of Cape Town}
+  url     = {http://hdl.handle.net/11427/30996}
 }
 
 @Article{2018:wang.garikipati:multi-physics,
-  doi     = {10.1149/2.0141811jes},
-  url     = {https://doi.org/10.1149/2.0141811jes},
+  author  = {Z. Wang and K. Garikipati},
+  title   = {A Multi-Physics Battery Model with Particle Scale Resolution of Porosity Evolution Driven by Intercalation Strain and Electrolyte Flow},
+  journal = {Journal of The Electrochemical Society},
   year    = 2018,
-  publisher = {The Electrochemical Society},
   volume  = 165,
   number  = 11,
   pages   = {A2421--A2438},
-  author  = {Z. Wang and K. Garikipati},
-  title   = {A Multi-Physics Battery Model with Particle Scale Resolution of Porosity Evolution Driven by Intercalation Strain and Electrolyte Flow},
-  journal = {Journal of The Electrochemical Society}
+  doi     = {10.1149/2.0141811jes},
+  url     = {https://doi.org/10.1149/2.0141811jes},
+  publisher = {The Electrochemical Society}
 }
 
 @Article{2018:wang.triantafyllou.ea:entropy-viscosity,
-  doi     = {10.1017/jfm.2018.808},
-  url     = {https://doi.org/10.1017/jfm.2018.808},
-  year    = 2018,
-  month   = nov,
-  publisher = {Cambridge University Press ({CUP})},
-  volume  = 859,
-  pages   = {691--730},
   author  = {Zhicheng Wang and Michael S. Triantafyllou and Yiannis Constantinides and George Em Karniadakis},
   title   = {An entropy-viscosity large eddy simulation study of turbulent flow in a flexible pipe},
-  journal = {Journal of Fluid Mechanics}
+  journal = {Journal of Fluid Mechanics},
+  year    = 2018,
+  volume  = 859,
+  pages   = {691--730},
+  month   = nov,
+  doi     = {10.1017/jfm.2018.808},
+  url     = {https://doi.org/10.1017/jfm.2018.808},
+  publisher = {Cambridge University Press ({CUP})}
 }
 
 @Article{2018:wei.wang.ea:study,
-  doi     = {10.3390/en11020329},
-  url     = {https://doi.org/10.3390/en11020329},
+  author  = {Chenji Wei and Liangang Wang and Baozhu Li and Lihui Xiong and Shuangshuang Liu and Jie Zheng and Suming Hu and Hongqing Song},
+  title   = {A Study of Nonlinear Elasticity Effects on Permeability of Stress Sensitive Shale Rocks Using an Improved Coupled Flow and Geomechanics Model: A Case Study of the Longmaxi Shale in China},
+  journal = {Energies},
   year    = 2018,
-  month   = feb,
-  publisher = {{MDPI} {AG}},
   volume  = 11,
   number  = 2,
   pages   = 329,
-  author  = {Chenji Wei and Liangang Wang and Baozhu Li and Lihui Xiong and Shuangshuang Liu and Jie Zheng and Suming Hu and Hongqing Song},
-  title   = {A Study of Nonlinear Elasticity Effects on Permeability of Stress Sensitive Shale Rocks Using an Improved Coupled Flow and Geomechanics Model: A Case Study of the Longmaxi Shale in China},
-  journal = {Energies}
+  month   = feb,
+  doi     = {10.3390/en11020329},
+  url     = {https://doi.org/10.3390/en11020329},
+  publisher = {{MDPI} {AG}}
 }
 
 @Article{2018:weier.wick:dual-weighted,
@@ -2309,10 +2309,10 @@
 
 @InProceedings{2018:wichrowski:multigrid-method-for-stokes-problem-with-discontinuous-viscosity,
   author  = {Wichrowski, M l},
-  journal = {congress.cimne.com},
   title   = {{Multigrid method for Stokes problem with discontinuous viscosity}},
-  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a2092.pdf},
-  year    = 2018
+  year    = 2018,
+  journal = {congress.cimne.com},
+  url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/fileabstract/a2092.pdf}
 }
 
 @Article{2018:wick:numerical,
@@ -2333,21 +2333,21 @@
 }
 
 @Article{2018:wilmers.bargmann:functionalisation,
-  doi     = {10.1016/j.eml.2018.03.002},
-  url     = {https://doi.org/10.1016/j.eml.2018.03.002},
-  year    = 2018,
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = 21,
-  pages   = {57--64},
   author  = {Jana Wilmers and Swantje Bargmann},
   title   = {Functionalisation of metal--polymer-nanocomposites: Chemoelectromechanical coupling and charge carrier transport},
-  journal = {Extreme Mechanics Letters}
+  journal = {Extreme Mechanics Letters},
+  year    = 2018,
+  volume  = 21,
+  pages   = {57--64},
+  month   = may,
+  doi     = {10.1016/j.eml.2018.03.002},
+  url     = {https://doi.org/10.1016/j.eml.2018.03.002},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2018:xiao:efficient,
-  title   = {Efficient and Accurate Splitting Methods for Flow Problems},
   author  = {Mengying Xiao},
+  title   = {Efficient and Accurate Splitting Methods for Flow Problems},
   school  = {Clemson University},
   year    = 2018,
   url     = {https://tigerprints.clemson.edu/all_dissertations/2174/}
@@ -2356,28 +2356,28 @@
 @PhDThesis{2018:zareei:transformation-based-wave-control,
   author  = {Zareei, Ahmad},
   title   = {{Transformation Based Wave Control}},
+  year    = 2018,
   url     = {https://escholarship.org/uc/item/21d6c40m},
-  publisher = {University of California, Berkeley},
-  year    = 2018
+  publisher = {University of California, Berkeley}
 }
 
 @Article{2018:zhang.gain.ea:geometry,
-  doi     = {10.1002/nme.5737},
-  url     = {https://doi.org/10.1002/nme.5737},
+  author  = {Shanglong Zhang and Arun L. Gain and Juli{\'{a}}n A. Norato},
+  title   = {A geometry projection method for the topology optimization of curved plate structures with placement bounds},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2018,
-  month   = jan,
-  publisher = {Wiley},
   volume  = 114,
   number  = 2,
   pages   = {128--146},
-  author  = {Shanglong Zhang and Arun L. Gain and Juli{\'{a}}n A. Norato},
-  title   = {A geometry projection method for the topology optimization of curved plate structures with placement bounds},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = jan,
+  doi     = {10.1002/nme.5737},
+  url     = {https://doi.org/10.1002/nme.5737},
+  publisher = {Wiley}
 }
 
 @Misc{2018:zhang.guo.ea:runge-kutta,
-  title   = {Runge-Kutta symmetric interior penalty discontinuous Galerkin methods for modified Buckley-Leverett equations},
   author  = {Hong Zhang and Yunrui Guo and Weibin Li and Paul Andries Zegeling},
+  title   = {Runge-Kutta symmetric interior penalty discontinuous Galerkin methods for modified Buckley-Leverett equations},
   year    = 2018,
   eprint  = {1801.07182},
   archiveprefix = {arXiv},
@@ -2396,54 +2396,54 @@
 }
 
 @InProceedings{2018:zhang.norato:finding,
-  doi     = {10.1115/detc2018-86116},
-  url     = {https://doi.org/10.1115/detc2018-86116},
+  author  = {Shanglong Zhang and Juli{\'{a}}n A. Norato},
+  title   = {Finding Better Local Optima in Topology Optimization via Tunneling},
+  booktitle = {Volume 2B: 44th Design Automation Conference},
   year    = 2018,
   month   = aug,
   publisher = {American Society of Mechanical Engineers},
-  author  = {Shanglong Zhang and Juli{\'{a}}n A. Norato},
-  title   = {Finding Better Local Optima in Topology Optimization via Tunneling},
-  booktitle = {Volume 2B: 44th Design Automation Conference}
+  doi     = {10.1115/detc2018-86116},
+  url     = {https://doi.org/10.1115/detc2018-86116}
 }
 
 @Article{2018:zhang.zegeling:simulation,
-  doi     = {10.1016/j.amc.2018.06.017},
-  url     = {https://doi.org/10.1016/j.amc.2018.06.017},
-  year    = 2018,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 338,
-  pages   = {274--289},
   author  = {Hong Zhang and Paul Andries Zegeling},
   title   = {Simulation of thin film flows with a moving mesh mixed finite element method},
-  journal = {Applied Mathematics and Computation}
+  journal = {Applied Mathematics and Computation},
+  year    = 2018,
+  volume  = 338,
+  pages   = {274--289},
+  month   = dec,
+  doi     = {10.1016/j.amc.2018.06.017},
+  url     = {https://doi.org/10.1016/j.amc.2018.06.017},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2018:zhao.tan:postvoiding,
-  doi     = {10.1109/tvlsi.2018.2861358},
-  url     = {https://doi.org/10.1109/tvlsi.2018.2861358},
+  author  = {Hengyang Zhao and Sheldon X.-D. Tan},
+  title   = {Postvoiding {FEM} Analysis for Electromigration Failure Characterization},
+  journal = {{IEEE} Transactions on Very Large Scale Integration ({VLSI}) Systems},
   year    = 2018,
-  month   = nov,
-  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})},
   volume  = 26,
   number  = 11,
   pages   = {2483--2493},
-  author  = {Hengyang Zhao and Sheldon X.-D. Tan},
-  title   = {Postvoiding {FEM} Analysis for Electromigration Failure Characterization},
-  journal = {{IEEE} Transactions on Very Large Scale Integration ({VLSI}) Systems}
+  month   = nov,
+  doi     = {10.1109/tvlsi.2018.2861358},
+  url     = {https://doi.org/10.1109/tvlsi.2018.2861358},
+  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})}
 }
 
 @PhDThesis{2018:zhao:fem-based-multiphysics-analysis-of-electromigration-voiding-process-in-nanometer-integrated-circuits,
   author  = {Zhao, H.},
   title   = {{FEM Based Multiphysics Analysis of Electromigration Voiding Process in Nanometer Integrated Circuits}},
+  school  = {University of California, Davis},
   year    = 2018,
-  url     = {https://cloudfront.escholarship.org/dist/prd/content/qt41f4p23x/qt41f4p23x.pdf},
-  school  = {University of California, Davis}
+  url     = {https://cloudfront.escholarship.org/dist/prd/content/qt41f4p23x/qt41f4p23x.pdf}
 }
 
 @PhDThesis{2018:zhao:numerical,
-  title   = {A numerical method for the Navier Stokes equations in {Velocity-Vorticity} form},
   author  = {Liang Zhao},
+  title   = {A numerical method for the Navier Stokes equations in {Velocity-Vorticity} form},
   school  = {Clemson University},
   year    = 2018,
   url     = {https://tigerprints.clemson.edu/all_dissertations/2288/}

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -1,16 +1,16 @@
 % Encoding: US-ASCII
 
 @Article{2019:adler.he.ea:vector-potential,
-  doi     = {10.1016/j.camwa.2018.09.051},
+  author  = {James H. Adler and Yunhui He and Xiaozhe Hu and Scott P. MacLachlan},
+  title   = {Vector-potential finite-element formulations for two-dimensional resistive magnetohydrodynamics},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2019,
-  month   = jan,
-  publisher = {Elsevier {BV}},
   volume  = 77,
   number  = 2,
   pages   = {476--493},
-  author  = {James H. Adler and Yunhui He and Xiaozhe Hu and Scott P. MacLachlan},
-  title   = {Vector-potential finite-element formulations for two-dimensional resistive magnetohydrodynamics},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = jan,
+  doi     = {10.1016/j.camwa.2018.09.051},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:africa:scalable,
@@ -23,165 +23,165 @@
 }
 
 @Article{2019:aggul.kaya.ea:two,
-  doi     = {10.1016/j.amc.2018.12.074},
-  year    = 2019,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 358,
-  pages   = {25--36},
   author  = {Mustafa Aggul and Songul Kaya and Alexander E. Labovsky},
   title   = {Two approaches to creating a turbulence model with increased temporal accuracy},
-  journal = {Applied Mathematics and Computation}
+  journal = {Applied Mathematics and Computation},
+  year    = 2019,
+  volume  = 358,
+  pages   = {25--36},
+  month   = oct,
+  doi     = {10.1016/j.amc.2018.12.074},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:al-arydah.carraro:reviewing,
-  doi     = {10.1016/j.camwa.2018.08.001},
+  author  = {Mo'tassem Al-arydah and Thomas Carraro},
+  title   = {Reviewing the mathematical validity of a fuel cell cathode model. Existence of weak bounded solution},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2019,
-  month   = mar,
-  publisher = {Elsevier {BV}},
   volume  = 77,
   number  = 6,
   pages   = {1425--1436},
-  author  = {Mo'tassem Al-arydah and Thomas Carraro},
-  title   = {Reviewing the mathematical validity of a fuel cell cathode model. Existence of weak bounded solution},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = mar,
+  doi     = {10.1016/j.camwa.2018.08.001},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:alhazmi:exploring,
-  doi     = {10.14569/ijacsa.2019.0100372},
-  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
-  year    = 2019,
-  publisher = {The Science and Information Organization},
-  volume  = 10,
-  number  = 3,
   author  = {Muflih Alhazmi},
   title   = {Exploring Mechanisms for Pattern Formation through Coupled Bulk-Surface {PDEs} in Case of Non-linear Reactions},
-  journal = {International Journal of Advanced Computer Science and Applications}
+  journal = {International Journal of Advanced Computer Science and Applications},
+  year    = 2019,
+  volume  = 10,
+  number  = 3,
+  doi     = {10.14569/ijacsa.2019.0100372},
+  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
+  publisher = {The Science and Information Organization}
 }
 
 @PhDThesis{2019:alzetta:coupling,
   author  = {Alzetta, Giovanni},
   title   = {Coupling methods for non-matching meshes through distributed Lagrange multipliers},
-  url     = {http://hdl.handle.net/20.500.11767/103034},
   school  = {Scuola Internazionale Superiore di Studi Avanzati},
-  year    = 2019
+  year    = 2019,
+  url     = {http://hdl.handle.net/20.500.11767/103034}
 }
 
 @Article{2019:ambartsumyan.khattatov.ea:higher,
-  doi     = {10.1142/s0218202519500167},
+  author  = {Ilona Ambartsumyan and Eldar Khattatov and Jeonghun J. Lee and Ivan Yotov},
+  title   = {Higher order multipoint flux mixed finite element methods on quadrilaterals and hexahedra},
+  journal = {Mathematical Models and Methods in Applied Sciences},
   year    = 2019,
-  month   = jun,
-  publisher = {World Scientific Pub Co Pte Lt},
   volume  = 29,
   number  = 06,
   pages   = {1037--1077},
-  author  = {Ilona Ambartsumyan and Eldar Khattatov and Jeonghun J. Lee and Ivan Yotov},
-  title   = {Higher order multipoint flux mixed finite element methods on quadrilaterals and hexahedra},
-  journal = {Mathematical Models and Methods in Applied Sciences}
+  month   = jun,
+  doi     = {10.1142/s0218202519500167},
+  publisher = {World Scientific Pub Co Pte Lt}
 }
 
 @MastersThesis{2019:ameri:improving,
+  author  = {Abtin Ameri},
+  title   = {Improving the Numerical Stability of Higher Order Methods with Applications to Fluid Dynamics},
+  year    = 2019,
+  note    = {Honors thesis},
   doi     = {10.13140/RG.2.2.25335.78247},
   url     = {http://rgdoi.net/10.13140/RG.2.2.25335.78247},
-  author  = {Abtin Ameri},
   language = {en},
-  title   = {Improving the Numerical Stability of Higher Order Methods with Applications to Fluid Dynamics},
-  publisher = {Unpublished},
-  year    = 2019,
-  note    = {Honors thesis}
+  publisher = {Unpublished}
 }
 
 @PhDThesis{2019:araujo-cabarcas:reliable,
   author  = {Araujo-Cabarcas, J. C.},
   title   = {Reliable hp finite element computations of scattering resonances in nano optics},
-  url     = {https://www.diva-portal.org/smash/record.jsf?pid=diva2:1316711},
   school  = {Umea University},
-  year    = 2019
+  year    = 2019,
+  url     = {https://www.diva-portal.org/smash/record.jsf?pid=diva2:1316711}
 }
 
 @InProceedings{2019:arbogast.huang.ea:von,
-  doi     = {10.2118/193817-ms},
-  year    = 2019,
-  publisher = {Society of Petroleum Engineers},
   author  = {Todd Arbogast and Chieh-Sen Huang and Xikai Zhao},
   title   = {Von Neumann Stable, Implicit, High Order, Finite Volume {WENO} Schemes},
-  booktitle = {{SPE} Reservoir Simulation Conference}
+  booktitle = {{SPE} Reservoir Simulation Conference},
+  year    = 2019,
+  publisher = {Society of Petroleum Engineers},
+  doi     = {10.2118/193817-ms}
 }
 
 @Article{2019:arbogast.tao:direct,
-  doi     = {10.1007/s10596-019-09871-2},
+  author  = {Todd Arbogast and Zhen Tao},
+  title   = {A direct mixed{\textendash}enriched Galerkin method on quadrilaterals for two-phase Darcy flow},
+  journal = {Computational Geosciences},
   year    = 2019,
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 23,
   number  = 5,
   pages   = {1141--1160},
-  author  = {Todd Arbogast and Zhen Tao},
-  title   = {A direct mixed{\textendash}enriched Galerkin method on quadrilaterals for two-phase Darcy flow},
-  journal = {Computational Geosciences}
+  month   = aug,
+  doi     = {10.1007/s10596-019-09871-2},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.1},
   author  = {D. Arndt and W. Bangerth and T. C. Clevenger and D. Davydov and M. Fehling and D. Garcia-Sanchez and G. Harper and T. Heister and L. Heltai and M. Kronbichler and R. M. Kynch and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
+  title   = {The \texttt{deal.II} Library, Version 9.1},
   journal = {Journal of Numerical Mathematics},
+  year    = 2019,
   volume  = 27,
   number  = 4,
   pages   = {203--213},
-  year    = 2019,
   doi     = {10.1515/jnma-2019-0064},
   url     = {https://dealii.org/deal91-preprint.pdf}
 }
 
 @Article{2019:aulisa.capodaglio.ea:construction,
-  doi     = {10.1137/18m1175409},
+  author  = {Eugenio Aulisa and Giacomo Capodaglio and Guoyi Ke},
+  title   = {Construction of H-Refined Continuous Finite Element Spaces with Arbitrary Hanging Node Configurations and Applications to Multigrid Algorithms},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2019,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 41,
   number  = 1,
   pages   = {A480--A507},
-  author  = {Eugenio Aulisa and Giacomo Capodaglio and Guoyi Ke},
-  title   = {Construction of H-Refined Continuous Finite Element Spaces with Arbitrary Hanging Node Configurations and Applications to Multigrid Algorithms},
-  journal = {{SIAM} Journal on Scientific Computing}
+  month   = jan,
+  doi     = {10.1137/18m1175409},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2019:babaei.basak.ea:algorithmic,
-  doi     = {10.1007/s00466-019-01699-y},
+  author  = {Hamed Babaei and Anup Basak and Valery I. Levitas},
+  title   = {Algorithmic aspects and finite element solutions for advanced phase field approach to martensitic phase transformation under large strains},
+  journal = {Computational Mechanics},
   year    = 2019,
-  month   = apr,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 64,
   number  = 4,
   pages   = {1177--1197},
-  author  = {Hamed Babaei and Anup Basak and Valery I. Levitas},
-  title   = {Algorithmic aspects and finite element solutions for advanced phase field approach to martensitic phase transformation under large strains},
-  journal = {Computational Mechanics}
+  month   = apr,
+  doi     = {10.1007/s00466-019-01699-y},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:babaei.levitas:effect,
-  doi     = {10.1016/j.actamat.2019.07.021},
-  year    = 2019,
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = 177,
-  pages   = {178--186},
   author  = {Hamed Babaei and Valery I. Levitas},
   title   = {Effect of $60^\circ$ dislocation on transformation stresses, nucleation, and growth for phase transformations between silicon I and silicon {II} under triaxial loading: Phase-field study},
-  journal = {Acta Materialia}
+  journal = {Acta Materialia},
+  year    = 2019,
+  volume  = 177,
+  pages   = {178--186},
+  month   = sep,
+  doi     = {10.1016/j.actamat.2019.07.021},
+  publisher = {Elsevier {BV}}
 }
 
 @MastersThesis{2019:balicki:abstrakte,
-  doi     = {10.25673/13842},
-  url     = {https://opendata.uni-halle.de//handle/1981185920/13968},
   author  = {Balicki, Linus},
-  language = {de},
   title   = {Eine abstrakte Implementierung der Low-Rank ADI Iteration f\"{u}r Lyapunovgleichungen in pyMOR},
-  publisher = {Otto von Guericke University Library, Magdeburg, Germany},
   school  = {Otto-von-Guericke-Universit{\"a}t Magdeburg},
   year    = 2019,
-  copyright = {Creative Commons Attribution Share Alike 4.0 International},
-  note    = {Bachelor's thesis}
+  note    = {Bachelor's thesis},
+  doi     = {10.25673/13842},
+  url     = {https://opendata.uni-halle.de//handle/1981185920/13968},
+  language = {de},
+  publisher = {Otto von Guericke University Library, Magdeburg, Germany},
+  copyright = {Creative Commons Attribution Share Alike 4.0 International}
 }
 
 @Article{2019:basak.levitas:finite,
@@ -199,49 +199,49 @@
 
 @InProceedings{2019:berselli.wells.ea:spatial,
   author  = {Berselli, L. C. and Wells, D. and Xie, X. and Iliescu, T.},
-  editor  = {Salvetti, Maria Vittoria and Armenio, Vincenzo and Fr{\"o}hlich, Jochen and Geurts, Bernard J. and Kuerten, Hans},
   title   = {Spatial Filtering for Reduced Order Modeling},
+  editor  = {Salvetti, Maria Vittoria and Armenio, Vincenzo and Fr{\"o}hlich, Jochen and Geurts, Bernard J. and Kuerten, Hans},
   booktitle = {Direct and Large-Eddy Simulation XI},
   year    = 2019,
-  publisher = {Springer International Publishing},
-  address = {Cham},
   pages   = {151--157},
+  address = {Cham},
+  publisher = {Springer International Publishing},
   doi     = {10.1007/978-3-030-04915-7_21}
 }
 
 @PhDThesis{2019:bettendorf:optimum,
-  doi     = {10.11588/HEIDOK.00027345},
-  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/27345},
   author  = {Bettendorf, Anja},
   title   = {Optimum experimental design for parameter estimation with 2D partial differential equation models},
   school  = {University of Heidelberg, Germany},
-  year    = 2019
+  year    = 2019,
+  doi     = {10.11588/HEIDOK.00027345},
+  url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/27345}
 }
 
 @Article{2019:bobadilla.carraro.ea:age,
-  doi     = {10.1007/s11538-019-00625-w},
+  author  = {Ana Victoria Ponce Bobadilla and Thomas Carraro and Helen M. Byrne and Philip K. Maini and Tom{\'{a}}s Alarc{\'{o}}n},
+  title   = {Age Structure Can Account for Delayed Logistic Proliferation of Scratch Assays},
+  journal = {Bulletin of Mathematical Biology},
   year    = 2019,
-  month   = jun,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 81,
   number  = 7,
   pages   = {2706--2724},
-  author  = {Ana Victoria Ponce Bobadilla and Thomas Carraro and Helen M. Byrne and Philip K. Maini and Tom{\'{a}}s Alarc{\'{o}}n},
-  title   = {Age Structure Can Account for Delayed Logistic Proliferation of Scratch Assays},
-  journal = {Bulletin of Mathematical Biology}
+  month   = jun,
+  doi     = {10.1007/s11538-019-00625-w},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:boddu.davydov.ea:cutoff-based,
-  doi     = {10.1007/s42493-019-00027-z},
+  author  = {Vishal Boddu and Denis Davydov and Bernhard Eidel and Paul Steinmann},
+  title   = {Cutoff-Based Modeling of Coulomb Interactions for Atomistic-to-Continuum Multiscale Methods},
+  journal = {Multiscale Science and Engineering},
   year    = 2019,
-  month   = oct,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 1,
   number  = 4,
   pages   = {299--317},
-  author  = {Vishal Boddu and Denis Davydov and Bernhard Eidel and Paul Steinmann},
-  title   = {Cutoff-Based Modeling of Coulomb Interactions for Atomistic-to-Continuum Multiscale Methods},
-  journal = {Multiscale Science and Engineering}
+  month   = oct,
+  doi     = {10.1007/s42493-019-00027-z},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:bonetti.cavaterra.ea:nonlinear,
@@ -255,133 +255,133 @@
 }
 
 @Article{2019:bonito.demlow:posteriori,
-  doi     = {10.1137/18m1169278},
+  author  = {Andrea Bonito and Alan Demlow},
+  title   = {A Posteriori Error Estimates for the Laplace--Beltrami Operator on Parametric $C^2$ Surfaces},
+  journal = {{SIAM} Journal on Numerical Analysis},
   year    = 2019,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 57,
   number  = 3,
   pages   = {973--996},
-  author  = {Andrea Bonito and Alan Demlow},
-  title   = {A Posteriori Error Estimates for the Laplace--Beltrami Operator on Parametric $C^2$ Surfaces},
-  journal = {{SIAM} Journal on Numerical Analysis}
+  month   = jan,
+  doi     = {10.1137/18m1169278},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2019:bonito.lei.ea:numerical,
-  doi     = {10.1007/s00211-019-01025-x},
+  author  = {Andrea Bonito and Wenyu Lei and Joseph E. Pasciak},
+  title   = {Numerical approximation of the integral fractional Laplacian},
+  journal = {Numerische Mathematik},
   year    = 2019,
-  month   = feb,
-  publisher = {Society for Mining, Metallurgy and Exploration Inc.},
   volume  = 142,
   number  = 2,
   pages   = {235--278},
-  author  = {Andrea Bonito and Wenyu Lei and Joseph E. Pasciak},
-  title   = {Numerical approximation of the integral fractional Laplacian},
-  journal = {Numerische Mathematik}
+  month   = feb,
+  doi     = {10.1007/s00211-019-01025-x},
+  publisher = {Society for Mining, Metallurgy and Exploration Inc.}
 }
 
 @Article{2019:borregales.kumar.ea:partially,
-  doi     = {10.1016/j.camwa.2018.09.005},
+  author  = {Manuel Borregales and Kundan Kumar and Florin Adrian Radu and Carmen Rodrigo and Francisco Jos{\'{e}} Gaspar},
+  title   = {A partially parallel-in-time fixed-stress splitting method for Biot's consolidation model},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2019,
-  month   = mar,
-  publisher = {Elsevier {BV}},
   volume  = 77,
   number  = 6,
   pages   = {1466--1478},
-  author  = {Manuel Borregales and Kundan Kumar and Florin Adrian Radu and Carmen Rodrigo and Francisco Jos{\'{e}} Gaspar},
-  title   = {A partially parallel-in-time fixed-stress splitting method for Biot's consolidation model},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = mar,
+  doi     = {10.1016/j.camwa.2018.09.005},
+  publisher = {Elsevier {BV}}
 }
 
 @InProceedings{2019:borregales.radu:higher,
-  doi     = {10.1007/978-3-319-96415-7_49},
   author  = {Borregales, Manuel and Radu, Florin Adrian},
-  editor  = {Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin},
   title   = {Higher Order Space-Time Elements for a Non-linear Biot Model},
+  editor  = {Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin},
   booktitle = {Numerical Mathematics and Advanced Applications ENUMATH 2017},
   year    = 2019,
-  publisher = {Springer International Publishing},
+  pages   = {541--549},
   address = {Cham},
-  pages   = {541--549}
+  publisher = {Springer International Publishing},
+  doi     = {10.1007/978-3-319-96415-7_49}
 }
 
 @InCollection{2019:both.kocher:numerical,
-  doi     = {10.1007/978-3-319-96415-7_74},
-  year    = 2019,
-  publisher = {Springer International Publishing},
-  pages   = {789--797},
   author  = {Jakub W. Both and Uwe K\"{o}cher},
   title   = {Numerical Investigation on the Fixed-Stress Splitting Scheme for {Biot}'s Equations: Optimality of the Tuning Parameter},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
+  booktitle = {Lecture Notes in Computational Science and Engineering},
+  publisher = {Springer International Publishing},
+  year    = 2019,
+  pages   = {789--797},
+  doi     = {10.1007/978-3-319-96415-7_74}
 }
 
 @Article{2019:brands.davydov.ea:reduced-order,
-  doi     = {10.3390/mca24010020},
+  author  = {Benjamin Brands and Denis Davydov and Julia Mergheim and Paul Steinmann},
+  title   = {Reduced-Order Modelling and Homogenisation in Magneto-Mechanics: A Numerical Comparison of Established Hyper-Reduction Methods},
+  journal = {Mathematical and Computational Applications},
   year    = 2019,
-  month   = feb,
-  publisher = {{MDPI} {AG}},
   volume  = 24,
   number  = 1,
   pages   = 20,
-  author  = {Benjamin Brands and Denis Davydov and Julia Mergheim and Paul Steinmann},
-  title   = {Reduced-Order Modelling and Homogenisation in Magneto-Mechanics: A Numerical Comparison of Established Hyper-Reduction Methods},
-  journal = {Mathematical and Computational Applications}
+  month   = feb,
+  doi     = {10.3390/mca24010020},
+  publisher = {{MDPI} {AG}}
 }
 
 @Article{2019:bruchhauser.schwegler.ea:numerical,
+  author  = {Bruchh{\"a}user, Marius Paul and Schwegler, Kristina and Bause, Markus},
   title   = {Numerical {S}tudy of {G}oal-{O}riented {E}rror {C}ontrol for {S}tabilized {F}inite {E}lement {M}ethods},
+  journal = {Advanced Finite Element Methods with Applications},
+  year    = 2019,
+  pages   = {85--106},
   isbn    = 9783030142445,
   issn    = {2197-7100},
   doi     = {10.1007/978-3-030-14244-5_5},
-  journal = {Advanced Finite Element Methods with Applications},
-  publisher = {Springer International Publishing},
-  author  = {Bruchh{\"a}user, Marius Paul and Schwegler, Kristina and Bause, Markus},
-  year    = 2019,
-  pages   = {85--106}
+  publisher = {Springer International Publishing}
 }
 
 @PhDThesis{2019:brun:upscaling,
   author  = {Brun, Mats Kirkes{\ae}ther},
   title   = {Upscaling, analysis, and iterative numerical solution schemes for thermo-poroelasticity},
-  url     = {http://bora.uib.no/handle/1956/20657},
   school  = {University of Bergen},
-  year    = 2019
+  year    = 2019,
+  url     = {http://bora.uib.no/handle/1956/20657}
 }
 
 @Article{2019:bryant.sun:micromorphically,
-  doi     = {10.1016/j.cma.2019.05.003},
-  year    = 2019,
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = 354,
-  pages   = {56--95},
   author  = {Eric C. Bryant and WaiChing Sun},
   title   = {A micromorphically regularized Cam-clay model for capturing size-dependent anisotropy of geomaterials},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
+  volume  = 354,
+  pages   = {56--95},
+  month   = sep,
+  doi     = {10.1016/j.cma.2019.05.003},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:bucci.christensen:modeling,
-  doi     = {10.1016/j.jpowsour.2019.227186},
-  year    = 2019,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 441,
-  pages   = 227186,
   author  = {Giovanna Bucci and Jake Christensen},
   title   = {Modeling of lithium electrodeposition at the lithium/ceramic electrolyte interface: The role of interfacial resistance and surface defects},
-  journal = {Journal of Power Sources}
+  journal = {Journal of Power Sources},
+  year    = 2019,
+  volume  = 441,
+  pages   = 227186,
+  month   = nov,
+  doi     = {10.1016/j.jpowsour.2019.227186},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:bzowski.rauch.ea:selection,
-  doi     = {10.1088/1757-899x/627/1/012018},
-  year    = 2019,
-  month   = oct,
-  publisher = {{IOP} Publishing},
-  volume  = 627,
-  pages   = 012018,
   author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk},
   title   = {Selection of the optimal heat treatment conditions using advanced phase transformation models},
-  journal = {{IOP} Conference Series: Materials Science and Engineering}
+  journal = {{IOP} Conference Series: Materials Science and Engineering},
+  year    = 2019,
+  volume  = 627,
+  pages   = 012018,
+  month   = oct,
+  doi     = {10.1088/1757-899x/627/1/012018},
+  publisher = {{IOP} Publishing}
 }
 
 @PhDThesis{2019:bzowski:application,
@@ -395,44 +395,44 @@
 @PhDThesis{2019:cajuhi:fracture,
   author  = {Cajuhi, Tuanny},
   title   = {Fracture in porous media: phase-field modeling, simulation and experimental validation},
-  url     = {https://core.ac.uk/download/pdf/196653165.pdf},
   school  = {Technischen Universit{\"a}t Carolo-Wilhelmina zu Braunschweig},
-  year    = 2019
+  year    = 2019,
+  url     = {https://core.ac.uk/download/pdf/196653165.pdf}
 }
 
 @Article{2019:carreno.bergamaschi.ea:block,
-  doi     = {10.3390/mca24010009},
+  author  = {Amanda Carre{\~{n}}o and Luca Bergamaschi and Angeles Martinez and Antoni Vidal-Ferr{\'{a}}ndiz and Damian Ginestar and Gumersindo Verd{\'{u}}},
+  title   = {Block Preconditioning Matrices for the Newton Method to Compute the Dominant $\lambda$-Modes Associated with the Neutron Diffusion Equation},
+  journal = {Mathematical and Computational Applications},
   year    = 2019,
-  month   = jan,
-  publisher = {{MDPI} {AG}},
   volume  = 24,
   number  = 1,
   pages   = 9,
-  author  = {Amanda Carre{\~{n}}o and Luca Bergamaschi and Angeles Martinez and Antoni Vidal-Ferr{\'{a}}ndiz and Damian Ginestar and Gumersindo Verd{\'{u}}},
-  title   = {Block Preconditioning Matrices for the Newton Method to Compute the Dominant $\lambda$-Modes Associated with the Neutron Diffusion Equation},
-  journal = {Mathematical and Computational Applications}
+  month   = jan,
+  doi     = {10.3390/mca24010009},
+  publisher = {{MDPI} {AG}}
 }
 
 @InCollection{2019:carreno.vidal-ferrandiz.ea:matrix-free,
-  doi     = {10.1007/978-3-030-22750-0_68},
-  year    = 2019,
-  publisher = {Springer International Publishing},
-  pages   = {702--709},
   author  = {Amanda Carre{\~{n}}o and Antoni Vidal-Ferr{\`{a}}ndiz and Damian Ginestar and Gumersindo Verd{\'{u}}},
   title   = {A Matrix-Free Eigenvalue Solver for the Multigroup Neutron Diffusion Equation},
-  booktitle = {Lecture Notes in Computer Science}
+  booktitle = {Lecture Notes in Computer Science},
+  publisher = {Springer International Publishing},
+  year    = 2019,
+  pages   = {702--709},
+  doi     = {10.1007/978-3-030-22750-0_68}
 }
 
 @Article{2019:carreno.vidal-ferrandiz.ea:modal,
-  doi     = {10.1016/j.pnucene.2019.03.040},
-  year    = 2019,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 115,
-  pages   = {181--193},
   author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
   title   = {Modal methods for the neutron diffusion equation using different spatial modes},
-  journal = {Progress in Nuclear Energy}
+  journal = {Progress in Nuclear Energy},
+  year    = 2019,
+  volume  = 115,
+  pages   = {181--193},
+  month   = aug,
+  doi     = {10.1016/j.pnucene.2019.03.040},
+  publisher = {Elsevier {BV}}
 }
 
 @InProceedings{2019:castelli.dorfler:efficient,
@@ -441,8 +441,8 @@
   editor  = {Gleim, T. and Lange, S.},
   booktitle = {Proceedings of 8th {GACM} Colloquium on Computational Mechanics},
   year    = 2019,
-  publisher = {Kassel University Press},
   pages   = {441--444},
+  publisher = {Kassel University Press},
   doi     = {10.19211/KUP978737650939}
 }
 
@@ -458,57 +458,57 @@
 }
 
 @Article{2019:cerroni.penati.ea:multiscale,
-  doi     = {10.3390/geosciences9110465},
+  author  = {Daniele Cerroni and Mattia Penati and Giovanni Porta and Edie Miglio and Paolo Zunino and Paolo Ruffo},
+  title   = {Multiscale Modeling of Glacial Loading by a 3D Thermo-Hydro-Mechanical Approach Including Erosion and Isostasy},
+  journal = {Geosciences},
   year    = 2019,
-  month   = oct,
-  publisher = {{MDPI} {AG}},
   volume  = 9,
   number  = 11,
   pages   = 465,
-  author  = {Daniele Cerroni and Mattia Penati and Giovanni Porta and Edie Miglio and Paolo Zunino and Paolo Ruffo},
-  title   = {Multiscale Modeling of Glacial Loading by a 3D Thermo-Hydro-Mechanical Approach Including Erosion and Isostasy},
-  journal = {Geosciences}
+  month   = oct,
+  doi     = {10.3390/geosciences9110465},
+  publisher = {{MDPI} {AG}}
 }
 
 @Article{2019:charnyi.heister.ea:efficient,
-  doi     = {10.1016/j.apnum.2018.11.013},
-  year    = 2019,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 141,
-  pages   = {220--233},
   author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
   title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier--Stokes equations},
-  journal = {Applied Numerical Mathematics}
+  journal = {Applied Numerical Mathematics},
+  year    = 2019,
+  volume  = 141,
+  pages   = {220--233},
+  month   = jul,
+  doi     = {10.1016/j.apnum.2018.11.013},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:cheng.yu.ea:openifem,
-  doi     = {10.32604/cmes.2019.04318},
+  author  = {Jie Cheng and Feimi Yu and Lucy T. Zhang},
+  title   = {{OpenIFEM}: A High Performance Modular Open-Source Software of the Immersed Finite Element Method for Fluid-Structure Interactions},
+  journal = {Computer Modeling in Engineering {\&} Sciences},
   year    = 2019,
-  publisher = {Computers, Materials and Continua (Tech Science Press)},
   volume  = 119,
   number  = 1,
   pages   = {91--124},
-  author  = {Jie Cheng and Feimi Yu and Lucy T. Zhang},
-  title   = {{OpenIFEM}: A High Performance Modular Open-Source Software of the Immersed Finite Element Method for Fluid-Structure Interactions},
-  journal = {Computer Modeling in Engineering {\&} Sciences}
+  doi     = {10.32604/cmes.2019.04318},
+  publisher = {Computers, Materials and Continua (Tech Science Press)}
 }
 
 @Article{2019:choo:stabilized,
-  doi     = {10.1016/j.cma.2019.112568},
-  year    = 2019,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 357,
-  pages   = 112568,
   author  = {Jinhyun Choo},
   title   = {Stabilized mixed continuous/enriched Galerkin formulations for locally mass conservative poromechanics},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
+  volume  = 357,
+  pages   = 112568,
+  month   = dec,
+  doi     = {10.1016/j.cma.2019.112568},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:clevenger:parallel,
-  title   = {A {P}arallel {G}eometric {M}ultigrid {M}ethod for {A}daptive {F}inite {E}lements},
   author  = {Thomas C. Clevenger},
+  title   = {A {P}arallel {G}eometric {M}ultigrid {M}ethod for {A}daptive {F}inite {E}lements},
   school  = {Clemson University},
   year    = 2019,
   url     = {https://tigerprints.clemson.edu/all_dissertations/2523/}
@@ -516,47 +516,47 @@
 
 @Article{2019:corti.cioni.ea:aborted-propagation-of-the-ethiopian-rift-caused-by-linkage-with-the-kenyan-rift,
   author  = {Giacomo Corti and Raffaello Cioni and Zara Franceschini and Federico Sani and St{\'{e}}phane Scaillet and Paola Molin and Ilaria Isola and Francesco Mazzarini and Sascha Brune and Derek Keir and Asfaw Erbello and Ameha Muluneh and Finnigan Illsley-Kemp and Anne Glerum},
-  doi     = {10.1038/s41467-019-09335-2},
-  journal = {Nature Communications},
-  pages   = 1309,
   title   = {{Aborted propagation of the Ethiopian rift caused by linkage with the Kenyan rift}},
+  journal = {Nature Communications},
+  year    = 2019,
   volume  = 10,
-  year    = 2019
+  pages   = 1309,
+  doi     = {10.1038/s41467-019-09335-2}
 }
 
 @Article{2019:dang.do.ea:effective,
-  doi     = {10.1155/2019/7560724},
-  year    = 2019,
-  month   = feb,
-  publisher = {Hindawi Limited},
-  volume  = 2019,
-  pages   = {1--21},
   author  = {Hong-Lam Dang and Duc Phi Do and Dashnor Hoxha},
   title   = {Effective Elastic and Hydraulic Properties of Fractured Rock Masses with High Contrast of Permeability: Numerical Calculation by an Embedded Fracture Continuum Approach},
-  journal = {Advances in Civil Engineering}
+  journal = {Advances in Civil Engineering},
+  year    = 2019,
+  volume  = 2019,
+  pages   = {1--21},
+  month   = feb,
+  doi     = {10.1155/2019/7560724},
+  publisher = {Hindawi Limited}
 }
 
 @Article{2019:dang:modeling,
-  doi     = {10.1155/2019/4034860},
-  year    = 2019,
-  month   = jul,
-  publisher = {Hindawi Limited},
-  volume  = 2019,
-  pages   = {1--10},
   author  = {Hong-Lam Dang},
   title   = {Modeling the Effect of Intersected Fractures on Oil Production Rate of Fractured Reservoirs by Embedded Fracture Continuum Approach},
-  journal = {Modelling and Simulation in Engineering}
+  journal = {Modelling and Simulation in Engineering},
+  year    = 2019,
+  volume  = 2019,
+  pages   = {1--10},
+  month   = jul,
+  doi     = {10.1155/2019/4034860},
+  publisher = {Hindawi Limited}
 }
 
 @Article{2019:dannberg.gassmoller.ea:new,
-  doi     = {10.1093/gji/ggz190},
-  title   = {A new formulation for coupled magma/mantle dynamics},
   author  = {Dannberg, Juliane and Gassm{\"o}ller, Rene and Grove, Ryan and Heister, Timo},
+  title   = {A new formulation for coupled magma/mantle dynamics},
   journal = {Geophysical Journal International},
+  year    = 2019,
   volume  = 219,
   number  = 1,
   pages   = {94--107},
-  year    = 2019,
+  doi     = {10.1093/gji/ggz190},
   publisher = {Oxford University Press}
 }
 
@@ -564,148 +564,148 @@
   author  = {Sambit Das and Phani Motamarri and Vikram Gavini and Bruno Turcksin and Ying Wai Li and Brent Leback},
   title   = {{F}ast, {S}calable and {A}ccurate {F}inite-{E}lements {B}ased {A}b {I}nitio {C}alculations {U}sing {M}ixed {P}recision {C}omputing: 46 {PFLOPS} {S}imulation of a {M}etallic {D}islocation {S}ystem},
   booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage, and Analysis},
-  series  = {SC '19},
   year    = 2019,
+  series  = {SC '19},
   pages   = {2:1--2:11},
+  address = {New York, NY, USA},
+  publisher = {ACM},
   articleno = 2,
   numpages = 11,
-  doi     = {10.1145/3295500.3357157},
-  publisher = {ACM},
-  address = {New York, NY, USA}
+  doi     = {10.1145/3295500.3357157}
 }
 
 @PhDThesis{2019:das:large,
   author  = {Das, Sambit},
   title   = {Large Scale Electronic Structure Studies on the Energetics of Dislocations in Al-Mg Materials System and Its Connection to Mesoscale Models},
-  url     = {https://deepblue.lib.umich.edu/handle/2027.42/153417},
   school  = {University of Michigan},
-  year    = 2019
+  year    = 2019,
+  url     = {https://deepblue.lib.umich.edu/handle/2027.42/153417}
 }
 
 @Article{2019:deolmi.muller.ea:reduced,
-  doi     = {10.1016/j.amc.2018.11.059},
-  year    = 2019,
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = 348,
-  pages   = {234--256},
   author  = {G. Deolmi and S. M\"{u}ller and M. Albers and P.S. Meysonnat and W. Schr\"{o}der},
   title   = {A reduced order model to simulate compressible flows over an actuated riblet surface},
-  journal = {Applied Mathematics and Computation}
+  journal = {Applied Mathematics and Computation},
+  year    = 2019,
+  volume  = 348,
+  pages   = {234--256},
+  month   = may,
+  doi     = {10.1016/j.amc.2018.11.059},
+  publisher = {Elsevier {BV}}
 }
 
 @InProceedings{2019:dong.lee.ea:numerical,
-  doi     = {10.2118/193862-ms},
-  year    = 2019,
-  publisher = {Society of Petroleum Engineers},
   author  = {Rencheng Dong and Sanghyun Lee and Mary Wheeler},
   title   = {Numerical Simulation of Matrix Acidizing in Fractured Carbonate Reservoirs Using Adaptive Enriched Galerkin Method},
-  booktitle = {{SPE} Reservoir Simulation Conference}
+  booktitle = {{SPE} Reservoir Simulation Conference},
+  year    = 2019,
+  publisher = {Society of Petroleum Engineers},
+  doi     = {10.2118/193862-ms}
 }
 
 @Article{2019:duijn.mikelic.ea:thermoporoelasticity,
-  doi     = {10.1016/j.ijengsci.2019.02.005},
-  year    = 2019,
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = 138,
-  pages   = {1--25},
   author  = {C.J. van Duijn and Andro Mikeli{\'{c}} and Mary F. Wheeler and Thomas Wick},
   title   = {Thermoporoelasticity via homogenization: Modeling and formal two-scale expansions},
-  journal = {International Journal of Engineering Science}
+  journal = {International Journal of Engineering Science},
+  year    = 2019,
+  volume  = 138,
+  pages   = {1--25},
+  month   = may,
+  doi     = {10.1016/j.ijengsci.2019.02.005},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:endtmayer.langer.ea:mesh,
   author  = {Endtmayer, Bernhard and Langer, Ulrich and Neitzel, Ira and Wick, Thomas and Wollner, Winnifried},
   title   = {Mesh adaptivity and error estimates applied to a regularized p-Laplacian constrainted optimal control problem for multiple quantities of interest},
   journal = {PAMM},
+  year    = 2019,
   volume  = 19,
   number  = 1,
   pages   = {e201900231},
   doi     = {10.1002/pamm.201900231},
   url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.201900231},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.201900231},
-  year    = 2019
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.201900231}
 }
 
 @PhDThesis{2019:exner:extended,
+  author  = {Exner, Pavel},
+  title   = {Extended finite element method for approximation of singularities in groundwater flow},
+  year    = 2019,
   doi     = {10.13140/RG.2.2.18015.41123},
   url     = {https://dspace.tul.cz/handle/15240/153160},
-  author  = {Exner, Pavel},
   language = {en},
-  title   = {Extended finite element method for approximation of singularities in groundwater flow},
-  publisher = {Unpublished},
-  year    = 2019
+  publisher = {Unpublished}
 }
 
 @InProceedings{2019:fan.wick.ea:phase-field,
   author  = {Meng Fan and Thomas Wick and Yan Jin},
-  editor  = {Tobias Gleim and Stephan Lange},
   title   = {A phase-field model for mixed-mode fracture},
+  editor  = {Tobias Gleim and Stephan Lange},
   booktitle = {8th GACM Colloquium on Computational Mechanics},
-  publisher = {Kassel University Press},
-  pages   = {51--54},
   year    = 2019,
+  pages   = {51--54},
+  publisher = {Kassel University Press},
   url     = {https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9}
 }
 
 @Article{2019:fehn.kronbichler.ea:high-order,
-  title   = {High-order DG solvers for underresolved turbulent incompressible flows: A comparison of L2 and H(div) methods},
   author  = {Fehn, Niklas and Kronbichler, Martin and Lehrenfeld, Christoph and Lube, Gert and Schroeder, Philipp W},
+  title   = {High-order DG solvers for underresolved turbulent incompressible flows: A comparison of L2 and H(div) methods},
   journal = {International Journal for Numerical Methods in Fluids},
+  year    = 2019,
   volume  = 91,
   number  = 11,
   pages   = {533--556},
-  year    = 2019,
   publisher = {Wiley Online Library},
   doi     = {10.1002/fld.4763}
 }
 
 @Article{2019:fehn.wall.ea:matrix-free,
-  title   = {A matrix-free high-order discontinuous Galerkin compressible Navier-Stokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
+  title   = {A matrix-free high-order discontinuous Galerkin compressible Navier-Stokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
   journal = {International Journal for Numerical Methods in Fluids},
+  year    = 2019,
   volume  = 89,
   number  = 3,
   pages   = {71--102},
-  year    = 2019,
   publisher = {Wiley Online Library},
   doi     = {10.1002/fld.4683}
 }
 
 @Article{2019:fehn.wall.ea:modern,
-  title   = {Modern discontinuous Galerkin methods for the simulation of transitional and turbulent flows in biomedical engineering: A comprehensive LES study of the FDA benchmark nozzle model},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
+  title   = {Modern discontinuous Galerkin methods for the simulation of transitional and turbulent flows in biomedical engineering: A comprehensive LES study of the FDA benchmark nozzle model},
   journal = {International journal for numerical methods in biomedical engineering},
+  year    = 2019,
   volume  = 35,
   number  = 12,
   pages   = {e3228},
-  year    = 2019,
   publisher = {Wiley Online Library},
   doi     = {10.1002/cnm.3228}
 }
 
 @Article{2019:fei.choo:phase-field,
-  doi     = {10.1002/nme.6242},
+  author  = {Fan Fei and Jinhyun Choo},
+  title   = {A phase-field method for modeling cracks with frictional contact},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2019,
-  month   = nov,
-  publisher = {Wiley},
   volume  = 121,
   number  = 4,
   pages   = {740--762},
-  author  = {Fan Fei and Jinhyun Choo},
-  title   = {A phase-field method for modeling cracks with frictional contact},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = nov,
+  doi     = {10.1002/nme.6242},
+  publisher = {Wiley}
 }
 
 @Article{2019:fraters.bangerth.ea:efficient,
   author  = {M. R. T. Fraters and W. Bangerth and C. Thieulot and A. C. Glerum and W. Spakman},
   title   = {Efficient and practical {N}ewton solvers for nonlinear {S}tokes systems in geodynamics problems},
   journal = {Geophysics Journal International},
+  year    = 2019,
   volume  = 218,
   number  = 2,
   pages   = {873--894},
-  year    = 2019,
   month   = apr,
   issn    = {0956-540X},
   doi     = {10.1093/gji/ggz183},
@@ -715,312 +715,312 @@
 @PhDThesis{2019:fraters:towards,
   author  = {Fraters, Menno R. T.},
   title   = {Towards numerical modelling of natural subduction systems with an application to Eastern Caribbean subduction},
-  url     = {https://dspace.library.uu.nl/handle/1874/379767},
   school  = {Utrecht University},
-  year    = 2019
+  year    = 2019,
+  url     = {https://dspace.library.uu.nl/handle/1874/379767}
 }
 
 @Article{2019:freddi:fracture,
-  doi     = {10.1016/j.mechrescom.2019.01.009},
-  year    = 2019,
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = 96,
-  pages   = {29--36},
   author  = {Francesco Freddi},
   title   = {Fracture energy in phase field models},
-  journal = {Mechanics Research Communications}
+  journal = {Mechanics Research Communications},
+  year    = 2019,
+  volume  = 96,
+  pages   = {29--36},
+  month   = mar,
+  doi     = {10.1016/j.mechrescom.2019.01.009},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:fu.jin.ea:parameter-free,
-  doi     = {10.1093/imanum/dry001},
+  author  = {Guosheng Fu and Yanyi Jin and Weifeng Qiu},
+  title   = {Parameter-free superconvergent H(div)-conforming {HDG} methods for the Brinkman equations},
+  journal = {{IMA} Journal of Numerical Analysis},
   year    = 2019,
-  month   = apr,
-  publisher = {Oxford University Press ({OUP})},
   volume  = 39,
   number  = 2,
   pages   = {957--982},
-  author  = {Guosheng Fu and Yanyi Jin and Weifeng Qiu},
-  title   = {Parameter-free superconvergent H(div)-conforming {HDG} methods for the Brinkman equations},
-  journal = {{IMA} Journal of Numerical Analysis}
+  month   = apr,
+  doi     = {10.1093/imanum/dry001},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @Article{2019:gassmoller.lokavarapu.ea:evaluating,
-  doi     = {10.1093/gji/ggz405},
-  title   = {Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible Stokes flow},
   author  = {Gassm{\"o}ller, Rene and Lokavarapu, Harsha and Bangerth, Wolfgang and Puckett, Elbridge Gerry},
+  title   = {Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible Stokes flow},
   journal = {Geophysical Journal International},
+  year    = 2019,
   volume  = 219,
   number  = 3,
   pages   = {1915--1938},
-  year    = 2019,
+  doi     = {10.1093/gji/ggz405},
   publisher = {Oxford University Press}
 }
 
 @Article{2019:gedicke.khan:divergence-conforming,
-  doi     = {10.1007/s00211-019-01095-x},
+  author  = {Joscha Gedicke and Arbaz Khan},
+  title   = {Divergence-conforming discontinuous Galerkin finite elements for Stokes eigenvalue problems},
+  journal = {Numerische Mathematik},
   year    = 2019,
-  month   = dec,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 144,
   number  = 3,
   pages   = {585--614},
-  author  = {Joscha Gedicke and Arbaz Khan},
-  title   = {Divergence-conforming discontinuous Galerkin finite elements for Stokes eigenvalue problems},
-  journal = {Numerische Mathematik}
+  month   = dec,
+  doi     = {10.1007/s00211-019-01095-x},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @PhDThesis{2019:gerken:dynamic,
-  title   = {Dynamic Inverse Problems for Wave Phenomena},
-  url     = {http://nbn-resolving.de/urn:nbn:de:gbv:46-00107730-18},
   author  = {Gerken, Thies},
+  title   = {Dynamic Inverse Problems for Wave Phenomena},
+  school  = {Universit{\"a}t Bremen},
   year    = 2019,
-  school  = {Universit{\"a}t Bremen}
+  url     = {http://nbn-resolving.de/urn:nbn:de:gbv:46-00107730-18}
 }
 
 @Article{2019:german.ragusa:reduced-order,
-  doi     = {10.1016/j.anucene.2019.05.049},
-  year    = 2019,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 134,
-  pages   = {144--157},
   author  = {P{\'{e}}ter German and Jean C. Ragusa},
   title   = {Reduced-order modeling of parameterized multi-group diffusion k-eigenvalue problems},
-  journal = {Annals of Nuclear Energy}
+  journal = {Annals of Nuclear Energy},
+  year    = 2019,
+  volume  = 134,
+  pages   = {144--157},
+  month   = dec,
+  doi     = {10.1016/j.anucene.2019.05.049},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:ghesmati.bangerth.ea:residual-based,
-  doi     = {10.1515/jnma-2018-0047},
+  author  = {Arezou Ghesmati and Wolfgang Bangerth and Bruno Turcksin},
+  title   = {Residual-based a posteriori error estimation for hp-adaptive finite element methods for the Stokes equations},
+  journal = {Journal of Numerical Mathematics},
   year    = 2019,
-  month   = dec,
-  publisher = {Walter de Gruyter {GmbH}},
   volume  = 27,
   number  = 4,
   pages   = {237--252},
-  author  = {Arezou Ghesmati and Wolfgang Bangerth and Bruno Turcksin},
-  title   = {Residual-based a posteriori error estimation for hp-adaptive finite element methods for the Stokes equations},
-  journal = {Journal of Numerical Mathematics}
+  month   = dec,
+  doi     = {10.1515/jnma-2018-0047},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @Article{2019:giuliani:blacknufft,
-  doi     = {10.1016/j.cpc.2018.10.005},
-  year    = 2019,
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = 235,
-  pages   = {324--335},
   author  = {Nicola Giuliani},
   title   = {{BlackNUFFT}: Modular customizable black box hybrid parallelization of type 3 {NUFFT} in 3D},
-  journal = {Computer Physics Communications}
+  journal = {Computer Physics Communications},
+  year    = 2019,
+  volume  = 235,
+  pages   = {324--335},
+  month   = feb,
+  doi     = {10.1016/j.cpc.2018.10.005},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:glerum:geodynamics-of-complex-plate-boundary-regions,
   author  = {Glerum, Anne},
-  school  = {{Universiteit Utrecht}},
   title   = {{Geodynamics of complex plate boundary regions}},
-  url     = {https://dspace.library.uu.nl/handle/1874/377338},
-  year    = 2019
+  school  = {{Universiteit Utrecht}},
+  year    = 2019,
+  url     = {https://dspace.library.uu.nl/handle/1874/377338}
 }
 
 @Article{2019:gong.chen.ea:quantitative,
-  doi     = {10.1016/j.ijheatmasstransfer.2019.01.104},
-  year    = 2019,
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = 135,
-  pages   = {262--273},
   author  = {Tong Zhao Gong and Yun Chen and Dian Zhong Li and Yan Fei Cao and Pai Xian Fu},
   title   = {Quantitative comparison of dendritic growth under forced flow between 2D and 3D phase-field simulation},
-  journal = {International Journal of Heat and Mass Transfer}
+  journal = {International Journal of Heat and Mass Transfer},
+  year    = 2019,
+  volume  = 135,
+  pages   = {262--273},
+  month   = jun,
+  doi     = {10.1016/j.ijheatmasstransfer.2019.01.104},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:gonzalez-valverde.garcia-aznar:agent-based,
-  doi     = {10.1007/s40571-018-0199-2},
+  author  = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
+  title   = {An agent-based and {FE} approach to simulate cell jamming and collective motion in epithelial layers},
+  journal = {Computational Particle Mechanics},
   year    = 2019,
-  month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 6,
   number  = 1,
   pages   = {85--96},
-  author  = {Ismael Gonz{\'{a}}lez-Valverde and Jos{\'{e}} Manuel Garc{\'{i}}a-Aznar},
-  title   = {An agent-based and {FE} approach to simulate cell jamming and collective motion in epithelial layers},
-  journal = {Computational Particle Mechanics}
+  month   = jan,
+  doi     = {10.1007/s40571-018-0199-2},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:grayver.driel.ea:three-dimensional,
-  title   = {Three-dimensional magnetotelluric modelling in spherical {Earth}},
   author  = {Grayver, Alexander V. and van Driel, Martin and Kuvshinov, Alexey V.},
+  title   = {Three-dimensional magnetotelluric modelling in spherical {Earth}},
   journal = {Geophysical Journal International},
+  year    = 2019,
   volume  = 217,
   number  = 1,
   pages   = {532--557},
-  year    = 2019,
   publisher = {Oxford University Press},
   doi     = {10.1093/gji/ggz030}
 }
 
 @Article{2019:grayver.olsen:magnetic,
-  doi     = {10.1029/2019gl082400},
+  author  = {Alexander V. Grayver and Nils Olsen},
+  title   = {The Magnetic Signatures of the M2, N2, and O1 Oceanic Tides Observed in Swarm and {CHAMP} Satellite Magnetic Data},
+  journal = {Geophysical Research Letters},
   year    = 2019,
-  month   = apr,
-  publisher = {American Geophysical Union ({AGU})},
   volume  = 46,
   number  = 8,
   pages   = {4230--4238},
-  author  = {Alexander V. Grayver and Nils Olsen},
-  title   = {The Magnetic Signatures of the M2, N2, and O1 Oceanic Tides Observed in Swarm and {CHAMP} Satellite Magnetic Data},
-  journal = {Geophysical Research Letters}
+  month   = apr,
+  doi     = {10.1029/2019gl082400},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @InCollection{2019:guermond.popov.ea:arbitrary,
-  doi     = {10.1007/978-3-319-78325-3_14},
-  year    = 2019,
-  publisher = {Springer International Publishing},
-  pages   = {251--272},
   author  = {Jean-Luc Guermond and Bojan Popov and Laura Saavedra and Yong Yang},
   title   = {Arbitrary Lagrangian-Eulerian Finite Element Method Preserving Convex Invariants of Hyperbolic Systems},
-  booktitle = {Computational Methods in Applied Sciences}
+  booktitle = {Computational Methods in Applied Sciences},
+  publisher = {Springer International Publishing},
+  year    = 2019,
+  pages   = {251--272},
+  doi     = {10.1007/978-3-319-78325-3_14}
 }
 
 @Article{2019:gulevich.koshelets.ea:bridging,
-  doi     = {10.1103/physrevb.99.060501},
-  year    = 2019,
-  month   = feb,
-  publisher = {American Physical Society ({APS})},
-  volume  = 99,
-  number  = 6,
   author  = {D. R. Gulevich and V. P. Koshelets and F.~V. Kusmartsev},
   title   = {Bridging the terahertz gap for chaotic sources with superconducting junctions},
-  journal = {Physical Review B}
+  journal = {Physical Review B},
+  year    = 2019,
+  volume  = 99,
+  number  = 6,
+  month   = feb,
+  doi     = {10.1103/physrevb.99.060501},
+  publisher = {American Physical Society ({APS})}
 }
 
 @Article{2019:guo.wu.ea:numerical,
-  doi     = {10.2118/195580-pa},
+  author  = {Xuyang Guo and Kan Wu and Cheng An and Jizhou Tang and John Killough},
+  title   = {Numerical Investigation of Effects of Subsequent Parent-Well Injection on Interwell Fracturing Interference Using Reservoir-Geomechanics-Fracturing Modeling},
+  journal = {{SPE} Journal},
   year    = 2019,
-  month   = aug,
-  publisher = {Society of Petroleum Engineers ({SPE})},
   volume  = 24,
   number  = 04,
   pages   = {1884--1902},
-  author  = {Xuyang Guo and Kan Wu and Cheng An and Jizhou Tang and John Killough},
-  title   = {Numerical Investigation of Effects of Subsequent Parent-Well Injection on Interwell Fracturing Interference Using Reservoir-Geomechanics-Fracturing Modeling},
-  journal = {{SPE} Journal}
+  month   = aug,
+  doi     = {10.2118/195580-pa},
+  publisher = {Society of Petroleum Engineers ({SPE})}
 }
 
 @Article{2019:guo.wu.ea:understanding,
-  doi     = {10.2118/194493-pa},
+  author  = {X. Guo and K. Wu and J. Killough and J. Tang},
+  title   = {Understanding the Mechanism of Interwell Fracturing Interference With Reservoir/Geomechanics/Fracturing Modeling in Eagle Ford Shale},
+  journal = {{SPE} Reservoir Evaluation {\&} Engineering},
   year    = 2019,
-  month   = feb,
-  publisher = {Society of Petroleum Engineers ({SPE})},
   volume  = 22,
   number  = 03,
   pages   = {842--860},
-  author  = {X. Guo and K. Wu and J. Killough and J. Tang},
-  title   = {Understanding the Mechanism of Interwell Fracturing Interference With Reservoir/Geomechanics/Fracturing Modeling in Eagle Ford Shale},
-  journal = {{SPE} Reservoir Evaluation {\&} Engineering}
+  month   = feb,
+  doi     = {10.2118/194493-pa},
+  publisher = {Society of Petroleum Engineers ({SPE})}
 }
 
 @Article{2019:gupta.keulen.ea:design,
-  doi     = {10.1002/nme.6217},
+  author  = {Deepak K. Gupta and Fred Keulen and Matthijs Langelaar},
+  title   = {Design and analysis adaptivity in multiresolution topology optimization},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2019,
-  month   = oct,
-  publisher = {Wiley},
   volume  = 121,
   number  = 3,
   pages   = {450--476},
-  author  = {Deepak K. Gupta and Fred Keulen and Matthijs Langelaar},
-  title   = {Design and analysis adaptivity in multiresolution topology optimization},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = oct,
+  doi     = {10.1002/nme.6217},
+  publisher = {Wiley}
 }
 
 @Article{2019:hagstrom.kim:complete,
-  doi     = {10.1007/s00211-018-1012-0},
+  author  = {Thomas Hagstrom and Seungil Kim},
+  title   = {Complete radiation boundary conditions for the Helmholtz equation I: waveguides},
+  journal = {Numerische Mathematik},
   year    = 2019,
-  month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 141,
   number  = 4,
   pages   = {917--966},
-  author  = {Thomas Hagstrom and Seungil Kim},
-  title   = {Complete radiation boundary conditions for the Helmholtz equation I: waveguides},
-  journal = {Numerische Mathematik}
+  month   = jan,
+  doi     = {10.1007/s00211-018-1012-0},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:hai.bause.ea:modeling,
-  doi     = {10.1016/j.jfluidstructs.2019.04.014},
-  year    = 2019,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 88,
-  pages   = {100--121},
   author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause and Paul Kuberry},
   title   = {Modeling and simulation of Ultrasonic Guided Waves propagation in the fluid-structure domain by a monolithic approach},
-  journal = {Journal of Fluids and Structures}
+  journal = {Journal of Fluids and Structures},
+  year    = 2019,
+  volume  = 88,
+  pages   = {100--121},
+  month   = jul,
+  doi     = {10.1016/j.jfluidstructs.2019.04.014},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:hai.bause.ea:modeling*1,
-  doi     = {10.1016/j.apm.2019.07.007},
-  year    = 2019,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 75,
-  pages   = {916--939},
   author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause and Paul Allen Kuberry},
   title   = {Modeling concept and numerical simulation of ultrasonic wave propagation in a moving fluid-structure domain based on a monolithic approach},
-  journal = {Applied Mathematical Modelling}
+  journal = {Applied Mathematical Modelling},
+  year    = 2019,
+  volume  = 75,
+  pages   = {916--939},
+  month   = nov,
+  doi     = {10.1016/j.apm.2019.07.007},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:hai.bause:numerical,
-  doi     = {10.1016/j.camwa.2019.01.009},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Numerical study and comparison of alternative time discretization schemes for an ultrasonic guided wave propagation problem coupled with fluid--structure interaction},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2019,
-  month   = nov,
-  publisher = {Elsevier {BV}},
   volume  = 78,
   number  = 9,
   pages   = {2867--2885},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Numerical study and comparison of alternative time discretization schemes for an ultrasonic guided wave propagation problem coupled with fluid--structure interaction},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = nov,
+  doi     = {10.1016/j.camwa.2019.01.009},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:han.park.ea:dteq,
-  doi     = {10.1080/15361055.2018.1554391},
+  author  = {K. S. Han and B. H. Park and A. Y. Aydemir and J. Seol},
+  title   = {The {DTEQ} Code for Toroidal {MHD} Equilibria with Diamagnetic Current Modeling Using the deal.{II} Finite Element Library},
+  journal = {Fusion Science and Technology},
   year    = 2019,
-  month   = feb,
-  publisher = {Informa {UK} Limited},
   volume  = 75,
   number  = 2,
   pages   = {137--147},
-  author  = {K. S. Han and B. H. Park and A. Y. Aydemir and J. Seol},
-  title   = {The {DTEQ} Code for Toroidal {MHD} Equilibria with Diamagnetic Current Modeling Using the deal.{II} Finite Element Library},
-  journal = {Fusion Science and Technology}
+  month   = feb,
+  doi     = {10.1080/15361055.2018.1554391},
+  publisher = {Informa {UK} Limited}
 }
 
 @MastersThesis{2019:hanophy:performance,
   author  = {Hanophy, Joshua Thomas},
   title   = {Performance of parallel approximate ideal restriction multigrid for transport applications},
-  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/187540},
   school  = {Texas A{\&}M University},
-  year    = 2019
+  year    = 2019,
+  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/187540}
 }
 
 @Article{2019:hao.yang:convergence,
-  doi     = {10.1051/m2an/2018046},
+  author  = {Wenrui Hao and Yong Yang},
+  title   = {Convergence of a homotopy finite element method for computing steady states of Burgers' equation},
+  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis},
   year    = 2019,
-  month   = aug,
-  publisher = {{EDP} Sciences},
   volume  = 53,
   number  = 5,
   pages   = {1629--1644},
-  author  = {Wenrui Hao and Yong Yang},
-  title   = {Convergence of a homotopy finite element method for computing steady states of Burgers' equation},
-  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
+  month   = aug,
+  doi     = {10.1051/m2an/2018046},
+  publisher = {{EDP} Sciences}
 }
 
 @Misc{2019:he:simulating,
-  title   = {Simulating the scattering of low-frequency Gravitational Waves by compact objects using the finite element method},
   author  = {Jian-hua He},
+  title   = {Simulating the scattering of low-frequency Gravitational Waves by compact objects using the finite element method},
   year    = 2019,
   eprint  = {1912.00325},
   archiveprefix = {arXiv},
@@ -1028,84 +1028,84 @@
 }
 
 @Article{2019:heinlein.rheinbach.ea:applying,
-  doi     = {10.1002/pamm.201900337},
-  year    = 2019,
-  month   = nov,
-  publisher = {Wiley},
-  volume  = 19,
-  number  = 1,
   author  = {Alexander Heinlein and Oliver Rheinbach and Friederike R\"{o}ver and Stefan Sandfeld and Dominik Steinberger},
   title   = {Applying the {FROSch} Overlapping Schwarz Preconditioner to Dislocation Mechanics in Deal.{II}},
-  journal = {{PAMM}}
+  journal = {{PAMM}},
+  year    = 2019,
+  volume  = 19,
+  number  = 1,
+  month   = nov,
+  doi     = {10.1002/pamm.201900337},
+  publisher = {Wiley}
 }
 
 @Article{2019:heltai.caiazzo:multiscale,
-  doi     = {10.1002/cnm.3264},
-  year    = 2019,
-  month   = dec,
-  publisher = {Wiley},
-  volume  = 35,
-  number  = 12,
   author  = {Luca Heltai and Alfonso Caiazzo},
   title   = {Multiscale modeling of vascularized tissues via nonmatching immersed methods},
-  journal = {International Journal for Numerical Methods in Biomedical Engineering}
+  journal = {International Journal for Numerical Methods in Biomedical Engineering},
+  year    = 2019,
+  volume  = 35,
+  number  = 12,
+  month   = dec,
+  doi     = {10.1002/cnm.3264},
+  publisher = {Wiley}
 }
 
 @Article{2019:heltai.rotundo:error,
-  doi     = {10.1016/j.camwa.2019.05.029},
+  author  = {Luca Heltai and Nella Rotundo},
+  title   = {Error estimates in weighted Sobolev norms for finite element immersed interface methods},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2019,
-  month   = dec,
-  publisher = {Elsevier {BV}},
   volume  = 78,
   number  = 11,
   pages   = {3586--3604},
-  author  = {Luca Heltai and Nella Rotundo},
-  title   = {Error estimates in weighted Sobolev norms for finite element immersed interface methods},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = dec,
+  doi     = {10.1016/j.camwa.2019.05.029},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:heron.peace.ea:segmentation,
   author  = {Heron, P. J. and Peace, A. L. and McCaffrey, K. J. W. and Welford, J. K. and Wilson, R. and van Hunen, J. and Pysklywec, R. N.},
   title   = {Segmentation of Rifts Through Structural Inheritance: Creation of the Davis Strait},
   journal = {Tectonics},
+  year    = 2019,
   volume  = 38,
   number  = 7,
   pages   = {2411--2430},
   doi     = {10.1029/2019TC005578},
   url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019TC005578},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019TC005578},
-  year    = 2019
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019TC005578}
 }
 
 @Article{2019:heron.pysklywec.ea:deformation,
-  doi     = {10.1130/g45690.1},
+  author  = {P. J. Heron and R. N. Pysklywec and R. Stephenson and J. van Hunen},
+  title   = {Deformation driven by deep and distant structures: Influence of a mantle lithosphere suture in the Ouachita orogeny, southeastern United States},
+  journal = {Geology},
   year    = 2019,
-  month   = dec,
-  publisher = {Geological Society of America},
   volume  = 47,
   number  = 2,
   pages   = {147--150},
-  author  = {P. J. Heron and R. N. Pysklywec and R. Stephenson and J. van Hunen},
-  title   = {Deformation driven by deep and distant structures: Influence of a mantle lithosphere suture in the Ouachita orogeny, southeastern United States},
-  journal = {Geology}
+  month   = dec,
+  doi     = {10.1130/g45690.1},
+  publisher = {Geological Society of America}
 }
 
 @Article{2019:hochbruck.maier.ea:heterogeneous,
-  doi     = {10.1137/18m1234072},
+  author  = {Marlis Hochbruck and Bernhard Maier and Christian Stohrer},
+  title   = {Heterogeneous Multiscale Method for Maxwell's Equations},
+  journal = {Multiscale Modeling {\&} Simulation},
   year    = 2019,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 17,
   number  = 4,
   pages   = {1147--1171},
-  author  = {Marlis Hochbruck and Bernhard Maier and Christian Stohrer},
-  title   = {Heterogeneous Multiscale Method for Maxwell's Equations},
-  journal = {Multiscale Modeling {\&} Simulation}
+  month   = jan,
+  doi     = {10.1137/18m1234072},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Misc{2019:holmgren.kreiss:hydrodynamic,
-  title   = {A Hydrodynamic Model of Movement of a Contact Line Over a Curved Wall},
   author  = {Hanna Holmgren and Gunilla Kreiss},
+  title   = {A Hydrodynamic Model of Movement of a Contact Line Over a Curved Wall},
   year    = 2019,
   eprint  = {1905.08788},
   archiveprefix = {arXiv},
@@ -1113,228 +1113,228 @@
 }
 
 @MastersThesis{2019:janssen:comparison,
-  title   = {A comparison of {GOCO05c} satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
   author  = {Janssen, W. J.},
-  year    = 2019,
+  title   = {A comparison of {GOCO05c} satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
   school  = {Utrecht University},
+  year    = 2019,
   url     = {https://dspace.library.uu.nl/handle/1874/393839}
 }
 
 @Article{2019:jiang.garikipati.ea:diffuse,
-  doi     = {10.1007/s11538-019-00577-1},
+  author  = {J. Jiang and K. Garikipati and S. Rudraraju},
+  title   = {A Diffuse Interface Framework for Modeling the Evolution of Multi-cell Aggregates as a Soft Packing Problem Driven by the Growth and Division of Cells},
+  journal = {Bulletin of Mathematical Biology},
   year    = 2019,
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 81,
   number  = 8,
   pages   = {3282--3300},
-  author  = {J. Jiang and K. Garikipati and S. Rudraraju},
-  title   = {A Diffuse Interface Framework for Modeling the Evolution of Multi-cell Aggregates as a Soft Packing Problem Driven by the Growth and Division of Cells},
-  journal = {Bulletin of Mathematical Biology}
+  month   = feb,
+  doi     = {10.1007/s11538-019-00577-1},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @PhDThesis{2019:jonathan-perry-hout:geodynamic-origin-of-the-columbia-river-flood-basalts,
   author  = {{Jonathan Perry-Hout}},
-  school  = {University of Oregon},
   title   = {{Geodynamic Origin of the Columbia River Flood Basalts}},
-  url     = {http://hdl.handle.net/1794/24526},
-  year    = 2019
+  school  = {University of Oregon},
+  year    = 2019,
+  url     = {http://hdl.handle.net/1794/24526}
 }
 
 @InProceedings{2019:kauffman.george.ea:overset,
-  doi     = {10.2514/6.2019-1986},
+  author  = {Justin A. Kauffman and William L. George and Jonathan S. Pitt},
+  title   = {An Overset Mesh Framework for an Isentropic {ALE} Navier-Stokes {HDG} Formulation},
+  booktitle = {{AIAA} Scitech 2019 Forum},
   year    = 2019,
   month   = jan,
   publisher = {American Institute of Aeronautics and Astronautics},
-  author  = {Justin A. Kauffman and William L. George and Jonathan S. Pitt},
-  title   = {An Overset Mesh Framework for an Isentropic {ALE} Navier-Stokes {HDG} Formulation},
-  booktitle = {{AIAA} Scitech 2019 Forum}
+  doi     = {10.2514/6.2019-1986}
 }
 
 @InProceedings{2019:kazemi.vaziri.ea:topology,
-  doi     = {10.1115/detc2019-97370},
+  author  = {Hesaneh Kazemi and Ashkan Vaziri and Juli{\'{a}}n Norato},
+  title   = {Topology Optimization of Multi-Material Lattices for Maximal Bulk Modulus},
+  booktitle = {Volume 2A: 45th Design Automation Conference},
   year    = 2019,
   month   = aug,
   publisher = {American Society of Mechanical Engineers},
-  author  = {Hesaneh Kazemi and Ashkan Vaziri and Juli{\'{a}}n Norato},
-  title   = {Topology Optimization of Multi-Material Lattices for Maximal Bulk Modulus},
-  booktitle = {Volume 2A: 45th Design Automation Conference}
+  doi     = {10.1115/detc2019-97370}
 }
 
 @Article{2019:kerganer.mergheim.ea:modeling,
-  doi     = {10.1016/j.camwa.2018.05.016},
-  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
+  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
+  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2019,
-  month   = oct,
-  publisher = {Elsevier {BV}},
   volume  = 78,
   number  = 7,
   pages   = {2338--2350},
-  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
-  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = oct,
+  doi     = {10.1016/j.camwa.2018.05.016},
+  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:khattatov.yotov:domain,
-  doi     = {10.1051/m2an/2019057},
+  author  = {Eldar Khattatov and Ivan Yotov},
+  title   = {Domain decomposition and multiscale mortar mixed finite element methods for linear elasticity with weak stress symmetry},
+  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis},
   year    = 2019,
-  month   = nov,
-  publisher = {{EDP} Sciences},
   volume  = 53,
   number  = 6,
   pages   = {2081--2108},
-  author  = {Eldar Khattatov and Ivan Yotov},
-  title   = {Domain decomposition and multiscale mortar mixed finite element methods for linear elasticity with weak stress symmetry},
-  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
+  month   = nov,
+  doi     = {10.1051/m2an/2019057},
+  publisher = {{EDP} Sciences}
 }
 
 @Article{2019:kim.singh.ea:uncertainty,
-  doi     = {10.1016/j.jnnfm.2019.07.002},
-  year    = 2019,
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = 271,
-  pages   = 104138,
   author  = {Jaekwang Kim and Piyush K. Singh and Jonathan B. Freund and Randy H. Ewoldt},
   title   = {Uncertainty propagation in simulation predictions of generalized Newtonian fluid flows},
-  journal = {Journal of Non-Newtonian Fluid Mechanics}
+  journal = {Journal of Non-Newtonian Fluid Mechanics},
+  year    = 2019,
+  volume  = 271,
+  pages   = 104138,
+  month   = sep,
+  doi     = {10.1016/j.jnnfm.2019.07.002},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:kim:error,
-  doi     = {10.1051/m2an/2019026},
+  author  = {Seungil Kim},
+  title   = {Error analysis of {PML}-{FEM} approximations for the Helmholtz equation in waveguides},
+  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis},
   year    = 2019,
-  month   = jul,
-  publisher = {{EDP} Sciences},
   volume  = 53,
   number  = 4,
   pages   = {1191--1222},
-  author  = {Seungil Kim},
-  title   = {Error analysis of {PML}-{FEM} approximations for the Helmholtz equation in waveguides},
-  journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
+  month   = jul,
+  doi     = {10.1051/m2an/2019026},
+  publisher = {{EDP} Sciences}
 }
 
 @Article{2019:kocher.bruchhauser.ea:efficient,
-  doi     = {10.1016/j.softx.2019.100239},
-  year    = 2019,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 10,
-  pages   = 100239,
   author  = {Uwe K\"{o}cher and Marius Paul Bruchh\"{a}user and Markus Bause},
   title   = {Efficient and scalable data structures and algorithms for goal-oriented adaptivity of space--time {FEM} codes},
-  journal = {{SoftwareX}}
+  journal = {{SoftwareX}},
+  year    = 2019,
+  volume  = 10,
+  pages   = 100239,
+  month   = jul,
+  doi     = {10.1016/j.softx.2019.100239},
+  publisher = {Elsevier {BV}}
 }
 
 @InCollection{2019:kocher:influence,
-  doi     = {10.1007/978-3-319-96415-7_18},
-  year    = 2019,
-  publisher = {Springer International Publishing},
-  pages   = {215--223},
   author  = {Uwe K\"{o}cher},
   title   = {Influence of the {SIPG} Penalisation on the Numerical Properties of Linear Systems for Elastic Wave Propagation},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
+  booktitle = {Lecture Notes in Computational Science and Engineering},
+  publisher = {Springer International Publishing},
+  year    = 2019,
+  pages   = {215--223},
+  doi     = {10.1007/978-3-319-96415-7_18}
 }
 
 @Article{2019:koepf.soldner.ea:numerical,
-  doi     = {10.1016/j.commatsci.2019.03.004},
-  year    = 2019,
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = 162,
-  pages   = {148--155},
   author  = {J.A. Koepf and D. Soldner and M. Ramsperger and J. Mergheim and M. Markl and C. K\"{o}rner},
   title   = {Numerical microstructure prediction by a coupled finite element cellular automaton model for selective electron beam melting},
-  journal = {Computational Materials Science}
+  journal = {Computational Materials Science},
+  year    = 2019,
+  volume  = 162,
+  pages   = {148--155},
+  month   = may,
+  doi     = {10.1016/j.commatsci.2019.03.004},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:kohler.rheinbach.ea:feti-dp,
-  doi     = {10.1002/pamm.201900292},
-  year    = 2019,
-  month   = nov,
-  publisher = {Wiley},
-  volume  = 19,
-  number  = 1,
   author  = {Stephan K\"{o}hler and Oliver Rheinbach and Stefan Sandfeld and Dominik Steinberger},
   title   = {{FETI}-{DP} Solvers and Deal.{II} for Problems in Dislocation Mechanics},
-  journal = {{PAMM}}
+  journal = {{PAMM}},
+  year    = 2019,
+  volume  = 19,
+  number  = 1,
+  month   = nov,
+  doi     = {10.1002/pamm.201900292},
+  publisher = {Wiley}
 }
 
 @Article{2019:konig.rom.ea:numerical,
-  doi     = {10.2514/1.t5457},
+  author  = {V. K\"{o}nig and M. Rom and S. M\"{u}ller and M. Selzer and S. Schweikert and J. Von Wolfersdorf},
+  title   = {Numerical and Experimental Investigation of Transpiration Cooling with Carbon/Carbon Characteristic Outflow Distributions},
+  journal = {Journal of Thermophysics and Heat Transfer},
   year    = 2019,
-  month   = apr,
-  publisher = {American Institute of Aeronautics and Astronautics ({AIAA})},
   volume  = 33,
   number  = 2,
   pages   = {449--461},
-  author  = {V. K\"{o}nig and M. Rom and S. M\"{u}ller and M. Selzer and S. Schweikert and J. Von Wolfersdorf},
-  title   = {Numerical and Experimental Investigation of Transpiration Cooling with Carbon/Carbon Characteristic Outflow Distributions},
-  journal = {Journal of Thermophysics and Heat Transfer}
+  month   = apr,
+  doi     = {10.2514/1.t5457},
+  publisher = {American Institute of Aeronautics and Astronautics ({AIAA})}
 }
 
 @Article{2019:konschin.lechleiter:reconstruction,
-  doi     = {10.1088/1361-6420/ab1c66},
+  author  = {Alexander Konschin and Armin Lechleiter},
+  title   = {Reconstruction of a local perturbation in inhomogeneous periodic layers from partial near field measurements},
+  journal = {Inverse Problems},
   year    = 2019,
-  month   = oct,
-  publisher = {{IOP} Publishing},
   volume  = 35,
   number  = 11,
   pages   = 114006,
-  author  = {Alexander Konschin and Armin Lechleiter},
-  title   = {Reconstruction of a local perturbation in inhomogeneous periodic layers from partial near field measurements},
-  journal = {Inverse Problems}
+  month   = oct,
+  doi     = {10.1088/1361-6420/ab1c66},
+  publisher = {{IOP} Publishing}
 }
 
 @PhDThesis{2019:konschin:direkte,
   author  = {Konschin, Alexander},
   title   = {Direkte und inverse elektromagnetische Streuprobleme f{\"u}r lokal gest{\"o}rte periodische Medien},
-  url     = {https://core.ac.uk/download/pdf/297283589.pdf},
   school  = {Universit{\"a}t Bremen},
-  year    = 2019
+  year    = 2019,
+  url     = {https://core.ac.uk/download/pdf/297283589.pdf}
 }
 
 @Article{2019:kottapalli.shams.ea:numerical,
-  doi     = {10.1016/j.anucene.2019.01.001},
-  year    = 2019,
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = 128,
-  pages   = {115--126},
   author  = {S. Kottapalli and A. Shams and A.H. Zuijlen and M.J.B.M. Pourquie},
   title   = {Numerical investigation of an advanced U-{RANS} based pressure fluctuation model to simulate non-linear vibrations of nuclear fuel rods due to turbulent parallel-flow},
-  journal = {Annals of Nuclear Energy}
+  journal = {Annals of Nuclear Energy},
+  year    = 2019,
+  volume  = 128,
+  pages   = {115--126},
+  month   = jun,
+  doi     = {10.1016/j.anucene.2019.01.001},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:krank.kronbichler.ea:multiscale,
-  doi     = {10.1002/fld.4712},
+  author  = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
+  title   = {A multiscale approach to hybrid {RANS}/{LES} wall modeling within a high-order discontinuous {G}alerkin scheme using function enrichment},
+  journal = {International Journal for Numerical Methods in Fluids},
   year    = 2019,
-  publisher = {Wiley},
   volume  = 90,
   number  = 2,
   pages   = {81--113},
-  author  = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
-  title   = {A multiscale approach to hybrid {RANS}/{LES} wall modeling within a high-order discontinuous {G}alerkin scheme using function enrichment},
-  journal = {International Journal for Numerical Methods in Fluids}
+  doi     = {10.1002/fld.4712},
+  publisher = {Wiley}
 }
 
 @Article{2019:krank.kronbichler.ea:wall,
-  doi     = {10.1016/j.compfluid.2018.07.019},
-  year    = 2019,
-  publisher = {Elsevier {BV}},
-  volume  = 179,
-  pages   = {718--725},
   author  = {Benjamin Krank and Martin Kronbichler and Wolfgang A. Wall},
   title   = {Wall modeling via function enrichment: Extension to detached-eddy simulation},
-  journal = {Computers {\&} Fluids}
+  journal = {Computers {\&} Fluids},
+  year    = 2019,
+  volume  = 179,
+  pages   = {718--725},
+  doi     = {10.1016/j.compfluid.2018.07.019},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:krank:wall,
   author  = {Krank, Benjamin},
   title   = {Wall Modeling via Function Enrichment for Computational Fluid Dynamics},
-  type    = {Dissertation},
   school  = {Technische Universit{\"a}t M{\"u}nchen},
-  address = {M{\"u}nchen},
-  year    = 2019
+  year    = 2019,
+  type    = {Dissertation},
+  address = {M{\"u}nchen}
 }
 
 @InProceedings{2019:kronbichler.kormann.ea:fast,
@@ -1342,225 +1342,225 @@
   title   = {Fast matrix-free evaluation of hybridizable discontinuous Galerkin operators},
   editor  = {Florin A. Radu and Kundan Kumar and Inga Berre and Jan M. Nordbotten and Iuliu S. Pop},
   booktitle = {Numerical Mathematics and Advanced Applications: ENUMATH 2017},
-  volume  = 126,
-  series  = {Lecture Notes in Computational Science and Engineering},
   year    = 2019,
+  series  = {Lecture Notes in Computational Science and Engineering},
+  volume  = 126,
   pages   = {581--589},
   doi     = {10.1007/978-3-319-96415-7_53}
 }
 
 @Article{2019:kronbichler.kormann.ea:hermite-like,
-  title   = {A Hermite-like basis for faster matrix-free evaluation of interior penalty discontinuous Galerkin operators},
   author  = {Kronbichler, Martin and Kormann, Katharina and Fehn, Niklas and Munch, Peter and Witte, Julius},
+  title   = {A Hermite-like basis for faster matrix-free evaluation of interior penalty discontinuous Galerkin operators},
   journal = {arXiv preprint arXiv:1907.08492},
   year    = 2019
 }
 
 @Article{2019:kronbichler.kormann:fast,
-  title   = {Fast matrix-free evaluation of discontinuous Galerkin finite element operators},
   author  = {Kronbichler, Martin and Kormann, Katharina},
+  title   = {Fast matrix-free evaluation of discontinuous Galerkin finite element operators},
   journal = {ACM Transactions on Mathematical Software (TOMS)},
+  year    = 2019,
   volume  = 45,
   number  = 3,
   pages   = {1--40},
-  year    = 2019,
   publisher = {ACM New York, NY, USA},
   doi     = {10.1145/3325864}
 }
 
 @Article{2019:kronbichler.ljungkvist:multigrid,
-  title   = {Multigrid for matrix-free high-order finite element computations on graphics processors},
   author  = {Kronbichler, Martin and Ljungkvist, Karl},
+  title   = {Multigrid for matrix-free high-order finite element computations on graphics processors},
   journal = {ACM Transactions on Parallel Computing (TOPC)},
+  year    = 2019,
   volume  = 6,
   number  = 1,
   pages   = {1--32},
-  year    = 2019,
   publisher = {ACM New York, NY, USA},
   doi     = {10.1145/3322813}
 }
 
 @Article{2019:lin.xu.ea:mantle,
-  title   = {Mantle upwelling beneath the South China Sea and links to surrounding subduction systems},
   author  = {Lin, Jian and Xu, Yigang and Sun, Zhen and Zhou, Zhiyuan},
+  title   = {Mantle upwelling beneath the South China Sea and links to surrounding subduction systems},
   journal = {National Science Review},
+  year    = 2019,
   volume  = 6,
   number  = 5,
   pages   = {877--881},
-  year    = 2019,
   publisher = {Oxford University Press},
   doi     = {10.1093/nsr/nwz123}
 }
 
 @Article{2019:liu.king:benchmark,
-  doi     = {10.1093/gji/ggz036},
+  author  = {Shangxin Liu and Scott D King},
+  title   = {A benchmark study of incompressible Stokes flow in a 3-D spherical shell using {ASPECT}},
+  journal = {Geophysical Journal International},
   year    = 2019,
-  month   = jan,
-  publisher = {Oxford University Press ({OUP})},
   volume  = 217,
   number  = 1,
   pages   = {650--667},
-  author  = {Shangxin Liu and Scott D King},
-  title   = {A benchmark study of incompressible Stokes flow in a 3-D spherical shell using {ASPECT}},
-  journal = {Geophysical Journal International}
+  month   = jan,
+  doi     = {10.1093/gji/ggz036},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @Article{2019:liu.reina:dynamic,
-  doi     = {10.1007/s00466-018-1662-x},
+  author  = {Chenchen Liu and Celia Reina},
+  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
+  journal = {Computational Mechanics},
   year    = 2019,
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 64,
   number  = 1,
   pages   = {147--161},
-  author  = {Chenchen Liu and Celia Reina},
-  title   = {Dynamic homogenization of resonant elastic metamaterials with space/time modulation},
-  journal = {Computational Mechanics}
+  month   = jul,
+  doi     = {10.1007/s00466-018-1662-x},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:liu.yin:unconditionally,
-  doi     = {10.1007/s10915-019-01038-6},
+  author  = {Hailiang Liu and Peimeng Yin},
+  title   = {Unconditionally Energy Stable {DG} Schemes for the Swift--Hohenberg Equation},
+  journal = {Journal of Scientific Computing},
   year    = 2019,
-  month   = aug,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 81,
   number  = 2,
   pages   = {789--819},
-  author  = {Hailiang Liu and Peimeng Yin},
-  title   = {Unconditionally Energy Stable {DG} Schemes for the Swift--Hohenberg Equation},
-  journal = {Journal of Scientific Computing}
+  month   = aug,
+  doi     = {10.1007/s10915-019-01038-6},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:luo.zhao:numerical,
-  doi     = {10.1007/s00170-019-03947-0},
+  author  = {Zhibo Luo and Yaoyao Zhao},
+  title   = {Numerical simulation of part-level temperature fields during selective laser melting of stainless steel 316L},
+  journal = {International Journal of Advanced Manufacturing Technology},
   year    = 2019,
-  month   = jun,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 104,
   number  = {5-8},
   pages   = {1615--1635},
-  author  = {Zhibo Luo and Yaoyao Zhao},
-  title   = {Numerical simulation of part-level temperature fields during selective laser melting of stainless steel 316L},
-  journal = {International Journal of Advanced Manufacturing Technology}
+  month   = jun,
+  doi     = {10.1007/s00170-019-03947-0},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:ma.bakhti.ea:laser-generated,
-  doi     = {10.1021/acs.jpcc.9b05561},
+  author  = {Hongfeng Ma and Said Bakhti and Anton Rudenko and Francis Vocanson and Daniel S. Slaughter and Nathalie Destouches and Tatiana E. Itina},
+  title   = {Laser-Generated Ag Nanoparticles in Mesoporous {TiO}2 Films: Formation Processes and Modeling-Based Size Prediction},
+  journal = {The Journal of Physical Chemistry C},
   year    = 2019,
-  month   = sep,
-  publisher = {American Chemical Society ({ACS})},
   volume  = 123,
   number  = 42,
   pages   = {25898--25907},
-  author  = {Hongfeng Ma and Said Bakhti and Anton Rudenko and Francis Vocanson and Daniel S. Slaughter and Nathalie Destouches and Tatiana E. Itina},
-  title   = {Laser-Generated Ag Nanoparticles in Mesoporous {TiO}2 Films: Formation Processes and Modeling-Based Size Prediction},
-  journal = {The Journal of Physical Chemistry C}
+  month   = sep,
+  doi     = {10.1021/acs.jpcc.9b05561},
+  publisher = {American Chemical Society ({ACS})}
 }
 
 @Article{2019:maday.marcati:regularity,
-  doi     = {10.1142/s0218202519500295},
+  author  = {Yvon Maday and Carlo Marcati},
+  title   = {Regularity and hp discontinuous Galerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
+  journal = {Mathematical Models and Methods in Applied Sciences},
   year    = 2019,
-  month   = jul,
-  publisher = {World Scientific Pub Co Pte Lt},
   volume  = 29,
   number  = 08,
   pages   = {1585--1617},
-  author  = {Yvon Maday and Carlo Marcati},
-  title   = {Regularity and hp discontinuous Galerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
-  journal = {Mathematical Models and Methods in Applied Sciences}
+  month   = jul,
+  doi     = {10.1142/s0218202519500295},
+  publisher = {World Scientific Pub Co Pte Lt}
 }
 
 @Article{2019:maier.mattheakis.ea:homogenization,
-  doi     = {10.1098/rspa.2019.0220},
+  author  = {M. Maier and M. Mattheakis and E. Kaxiras and M. Luskin and D. Margetis},
+  title   = {Homogenization of plasmonic crystals: seeking the epsilon-near-zero effect},
+  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences},
   year    = 2019,
-  month   = oct,
-  publisher = {The Royal Society},
   volume  = 475,
   number  = 2230,
   pages   = 20190220,
-  author  = {M. Maier and M. Mattheakis and E. Kaxiras and M. Luskin and D. Margetis},
-  title   = {Homogenization of plasmonic crystals: seeking the epsilon-near-zero effect},
-  journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
+  month   = oct,
+  doi     = {10.1098/rspa.2019.0220},
+  publisher = {The Royal Society}
 }
 
 @Article{2019:mang.walloth.ea:mesh,
-  doi     = {10.1002/gamm.202000003},
-  year    = 2019,
-  month   = aug,
-  publisher = {Wiley},
-  volume  = 43,
-  number  = 1,
   author  = {K. Mang and M. Walloth and T. Wick and W. Wollner},
   title   = {Mesh adaptivity for quasi-static phase-field fractures based on a residual-type a posteriori error estimator},
-  journal = {{GAMM}-Mitteilungen}
+  journal = {{GAMM}-Mitteilungen},
+  year    = 2019,
+  volume  = 43,
+  number  = 1,
+  month   = aug,
+  doi     = {10.1002/gamm.202000003},
+  publisher = {Wiley}
 }
 
 @Article{2019:mang.wick.ea:phase-field,
-  doi     = {10.1007/s00466-019-01752-w},
+  author  = {Katrin Mang and Thomas Wick and Winnifried Wollner},
+  title   = {A phase-field model for fractures in nearly incompressible solids},
+  journal = {Computational Mechanics},
   year    = 2019,
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 65,
   number  = 1,
   pages   = {61--78},
-  author  = {Katrin Mang and Thomas Wick and Winnifried Wollner},
-  title   = {A phase-field model for fractures in nearly incompressible solids},
-  journal = {Computational Mechanics}
+  month   = jul,
+  doi     = {10.1007/s00466-019-01752-w},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Misc{2019:mang.wick:numerical,
+  author  = {Mang, Katrin and Wick, Thomas},
+  title   = {Numerical Methods for Variational Phase-Field Fracture Problems},
+  year    = 2019,
   doi     = {10.15488/5129},
   url     = {https://www.repo.uni-hannover.de/handle/123456789/5175},
-  author  = {Mang, Katrin and Wick, Thomas},
   language = {en},
-  title   = {Numerical Methods for Variational Phase-Field Fracture Problems},
   publisher = {Hannover : Institutionelles Repositorium der Leibniz Universit\"{a}t Hannover},
-  year    = 2019,
   copyright = {CC BY 3.0 DE}
 }
 
 @InProceedings{2019:mcbride.davydov.ea:modelling,
-  doi     = {10.1201/9780429426506},
-  url     = {https://books.google.com/books?id=4natDwAAQBAJ&pg=PA278},
-  year    = 2019,
   author  = {McBride, A. and Davydov, D. and Steinmann, P.},
   title   = {Modelling the Flexoelectric Effect in Solids},
+  booktitle = {Advances in Engineering Materials, Structures and Systems: Innovations, Mechanics and Applications. Proceedings of the 7th International Conference on Structural Engineering, Mechanics and Computation (SEMC 2019), September 2-4, 2019, Cape Town, South Africa.},
+  year    = 2019,
   pages   = {278--279},
-  booktitle = {Advances in Engineering Materials, Structures and Systems: Innovations, Mechanics and Applications. Proceedings of the 7th International Conference on Structural Engineering, Mechanics and Computation (SEMC 2019), September 2-4, 2019, Cape Town, South Africa.}
+  doi     = {10.1201/9780429426506},
+  url     = {https://books.google.com/books?id=4natDwAAQBAJ&pg=PA278}
 }
 
 @Article{2019:mehnert.hossain.ea:experimental,
-  doi     = {10.1016/j.euromechsol.2019.103797},
-  year    = 2019,
-  month   = sep,
-  publisher = {Elsevier {BV}},
-  volume  = 77,
-  pages   = 103797,
   author  = {Markus Mehnert and Mokarram Hossain and Paul Steinmann},
   title   = {Experimental and numerical investigations of the electro-viscoelastic behavior of {VHB} $4905^{TM}$},
-  journal = {European Journal of Mechanics - A/Solids}
+  journal = {European Journal of Mechanics - A/Solids},
+  year    = 2019,
+  volume  = 77,
+  pages   = 103797,
+  month   = sep,
+  doi     = {10.1016/j.euromechsol.2019.103797},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:mikelic.wheeler.ea:phase-field,
-  doi     = {10.1007/s13137-019-0113-y},
-  year    = 2019,
-  month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 10,
-  number  = 1,
   author  = {A. Mikeli{\'{c}} and M. F. Wheeler and T. Wick},
   title   = {Phase-field modeling through iterative splitting of hydraulic fractures in a poroelastic medium},
-  journal = {{GEM} -- International Journal on Geomathematics}
+  journal = {{GEM} -- International Journal on Geomathematics},
+  year    = 2019,
+  volume  = 10,
+  number  = 1,
+  month   = jan,
+  doi     = {10.1007/s13137-019-0113-y},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:morschhauser.grayver.ea:tippers,
-  title   = {Tippers at island geomagnetic observatories constrain electrical conductivity of oceanic lithosphere and upper mantle},
   author  = {Morschhauser, Achim and Grayver, Alexander and Kuvshinov, Alexey and Samrock, Friedemann and Matzka, J{\"u}rgen},
+  title   = {Tippers at island geomagnetic observatories constrain electrical conductivity of oceanic lithosphere and upper mantle},
   journal = {Earth, Planets and Space},
+  year    = 2019,
   volume  = 71,
   number  = 1,
   pages   = 17,
-  year    = 2019,
   publisher = {SpringerOpen},
   doi     = {10.1186/s40623-019-0991-0}
 }
@@ -1574,88 +1574,88 @@
 }
 
 @PhDThesis{2019:mulita:smoothed-adaptive-finite-element-methods,
-  title   = {{Smoothed Adaptive Finite Element Methods}},
   author  = {Mulita, Ornela},
-  url     = {http://hdl.handle.net/20.500.11767/103102},
+  title   = {{Smoothed Adaptive Finite Element Methods}},
   school  = {{Scuola Internazionale Superiore di Studi Avanzati (SISSA)}},
   year    = 2019,
   month   = sep,
+  url     = {http://hdl.handle.net/20.500.11767/103102},
   pdf     = {https://iris.sissa.it/retrieve/handle/20.500.11767/103102/107276/PhD_thesis_dissertation_Mulita.pdf}
 }
 
 @PhDThesis{2019:murphy:mathematical,
   author  = {Murphy, Laura},
   title   = {Mathematical studies of a mechanobiochemical model for 3D cell migration},
-  url     = {http://sro.sussex.ac.uk/id/eprint/83522/},
   school  = {University of Sussex},
-  year    = 2019
+  year    = 2019,
+  url     = {http://sro.sussex.ac.uk/id/eprint/83522/}
 }
 
 @Article{2019:na.bryant.ea:configurational,
-  doi     = {10.1016/j.cma.2019.112572},
-  year    = 2019,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 357,
-  pages   = 112572,
   author  = {SeonHong Na and Eric C. Bryant and WaiChing Sun},
   title   = {A configurational force for adaptive re-meshing of gradient-enhanced poromechanics problems with history-dependent variables},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
+  volume  = 357,
+  pages   = 112572,
+  month   = dec,
+  doi     = {10.1016/j.cma.2019.112572},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:neitzel.wick.ea:optimal,
-  doi     = {10.1137/18m122385x},
+  author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
+  title   = {An Optimal Control Problem Governed by a Regularized Phase-Field Fracture Propagation Model. Part {II}: The Regularization Limit},
+  journal = {{SIAM} Journal on Control and Optimization},
   year    = 2019,
-  month   = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 57,
   number  = 3,
   pages   = {1672--1690},
-  author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
-  title   = {An Optimal Control Problem Governed by a Regularized Phase-Field Fracture Propagation Model. Part {II}: The Regularization Limit},
-  journal = {{SIAM} Journal on Control and Optimization}
+  month   = jan,
+  doi     = {10.1137/18m122385x},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2019:njinju.atekwana.ea:lithospheric,
-  doi     = {10.1029/2019tc005549},
-  year    = 2019,
-  month   = oct,
-  publisher = {American Geophysical Union ({AGU})},
   author  = {Emmanuel A. Njinju and Estella A. Atekwana and D. Sarah Stamps and Mohamed G. Abdelsalam and Eliot A. Atekwana and Kevin L. Mickus and Stewart Fishwick and Folarin Kolawole and Tahiry A. Rajaonarison and Victor N. Nyalugwe},
   title   = {Lithospheric Structure of the Malawi Rift: Implications for Magma-Poor Rifting Processes},
-  journal = {Tectonics}
+  journal = {Tectonics},
+  year    = 2019,
+  month   = oct,
+  doi     = {10.1029/2019tc005549},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2019:noii.wick:phase-field,
+  author  = {Noii, Nima and Wick, Thomas},
   title   = {A phase-field description for pressurized and non-isothermal propagating fractures},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
   volume  = 351,
+  pages   = {860--890},
+  month   = jul,
   issn    = {0045-7825},
   doi     = {10.1016/j.cma.2019.03.058},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  publisher = {Elsevier BV},
-  author  = {Noii, Nima and Wick, Thomas},
-  year    = 2019,
-  month   = jul,
-  pages   = {860--890}
+  publisher = {Elsevier BV}
 }
 
 @Article{2019:odster.kvamsdal.ea:simple,
-  doi     = {10.1016/j.cma.2018.09.003},
-  year    = 2019,
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = 343,
-  pages   = {572--601},
   author  = {Lars H. Ods{\ae}ter and Trond Kvamsdal and Mats G. Larson},
   title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
+  volume  = 343,
+  pages   = {572--601},
+  month   = jan,
+  doi     = {10.1016/j.cma.2018.09.003},
+  publisher = {Elsevier {BV}}
 }
 
 @Book{2019:pelteret.steinmann:magneto-active,
+  author  = {Jean-Paul Pelteret and Paul Steinmann},
   title   = {{M}agneto-{A}ctive {P}olymers: {F}abrication, characterisation, modelling and simulation at the micro- and macro-scale},
   publisher = {Walter de Gruyter {GmbH}},
   year    = 2019,
-  author  = {Jean-Paul Pelteret and Paul Steinmann},
   isbn    = 3110419513,
   doi     = {10.1515/9783110418576},
   url     = {https://www.degruyter.com/view/product/455548}
@@ -1663,86 +1663,86 @@
 
 @Article{2019:perry-houts.karlstrom:anisotropic-viscosity-and-time-evolving-lithospheric-instabilities-due-to-aligned-igneous-intrusions,
   author  = {Perry-Houts, Jonathan and Karlstrom, Leif},
+  title   = {{Anisotropic viscosity and time-evolving lithospheric instabilities due to aligned igneous intrusions}},
   journal = {Geophysical Journal International},
+  year    = 2019,
+  volume  = 216,
   number  = 2,
   pages   = {794--802},
   publisher = {Oxford University Press},
-  title   = {{Anisotropic viscosity and time-evolving lithospheric instabilities due to aligned igneous intrusions}},
-  volume  = 216,
-  year    = 2019,
   doi     = {10.1093/gji/ggy466}
 }
 
 @Article{2019:pitton.heltai:accelerating,
-  doi     = {10.1002/nla.2211},
+  author  = {G. Pitton and L. Heltai},
+  title   = {Accelerating the iterative solution of convection-diffusion problems using singular value decomposition},
+  journal = {Numerical Linear Algebra with Applications},
   year    = 2019,
-  month   = jan,
-  publisher = {Wiley},
   volume  = 26,
   number  = 1,
   pages   = {e2211},
-  author  = {G. Pitton and L. Heltai},
-  title   = {Accelerating the iterative solution of convection-diffusion problems using singular value decomposition},
-  journal = {Numerical Linear Algebra with Applications}
+  month   = jan,
+  doi     = {10.1002/nla.2211},
+  publisher = {Wiley}
 }
 
 @Article{2019:ponce-bobadilla.carraro.ea:age-structure,
   author  = {Ponce Bobadilla, Ana Victoria and Carraro, Thomas and Byrne, Helen M. and Maini, Philip K. and Alarcon, Tomas},
   title   = {Age-structure as key to delayed logistic proliferation of scratch assays},
+  journal = {bioRxiv},
   year    = 2019,
   doi     = {10.1101/540526},
   publisher = {Cold Spring Harbor Laboratory},
-  url     = {https://www.biorxiv.org/content/early/2019/02/04/540526},
-  journal = {bioRxiv}
+  url     = {https://www.biorxiv.org/content/early/2019/02/04/540526}
 }
 
 @PhDThesis{2019:ponce-bobadilla:mathematical,
-  doi     = {10.11588/HEIDOK.00027466},
-  url     = {http://www.ub.uni-heidelberg.de/archiv/27466},
   author  = {Ponce Bobadilla, Ana Victoria},
   title   = {Mathematical Models of Cell Migration and Proliferation in Scratch Assays},
-  publisher = {Heidelberg University Library},
-  year    = 2019
+  year    = 2019,
+  doi     = {10.11588/HEIDOK.00027466},
+  url     = {http://www.ub.uni-heidelberg.de/archiv/27466},
+  publisher = {Heidelberg University Library}
 }
 
 @Article{2019:potschka:backward,
-  doi     = {10.1007/s11075-018-0539-6},
+  author  = {Andreas Potschka},
+  title   = {Backward step control for Hilbert space problems},
+  journal = {Numerical Algorithms},
   year    = 2019,
-  month   = may,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 81,
   number  = 1,
   pages   = {151--180},
-  author  = {Andreas Potschka},
-  title   = {Backward step control for Hilbert space problems},
-  journal = {Numerical Algorithms}
+  month   = may,
+  doi     = {10.1007/s11075-018-0539-6},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @PhDThesis{2019:prince:reduced-order-modeling-of-neutron-diffusion-and-transport-using-proper-generalized-decomposition,
-  title   = {{Reduced Order Modeling of Neutron Diffusion and Transport Using Proper Generalized Decomposition}},
   author  = {Prince, Zachary Merritt},
-  url     = {https://hdl.handle.net/1969.1/186463},
+  title   = {{Reduced Order Modeling of Neutron Diffusion and Transport Using Proper Generalized Decomposition}},
   school  = {{Texas A{\&}M University}},
   year    = 2019,
   month   = jul,
+  url     = {https://hdl.handle.net/1969.1/186463},
   pdf     = {https://oaktrust.library.tamu.edu/bitstream/handle/1969.1/186463/PRINCE-DISSERTATION-2019.pdf}
 }
 
 @Article{2019:qinami.bryant.ea:circumventing,
-  doi     = {10.1007/s10704-019-00349-x},
-  year    = 2019,
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
   author  = {Aurel Qinami and Eric Cushman Bryant and WaiChing Sun and Michael Kaliske},
   title   = {Circumventing mesh bias by r- and h-adaptive techniques for variational eigenfracture},
-  journal = {International Journal of Fracture}
+  journal = {International Journal of Fracture},
+  year    = 2019,
+  month   = feb,
+  doi     = {10.1007/s10704-019-00349-x},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @PhDThesis{2019:renaud:study,
-  title   = {A Study of the Tidal and Thermal Evolution of Rocky \& Icy Worlds Utilizing Advanced Rheological Models},
   author  = {Renaud, Joseph P.},
-  year    = 2019,
+  title   = {A Study of the Tidal and Thermal Evolution of Rocky \& Icy Worlds Utilizing Advanced Rheological Models},
   school  = {George Mason University},
+  year    = 2019,
   url     = {https://search.proquest.com/docview/2303307944}
 }
 
@@ -1756,127 +1756,127 @@
 }
 
 @Article{2019:robey.puckett:implementation,
-  doi     = {10.1016/j.compfluid.2019.05.015},
-  year    = 2019,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 190,
-  pages   = {217--253},
   author  = {Jonathan M. Robey and Elbridge Gerry Puckett},
   title   = {Implementation of a Volume-of-Fluid method in a finite element code with applications to thermochemical convection in a density stratified fluid in the Earth's mantle},
-  journal = {Computers {\&} Fluids}
+  journal = {Computers {\&} Fluids},
+  year    = 2019,
+  volume  = 190,
+  pages   = {217--253},
+  month   = aug,
+  doi     = {10.1016/j.compfluid.2019.05.015},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:robey:on,
   author  = {Robey, Jonathan Michael},
   title   = {On the Design, Implementation, and Use of a Volume-of-fluid Interface Tracking Algorithm for Modeling Convection and Other Processes in the Earth's Mantle},
-  url     = {https://search.proquest.com/openview/9b5da8487a6316441916616dcd4b2de4/1?pq-origsite=gscholar&cbl=51922&diss=y},
   school  = {University of California Davis},
-  year    = 2019
+  year    = 2019,
+  url     = {https://search.proquest.com/openview/9b5da8487a6316441916616dcd4b2de4/1?pq-origsite=gscholar&cbl=51922&diss=y}
 }
 
 @Article{2019:roelofs.dovizio.ea:core,
-  doi     = {10.1016/j.nucengdes.2019.110322},
-  year    = 2019,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 355,
-  pages   = 110322,
   author  = {F. Roelofs and D. Dovizio and H. Uitslag-Doolaard and D. De Santis and A. Mathur and B. Mikuz and A. Shams},
   title   = {Core thermal hydraulic {CFD} support for liquid metal reactors},
-  journal = {Nuclear Engineering and Design}
+  journal = {Nuclear Engineering and Design},
+  year    = 2019,
+  volume  = 355,
+  pages   = 110322,
+  month   = dec,
+  doi     = {10.1016/j.nucengdes.2019.110322},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:rom.muller:new,
-  doi     = {10.1016/j.triboint.2018.12.030},
-  year    = 2019,
-  month   = may,
-  publisher = {Elsevier {BV}},
-  volume  = 133,
-  pages   = {55--66},
   author  = {Michael Rom and Siegfried M\"{u}ller},
   title   = {A new model for textured surface lubrication based on a modified Reynolds equation including inertia effects},
-  journal = {Tribology International}
+  journal = {Tribology International},
+  year    = 2019,
+  volume  = 133,
+  pages   = {55--66},
+  month   = may,
+  doi     = {10.1016/j.triboint.2018.12.030},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:rudraraju.moulton.ea:computational,
-  doi     = {10.1371/journal.pcbi.1007213},
+  author  = {Shiva Rudraraju and Derek E. Moulton and R{\'{e}}gis Chirat and Alain Goriely and Krishna Garikipati},
+  title   = {A computational framework for the morpho-elastic development of molluskan shells by surface and volume growth},
+  journal = {{PLOS} Computational Biology},
   year    = 2019,
-  month   = jul,
-  publisher = {Public Library of Science ({PLoS})},
   volume  = 15,
   number  = 7,
   pages   = {e1007213},
-  author  = {Shiva Rudraraju and Derek E. Moulton and R{\'{e}}gis Chirat and Alain Goriely and Krishna Garikipati},
-  editor  = {Qing Nie},
-  title   = {A computational framework for the morpho-elastic development of molluskan shells by surface and volume growth},
-  journal = {{PLOS} Computational Biology}
+  month   = jul,
+  doi     = {10.1371/journal.pcbi.1007213},
+  publisher = {Public Library of Science ({PLoS})},
+  editor  = {Qing Nie}
 }
 
 @Article{2019:samii.kazhyken.ea:comparison,
-  doi     = {10.1007/s10915-019-01007-z},
+  author  = {Ali Samii and Kazbek Kazhyken and Craig Michoski and Clint Dawson},
+  title   = {A Comparison of the Explicit and Implicit Hybridizable Discontinuous Galerkin Methods for Nonlinear Shallow Water Equations},
+  journal = {Journal of Scientific Computing},
   year    = 2019,
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 80,
   number  = 3,
   pages   = {1936--1956},
-  author  = {Ali Samii and Kazbek Kazhyken and Craig Michoski and Clint Dawson},
-  title   = {A Comparison of the Explicit and Implicit Hybridizable Discontinuous Galerkin Methods for Nonlinear Shallow Water Equations},
-  journal = {Journal of Scientific Computing}
+  month   = jul,
+  doi     = {10.1007/s10915-019-01007-z},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:santis.shams:advanced,
-  doi     = {10.1016/j.anucene.2019.02.049},
-  year    = 2019,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 130,
-  pages   = {218--231},
   author  = {Dante De Santis and Afaque Shams},
   title   = {An advanced numerical framework for the simulation of flow induced vibration for nuclear applications},
-  journal = {Annals of Nuclear Energy}
+  journal = {Annals of Nuclear Energy},
+  year    = 2019,
+  volume  = 130,
+  pages   = {218--231},
+  month   = aug,
+  doi     = {10.1016/j.anucene.2019.02.049},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:sarna:entropy,
+  author  = {Sarna, Neeraj},
+  title   = {Entropy stable hermite approximations of the Boltzmann equation},
+  year    = 2019,
   doi     = {10.18154/RWTH-2019-05544},
   url     = {http://publications.rwth-aachen.de/record/762264},
-  author  = {Sarna, Neeraj},
   language = {en},
-  title   = {Entropy stable hermite approximations of the Boltzmann equation},
   journal = {Dissertation},
   volume  = {RWTH Aachen University},
   pages   = 2019,
-  publisher = {RWTH Aachen University},
-  year    = 2019
+  publisher = {RWTH Aachen University}
 }
 
 @MastersThesis{2019:sashko:enhancing,
-  title   = {Enhancing data locality in a matrix-free conjugate gradient method on modern computer architectures},
   author  = {Dmytro Sashko},
+  title   = {Enhancing data locality in a matrix-free conjugate gradient method on modern computer architectures},
   school  = {Technical University of Munich},
   year    = 2019
 }
 
 @PhDThesis{2019:scherff:modellierung,
-  doi     = {10.22028/D291-28367},
-  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/27748},
   author  = {Scherff, Marc Frederik},
   title   = {Modellierung der Gef\"{u}ge-Eigenschafts-Korrelation bei Dualphasenstahl},
   school  = {Universit\"{a}t des Saarlandes},
-  year    = 2019
+  year    = 2019,
+  doi     = {10.22028/D291-28367},
+  url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/27748}
 }
 
 @Article{2019:schoeder.wall.ea:exwave,
-  doi     = {10.1016/j.softx.2019.01.001},
-  year    = 2019,
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = 9,
-  pages   = {49--54},
   author  = {S. Schoeder and W.A. Wall and M. Kronbichler},
   title   = {{ExWave}: A high performance discontinuous Galerkin solver for the acoustic wave equation},
-  journal = {{SoftwareX}}
+  journal = {{SoftwareX}},
+  year    = 2019,
+  volume  = 9,
+  pages   = {49--54},
+  month   = jan,
+  doi     = {10.1016/j.softx.2019.01.001},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:schoeder:efficient,
@@ -1888,35 +1888,35 @@
 }
 
 @Article{2019:schussnig.fries:concept,
-  doi     = {10.1002/pamm.201900100},
-  year    = 2019,
-  month   = sep,
-  publisher = {Wiley},
-  volume  = 19,
-  number  = 1,
   author  = {Richard Schussnig and Thomas-Peter Fries},
   title   = {A concept for aortic dissection with fluid-structure-crack interaction},
-  journal = {{PAMM}}
+  journal = {{PAMM}},
+  year    = 2019,
+  volume  = 19,
+  number  = 1,
+  month   = sep,
+  doi     = {10.1002/pamm.201900100},
+  publisher = {Wiley}
 }
 
 @Article{2019:schutz.beneyton.ea:rational,
-  doi     = {10.1039/c9lc00149b},
+  author  = {Simon S. Sch\"{u}tz and Thomas Beneyton and Jean-Christophe Baret and Tobias M. Schneider},
+  title   = {Rational design of a high-throughput droplet sorter},
+  journal = {Lab on a Chip},
   year    = 2019,
-  publisher = {Royal Society of Chemistry ({RSC})},
   volume  = 19,
   number  = 13,
   pages   = {2220--2232},
-  author  = {Simon S. Sch\"{u}tz and Thomas Beneyton and Jean-Christophe Baret and Tobias M. Schneider},
-  title   = {Rational design of a high-throughput droplet sorter},
-  journal = {Lab on a Chip}
+  doi     = {10.1039/c9lc00149b},
+  publisher = {Royal Society of Chemistry ({RSC})}
 }
 
 @Article{2019:shiozawa.lee.ea:effect,
   author  = {Shiozawa, Sogo and Lee, Sanghyun and Wheeler, Mary F.},
   title   = {The effect of stress boundary conditions on fluid-driven fracture propagation in porous media using a phase-field modeling approach},
   journal = {International Journal for Numerical and Analytical Methods in Geomechanics},
-  volume  = 43,
   year    = 2019,
+  volume  = 43,
   number  = 6,
   pages   = {1316--1340},
   doi     = {10.1002/nag.2899},
@@ -1928,222 +1928,222 @@
   author  = {Emerson J. da Silva and Iury Igreja and Bernardo M. Rocha},
   title   = {Formula{\c{c}}{\~{a}}o H{\'{i}}brida de Elementos Finitos de Alta Ordem para a Resolu{\c{c}}{\~{a}}o de Problemas de Rea{\c{c}}{\~{a}}o-Difus{\~{a}}o},
   journal = {Mec{\'{a}}nica Computacional},
+  year    = 2019,
   volume  = 37,
   number  = 24,
   pages   = {943--952},
-  year    = 2019,
   month   = nov,
   url     = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/view/5882},
   pdf     = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/download/5882/5869}
 }
 
 @Article{2019:soldner.mergheim:thermal,
-  doi     = {10.1016/j.camwa.2018.04.036},
+  author  = {Dominic Soldner and Julia Mergheim},
+  title   = {Thermal modelling of selective beam melting processes using heterogeneous time step sizes},
+  journal = {Computers {\&} Mathematics with Applications},
   year    = 2019,
-  month   = oct,
-  publisher = {Elsevier {BV}},
   volume  = 78,
   number  = 7,
   pages   = {2183--2196},
-  author  = {Dominic Soldner and Julia Mergheim},
-  title   = {Thermal modelling of selective beam melting processes using heterogeneous time step sizes},
-  journal = {Computers {\&} Mathematics with Applications}
+  month   = oct,
+  doi     = {10.1016/j.camwa.2018.04.036},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:song.maier.ea:adaptive,
   author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
-  doi     = {10.1016/j.cma.2019.03.039},
   title   = {Adaptive finite element simulations of waveguide configurations involving parallel 2D material sheets},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   year    = 2019,
   volume  = 351,
-  pages   = {20--34}
+  pages   = {20--34},
+  doi     = {10.1016/j.cma.2019.03.039}
 }
 
 @Article{2019:steinberger.bredow.ea:widespread,
   author  = {Steinberger, Bernhard and Bredow, Eva and Lebedev, Sergei and Schaeffer, Andrew and Torsvik, Trond H},
+  title   = {Widespread volcanism in the {G}reenland-{N}orth {A}tlantic region explained by the {I}celand plume},
   journal = {Nature Geoscience},
+  year    = 2019,
+  volume  = 12,
   number  = 1,
   pages   = 61,
   publisher = {Nature Publishing Group},
-  title   = {Widespread volcanism in the {G}reenland-{N}orth {A}tlantic region explained by the {I}celand plume},
-  volume  = 12,
-  year    = 2019,
   doi     = {10.1038/s41561-018-0251-0}
 }
 
 @Article{2019:steinmann.kerganer.ea:novel,
-  doi     = {10.1016/j.jmps.2019.103680},
-  year    = 2019,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 132,
-  pages   = 103680,
   author  = {Paul Steinmann and Andreas Kerga{\ss}ner and Philipp Landkammer and Hussein M. Zbib},
   title   = {A novel continuum approach to gradient plasticity based on the complementing concepts of dislocation and disequilibrium densities},
-  journal = {Journal of the Mechanics and Physics of Solids}
+  journal = {Journal of the Mechanics and Physics of Solids},
+  year    = 2019,
+  volume  = 132,
+  pages   = 103680,
+  month   = nov,
+  doi     = {10.1016/j.jmps.2019.103680},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:sticko.kreiss:higher,
-  doi     = {10.1007/s10915-019-01004-2},
+  author  = {Simon Sticko and Gunilla Kreiss},
+  title   = {Higher Order Cut Finite Elements for the Wave Equation},
+  journal = {Journal of Scientific Computing},
   year    = 2019,
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 80,
   number  = 3,
   pages   = {1867--1887},
-  author  = {Simon Sticko and Gunilla Kreiss},
-  title   = {Higher Order Cut Finite Elements for the Wave Equation},
-  journal = {Journal of Scientific Computing}
+  month   = jul,
+  doi     = {10.1007/s10915-019-01004-2},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:stoop.waisbord.ea:disorder-induced,
-  doi     = {10.1016/j.jnnfm.2019.05.002},
-  year    = 2019,
-  month   = jun,
-  publisher = {Elsevier {BV}},
-  volume  = 268,
-  pages   = {66--74},
   author  = {Norbert Stoop and Nicolas Waisbord and Vasily Kantsler and Vili Heinonen and Jeffrey S. Guasto and J\"{o}rn Dunkel},
   title   = {Disorder-induced topological transition in porous media flow networks},
-  journal = {Journal of Non-Newtonian Fluid Mechanics}
+  journal = {Journal of Non-Newtonian Fluid Mechanics},
+  year    = 2019,
+  volume  = 268,
+  pages   = {66--74},
+  month   = jun,
+  doi     = {10.1016/j.jnnfm.2019.05.002},
+  publisher = {Elsevier {BV}}
 }
 
 @TechReport{2019:sun:integrated,
-  doi     = {10.2172/1604128},
+  author  = {WaiChing Sun},
+  title   = {An integrated multiscale experimental-numerical analysis on reconsolidation of salt-clay mixture for disposal of heat-generating waste},
   year    = 2019,
   month   = dec,
-  publisher = {Office of Scientific and Technical Information ({OSTI})},
-  author  = {WaiChing Sun},
-  title   = {An integrated multiscale experimental-numerical analysis on reconsolidation of salt-clay mixture for disposal of heat-generating waste}
+  doi     = {10.2172/1604128},
+  publisher = {Office of Scientific and Technical Information ({OSTI})}
 }
 
 @MastersThesis{2019:tahhan:topology,
   author  = {Manal Tahhan},
   title   = {Topology Optimization of Space Frames via Geometry Projection},
-  url     = {https://opencommons.uconn.edu/gs_theses/1325},
+  school  = {University of Connecticut},
   year    = 2019,
   month   = mar,
-  school  = {University of Connecticut}
+  url     = {https://opencommons.uconn.edu/gs_theses/1325}
 }
 
 @Article{2019:teichert.garikipati:machine,
-  doi     = {10.1016/j.cma.2018.10.025},
-  year    = 2019,
-  month   = feb,
-  publisher = {Elsevier {BV}},
-  volume  = 344,
-  pages   = {666--693},
   author  = {Gregory H. Teichert and Krishna Garikipati},
   title   = {Machine learning materials physics: Surrogate optimization and multi-fidelity algorithms predict precipitate morphology in an alternative to phase field dynamics},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
+  volume  = 344,
+  pages   = {666--693},
+  month   = feb,
+  doi     = {10.1016/j.cma.2018.10.025},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:uatay:multiscale,
   author  = {Uatay, Aydar},
   title   = {Multiscale mathematical modeling of cell migration: from single cells to populations},
-  url     = {https://kluedo.ub.uni-kl.de/frontdoor/index/index/docId/5625},
   school  = {Technische Universit{\"a}t Kaiserslautern},
-  year    = 2019
+  year    = 2019,
+  url     = {https://kluedo.ub.uni-kl.de/frontdoor/index/index/docId/5625}
 }
 
 @Article{2019:uluocak.pysklywec.ea:multi-dimensional,
-  doi     = {10.1029/2019gc008277},
-  year    = 2019,
-  month   = jun,
-  publisher = {American Geophysical Union ({AGU})},
   author  = {E. {\c{S}}eng\"{u}l Uluocak and R.N. Pysklywec and O.H. G\"{o}{\u{g}}\"{u}{\c{s}} and E.U. Ulugergerli},
   title   = {Multi-Dimensional Geodynamic Modeling in the Southeast Carpathians: Upper Mantle Flow Induced Surface Topography Anomalies},
-  journal = {Geochemistry, Geophysics, Geosystems}
+  journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2019,
+  month   = jun,
+  doi     = {10.1029/2019gc008277},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @PhDThesis{2019:van-liedekerke:quantitative-modeling-of-cell-and-tissue-mechanics-with-agent-based-models,
-  title   = {{Quantitative modeling of cell and tissue mechanics with agent-based models}},
   author  = {Van Liedekerke, Paul},
-  url     = {https://hal.inria.fr/tel-02064216},
+  title   = {{Quantitative modeling of cell and tissue mechanics with agent-based models}},
   school  = {{Inria Paris, Sobonne Universit{\'e}}},
   year    = 2019,
-  month   = mar,
   type    = {Habilitation {\`a} diriger des recherches},
+  month   = mar,
+  url     = {https://hal.inria.fr/tel-02064216},
   pdf     = {https://hal.inria.fr/tel-02064216/file/HDR_pvl.pdf},
   hal_id  = {tel-02064216},
   hal_version = {v1}
 }
 
 @Article{2019:vassaux.richardson.ea:heterogeneous,
-  doi     = {10.1098/rsta.2018.0150},
+  author  = {M. Vassaux and R. A. Richardson and P. V. Coveney},
+  title   = {The heterogeneous multiscale method applied to inelastic polymer mechanics},
+  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
   year    = 2019,
-  month   = feb,
-  publisher = {The Royal Society},
   volume  = 377,
   number  = 2142,
   pages   = 20180150,
-  author  = {M. Vassaux and R. A. Richardson and P. V. Coveney},
-  title   = {The heterogeneous multiscale method applied to inelastic polymer mechanics},
-  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences}
+  month   = feb,
+  doi     = {10.1098/rsta.2018.0150},
+  publisher = {The Royal Society}
 }
 
 @Article{2019:vassaux.sinclair.ea:role,
-  doi     = {10.1002/adts.201800168},
+  author  = {Maxime Vassaux and Robert C. Sinclair and Robin A. Richardson and James L. Suter and Peter V. Coveney},
+  title   = {The Role of Graphene in Enhancing the Material Properties of Thermosetting Polymers},
+  journal = {Advanced Theory and Simulations},
   year    = 2019,
-  month   = feb,
-  publisher = {Wiley},
   volume  = 2,
   number  = 5,
   pages   = 1800168,
-  author  = {Maxime Vassaux and Robert C. Sinclair and Robin A. Richardson and James L. Suter and Peter V. Coveney},
-  title   = {The Role of Graphene in Enhancing the Material Properties of Thermosetting Polymers},
-  journal = {Advanced Theory and Simulations}
+  month   = feb,
+  doi     = {10.1002/adts.201800168},
+  publisher = {Wiley}
 }
 
 @Article{2019:walker.kramer.ea:accelerating,
-  doi     = {10.1002/cpe.5265},
-  year    = 2019,
-  month   = apr,
-  publisher = {Wiley},
-  pages   = {e5265},
   author  = {David W. Walker and Stephan C. Kramer and Fabian R. A. Biebl and Paul D. Ledger and Malcolm Brown},
   title   = {Accelerating magnetic induction tomography-based imaging through heterogeneous parallel computing},
-  journal = {Concurrency and Computation: Practice and Experience}
+  journal = {Concurrency and Computation: Practice and Experience},
+  year    = 2019,
+  pages   = {e5265},
+  month   = apr,
+  doi     = {10.1002/cpe.5265},
+  publisher = {Wiley}
 }
 
 @InCollection{2019:wang.harper.ea:deal,
-  doi     = {10.1007/978-3-030-22747-0_37},
-  year    = 2019,
-  publisher = {Springer International Publishing},
-  pages   = {495--509},
   author  = {Zhuoran Wang and Graham Harper and Patrick O'Leary and Jiangguo Liu and Simon Tavener},
   title   = {deal.{II} Implementation of a Weak Galerkin Finite Element Solver for Darcy Flow},
-  booktitle = {Lecture Notes in Computer Science}
+  booktitle = {Lecture Notes in Computer Science},
+  publisher = {Springer International Publishing},
+  year    = 2019,
+  pages   = {495--509},
+  doi     = {10.1007/978-3-030-22747-0_37}
 }
 
 @PhDThesis{2019:wei:numerical,
   author  = {Wei, Peng},
   title   = {Numerical Approximation of Time Dependent Fractional Diffusion With Drift: Numerical Analysis and Applications to Surface Quasi-Geostrophic Dynamics and Electroconvection},
-  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/186239},
   school  = {Texas A{\&}M University},
-  year    = 2019
+  year    = 2019,
+  url     = {https://oaktrust.library.tamu.edu/handle/1969.1/186239}
 }
 
 @InProceedings{2019:wheeler.srinivasan.ea:unconventional,
-  doi     = {10.2118/193830-ms},
-  year    = 2019,
-  publisher = {Society of Petroleum Engineers},
   author  = {Mary F. Wheeler and Sanjay Srinivasan and Sanghyun Lee and Manik Singh},
   title   = {Unconventional Reservoir Management Modeling Coupling Diffusive Zone/Phase Field Fracture Modeling and Fracture Probability Maps},
-  booktitle = {{SPE} Reservoir Simulation Conference}
+  booktitle = {{SPE} Reservoir Simulation Conference},
+  year    = 2019,
+  publisher = {Society of Petroleum Engineers},
+  doi     = {10.2118/193830-ms}
 }
 
 @Article{2019:white.castelletto.ea:two-stage,
-  doi     = {10.1016/j.cma.2019.112575},
-  year    = 2019,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 357,
-  pages   = 112575,
   author  = {Joshua A. White and Nicola Castelletto and Sergey Klevtsov and Quan M. Bui and Daniel Osei-Kuffuor and Hamdi A. Tchelepi},
   title   = {A two-stage preconditioner for multiphase poromechanics in reservoir simulation},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
+  volume  = 357,
+  pages   = 112575,
+  month   = dec,
+  doi     = {10.1016/j.cma.2019.112575},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2019:wichmann:performance,
@@ -2155,59 +2155,59 @@
 }
 
 @Article{2019:wick.wollner:on,
-  doi     = {10.1007/s00021-019-0439-0},
-  year    = 2019,
-  month   = jun,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 21,
-  number  = 3,
   author  = {Thomas Wick and Winnifried Wollner},
   title   = {On the Differentiability of Fluid-Structure Interaction Problems with Respect to the Problem Data},
-  journal = {Journal of Mathematical Fluid Mechanics}
+  journal = {Journal of Mathematical Fluid Mechanics},
+  year    = 2019,
+  volume  = 21,
+  number  = 3,
+  month   = jun,
+  doi     = {10.1007/s00021-019-0439-0},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2019:yaghoobi.ganesan.ea:prisms-plasticity,
-  doi     = {10.1016/j.commatsci.2019.109078},
-  year    = 2019,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 169,
-  pages   = 109078,
   author  = {Mohammadreza Yaghoobi and Sriram Ganesan and Srihari Sundar and Aaditya Lakshmanan and Shiva Rudraraju and John E. Allison and Veera Sundararaghavan},
   title   = {{PRISMS}-Plasticity: An open-source crystal plasticity finite element software},
-  journal = {Computational Materials Science}
+  journal = {Computational Materials Science},
+  year    = 2019,
+  volume  = 169,
+  pages   = 109078,
+  month   = nov,
+  doi     = {10.1016/j.commatsci.2019.109078},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:zhang.choo.ea:on,
-  doi     = {10.1016/j.cma.2019.04.037},
-  year    = 2019,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 353,
-  pages   = {570--592},
   author  = {Qi Zhang and Jinhyun Choo and Ronaldo I. Borja},
   title   = {On the preferential flow patterns induced by transverse isotropy and non-Darcy flow in double porosity media},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2019,
+  volume  = 353,
+  pages   = {570--592},
+  month   = aug,
+  doi     = {10.1016/j.cma.2019.04.037},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2019:zhang.yue:high-order,
+  author  = {Jiaqi Zhang and Pengtao Yue},
   title   = {A high-order and interface-preserving discontinuous Galerkin method for level-set reinitialization},
   journal = {Journal of Computational Physics},
+  year    = 2019,
   volume  = 378,
   pages   = {634--664},
-  year    = 2019,
   issn    = {0021-9991},
   doi     = {10.1016/j.jcp.2018.11.029},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0021999118307733},
-  author  = {Jiaqi Zhang and Pengtao Yue}
+  url     = {http://www.sciencedirect.com/science/article/pii/S0021999118307733}
 }
 
 @PhDThesis{2019:zhang:topology,
   author  = {Zhang, Shanglong},
   title   = {Topology Optimization with Geometric Primitives},
-  url     = {https://www.researchgate.net/profile/Shanglong_Zhang/publication/330873130_Topology_Optimization_with_Geometric_Primitives/links/5e62bf364585153fb3c818d9/Topology-Optimization-with-Geometric-Primitives.pdf},
   school  = {University of Connecticut},
-  year    = 2019
+  year    = 2019,
+  url     = {https://www.researchgate.net/profile/Shanglong_Zhang/publication/330873130_Topology_Optimization_with_Geometric_Primitives/links/5e62bf364585153fb3c818d9/Topology-Optimization-with-Geometric-Primitives.pdf}
 }
 
 @Article{2019:zhao.heister:preconditioner,
@@ -2219,22 +2219,22 @@
 }
 
 @Article{2019:zhao.li.ea:linear,
-  doi     = {10.1016/j.aml.2019.05.029},
-  year    = 2019,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 98,
-  pages   = {142--148},
   author  = {Yucan Zhao and Jun Li and Jia Zhao and Qi Wang},
   title   = {A linear energy and entropy-production-rate preserving scheme for thermodynamically consistent crystal growth models},
-  journal = {Applied Mathematics Letters}
+  journal = {Applied Mathematics Letters},
+  year    = 2019,
+  volume  = 98,
+  pages   = {142--148},
+  month   = dec,
+  doi     = {10.1016/j.aml.2019.05.029},
+  publisher = {Elsevier {BV}}
 }
 
 @MastersThesis{2019:zimmerman:modeling,
-  title   = {Modeling and simulation of heat source trajectories through phase-change materials},
   author  = {Alexander Gary Zimmerman},
-  year    = 2019,
+  title   = {Modeling and simulation of heat source trajectories through phase-change materials},
   school  = {RWTH Aachen},
+  year    = 2019,
   url     = {https://arxiv.org/abs/1909.08882}
 }
 

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -2,71 +2,71 @@
 
 @Article{2020:alzetta.heltai:multiscale,
   author  = {Giovanni Alzetta and Luca Heltai},
-  journal = {Computers {\&} Structures},
-  pages   = 106334,
   title   = {Multiscale modeling of fiber reinforced materials via non-matching immersed methods},
-  volume  = 239,
+  journal = {Computers {\&} Structures},
   year    = 2020,
+  volume  = 239,
+  pages   = 106334,
   doi     = {10.1016/j.compstruc.2020.106334}
 }
 
 @Article{2020:anzt.cojean.ea:ginkgo,
-  doi     = {10.21105/joss.02260},
+  author  = {Hartwig Anzt and Terry Cojean and Yen-Chen Chen and Goran Flegar and Fritz G\"{o}bel and Thomas Gr\"{u}tzmacher and Pratik Nayak and Tobias Ribizel and Yu-Hsiang Tsai},
+  title   = {Ginkgo: A high performance numerical linear algebra library},
+  journal = {Journal of Open Source Software},
   year    = 2020,
-  month   = aug,
-  publisher = {The Open Journal},
   volume  = 5,
   number  = 52,
   pages   = 2260,
-  author  = {Hartwig Anzt and Terry Cojean and Yen-Chen Chen and Goran Flegar and Fritz G\"{o}bel and Thomas Gr\"{u}tzmacher and Pratik Nayak and Tobias Ribizel and Yu-Hsiang Tsai},
-  title   = {Ginkgo: A high performance numerical linear algebra library},
-  journal = {Journal of Open Source Software}
+  month   = aug,
+  doi     = {10.21105/joss.02260},
+  publisher = {The Open Journal}
 }
 
 @Article{2020:araujo.campos.ea:computation,
   author  = {Ara\'{u}jo, Juan C. and Campos, Carmen and Engstr\"{o}m, Christian and Roman, Jose E.},
   title   = {Computation of scattering resonances in absorptive and dispersive media with applications to metal-dielectric nano-structures},
   journal = {Journal of Computational Physics},
+  year    = 2020,
   volume  = 407,
   pages   = 109220,
-  year    = 2020,
   issn    = {0021-9991},
   doi     = {10.1016/j.jcp.2019.109220},
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999119309258}
 }
 
 @Article{2020:arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.2},
   author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Thomas C. Clevenger and Marc Fehling and Alexander V. Grayver and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Reza Rastak and Ignacio Thomas and Bruno Turcksin and Zhuoran Wang and David Wells},
+  title   = {The \texttt{deal.II} Library, Version 9.2},
   journal = {Journal of Numerical Mathematics},
-  publisher = {De Gruyter},
   year    = 2020,
   volume  = 28,
   number  = 3,
   pages   = {131--146},
+  publisher = {De Gruyter},
   doi     = {10.1515/jnma-2020-0043},
   url     = {https://dealii.org/deal92-preprint.pdf}
 }
 
 @InProceedings{2020:arndt.fehn.ea:exadg,
   author  = {Arndt, Daniel and Fehn, Niklas and Kanschat, Guido and Kormann, Katharina and Kronbichler, Martin and Munch, Peter and Wall, Wolfgang A. and Witte, Julius},
-  editor  = {Bungartz, Hans-Joachim and Reiz, Severin and Uekermann, Benjamin and Neumann, Philipp and Nagel, Wolfgang E.},
   title   = {Exa{DG}: {H}igh-{O}rder {D}iscontinuous {G}alerkin for the {E}xa-{S}cale},
+  editor  = {Bungartz, Hans-Joachim and Reiz, Severin and Uekermann, Benjamin and Neumann, Philipp and Nagel, Wolfgang E.},
   booktitle = {Software for Exascale Computing - SPPEXA 2016-2019},
   year    = 2020,
-  publisher = {Springer International Publishing},
-  address = {Cham},
   pages   = {189--224},
+  address = {Cham},
+  publisher = {Springer International Publishing},
   isbn    = {978-3-030-47956-5},
   doi     = {10.1007/978-3-030-47956-5_8}
 }
 
 @Article{2020:arndt.kanschat:differentiable,
-  title   = {A Differentiable Mapping of Mesh Cells Based on Finite Elements on Quadrilateral and Hexahedral Meshes},
   author  = {Arndt, Daniel and Kanschat, Guido},
+  title   = {A Differentiable Mapping of Mesh Cells Based on Finite Elements on Quadrilateral and Hexahedral Meshes},
   journal = {Computational Methods in Applied Mathematics},
-  volume  = 1,
   year    = 2020,
+  volume  = 1,
   publisher = {De Gruyter},
   doi     = {10.1515/cmam-2020-0159}
 }
@@ -85,220 +85,220 @@
 }
 
 @Article{2020:badia.martin.ea:generic,
-  doi     = {10.1137/20m1328786},
+  author  = {Santiago Badia and Alberto F. Mart{\'{i}}n and Eric Neiva and Francesc Verdugo},
+  title   = {A Generic Finite Element Framework on Parallel Tree-Based Adaptive Meshes},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2020,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 42,
   number  = 6,
   pages   = {C436--C468},
-  author  = {Santiago Badia and Alberto F. Mart{\'{i}}n and Eric Neiva and Francesc Verdugo},
-  title   = {A Generic Finite Element Framework on Parallel Tree-Based Adaptive Meshes},
-  journal = {{SIAM} Journal on Scientific Computing}
+  doi     = {10.1137/20m1328786},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2020:benbow.kawama.ea:coupled,
-  doi     = {10.3390/cryst10090767},
+  author  = {Steven J. Benbow and Daisuke Kawama and Hiroyasu Takase and Hiroyuki Shimizu and Chie Oda and Fumio Hirano and Yusuke Takayama and Morihiro Mihara and Akira Honda},
+  title   = {A Coupled Modeling Simulator for Near-Field Processes in Cement Engineered Barrier Systems for Radioactive Waste Disposal},
+  journal = {Crystals},
   year    = 2020,
-  month   = aug,
-  publisher = {{MDPI} {AG}},
   volume  = 10,
   number  = 9,
   pages   = 767,
-  author  = {Steven J. Benbow and Daisuke Kawama and Hiroyasu Takase and Hiroyuki Shimizu and Chie Oda and Fumio Hirano and Yusuke Takayama and Morihiro Mihara and Akira Honda},
-  title   = {A Coupled Modeling Simulator for Near-Field Processes in Cement Engineered Barrier Systems for Radioactive Waste Disposal},
-  journal = {Crystals}
+  month   = aug,
+  doi     = {10.3390/cryst10090767},
+  publisher = {{MDPI} {AG}}
 }
 
 @Article{2020:blais.barbeau.ea:lethe,
-  doi     = {10.1016/j.softx.2020.100579},
-  year    = 2020,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 12,
-  pages   = 100579,
   author  = {Bruno Blais and Lucka Barbeau and Val{\'{e}}rie Bibeau and Simon Gauvin and Toni El Geitani and Shahab Golshan and Rajeshwari Kamble and Ghazaleh Mirakhori and Jamal Chaouki},
   title   = {Lethe: An open-source parallel high-order adaptative {CFD} solver for incompressible flows},
-  journal = {{SoftwareX}}
+  journal = {{SoftwareX}},
+  year    = 2020,
+  volume  = 12,
+  pages   = 100579,
+  month   = jul,
+  doi     = {10.1016/j.softx.2020.100579},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:brun.wick.ea:iterative,
-  doi     = {10.1016/j.cma.2019.112752},
-  year    = 2020,
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = 361,
-  pages   = 112752,
   author  = {Mats Kirkes{\ae}ther Brun and Thomas Wick and Inga Berre and Jan Martin Nordbotten and Florin Adrian Radu},
   title   = {An iterative staggered scheme for phase field brittle fracture propagation with stabilizing parameters},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2020,
+  volume  = 361,
+  pages   = 112752,
+  month   = apr,
+  doi     = {10.1016/j.cma.2019.112752},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:bruna-rosso.mergheim.ea:finite,
-  doi     = {10.1177/0954406220943225},
-  year    = 2020,
-  month   = aug,
-  publisher = {{SAGE} Publications},
-  pages   = 095440622094322,
   author  = {Claire Bruna-Rosso and Julia Mergheim and Barbara Previtali},
   title   = {Finite element modeling of residual stress and geometrical error formations in selective laser melting of metals},
-  journal = {Proceedings of the Institution of Mechanical Engineers, Part C: Journal of Mechanical Engineering Science}
+  journal = {Proceedings of the Institution of Mechanical Engineers, Part C: Journal of Mechanical Engineering Science},
+  year    = 2020,
+  pages   = 095440622094322,
+  month   = aug,
+  doi     = {10.1177/0954406220943225},
+  publisher = {{SAGE} Publications}
 }
 
 @Article{2020:cangiani.georgoulis.ea:posteriori,
-  doi     = {10.1007/s10915-020-01130-2},
-  year    = 2020,
-  month   = jan,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 82,
-  number  = 2,
   author  = {Andrea Cangiani and Emmanuil H. Georgoulis and Mohammad Sabawi},
   title   = {A Posteriori Error Analysis for Implicit--Explicit hp-Discontinuous Galerkin Timestepping Methods for Semilinear Parabolic Problems},
-  journal = {Journal of Scientific Computing}
+  journal = {Journal of Scientific Computing},
+  year    = 2020,
+  volume  = 82,
+  number  = 2,
+  month   = jan,
+  doi     = {10.1007/s10915-020-01130-2},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2020:choi.lee:optimal,
-  doi     = {10.1016/j.apnum.2019.09.010},
-  year    = 2020,
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = 150,
-  pages   = {76--104},
   author  = {Woocheol Choi and Sanghyun Lee},
   title   = {Optimal error estimate of elliptic problems with Dirac sources for discontinuous and enriched Galerkin methods},
-  journal = {Applied Numerical Mathematics}
+  journal = {Applied Numerical Mathematics},
+  year    = 2020,
+  volume  = 150,
+  pages   = {76--104},
+  month   = apr,
+  doi     = {10.1016/j.apnum.2019.09.010},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:citron.lourenco.ea:effects,
-  title   = {Effects of Heat-Producing Elements on the Stability of Deep Mantle Thermochemical Piles},
   author  = {Citron, Robert I. and Louren{\c{c}}o, Diogo L. and Wilson, Alfred J. and Grima, Antoniette G. and Wipperfurth, Scott A. and Rudolph, Maxwell L. and Cottaar, Sanne and Mont{\'e}si, Laurent G. J.},
+  title   = {Effects of Heat-Producing Elements on the Stability of Deep Mantle Thermochemical Piles},
   journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2020,
   volume  = 21,
   number  = 4,
   pages   = {e2019GC008895},
-  year    = 2020,
   publisher = {Wiley Online Library},
   doi     = {10.1029/2019GC008895}
 }
 
 @Article{2020:cobb.dommain.ea:carbon,
-  doi     = {10.1088/1748-9326/aba867},
+  author  = {Alexander R. Cobb and Ren{\'{e}} Dommain and Fangyi Tan and Naomi Hwee En Heng and Charles F Harvey},
+  title   = {Carbon storage capacity of tropical peatlands in natural and artificial drainage networks},
+  journal = {Environmental Research Letters},
   year    = 2020,
-  month   = oct,
-  publisher = {{IOP} Publishing},
   volume  = 15,
   number  = 11,
   pages   = 114009,
-  author  = {Alexander R. Cobb and Ren{\'{e}} Dommain and Fangyi Tan and Naomi Hwee En Heng and Charles F Harvey},
-  title   = {Carbon storage capacity of tropical peatlands in natural and artificial drainage networks},
-  journal = {Environmental Research Letters}
+  month   = oct,
+  doi     = {10.1088/1748-9326/aba867},
+  publisher = {{IOP} Publishing}
 }
 
 @Article{2020:comellas.budday.ea:modeling,
-  doi     = {10.1016/J.CMA.2020.113128},
-  issn    = {0045-7825},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  month   = sep,
-  pages   = 113128,
-  publisher = {North-Holland},
   author  = {Ester Comellas and Silvia Budday and Jean-Paul Pelteret and Gerhard A. Holzapfel and Paul Steinmann},
   title   = {Modeling the porous and viscous responses of human brain tissue behavior},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2020,
   volume  = 369,
-  year    = 2020
+  pages   = 113128,
+  month   = sep,
+  doi     = {10.1016/J.CMA.2020.113128},
+  issn    = {0045-7825},
+  publisher = {North-Holland}
 }
 
 @Article{2020:davydov.kronbichler:algorithms,
-  doi     = {10.1145/3399736},
-  title   = {Algorithms and data structures for matrix-free finite element operators with MPI-parallel sparse multi-vectors},
   author  = {Davydov, Denis and Kronbichler, Martin},
+  title   = {Algorithms and data structures for matrix-free finite element operators with MPI-parallel sparse multi-vectors},
   journal = {ACM Transactions on Parallel Computing},
+  year    = 2020,
   volume  = 7,
   number  = 3,
   pages   = {20:1--20:30},
-  year    = 2020,
-  month   = jun
+  month   = jun,
+  doi     = {10.1145/3399736}
 }
 
 @Article{2020:davydov.pelteret.ea:matrix-free,
-  doi     = {10.1002/nme.6336},
+  author  = {Denis Davydov and Jean-Paul Pelteret and Daniel Arndt and Martin Kronbichler and Paul Steinmann},
+  title   = {A matrix-free approach for finite-strain hyperelastic problems using geometric multigrid},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2020,
-  month   = jul,
-  publisher = {Wiley},
   volume  = 121,
   number  = 13,
   pages   = {2874--2895},
-  author  = {Denis Davydov and Jean-Paul Pelteret and Daniel Arndt and Martin Kronbichler and Paul Steinmann},
-  title   = {A matrix-free approach for finite-strain hyperelastic problems using geometric multigrid},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = jul,
+  doi     = {10.1002/nme.6336},
+  publisher = {Wiley}
 }
 
 @Article{2020:dewitt.rudraraju.ea:prisms-pf,
-  doi     = {10.1038/s41524-020-0298-5},
-  year    = 2020,
-  month   = mar,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 6,
-  number  = 1,
   author  = {Stephen DeWitt and Shiva Rudraraju and David Montiel and W. Beck Andrews and Katsuyo Thornton},
   title   = {{PRISMS}-{PF}: A general framework for phase-field modeling with a matrix-free finite element method},
-  journal = {npj Computational Materials}
+  journal = {npj Computational Materials},
+  year    = 2020,
+  volume  = 6,
+  number  = 1,
+  month   = mar,
+  doi     = {10.1038/s41524-020-0298-5},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @InCollection{2020:endtmayer.langer.ea:hierarchical,
-  doi     = {10.1007/978-3-030-55874-1_35},
-  year    = 2020,
-  month   = aug,
-  publisher = {Springer International Publishing},
-  pages   = {363--372},
   author  = {B. Endtmayer and U. Langer and J. P. Thiele and T. Wick},
   title   = {Hierarchical {DWR} Error Estimates for the Navier-Stokes Equations: h and p Enrichment},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
+  booktitle = {Lecture Notes in Computational Science and Engineering},
+  publisher = {Springer International Publishing},
+  year    = 2020,
+  pages   = {363--372},
+  month   = aug,
+  doi     = {10.1007/978-3-030-55874-1_35}
 }
 
 @Article{2020:endtmayer.langer.ea:multigoal-oriented,
+  author  = {B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner},
   title   = {Multigoal-oriented optimal control problems with nonlinear PDE constraints},
   journal = {Computers {\&} Mathematics with Applications},
+  year    = 2020,
   volume  = 79,
   number  = 10,
   pages   = {3001--3026},
-  year    = 2020,
   issn    = {0898-1221},
-  doi     = {10.1016/j.camwa.2020.01.005},
-  author  = {B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner}
+  doi     = {10.1016/j.camwa.2020.01.005}
 }
 
 @Article{2020:endtmayer.langer.ea:two-side,
-  doi     = {10.1137/18m1227275},
+  author  = {B. Endtmayer and U. Langer and T. Wick},
+  title   = {Two-Side a Posteriori Error Estimates for the Dual-Weighted Residual Method},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2020,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 42,
   number  = 1,
   pages   = {A371--A394},
-  author  = {B. Endtmayer and U. Langer and T. Wick},
-  title   = {Two-Side a Posteriori Error Estimates for the Dual-Weighted Residual Method},
-  journal = {{SIAM} Journal on Scientific Computing}
+  doi     = {10.1137/18m1227275},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @InCollection{2020:engwer.pop.ea:dynamic,
-  doi     = {10.1007/978-3-030-55874-1_117},
-  year    = 2020,
-  month   = aug,
-  publisher = {Springer International Publishing},
-  pages   = {1177--1184},
   author  = {Christian Engwer and Iuliu Sorin Pop and Thomas Wick},
   title   = {Dynamic and Weighted Stabilizations of the L-scheme Applied to a Phase-Field Model for Fracture Propagation},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
+  booktitle = {Lecture Notes in Computational Science and Engineering},
+  publisher = {Springer International Publishing},
+  year    = 2020,
+  pages   = {1177--1184},
+  month   = aug,
+  doi     = {10.1007/978-3-030-55874-1_117}
 }
 
 @Article{2020:farangitakis.heron.ea:impact,
-  doi     = {10.1016/j.epsl.2020.116277},
-  year    = 2020,
-  month   = jul,
-  publisher = {Elsevier {BV}},
-  volume  = 541,
-  pages   = 116277,
   author  = {G. P. Farangitakis and P. J. Heron and K. J. W. McCaffrey and J. van Hunen and L. M. Kalnins},
   title   = {The impact of oblique inheritance and changes in relative plate motion on the development of rift-transform systems},
-  journal = {Earth and Planetary Science Letters}
+  journal = {Earth and Planetary Science Letters},
+  year    = 2020,
+  volume  = 541,
+  pages   = 116277,
+  month   = jul,
+  doi     = {10.1016/j.epsl.2020.116277},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2020:fehling:algorithms,
@@ -306,8 +306,8 @@
   title   = {Algorithms for massively parallel generic $hp$-adaptive finite element methods},
   school  = {Bergische Universit{\"a}t Wuppertal},
   year    = 2020,
-  url     = {https://juser.fz-juelich.de/record/878206},
   address = {J{\"u}lich},
+  url     = {https://juser.fz-juelich.de/record/878206},
   publisher = {Forschungszentrum J{\"u}lich GmbH Zentralbibliothek, Verlag},
   reportid = {FZJ-2020-02694},
   isbn    = {978-3-95806-486-7},
@@ -318,53 +318,53 @@
 }
 
 @Article{2020:fehn.munch.ea:hybrid,
-  doi     = {10.1016/j.jcp.2020.109538},
-  year    = 2020,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  volume  = 415,
-  pages   = 109538,
   author  = {Niklas Fehn and Peter Munch and Wolfgang A. Wall and Martin Kronbichler},
   title   = {Hybrid multigrid methods for high-order discontinuous {G}alerkin discretizations},
-  journal = {Journal of Computational Physics}
+  journal = {Journal of Computational Physics},
+  year    = 2020,
+  volume  = 415,
+  pages   = 109538,
+  month   = aug,
+  doi     = {10.1016/j.jcp.2020.109538},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:finlay.kloss.ea:chaos-7,
-  title   = {The CHAOS-7 geomagnetic field model and observed changes in the South Atlantic Anomaly},
   author  = {Finlay, Christopher C and Kloss, Clemens and Olsen, Nils and Hammer, Magnus D and T{\o}ffner-Clausen, Lars and Grayver, Alexander and Kuvshinov, Alexey},
+  title   = {The CHAOS-7 geomagnetic field model and observed changes in the South Atlantic Anomaly},
   journal = {Earth, Planets and Space},
+  year    = 2020,
   volume  = 72,
   number  = 1,
   pages   = {1--31},
-  year    = 2020,
   publisher = {SpringerOpen},
   doi     = {10.1186/s40623-020-01252-9}
 }
 
 @Article{2020:fischer.min.ea:scalability,
-  doi     = {10.1177/1094342020915762},
+  author  = {Paul Fischer and Misun Min and Thilina Rathnayake and Som Dutta and Tzanio Kolev and Veselin Dobrev and Jean-Sylvain Camier and Martin Kronbichler and Tim Warburton and Kasia {\'{S}}wirydowicz and Jed Brown},
+  title   = {Scalability of high-performance {PDE} solvers},
+  journal = {The International Journal of High Performance Computing Applications},
   year    = 2020,
-  month   = jun,
-  publisher = {{SAGE} Publications},
   volume  = 34,
   number  = 5,
   pages   = {562--586},
-  author  = {Paul Fischer and Misun Min and Thilina Rathnayake and Som Dutta and Tzanio Kolev and Veselin Dobrev and Jean-Sylvain Camier and Martin Kronbichler and Tim Warburton and Kasia {\'{S}}wirydowicz and Jed Brown},
-  title   = {Scalability of high-performance {PDE} solvers},
-  journal = {The International Journal of High Performance Computing Applications}
+  month   = jun,
+  doi     = {10.1177/1094342020915762},
+  publisher = {{SAGE} Publications}
 }
 
 @Article{2020:gassmoller.dannberg.ea:on,
-  doi     = {10.1093/gji/ggaa078},
+  author  = {Rene Gassm\"{o}ller and Juliane Dannberg and Wolfgang Bangerth and Timo Heister and Robert Myhill},
+  title   = {On formulations of compressible mantle convection},
+  journal = {Geophysical Journal International},
   year    = 2020,
-  month   = feb,
-  publisher = {Oxford University Press ({OUP})},
   volume  = 221,
   number  = 2,
   pages   = {1264--1280},
-  author  = {Rene Gassm\"{o}ller and Juliane Dannberg and Wolfgang Bangerth and Timo Heister and Robert Myhill},
-  title   = {On formulations of compressible mantle convection},
-  journal = {Geophysical Journal International}
+  month   = feb,
+  doi     = {10.1093/gji/ggaa078},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @Article{2020:glerum.brune.ea:victoria,
@@ -380,145 +380,145 @@
 }
 
 @Article{2020:grieshaber.mcbride.ea:convergence,
-  doi     = {10.1016/j.cma.2020.113233},
-  year    = 2020,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 370,
-  pages   = 113233,
   author  = {Beverley J. Grieshaber and Andrew T. McBride and B. Daya Reddy},
   title   = {Convergence in the incompressible limit of new discontinuous Galerkin methods with general quadrilateral and hexahedral elements},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2020,
+  volume  = 370,
+  pages   = 113233,
+  month   = oct,
+  doi     = {10.1016/j.cma.2020.113233},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:gurkan.sticko.ea:stabilized,
+  author  = {G\"{u}rkan, Ceren and Sticko, Simon and Massing, Andr\'{e}},
   title   = {Stabilized {Cut} {Discontinuous} {Galerkin} {Methods} for {Advection}-{Reaction} {Problems}},
+  journal = {SIAM Journal on Scientific Computing},
+  year    = 2020,
   volume  = 42,
+  number  = 5,
+  pages   = {A2620--A2654},
+  month   = sep,
   issn    = {1064-8275, 1095-7197},
   url     = {https://epubs.siam.org/doi/10.1137/18M1206461},
   doi     = {10.1137/18M1206461},
-  language = {en},
-  number  = 5,
-  journal = {SIAM Journal on Scientific Computing},
-  author  = {G\"{u}rkan, Ceren and Sticko, Simon and Massing, Andr\'{e}},
-  month   = sep,
-  year    = 2020,
-  pages   = {A2620--A2654}
+  language = {en}
 }
 
 @Article{2020:heister.wick:pfm-cracks,
+  author  = {Timo Heister and Thomas Wick},
   title   = {pfm-cracks: A parallel-adaptive framework for phase-field fracture propagation},
   journal = {Software Impacts},
+  year    = 2020,
   volume  = 6,
   pages   = 100045,
-  year    = 2020,
   issn    = {2665-9638},
   doi     = {10.1016/j.simpa.2020.100045},
-  url     = {http://www.sciencedirect.com/science/article/pii/S2665963820300361},
-  author  = {Timo Heister and Thomas Wick}
+  url     = {http://www.sciencedirect.com/science/article/pii/S2665963820300361}
 }
 
 @Article{2020:heltai.lei:priori,
   author  = {Luca Heltai and Wenyu Lei},
+  title   = {A priori error estimates of regularized elliptic problems},
   journal = {Numerische Mathematik},
+  year    = 2020,
+  volume  = 146,
   number  = 3,
   pages   = {571--596},
-  title   = {A priori error estimates of regularized elliptic problems},
-  volume  = 146,
-  year    = 2020,
   doi     = {10.1007/s00211-020-01152-w}
 }
 
 @Article{2020:heron.murphy.ea:pannotias,
   author  = {Heron, Philip J. and Murphy, J. Brendan and Nance, R. Damian and Pysklywec, R. N.},
   title   = {Pannotia{\textquoteright}s mantle signature: the quest for supercontinent identification},
+  journal = {Geological Society, London, Special Publications},
+  year    = 2020,
   volume  = 503,
   elocation-id = {SP503-2020-7},
-  year    = 2020,
   doi     = {10.1144/SP503-2020-7},
   publisher = {Geological Society of London},
   issn    = {0305-8719},
-  url     = {https://sp.lyellcollection.org/content/early/2020/07/14/SP503-2020-7},
-  journal = {Geological Society, London, Special Publications}
+  url     = {https://sp.lyellcollection.org/content/early/2020/07/14/SP503-2020-7}
 }
 
 @Article{2020:heyn.conrad.ea:core-mantle,
+  author  = {Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes},
   title   = {Core-mantle boundary topography and its relation to the viscosity structure of the lowermost mantle},
   journal = {Earth and Planetary Science Letters},
+  year    = 2020,
   volume  = 543,
   pages   = 116358,
-  year    = 2020,
   issn    = {0012-821X},
   doi     = {10.1016/j.epsl.2020.116358},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0012821X20303022},
-  author  = {Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes}
+  url     = {http://www.sciencedirect.com/science/article/pii/S0012821X20303022}
 }
 
 @Article{2020:heyn.conrad.ea:how,
   author  = {Heyn, Bj{\"o}rn H. and Conrad, Clinton P. and Tr{\o}nnes, Reidar G.},
   title   = {How Thermochemical Piles Can (Periodically) Generate Plumes at Their Edges},
   journal = {Journal of Geophysical Research: Solid Earth},
+  year    = 2020,
   volume  = 125,
   number  = 6,
   pages   = {e2019JB018726},
   doi     = {10.1029/2019JB018726},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019JB018726},
-  year    = 2020
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019JB018726}
 }
 
 @Article{2020:hochbruck.leibold:finite,
-  doi     = {10.1553/etna_vol53s522},
-  year    = 2020,
-  publisher = {Osterreichische Akademie der Wissenschaften},
-  volume  = 53,
-  pages   = {522--540},
   author  = {Marlis Hochbruck and Jan Leibold},
   title   = {Finite element discretization of semilinear acoustic wave equations with kinetic boundary conditions},
-  journal = {{ETNA} - Electronic Transactions on Numerical Analysis}
+  journal = {{ETNA} - Electronic Transactions on Numerical Analysis},
+  year    = 2020,
+  volume  = 53,
+  pages   = {522--540},
+  doi     = {10.1553/etna_vol53s522},
+  publisher = {Osterreichische Akademie der Wissenschaften}
 }
 
 @Article{2020:jerg.austermuhl.ea:diffuse,
-  title   = {Diffuse domain method for needle insertion simulations},
   author  = {Jerg, Katharina I and Austerm{\"u}hl, Ren{\'e} Phillip and Roth, Karsten and Gro{\ss}e Sundrup, Jonas and Kanschat, Guido and Hesser, J{\"u}rgen W and Wittmayer, Lisa},
+  title   = {Diffuse domain method for needle insertion simulations},
   journal = {International journal for numerical methods in biomedical engineering},
+  year    = 2020,
   volume  = 36,
   number  = 9,
   pages   = {e3377},
-  year    = 2020,
   publisher = {Wiley Online Library},
   doi     = {10.1002/cnm.3377}
 }
 
 @Article{2020:jodlbauer.langer.ea:matrix-free,
+  author  = {D. Jodlbauer and U. Langer and T. Wick},
   title   = {Matrix-free multigrid solvers for phase-field fracture problems},
   journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2020,
   volume  = 372,
   pages   = 113431,
-  year    = 2020,
   issn    = {0045-7825},
-  doi     = {10.1016/j.cma.2020.113431},
-  author  = {D. Jodlbauer and U. Langer and T. Wick}
+  doi     = {10.1016/j.cma.2020.113431}
 }
 
 @Article{2020:jodlbauer.langer.ea:parallel,
   author  = {Jodlbauer, D. and Langer, U. and Wick, T.},
   title   = {Parallel Matrix-Free Higher-Order Finite Element Solvers for Phase-Field Fracture Problems},
   journal = {Mathematical and Computational Applications},
+  year    = 2020,
   volume  = 25,
   number  = 3,
   pages   = 40,
-  year    = 2020,
   doi     = {10.3390/mca25030040}
 }
 
 @Article{2020:kaufl.grayver.ea:magnetotelluric,
-  title   = {Magnetotelluric multiscale 3-{D} inversion reveals crustal and upper mantle structure beneath the Hangai and {G}obi-{A}ltai region in {M}ongolia},
   author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Comeau, Matthew J and Kuvshinov, Alexey V and Becken, Michael and Kamm, Jochen and Batmagnai, Erdenechimeg and Demberel, Sodnomsambuu},
+  title   = {Magnetotelluric multiscale 3-{D} inversion reveals crustal and upper mantle structure beneath the Hangai and {G}obi-{A}ltai region in {M}ongolia},
   journal = {Geophysical Journal International},
+  year    = 2020,
   volume  = 221,
   number  = 2,
   pages   = {1002--1028},
-  year    = 2020,
   publisher = {Oxford University Press},
   doi     = {10.1093/gji/ggaa039}
 }
@@ -527,102 +527,102 @@
   author  = {D. Khimin},
   title   = {Numerische Modellierung von Optimalsteuerungsproblemen f{\"u}r Phasenfeld-Riss-Ausbreitung},
   school  = {Leibniz University Hannover},
-  month   = jun,
-  year    = 2020
+  year    = 2020,
+  month   = jun
 }
 
 @Article{2020:kim:application,
-  doi     = {10.1016/j.cam.2019.112458},
-  year    = 2020,
-  month   = mar,
-  publisher = {Elsevier {BV}},
-  volume  = 367,
-  pages   = 112458,
   author  = {Seungil Kim},
   title   = {Application of a complete radiation boundary condition for the Helmholtz equation in locally perturbed waveguides},
-  journal = {Journal of Computational and Applied Mathematics}
+  journal = {Journal of Computational and Applied Mathematics},
+  year    = 2020,
+  volume  = 367,
+  pages   = 112458,
+  month   = mar,
+  doi     = {10.1016/j.cam.2019.112458},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:kramer.wilde.ea:lattice-boltzmann-simulations-on-irregular-grids--introduction-of-the-natrium-library,
   author  = {Kr{\"{a}}mer, Andreas and Wilde, Dominik and K{\"{u}}llmer, Knut and Reith, Dirk and Foysi, Holger and Joppich, Wolfgang},
-  doi     = {10.1016/j.camwa.2018.10.041},
-  issn    = 08981221,
+  title   = {{Lattice Boltzmann simulations on irregular grids: Introduction of the NATriuM library}},
   journal = {Comput. Math. with Appl.},
+  year    = 2020,
+  volume  = 79,
   number  = 1,
   pages   = {34--54},
-  publisher = {Elsevier Ltd},
-  title   = {{Lattice Boltzmann simulations on irregular grids: Introduction of the NATriuM library}},
-  volume  = 79,
-  year    = 2020
+  doi     = {10.1016/j.camwa.2018.10.041},
+  issn    = 08981221,
+  publisher = {Elsevier Ltd}
 }
 
 @Article{2020:lee.shon.ea:adaptive,
-  doi     = {10.5757/asct.2020.29.3.062},
+  author  = {Sora Lee and Yejin Shon and Dong-gil Kim and Deuk-Chul Kwon and Hee Hwan Choe},
+  title   = {Adaptive Mesh Method Applied to Poisson Solver Module for 3D Capacitively Coupled Plasma Discharge Simulation},
+  journal = {Applied Science and Convergence Technology},
   year    = 2020,
-  month   = may,
-  publisher = {The Korean Vacuum Society},
   volume  = 29,
   number  = 3,
   pages   = {62--66},
-  author  = {Sora Lee and Yejin Shon and Dong-gil Kim and Deuk-Chul Kwon and Hee Hwan Choe},
-  title   = {Adaptive Mesh Method Applied to Poisson Solver Module for 3D Capacitively Coupled Plasma Discharge Simulation},
-  journal = {Applied Science and Convergence Technology}
+  month   = may,
+  doi     = {10.5757/asct.2020.29.3.062},
+  publisher = {The Korean Vacuum Society}
 }
 
 @Article{2020:lees.rudge.ea:gravity,
   author  = {Lees, Matthew E. and Rudge, John F. and McKenzie, Dan},
   title   = {Gravity, Topography, and Melt Generation Rates From Simple 3-D Models of Mantle Convection},
   journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2020,
   volume  = 21,
   number  = 4,
   pages   = {e2019GC008809},
+  note    = {e2019GC008809 10.1029/2019GC008809},
   doi     = {10.1029/2019GC008809},
   url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
-  note    = {e2019GC008809 10.1029/2019GC008809},
-  year    = 2020
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809}
 }
 
 @Article{2020:lesher.dannberg.ea:iron,
-  title   = {Iron isotope fractionation at the core--mantle boundary by thermodiffusion},
   author  = {Lesher, Charles E. and Dannberg, Juliane and Barfod, Gry H. and Bennett, Neil R. and Glessner, Justin J. G. and Lacks, Daniel J. and Brenan, James M.},
+  title   = {Iron isotope fractionation at the core--mantle boundary by thermodiffusion},
   journal = {Nature Geoscience},
+  year    = 2020,
   volume  = 13,
   number  = 5,
   pages   = {382--386},
-  year    = 2020,
   publisher = {Nature Publishing Group},
   doi     = {10.1038/s41561-020-0560-y}
 }
 
 @Article{2020:liu.mcbride.ea:assessment-of-an-isogeometric-approach-with-catmull-clark-subdivision-surfaces-using-the-laplace-beltrami-problems,
   author  = {Liu, Zhaowei and McBride, Andrew and Saxena, Prashant and Steinmann, Paul},
-  doi     = {10.1007/s00466-020-01877-3},
-  issn    = 14320924,
-  journal = {Computational Mechanics},
   title   = {{Assessment of an isogeometric approach with Catmull-Clark subdivision surfaces using the Laplace-Beltrami problems}},
-  year    = 2020
+  journal = {Computational Mechanics},
+  year    = 2020,
+  doi     = {10.1007/s00466-020-01877-3},
+  issn    = 14320924
 }
 
 @Article{2020:lorentzon.revstedt:numerical,
   author  = {Lorentzon, Johan and Revstedt, Johan},
   title   = {A numerical study of partitioned fluid-structure interaction applied to a cantilever in incompressible turbulent flow},
   journal = {International Journal for Numerical Methods in Engineering},
+  year    = 2020,
   volume  = 121,
   number  = 5,
   pages   = {806--827},
-  doi     = {10.1002/nme.6245},
-  year    = 2020
+  doi     = {10.1002/nme.6245}
 }
 
 @Article{2020:louis-napoleon.gerbault.ea:3-d,
-  title   = {3-D numerical modelling of crustal polydiapirs with volume-of-fluid methods},
   author  = {Louis-Napol{\'e}on, Aur{\'e}lie and Gerbault, Muriel and Bonometti, Thomas and Thieulot, C{\'e}dric and Martin, Roland and Vanderhaeghe, Olivier},
+  title   = {3-D numerical modelling of crustal polydiapirs with volume-of-fluid methods},
   journal = {Geophysical Journal International},
+  year    = 2020,
   volume  = 222,
   number  = 1,
   pages   = {474--506},
-  year    = 2020,
   publisher = {Oxford University Press},
   doi     = {10.1093/gji/ggaa141}
 }
@@ -630,23 +630,23 @@
 @Article{2020:maier.margetis.ea:finite-size,
   author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
   title   = {Finite-size effects in wave transmission through plasmonic crystals: A tale of two scales},
-  doi     = {10.1103/PhysRevB.102.075308},
   journal = {Physical Review B},
   year    = 2020,
   volume  = 102,
-  pages   = 075308
+  pages   = 075308,
+  doi     = {10.1103/PhysRevB.102.075308}
 }
 
 @Article{2020:mcbride.davydov.ea:modelling,
-  doi     = {10.1016/j.cma.2020.113320},
-  year    = 2020,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 371,
-  pages   = 113320,
   author  = {A.T. McBride and D. Davydov and P. Steinmann},
   title   = {Modelling the flexoelectric effect in solids: A micromorphic approach},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2020,
+  volume  = 371,
+  pages   = 113320,
+  month   = nov,
+  doi     = {10.1016/j.cma.2020.113320},
+  publisher = {Elsevier {BV}}
 }
 
 @PhDThesis{2020:mcgovern:high,
@@ -661,49 +661,49 @@
   author  = {Mitrovica, J. X. and Austermann, J. and Coulson, S. and Creveling, J. R. and Hoggard, M. J. and Jarvis, G. T. and Richards, F. D.},
   title   = {Dynamic Topography and Ice Age Paleoclimate},
   journal = {Annual Review of Earth and Planetary Sciences},
+  year    = 2020,
   volume  = 48,
   number  = 1,
   pages   = {585--621},
-  year    = 2020,
   doi     = {10.1146/annurev-earth-082517-010225}
 }
 
 @Article{2020:motamarri.das.ea:dft-fe,
-  doi     = {10.1016/j.cpc.2019.07.016},
-  year    = 2020,
-  month   = jan,
-  publisher = {Elsevier {BV}},
-  volume  = 246,
-  pages   = 106853,
   author  = {Phani Motamarri and Sambit Das and Shiva Rudraraju and Krishnendu Ghosh and Denis Davydov and Vikram Gavini},
   title   = {{DFT}-{FE} -- A massively parallel adaptive finite-element code for large-scale density functional theory calculations},
-  journal = {Computer Physics Communications}
+  journal = {Computer Physics Communications},
+  year    = 2020,
+  volume  = 246,
+  pages   = 106853,
+  month   = jan,
+  doi     = {10.1016/j.cpc.2019.07.016},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:muluneh.brune.ea:mechanism,
   author  = {Muluneh, Ameha A. and Brune, Sascha and Illsley-Kemp, Finnigan and Corti, Giacomo and Keir, Derek and Glerum, Anne and Kidane, Tesfaye and Mori, Jim},
   title   = {Mechanism for Deep Crustal Seismicity: Insight From Modeling of Deformation Processes at the Main Ethiopian Rift},
   journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2020,
   volume  = 21,
   number  = 7,
   pages   = {e2020GC008935},
+  note    = {e2020GC008935 10.1029/2020GC008935},
   doi     = {10.1029/2020GC008935},
   url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020GC008935},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2020GC008935},
-  note    = {e2020GC008935 10.1029/2020GC008935},
-  year    = 2020
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2020GC008935}
 }
 
 @Article{2020:murphy.madzvamuse:moving,
-  doi     = {10.1016/j.apnum.2020.08.004},
-  year    = 2020,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 158,
-  pages   = {336--359},
   author  = {Laura Murphy and Anotida Madzvamuse},
   title   = {A moving grid finite element method applied to a mechanobiochemical model for 3D cell migration},
-  journal = {Applied Numerical Mathematics}
+  journal = {Applied Numerical Mathematics},
+  year    = 2020,
+  volume  = 158,
+  pages   = {336--359},
+  month   = dec,
+  doi     = {10.1016/j.apnum.2020.08.004},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2020:naliboff.glerum.ea:development,
@@ -718,78 +718,78 @@
 }
 
 @Article{2020:nayak.cojean.ea:evaluating,
-  doi     = {10.1177/1094342020946814},
-  year    = 2020,
-  month   = aug,
-  publisher = {{SAGE} Publications},
-  pages   = 109434202094681,
   author  = {Pratik Nayak and Terry Cojean and Hartwig Anzt},
   title   = {Evaluating asynchronous Schwarz solvers on {GPUs}},
-  journal = {The International Journal of High Performance Computing Applications}
+  journal = {The International Journal of High Performance Computing Applications},
+  year    = 2020,
+  pages   = 109434202094681,
+  month   = aug,
+  doi     = {10.1177/1094342020946814},
+  publisher = {{SAGE} Publications}
 }
 
 @Article{2020:negredo.mancilla.ea:geodynamic,
   author  = {Negredo, A. M. and Mancilla, F. d. L. and Clemente, C. and Morales, J. and Fullea, J.},
   title   = {Geodynamic Modeling of Edge-Delamination Driven by Subduction-Transform Edge Propagator Faults: The Westernmost Mediterranean Margin (Central Betic Orogen) Case Study},
   journal = {Frontiers in Earth Science},
+  year    = 2020,
   volume  = 8,
   pages   = 435,
-  year    = 2020,
   url     = {https://www.frontiersin.org/article/10.3389/feart.2020.533392},
   doi     = {10.3389/feart.2020.533392},
   issn    = {2296-6463}
 }
 
 @Article{2020:nitzler.biehler.ea:generalized,
-  title   = {A Generalized Probabilistic Learning Approach for Multi-Fidelity Uncertainty Propagation in Complex Physical Simulations},
   author  = {Nitzler, Jonas and Biehler, Jonas and Fehn, Niklas and Koutsourelakis, Phaedon-Stelios and Wall, Wolfgang A},
+  title   = {A Generalized Probabilistic Learning Approach for Multi-Fidelity Uncertainty Propagation in Complex Physical Simulations},
   journal = {arXiv preprint arXiv:2001.02892},
   year    = 2020
 }
 
 @Article{2020:njinju.stamps.ea:lithospheric,
-  doi     = {10.1002/essoar.10503939.1},
-  pages   = 37,
-  year    = 2020,
-  month   = aug,
-  journal = {Earth and Space Science Open Archive},
   author  = {Emmanuel A. Njinju and D. Sarah Stamps and James Gallagher and Kodi Neumiller},
-  title   = {Lithospheric Control of Melt Generation Beneath the Rungwe Volcanic Province, East Africa}
+  title   = {Lithospheric Control of Melt Generation Beneath the Rungwe Volcanic Province, East Africa},
+  journal = {Earth and Space Science Open Archive},
+  year    = 2020,
+  pages   = 37,
+  month   = aug,
+  doi     = {10.1002/essoar.10503939.1}
 }
 
 @InCollection{2020:paula.quinelato.ea:numerical,
-  doi     = {10.1007/978-3-030-50436-6_2},
-  year    = 2020,
-  publisher = {Springer International Publishing},
-  pages   = {18--31},
   author  = {Filipe Fernandes de Paula and Thiago Quinelato and Iury Igreja and Grigori Chapiro},
   title   = {A Numerical Algorithm to Solve the Two-Phase Flow in Porous Media Including Foam Displacement},
-  booktitle = {Lecture Notes in Computer Science}
+  booktitle = {Lecture Notes in Computer Science},
+  publisher = {Springer International Publishing},
+  year    = 2020,
+  pages   = {18--31},
+  doi     = {10.1007/978-3-030-50436-6_2}
 }
 
 @Article{2020:rajaonarison.stamps.ea:numerical,
-  title   = {Numerical Modeling of Mantle Flow Beneath Madagascar to Constrain Upper Mantle Rheology Beneath Continental Regions},
   author  = {Rajaonarison, T. A. and Stamps, D. S. and Fishwick, S. and Brune, Sascha and Glerum, A. and Hu, J.},
+  title   = {Numerical Modeling of Mantle Flow Beneath Madagascar to Constrain Upper Mantle Rheology Beneath Continental Regions},
   journal = {Journal of Geophysical Research. Solid Earth},
+  year    = 2020,
   volume  = 125,
   number  = 2,
   pages   = {Art--No},
-  year    = 2020,
   publisher = {American Geophysical Union},
   doi     = {10.1029/2019JB018560}
 }
 
 @Article{2020:reveron.kumar.ea:iterative,
-  doi     = {10.1007/s10596-020-09983-0},
+  author  = {Manuel Antonio Borregales Rever{\'{o}}n and Kundan Kumar and Jan Martin Nordbotten and Florin Adrian Radu},
+  title   = {Iterative solvers for Biot model under small and large deformations},
+  journal = {Computational Geosciences},
   year    = 2020,
-  month   = jul,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 25,
   number  = 2,
   pages   = {687--699},
-  author  = {Manuel Antonio Borregales Rever{\'{o}}n and Kundan Kumar and Jan Martin Nordbotten and Florin Adrian Radu},
-  title   = {Iterative solvers for Biot model under small and large deformations},
-  journal = {Computational Geosciences}
+  month   = jul,
+  doi     = {10.1007/s10596-020-09983-0},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @MastersThesis{2020:roth:geometric,
@@ -798,115 +798,115 @@
   school  = {Leibniz Universit{\"a}t Hannover},
   year    = 2020,
   month   = jul,
-  url     = {https://julianroth.org/res/bachelorarbeit.pdf},
-  note    = {Bachelor's Thesis}
+  note    = {Bachelor's Thesis},
+  url     = {https://julianroth.org/res/bachelorarbeit.pdf}
 }
 
 @Article{2020:ryan.dominguez.ea:energy,
-  doi     = {10.3389/fphys.2020.538522},
-  year    = 2020,
-  month   = nov,
-  publisher = {Frontiers Media {SA}},
-  volume  = 11,
   author  = {David S. Ryan and Sebasti{\'{a}}n Dom{\'{i}}nguez and Stephanie A. Ross and Nilima Nigam and James M. Wakeling},
   title   = {The Energy of Muscle Contraction. {II}. Transverse Compression and Work},
-  journal = {Frontiers in Physiology}
+  journal = {Frontiers in Physiology},
+  year    = 2020,
+  volume  = 11,
+  month   = nov,
+  doi     = {10.3389/fphys.2020.538522},
+  publisher = {Frontiers Media {SA}}
 }
 
 @Article{2020:schoeder.sticko.ea:high-order,
-  doi     = {10.1002/nme.6343},
+  author  = {Svenja Schoeder and Simon Sticko and Gunilla Kreiss and Martin Kronbichler},
+  title   = {High-order cut discontinuous {G}alerkin methods with local time stepping for acoustics},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2020,
-  month   = jul,
-  publisher = {Wiley},
   volume  = 121,
   number  = 13,
   pages   = {2979--3003},
-  author  = {Svenja Schoeder and Simon Sticko and Gunilla Kreiss and Martin Kronbichler},
-  title   = {High-order cut discontinuous {G}alerkin methods with local time stepping for acoustics},
-  journal = {International Journal for Numerical Methods in Engineering}
+  month   = jul,
+  doi     = {10.1002/nme.6343},
+  publisher = {Wiley}
 }
 
 @Article{2020:schroder.wick.ea:selection,
-  title   = {A Selection of Benchmark Problems in Solid Mechanics and Applied Mathematics},
   author  = {Schr\"{o}der, J\"{o}rg and Wick, Thomas and Reese, Stefanie and Wriggers, Peter and M\"{u}ller, Ralf and Kollmannsberger, Stefan and K\"{a}stner, Markus and Schwarz, Alexander and Igelb\"{u}scher, Maximilian and Viebahn, Nils and Bayat, Hamid Reza and Wulfinghoff, Stephan and Mang, Katrin and Rank, Ernst and Bog, Tino and D'Angella, Davide and Elhaddad, Mohamed and Hennig, Paul and D\"{u}ster, Alexander and Garhuom, Wadhah and Hubrich, Simeon and Walloth, Mirjam and Wollner, Winnifried and Kuhn, Charlotte and Heister, Timo},
+  title   = {A Selection of Benchmark Problems in Solid Mechanics and Applied Mathematics},
   journal = {Archives of Computational Methods in Engineering},
   year    = 2020,
   doi     = {10.1007/s11831-020-09477-3}
 }
 
 @Article{2020:schuh-senlis.thieulot.ea:towards,
-  doi     = {10.5194/se-11-1909-2020},
+  author  = {Melchior Schuh-Senlis and Cedric Thieulot and Paul Cupillard and Guillaume Caumon},
+  title   = {Towards the application of Stokes flow equations to structural restoration simulations},
+  journal = {Solid Earth},
   year    = 2020,
-  month   = oct,
-  publisher = {Copernicus {GmbH}},
   volume  = 11,
   number  = 5,
   pages   = {1909--1930},
-  author  = {Melchior Schuh-Senlis and Cedric Thieulot and Paul Cupillard and Guillaume Caumon},
-  title   = {Towards the application of Stokes flow equations to structural restoration simulations},
-  journal = {Solid Earth}
+  month   = oct,
+  doi     = {10.5194/se-11-1909-2020},
+  publisher = {Copernicus {GmbH}}
 }
 
 @Article{2020:song.maier.ea:nonlinear,
   author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
   title   = {Nonlinear eigenvalue problems for coupled {H}elmholtz equations modeling gradient-index graphene waveguides},
-  doi     = {10.1016/j.jcp.2020.109871},
   journal = {Journal of Computational Physics},
   year    = 2020,
   volume  = 423,
   number  = 15,
-  pages   = 109871
+  pages   = 109871,
+  doi     = {10.1016/j.jcp.2020.109871}
 }
 
 @Article{2020:stella.vergara.ea:integration,
-  doi     = {10.1016/j.compbiomed.2020.104047},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0010482520303784},
-  year    = 2020,
-  month   = oct,
-  publisher = {Elsevier},
-  volume  = 127,
-  pages   = 104047,
   author  = {Simone Stella and Christian Vergara and Massimiliano Maines and Domenico Catanzariti and Pasquale Claudio Africa and Cristina Dematt{\`{e}} and Maurizio Centonze and Fabio Nobile and Maurizio Del Greco and Alfio Quarteroni},
   title   = {Integration of activation maps of epicardial veins in computational cardiac electrophysiology},
-  journal = {Computers in Biology and Medicine}
+  journal = {Computers in Biology and Medicine},
+  year    = 2020,
+  volume  = 127,
+  pages   = 104047,
+  month   = oct,
+  doi     = {10.1016/j.compbiomed.2020.104047},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0010482520303784},
+  publisher = {Elsevier}
 }
 
 @Article{2020:sticko.ludvigsson.ea:high-order,
+  author  = {Sticko, Simon and Ludvigsson, Gustav and Kreiss, Gunilla},
   title   = {High-order cut finite elements for the elastic wave equation},
+  journal = {Advances in Computational Mathematics},
+  year    = 2020,
   volume  = 46,
+  number  = 3,
+  pages   = 45,
+  month   = may,
   issn    = {1572-9044},
   doi     = {10.1007/s10444-020-09785-z},
-  language = {en},
-  number  = 3,
-  journal = {Advances in Computational Mathematics},
-  author  = {Sticko, Simon and Ludvigsson, Gustav and Kreiss, Gunilla},
-  month   = may,
-  year    = 2020,
-  pages   = 45
+  language = {en}
 }
 
 @Article{2020:wakeling.ross.ea:energy,
-  doi     = {10.3389/fphys.2020.00813},
-  year    = 2020,
-  month   = aug,
-  publisher = {Frontiers Media {SA}},
-  volume  = 11,
   author  = {James M. Wakeling and Stephanie A. Ross and David S. Ryan and Bart Bolsterlee and Ryan Konno and Sebasti{\'{a}}n Dom{\'{i}}nguez and Nilima Nigam},
   title   = {The Energy of Muscle Contraction. I. Tissue Force and Deformation During Fixed-End Contractions},
-  journal = {Frontiers in Physiology}
+  journal = {Frontiers in Physiology},
+  year    = 2020,
+  volume  = 11,
+  month   = aug,
+  doi     = {10.3389/fphys.2020.00813},
+  publisher = {Frontiers Media {SA}}
 }
 
 @Article{2020:wang.marshak.ea:cpu,
-  doi     = {10.1111/cgf.13958},
+  author  = {Feng Wang and Nathan Marshak and Will Usher and Carsten Burstedde and Aaron Knoll and Timo Heister and Chris R. Johnson},
+  title   = {{CPU} Ray Tracing of Tree-Based Adaptive Mesh Refinement Data},
+  journal = {Computer Graphics Forum},
   year    = 2020,
-  month   = jun,
-  publisher = {Wiley},
   volume  = 39,
   number  = 3,
   pages   = {1--12},
-  author  = {Feng Wang and Nathan Marshak and Will Usher and Carsten Burstedde and Aaron Knoll and Timo Heister and Chris R. Johnson},
-  title   = {{CPU} Ray Tracing of Tree-Based Adaptive Mesh Refinement Data},
-  journal = {Computer Graphics Forum}
+  month   = jun,
+  doi     = {10.1111/cgf.13958},
+  publisher = {Wiley}
 }
 
 @PhDThesis{2020:wang:two-field,
@@ -918,27 +918,27 @@
 }
 
 @Article{2020:welper:transformed,
-  doi     = {10.1137/19m126356x},
+  author  = {G. Welper},
+  title   = {Transformed Snapshot Interpolation with High Resolution Transforms},
+  journal = {{SIAM} Journal on Scientific Computing},
   year    = 2020,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume  = 42,
   number  = 4,
   pages   = {A2037--A2061},
-  author  = {G. Welper},
-  title   = {Transformed Snapshot Interpolation with High Resolution Transforms},
-  journal = {{SIAM} Journal on Scientific Computing}
+  doi     = {10.1137/19m126356x},
+  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
 @Article{2020:wheeler.wick.ea:ipacs--integrated-phase-field-advanced-crack-propagation-simulator--an-adaptive--parallel--physics-based-discretization-phase-field-framework-for-fracture-propagation-in-porous-media,
+  author  = {Mary F. Wheeler and Thomas Wick and Sanghyun Lee},
   title   = {{IPACS: Integrated Phase-Field Advanced Crack Propagation Simulator. An adaptive, parallel, physics-based-discretization phase-field framework for fracture propagation in porous media}},
   journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2020,
   volume  = 367,
   pages   = 113124,
-  year    = 2020,
   issn    = {0045-7825},
   doi     = {10.1016/j.cma.2020.113124},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0045782520303091},
-  author  = {Mary F. Wheeler and Thomas Wick and Sanghyun Lee}
+  url     = {http://www.sciencedirect.com/science/article/pii/S0045782520303091}
 }
 
 @Article{2020:wick.wollner:optimization,
@@ -955,8 +955,8 @@
 @Book{2020:wick:multiphysics,
   author  = {Thomas Wick},
   title   = {Multiphysics Phase-Field Fracture: Modeling, Adaptive Discretizations, and Solvers},
-  year    = 2020,
   publisher = {De Gruyter},
+  year    = 2020,
   address = {Berlin, Boston},
   isbn    = {978-3-11-049739-7},
   doi     = {10.1515/9783110497397},
@@ -965,62 +965,62 @@
 
 @Article{2020:wilde.kramer.ea:semi-lagrangian-lattice-boltzmann-method-for-compressible-flows,
   author  = {Wilde, Dominik and Kr{\"{a}}mer, Andreas and Reith, Dirk and Foysi, Holger},
-  doi     = {10.1103/PhysRevE.101.053306},
-  issn    = 24700053,
+  title   = {{Semi-Lagrangian lattice Boltzmann method for compressible flows}},
   journal = {Phys. Rev. E},
-  month   = may,
+  year    = 2020,
+  volume  = 101,
   number  = 5,
   pages   = {1--11},
+  month   = may,
+  doi     = {10.1103/PhysRevE.101.053306},
+  issn    = 24700053,
   publisher = {American Physical Society},
-  title   = {{Semi-Lagrangian lattice Boltzmann method for compressible flows}},
-  url     = {https://link.aps.org/doi/10.1103/PhysRevE.101.053306},
-  volume  = 101,
-  year    = 2020
+  url     = {https://link.aps.org/doi/10.1103/PhysRevE.101.053306}
 }
 
 @Article{2020:witte.arndt.ea:fast,
-  doi     = {10.1515/cmam-2020-0078},
-  year    = 2020,
-  month   = nov,
-  publisher = {Walter de Gruyter {GmbH}},
-  volume  = 21,
-  number  = 3,
   author  = {Julius Witte and Daniel Arndt and Guido Kanschat},
   title   = {Fast Tensor Product Schwarz Smoothers for High-Order Discontinuous Galerkin Methods},
-  journal = {Computational Methods in Applied Mathematics}
+  journal = {Computational Methods in Applied Mathematics},
+  year    = 2020,
+  volume  = 21,
+  number  = 3,
+  month   = nov,
+  doi     = {10.1515/cmam-2020-0078},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @Article{2020:zhang.yue:level-set,
-  title   = {A level-set method for moving contact lines with contact angle hysteresis},
   author  = {Zhang, Jiaqi and Yue, Pengtao},
+  title   = {A level-set method for moving contact lines with contact angle hysteresis},
   journal = {Journal of Computational Physics},
+  year    = 2020,
   volume  = 418,
   pages   = 109636,
-  year    = 2020,
   doi     = {10.1016/j.jcp.2020.109636},
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999120304101},
   publisher = {Elsevier}
 }
 
 @PhDThesis{2020:zhang:finite-element,
-  title   = {Finite-element simulations of interfacial flows with moving contact lines},
   author  = {Zhang, Jiaqi},
+  title   = {Finite-element simulations of interfacial flows with moving contact lines},
+  school  = {Virginia Tech},
   year    = 2020,
   month   = jun,
-  url     = {http://hdl.handle.net/10919/99058},
-  school  = {Virginia Tech}
+  url     = {http://hdl.handle.net/10919/99058}
 }
 
 @Article{2020:zhao.choo:stabilized,
-  doi     = {10.1016/j.cma.2019.112742},
-  year    = 2020,
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = 362,
-  pages   = 112742,
   author  = {Yidong Zhao and Jinhyun Choo},
   title   = {Stabilized material point methods for coupled large deformation and fluid flow in porous materials},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2020,
+  volume  = 362,
+  pages   = 112742,
+  month   = apr,
+  doi     = {10.1016/j.cma.2019.112742},
+  publisher = {Elsevier {BV}}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -1,24 +1,24 @@
 % Encoding: US-ASCII
 
 @Article{2021:anselmann.bause:higher,
-  doi     = {10.1016/j.matcom.2020.10.027},
-  year    = 2021,
-  month   = nov,
-  publisher = {Elsevier {BV}},
-  volume  = 189,
-  pages   = {141--162},
   author  = {Mathias Anselmann and Markus Bause},
   title   = {Higher order Galerkin{\textendash}collocation time discretization with Nitsche's method for the Navier{\textendash}Stokes equations},
-  journal = {Mathematics and Computers in Simulation}
+  journal = {Mathematics and Computers in Simulation},
+  year    = 2021,
+  volume  = 189,
+  pages   = {141--162},
+  month   = nov,
+  doi     = {10.1016/j.matcom.2020.10.027},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2021:araujo.engstrom:on,
-  title   = {On spurious solutions encountered in Helmholtz scattering resonance computations in {$R^d$} with applications to nano-photonics and acoustics},
   author  = {Ara\'{u}jo, Juan C. and Engstr\"{o}m, Christian},
+  title   = {On spurious solutions encountered in Helmholtz scattering resonance computations in {$R^d$} with applications to nano-photonics and acoustics},
   journal = {Journal of Computational Physics},
+  year    = 2021,
   volume  = 429,
   pages   = 110024,
-  year    = 2021,
   issn    = {0021-9991},
   doi     = {10.1016/j.jcp.2020.110024}
 }
@@ -27,32 +27,32 @@
   author  = {Ara\'{u}jo, Juan C. and Wadbro, Eddie},
   title   = {Shape optimization for the strong directional scattering of dielectric nanorods},
   journal = {International Journal for Numerical Methods in Engineering},
+  year    = 2021,
   volume  = {in press},
   doi     = {10.1002/nme.6677},
-  year    = 2021,
   url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.6677},
   eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6677}
 }
 
 @Article{2021:arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.3},
   author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Uwe K{\"o}cher and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Sebastian Proell and Konrad Simon and Bruno Turcksin and David Wells and Jiaqi Zhang},
+  title   = {The \texttt{deal.II} Library, Version 9.3},
   journal = {Journal of Numerical Mathematics},
   year    = 2021,
-  url     = {https://dealii.org/deal93-preprint.pdf},
-  doi     = {10.1515/jnma-2021-0081},
   volume  = 29,
   number  = 3,
-  pages   = {171--186}
+  pages   = {171--186},
+  url     = {https://dealii.org/deal93-preprint.pdf},
+  doi     = {10.1515/jnma-2021-0081}
 }
 
 @Article{2021:arndt.bangerth.ea:deal-ii*1,
-  title   = {The {deal.II} finite element library: design, features, and insights},
   author  = {Daniel Arndt and Wolfgang Bangerth and Denis Davydov and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Jean-Paul Pelteret and Bruno Turcksin and David Wells},
+  title   = {The {deal.II} finite element library: design, features, and insights},
   journal = {Computers \& Mathematics with Applications},
   year    = 2021,
-  pages   = {407--422},
   volume  = 81,
+  pages   = {407--422},
   doi     = {10.1016/j.camwa.2020.02.022},
   issn    = {0898-1221}
 }
@@ -69,65 +69,65 @@
   author  = {Beuchler, Sven and Endtmayer, Bernhard and Wick, Thomas},
   title   = {Goal oriented error control for stationary incompressible flow coupled to a heat equation},
   journal = {PAMM},
+  year    = 2021,
   volume  = 21,
   number  = 1,
   pages   = {e202100151},
   doi     = {10.1002/pamm.202100151},
   url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202100151},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100151},
-  year    = 2021
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100151}
 }
 
 @Article{2021:beuchler.kinnewig.ea:residual-based,
   author  = {Beuchler, Sven and Kinnewig, Sebastian and Koenig, Philipp and Wick, Thomas},
   title   = {A residual-based error estimator and mesh adaptivity for the time harmonic Maxwell equations applied to a Y-beam splitter},
   journal = {PAMM},
+  year    = 2021,
   volume  = 21,
   number  = 1,
   pages   = {e202100175},
   doi     = {10.1002/pamm.202100175},
   url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202100175},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100175},
-  year    = 2021
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100175}
 }
 
 @Article{2021:bonito.nochetto.ea:dg,
-  doi     = {10.1142/s0218202521500044},
+  author  = {Andrea Bonito and Ricardo H. Nochetto and Dimitrios Ntogkas},
+  title   = {{DG} approach to large bending plate deformations with isometry constraint},
+  journal = {Mathematical Models and Methods in Applied Sciences},
   year    = 2021,
-  publisher = {World Scientific Pub Co Pte Lt},
   volume  = 31,
   number  = 01,
   pages   = {133--175},
-  author  = {Andrea Bonito and Ricardo H. Nochetto and Dimitrios Ntogkas},
-  title   = {{DG} approach to large bending plate deformations with isometry constraint},
-  journal = {Mathematical Models and Methods in Applied Sciences}
+  doi     = {10.1142/s0218202521500044},
+  publisher = {World Scientific Pub Co Pte Lt}
 }
 
 @Article{2021:bredow.steinberger:mantle,
   author  = {Bredow, Eva and Steinberger, Bernhard},
   title   = {Mantle Convection and Possible Mantle Plumes beneath Antarctica - Insights from Geodynamic Models and Implications for Topography},
+  journal = {Geological Society, London, Memoirs},
+  year    = 2021,
   volume  = 56,
   elocation-id = {M56-2020-2},
-  year    = 2021,
   doi     = {10.1144/M56-2020-2},
   publisher = {Geological Society of London},
   issn    = {0435-4052},
   url     = {https://mem.lyellcollection.org/content/early/2021/02/22/M56-2020-2},
-  eprint  = {https://mem.lyellcollection.org/content/early/2021/02/22/M56-2020-2.full.pdf},
-  journal = {Geological Society, London, Memoirs}
+  eprint  = {https://mem.lyellcollection.org/content/early/2021/02/22/M56-2020-2.full.pdf}
 }
 
 @Article{2021:camargo.white.ea:macroelement,
-  doi     = {10.1007/s10596-020-09964-3},
+  author  = {Julia T. Camargo and Joshua A. White and Ronaldo I. Borja},
+  title   = {A macroelement stabilization for mixed finite element/finite volume discretizations of multiphase poromechanics},
+  journal = {Computational Geosciences},
   year    = 2021,
-  month   = apr,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 25,
   number  = 2,
   pages   = {775--792},
-  author  = {Julia T. Camargo and Joshua A. White and Ronaldo I. Borja},
-  title   = {A macroelement stabilization for mixed finite element/finite volume discretizations of multiphase poromechanics},
-  journal = {Computational Geosciences}
+  month   = apr,
+  doi     = {10.1007/s10596-020-09964-3},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2021:castelli.dorfler:parallel,
@@ -147,10 +147,10 @@
   editor  = {Vermolen, F. J. and Vuik, C.},
   booktitle = {Numerical Mathematics and Advanced Applications {ENUMATH} 2019},
   year    = 2021,
-  volume  = 139,
   series  = {Lecture Notes in Computational Science and Engineering},
-  publisher = {Springer, Cham},
+  volume  = 139,
   pages   = {245--253},
+  publisher = {Springer, Cham},
   doi     = {10.1007/978-3-030-55874-1_23}
 }
 
@@ -174,21 +174,21 @@
 }
 
 @Article{2021:clevenger.heister.ea:flexible,
-  doi     = {10.1145/3425193},
+  author  = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
+  title   = {A Flexible, Parallel, Adaptive Geometric Multigrid Method for {FEM}},
+  journal = {{ACM} Transactions on Mathematical Software},
   year    = 2021,
-  month   = mar,
-  publisher = {Association for Computing Machinery ({ACM})},
   volume  = 47,
   number  = 1,
   pages   = {1--27},
-  author  = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
-  title   = {A Flexible, Parallel, Adaptive Geometric Multigrid Method for {FEM}},
-  journal = {{ACM} Transactions on Mathematical Software}
+  month   = mar,
+  doi     = {10.1145/3425193},
+  publisher = {Association for Computing Machinery ({ACM})}
 }
 
 @Article{2021:clevenger.heister:comparison,
-  title   = {Comparison Between Algebraic and Matrix-free Geometric Multigrid for a {S}tokes Problem on an Adaptive Mesh with Variable Viscosity},
   author  = {Thomas C. Clevenger and Timo Heister},
+  title   = {Comparison Between Algebraic and Matrix-free Geometric Multigrid for a {S}tokes Problem on an Adaptive Mesh with Variable Viscosity},
   journal = {Numerical Linear Algebra with Applications},
   year    = 2021,
   month   = mar,
@@ -197,15 +197,15 @@
 }
 
 @Article{2021:comeau.stein.ea:geodynamic,
-  doi     = {10.1029/2020jb021304},
-  year    = 2021,
-  month   = may,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = 126,
-  number  = 5,
   author  = {Matthew J. Comeau and Claudia Stein and Michael Becken and Ulrich Hansen},
   title   = {Geodynamic Modeling of Lithospheric Removal and Surface Deformation: Application to Intraplate Uplift in {C}entral {M}ongolia},
-  journal = {Journal of Geophysical Research: Solid Earth}
+  journal = {Journal of Geophysical Research: Solid Earth},
+  year    = 2021,
+  volume  = 126,
+  number  = 5,
+  month   = may,
+  doi     = {10.1029/2020jb021304},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @InProceedings{2021:d-jodlbauer:efficient,
@@ -213,9 +213,9 @@
   title   = {Efficient monolithic solvers for fluid-structure interaction applied to flapping membranes},
   booktitle = {Domain Decomposition Methods in Science and Engineering XXVI},
   year    = 2021,
-  publisher = {Springer International Publishing},
+  pages   = {accepted},
   address = {Cham},
-  pages   = {accepted}
+  publisher = {Springer International Publishing}
 }
 
 @InProceedings{2021:d-jodlbauer:parallel,
@@ -223,103 +223,103 @@
   title   = {Parallel domain decomposition solvers for the time harmonic Maxwell equations},
   booktitle = {Domain Decomposition Methods in Science and Engineering XXVI},
   year    = 2021,
-  publisher = {Springer International Publishing},
+  pages   = {accepted},
   address = {Cham},
-  pages   = {accepted}
+  publisher = {Springer International Publishing}
 }
 
 @Article{2021:dal-maso.heltai:numerical,
   author  = {Gianni {Dal Maso} and Luca Heltai},
+  title   = {A numerical study of the jerky crack growth in elastoplastic materials with localized plasticity},
   journal = {Journal of Convex Analysis},
+  year    = 2021,
+  volume  = 28,
   number  = 2,
   pages   = {535--548},
-  title   = {A numerical study of the jerky crack growth in elastoplastic materials with localized plasticity},
-  volume  = 28,
-  year    = 2021,
   url     = {https://www.heldermann.de/JCA/JCA28/JCA282/jca28030.htm}
 }
 
 @Article{2021:dede.quarteroni.ea:mathematical,
-  title   = {Mathematical and numerical models for the cardiac electromechanical function},
   author  = {Ded{\`e}, L. and Quarteroni, A. and Regazzoni, F.},
+  title   = {Mathematical and numerical models for the cardiac electromechanical function},
   journal = {Atti della Accademia Nazionale dei Lincei, Classe di Scienze Fisiche, Matematiche e Naturali. Rendiconti Lincei - Matematica e Applicazioni},
   year    = 2021,
-  publisher = {EMS Press},
   volume  = 32,
   number  = 2,
   pages   = {233--272},
+  publisher = {EMS Press},
   issn    = {1120-6330}
 }
 
 @Article{2021:dede.regazzoni.ea:modeling,
-  title   = {Modeling the cardiac response to hemodynamic changes associated with COVID-19: a computational study},
   author  = {Ded{\`e}, Luca and Regazzoni, Francesco and Vergara, Christian and Zunino, Paolo and Guglielmo, Marco and Scrofani, Roberto and Fusini, Laura and Cogliati, Chiara and Pontone, Gianluca and Quarteroni, Alfio},
+  title   = {Modeling the cardiac response to hemodynamic changes associated with COVID-19: a computational study},
   journal = {Mathematical Biosciences and Engineering},
+  year    = 2021,
   volume  = 18,
   number  = 4,
-  pages   = {3364--3383},
-  year    = 2021
+  pages   = {3364--3383}
 }
 
 @Article{2021:endtmayer.langer.ea:reliability,
   author  = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
-  doi     = {10.1515/cmam-2020-0036},
   title   = {Reliability and Efficiency of DWR-Type A Posteriori Error Estimates with Smart Sensitivity Weight Recovering},
   journal = {Computational Methods in Applied Mathematics},
+  year    = 2021,
   volume  = 21,
   number  = 2,
-  year    = 2021
+  doi     = {10.1515/cmam-2020-0036}
 }
 
 @Article{2021:faccenna.becker.ea:mountain,
+  author  = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pierre Brun},
   title   = {Mountain building, mantle convection, and supercontinents: Holmes (1931) revisited},
   journal = {Earth and Planetary Science Letters},
+  year    = 2021,
   volume  = 564,
   pages   = 116905,
-  year    = 2021,
   issn    = {0012-821X},
   doi     = {10.1016/j.epsl.2021.116905},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X21001643},
-  author  = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pierre Brun}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X21001643}
 }
 
 @Article{2021:fan.jin.ea:quasi-monolithic,
-  doi     = {10.1007/s00366-021-01423-6},
   author  = {M. Fan and Y. Jin and T. Wick},
   title   = {A quasi-monolithic phase-field description for mixed-mode fracture using predictor-corrector mesh adaptivity},
   journal = {Engineering with Computers (EWCO)},
+  year    = 2021,
   note    = {Accepted},
-  year    = 2021
+  doi     = {10.1007/s00366-021-01423-6}
 }
 
 @Article{2021:fehn.heinz.ea:high-order,
+  author  = {Niklas Fehn and Johannes Heinz and Wolfgang A. Wall and Martin Kronbichler},
   title   = {High-order arbitrary {L}agrangian--{E}ulerian discontinuous {G}alerkin methods for the incompressible {N}avier--{S}tokes equations},
   journal = {Journal of Computational Physics},
+  year    = 2021,
   volume  = 430,
   pages   = 110040,
-  year    = 2021,
   issn    = {0021-9991},
   doi     = {10.1016/j.jcp.2020.110040},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0021999120308147},
-  author  = {Niklas Fehn and Johannes Heinz and Wolfgang A. Wall and Martin Kronbichler}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0021999120308147}
 }
 
 @Article{2021:fehn.kronbichler.ea:numerical,
-  doi     = {10.1017/jfm.2021.1003},
-  year    = 2021,
-  month   = dec,
-  publisher = {Cambridge University Press ({CUP})},
-  volume  = 932,
   author  = {Niklas Fehn and Martin Kronbichler and Peter Munch and Wolfgang A. Wall},
   title   = {Numerical evidence of anomalous energy dissipation in incompressible Euler flows: towards grid-converged results for the inviscid Taylor{\textendash}Green problem},
-  journal = {Journal of Fluid Mechanics}
+  journal = {Journal of Fluid Mechanics},
+  year    = 2021,
+  volume  = 932,
+  month   = dec,
+  doi     = {10.1017/jfm.2021.1003},
+  publisher = {Cambridge University Press ({CUP})}
 }
 
 @PhDThesis{2021:fehn:robust,
-  title   = {Robust and Efficient Discontinuous {G}alerkin Methods for Incompressible Flows},
   author  = {Fehn, Niklas},
-  year    = 2021,
+  title   = {Robust and Efficient Discontinuous {G}alerkin Methods for Incompressible Flows},
   school  = {Technische Universit{\"a}t M{\"u}nchen},
+  year    = 2021,
   url     = {https://mediatum.ub.tum.de/1601025}
 }
 
@@ -327,58 +327,58 @@
   author  = {Fehse, Andreas and Kr{\"o}ger, Nils Hendrik and Mang, Katrin and Wick, Thomas},
   title   = {Crack path comparisons of a mixed phase-field fracture model and experiments in punctured EPDM strips},
   journal = {PAMM},
+  year    = 2021,
   volume  = 20,
   number  = 1,
   pages   = {e202000335},
   doi     = {10.1002/pamm.202000335},
   url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202000335},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202000335},
-  year    = 2021
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202000335}
 }
 
 @Article{2021:fraters.billen:on,
-  doi     = {10.1029/2021gc009846},
-  year    = 2021,
-  month   = oct,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = 22,
-  number  = 10,
   author  = {M. R. T. Fraters and M. I. Billen},
   title   = {On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling},
-  journal = {Geochemistry, Geophysics, Geosystems}
+  journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2021,
+  volume  = 22,
+  number  = 10,
+  month   = oct,
+  doi     = {10.1029/2021gc009846},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2021:frei.richter.ea:locmodfe--locally-modified-finite-elements-for-approximating-interface-problems-in-deal-ii,
+  author  = {Stefan Frei and Thomas Richter and Thomas Wick},
   title   = {{LocModFE: Locally modified finite elements for approximating interface problems in deal.II}},
   journal = {Software Impacts},
+  year    = 2021,
   volume  = 8,
   pages   = 100070,
-  year    = 2021,
   issn    = {2665-9638},
   doi     = {10.1016/j.simpa.2021.100070},
-  url     = {https://www.sciencedirect.com/science/article/pii/S266596382100018X},
-  author  = {Stefan Frei and Thomas Richter and Thomas Wick}
+  url     = {https://www.sciencedirect.com/science/article/pii/S266596382100018X}
 }
 
 @Article{2021:giani.grubisic.ea:smoothed-adaptive,
   author  = {Stefano Giani and Luka Grubisic and Luca Heltai and Ornela Mulita},
+  title   = {Smoothed-adaptive perturbed inverse iteration for elliptic eigenvalue problems},
   journal = {Computational Methods in Applied Mathematics},
+  year    = 2021,
+  volume  = 21,
   number  = 2,
   pages   = {385--405},
-  title   = {Smoothed-adaptive perturbed inverse iteration for elliptic eigenvalue problems},
-  volume  = 21,
-  year    = 2021,
   doi     = {10.1515/cmam-2020-0027}
 }
 
 @Article{2021:golshan.blais:load-balancing,
-  title   = {Load-Balancing Strategies in Discrete Element Method Simulations},
   author  = {Golshan, Shahab and Blais, Bruno},
+  title   = {Load-Balancing Strategies in Discrete Element Method Simulations},
   journal = {Processes},
+  year    = 2021,
   volume  = 10,
   number  = 1,
   pages   = 79,
-  year    = 2021,
   doi     = {10.3390/pr10010079},
   publisher = {MDPI}
 }
@@ -399,57 +399,57 @@
   author  = {Grayver, Alexander V. and Kuvshinov, Alexey and Werthm{\"u}ller, Dieter},
   title   = {Time-domain modeling of 3-D Earth's and planetary electromagnetic induction effect in ground and satellite observations},
   journal = {Journal of Geophysical Research: Space Physics},
-  volume  = 129,
   year    = 2021,
+  volume  = 129,
   pages   = {e2020JA028672},
   doi     = {10.1029/2020JA028672}
 }
 
 @Article{2021:greiner.reiter.ea:poro-viscoelastic,
   author  = {Greiner, Alexander and Reiter, Nina and Paulsen, Friedrich and Holzapfel, Gerhard A. and Steinmann, Paul and Comellas, Ester and Budday, Silvia},
-  doi     = {10.3389/fmech.2021.708350},
+  title   = {Poro-Viscoelastic Effects During Biomechanical Testing of Human Brain Tissue},
   journal = {Frontiers in Mechanical Engineering},
+  year    = 2021,
+  volume  = 7,
   number  = 708350,
   pages   = {1--18},
-  title   = {Poro-Viscoelastic Effects During Biomechanical Testing of Human Brain Tissue},
-  volume  = 7,
-  year    = 2021
+  doi     = {10.3389/fmech.2021.708350}
 }
 
 @Article{2021:guermond.maier.ea:second-order,
   author  = {Jean-Luc Guermond and Matthias Maier and Bojan Popov and Ignacio Tomas},
   title   = {Second-order invariant domain preserving approximation of the compressible Navier--Stokes equations},
-  doi     = {10.1016/j.cma.2020.113608},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   year    = 2021,
   volume  = 375,
   number  = 1,
-  pages   = 113608
+  pages   = 113608,
+  doi     = {10.1016/j.cma.2020.113608}
 }
 
 @Article{2021:he:gwsim,
-  doi     = {10.1093/mnras/stab2080},
+  author  = {Jian-hua He},
+  title   = {gwsim: a code to simulate gravitational waves propagating in a potential well},
+  journal = {Monthly Notices of the Royal Astronomical Society},
   year    = 2021,
-  month   = jul,
-  publisher = {Oxford University Press ({OUP})},
   volume  = 506,
   number  = 4,
   pages   = {5278--5293},
-  author  = {Jian-hua He},
-  title   = {gwsim: a code to simulate gravitational waves propagating in a potential well},
-  journal = {Monthly Notices of the Royal Astronomical Society}
+  month   = jul,
+  doi     = {10.1093/mnras/stab2080},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @Article{2021:heckenbach.brune.ea:is,
   author  = {Heckenbach, Esther L. and Brune, Sascha and Glerum, Anne C. and Bott, Judith},
   title   = {Is there a Speed Limit for the Thermal Steady-State Assumption in Continental Rifts?},
   journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2021,
   volume  = 22,
   number  = 3,
   pages   = {e2020GC009577},
   doi     = {10.1029/2020GC009577},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020GC009577},
-  year    = 2021
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020GC009577}
 }
 
 @Article{2021:heister.mang.ea:schur-type,
@@ -466,19 +466,19 @@
 
 @Article{2021:heltai.bangerth.ea:propagating,
   author  = {Luca Heltai and Wolfgang Bangerth and Martin Kronbichler and Andrea Mola},
+  title   = {Propagating geometry information to finite element computations},
   journal = {Transactions on Mathematical Software},
+  year    = 2021,
+  volume  = 47,
   number  = 4,
   pages   = {1--30},
-  title   = {Propagating geometry information to finite element computations},
-  volume  = 47,
-  year    = 2021,
   doi     = {10.1145/3468428}
 }
 
 @Article{2021:heltai.caiazzo.ea:multiscale,
   author  = {Luca Heltai and Alfonso Caiazzo and Lucas O. M\"{u}ller},
-  journal = {Annals of Biomedical Engineering},
   title   = {Multiscale Coupling of One-dimensional Vascular Models and Elastic Tissues},
+  journal = {Annals of Biomedical Engineering},
   year    = 2021,
   volume  = 49,
   pages   = {3243--3254},
@@ -486,63 +486,63 @@
 }
 
 @Article{2021:herrnbock.kumar.ea:geometrically,
-  doi     = {10.1007/s00466-020-01957-4},
+  author  = {Ludwig Herrnb\"{o}ck and Ajeet Kumar and Paul Steinmann},
+  title   = {Geometrically exact elastoplastic rods: determination of yield surface in terms of stress resultants},
+  journal = {Computational Mechanics},
   year    = 2021,
-  month   = feb,
-  publisher = {Springer Science and Business Media {LLC}},
   volume  = 67,
   number  = 3,
   pages   = {723--742},
-  author  = {Ludwig Herrnb\"{o}ck and Ajeet Kumar and Paul Steinmann},
-  title   = {Geometrically exact elastoplastic rods: determination of yield surface in terms of stress resultants},
-  journal = {Computational Mechanics}
+  month   = feb,
+  doi     = {10.1007/s00466-020-01957-4},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @InBook{2021:hoggard.austermann.ea:mantle,
   author  = {Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon},
   editor  = {H. Marquardt, M. Ballmer},
-  chapter = {Observational estimates of dynamic topography through space and time},
   title   = {Mantle convection and surface expressions},
-  series  = {AGU Geophysical Monograph Series},
-  year    = 2021,
-  address = {Washington, D.C.},
+  chapter = {Observational estimates of dynamic topography through space and time},
   publisher = {AGU},
+  year    = 2021,
+  series  = {AGU Geophysical Monograph Series},
+  address = {Washington, D.C.},
   doi     = {10.1002/9781119528609.ch15}
 }
 
 @Article{2021:jammoul.wheeler.ea:phase-field,
+  author  = {Mohamad Jammoul and Mary F. Wheeler and Thomas Wick},
   title   = {A phase-field multirate scheme with stabilized iterative coupling for pressure driven fracture propagation in porous media},
   journal = {Computers {\&} Mathematics with Applications},
+  year    = 2021,
   volume  = 91,
   pages   = {176--191},
-  year    = 2021,
   note    = {Robust and Reliable Finite Element Methods in Poromechanics},
   issn    = {0898-1221},
   doi     = {10.1016/j.camwa.2020.11.009},
-  url     = {https://www.sciencedirect.com/science/article/pii/S089812212030434X},
-  author  = {Mohamad Jammoul and Mary F. Wheeler and Thomas Wick}
+  url     = {https://www.sciencedirect.com/science/article/pii/S089812212030434X}
 }
 
 @Article{2021:kinnewig.roth.ea:geometric,
+  author  = {Sebastian Kinnewig and Julian Roth and Thomas Wick},
   title   = {Geometric multigrid with multiplicative Schwarz smoothers for eddy-current and Maxwell's equations in deal.II},
   journal = {Examples and Counterexamples},
+  year    = 2021,
   volume  = 1,
   pages   = 100027,
-  year    = 2021,
   issn    = {2666-657X},
   doi     = {10.1016/j.exco.2021.100027},
-  url     = {https://www.sciencedirect.com/science/article/pii/S2666657X2100015X},
-  author  = {Sebastian Kinnewig and Julian Roth and Thomas Wick}
+  url     = {https://www.sciencedirect.com/science/article/pii/S2666657X2100015X}
 }
 
 @InCollection{2021:klein.schuster.ea:sequential,
-  doi     = {10.1007/978-3-030-57784-1_6},
-  year    = 2021,
-  publisher = {Springer International Publishing},
-  pages   = {165--190},
   author  = {Rebecca Klein and Thomas Schuster and Anne Wald},
   title   = {Sequential Subspace Optimization for Recovering Stored Energy Functions in Hyperelastic Materials from Time-Dependent Data},
-  booktitle = {Time-dependent Problems in Imaging and Parameter Identification}
+  booktitle = {Time-dependent Problems in Imaging and Parameter Identification},
+  publisher = {Springer International Publishing},
+  year    = 2021,
+  pages   = {165--190},
+  doi     = {10.1007/978-3-030-57784-1_6}
 }
 
 @Article{2021:kourakos.harter:simulation,
@@ -560,16 +560,16 @@
 @InProceedings{2021:kronbichler.fehn.ea:next-generation,
   author  = {Kronbichler, Martin and Fehn, Niklas and Munch, Peter and Bergbauer, Maximilian and Wichmann, Karl-Robert and Geitner, Carolin and Allalen, Momme and Schulz, Martin and Wall, Wolfgang A.},
   title   = {A Next-Generation Discontinuous {G}alerkin Fluid Dynamics Solver with Application to High-Resolution Lung Airflow Simulations},
-  year    = 2021,
-  isbn    = 9781450384421,
-  publisher = {Association for Computing Machinery},
-  address = {New York, NY, USA},
-  doi     = {10.1145/3458817.3476171},
   booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis},
+  year    = 2021,
+  series  = {SC '21},
+  address = {New York, NY, USA},
+  publisher = {Association for Computing Machinery},
+  isbn    = 9781450384421,
+  doi     = {10.1145/3458817.3476171},
   articleno = 21,
   numpages = 15,
-  location = {St. Louis, Missouri},
-  series  = {SC '21}
+  location = {St. Louis, Missouri}
 }
 
 @Article{2021:lee.saxena.ea:contributions-from-lithospheric-and-upper-mantle-heterogeneities-to-upper-crustal-seismicity-in-the-korean-peninsula,
@@ -578,81 +578,81 @@
   journal = {Geophysical Journal International},
   year    = 2021,
   month   = dec,
+  note    = {ggab527},
   issn    = {0956-540X},
   doi     = {10.1093/gji/ggab527},
-  note    = {ggab527},
   eprint  = {https://academic.oup.com/gji/advance-article-pdf/doi/10.1093/gji/ggab527/41971016/ggab527.pdf}
 }
 
 @Article{2021:li.lipton.ea:lorentz,
   author  = {Wei Li and Robert Lipton and Matthias Maier},
   title   = {{L}orentz resonance in the homogenization of plasmonic crystals},
-  doi     = {10.1098/rspa.2021.0609},
   journal = {Proceedings of the Royal Society A: Mathematical, Physical, and Engineering Sciences},
   year    = 2021,
   volume  = 477,
-  pages   = 20210609
+  pages   = 20210609,
+  doi     = {10.1098/rspa.2021.0609}
 }
 
 @Article{2021:liu.moller.ea:balancing,
-  doi     = {10.1016/j.cam.2020.113219},
-  year    = 2021,
-  month   = apr,
-  publisher = {Elsevier {BV}},
-  volume  = 386,
-  pages   = 113219,
   author  = {Jie Liu and Matthias M\"{o}ller and Henk M. Schuttelaars},
   title   = {Balancing truncation and round-off errors in {FEM}: One-dimensional analysis},
-  journal = {Journal of Computational and Applied Mathematics}
+  journal = {Journal of Computational and Applied Mathematics},
+  year    = 2021,
+  volume  = 386,
+  pages   = 113219,
+  month   = apr,
+  doi     = {10.1016/j.cam.2020.113219},
+  publisher = {Elsevier {BV}}
 }
 
 @Article{2021:lundin.dore.ea:utilization,
   author  = {Lundin, E. R. and Dor{\'e}, A. G. and Naliboff, J. and Van Wijk, J.},
   title   = {Utilization of continental transforms in break-up: observations, models, and a potential link to magmatism},
+  journal = {Geological Society, London, Special Publications},
+  year    = 2021,
   volume  = 524,
   elocation-id = {SP524-2021-119},
-  year    = 2021,
   doi     = {10.1144/SP524-2021-119},
   publisher = {Geological Society of London},
   issn    = {0305-8719},
   url     = {https://sp.lyellcollection.org/content/early/2021/12/22/SP524-2021-119},
-  eprint  = {https://sp.lyellcollection.org/content/early/2021/12/22/SP524-2021-119.full.pdf},
-  journal = {Geological Society, London, Special Publications}
+  eprint  = {https://sp.lyellcollection.org/content/early/2021/12/22/SP524-2021-119.full.pdf}
 }
 
 @Article{2021:magni.naliboff.ea:ridge,
-  doi     = {10.3390/geosciences11110475},
+  author  = {Valentina Magni and John Naliboff and Manel Prada and Carmen Gaina},
+  title   = {Ridge Jumps and Mantle Exhumation in Back-Arc Basins},
+  journal = {Geosciences},
   year    = 2021,
-  month   = nov,
-  publisher = {{MDPI} {AG}},
   volume  = 11,
   number  = 11,
   pages   = 475,
-  author  = {Valentina Magni and John Naliboff and Manel Prada and Carmen Gaina},
-  title   = {Ridge Jumps and Mantle Exhumation in Back-Arc Basins},
-  journal = {Geosciences}
+  month   = nov,
+  doi     = {10.3390/geosciences11110475},
+  publisher = {{MDPI} {AG}}
 }
 
 @Article{2021:maier.kronbichler:efficient,
   author  = {Matthias Maier and Martin Kronbichler},
   title   = {Efficient parallel 3D computation of the compressible Euler equations with an invariant-domain preserving second-order finite-element scheme},
-  doi     = {10.1145/3470637},
   journal = {ACM Transactions on Parallel Computing},
   year    = 2021,
   volume  = 8,
   number  = 3,
-  pages   = {16:1--30}
+  pages   = {16:1--30},
+  doi     = {10.1145/3470637}
 }
 
 @Article{2021:mang.fehse.ea:mixed,
-  doi     = {10.1016/j.tafmec.2021.103076},
-  year    = 2021,
-  month   = aug,
-  publisher = {Elsevier {BV}},
-  pages   = 103076,
   author  = {Katrin Mang and Andreas Fehse and Nils Hendrik Kr\"{o}ger and Thomas Wick},
   title   = {A mixed phase-field fracture model for crack propagation in punctured {EPDM} strips},
-  journal = {Theoretical and Applied Fracture Mechanics}
+  journal = {Theoretical and Applied Fracture Mechanics},
+  year    = 2021,
+  pages   = 103076,
+  month   = aug,
+  doi     = {10.1016/j.tafmec.2021.103076},
+  publisher = {Elsevier {BV}}
 }
 
 @InProceedings{2021:mang.wick:numerical-studies-of-different-mixed-phase-field-fracture-models-for-simulating-crack-propagation-in-punctured-epdm-strips,
@@ -674,112 +674,112 @@
 
 @Article{2021:mulita.giani.ea:quasi-optimal,
   author  = {Ornela Mulita and Stefano Giani and Luca Heltai},
+  title   = {Quasi-Optimal Mesh Sequence Construction through Smoothed Adaptive Finite Element Methods},
   journal = {{SIAM} Journal on Scientific Computing},
+  year    = 2021,
+  volume  = 43,
   number  = 3,
   pages   = {A2211--A2241},
-  title   = {Quasi-Optimal Mesh Sequence Construction through Smoothed Adaptive Finite Element Methods},
-  volume  = 43,
-  year    = 2021,
   doi     = {10.1137/19m1262097}
 }
 
 @Article{2021:munch.kormann.ea:hyper,
-  title   = {hyper.deal: An Efficient, Matrix-Free Finite-Element Library for High-Dimensional Partial Differential Equations},
   author  = {Munch, Peter and Kormann, Katharina and Kronbichler, Martin},
+  title   = {hyper.deal: An Efficient, Matrix-Free Finite-Element Library for High-Dimensional Partial Differential Equations},
+  journal = {ACM Trans. Math. Softw.},
   year    = 2021,
+  volume  = 47,
+  number  = 4,
+  month   = sep,
   issue_date = {December 2021},
   publisher = {Association for Computing Machinery},
   address = {New York, NY, USA},
-  volume  = 47,
-  number  = 4,
   issn    = {0098-3500},
   doi     = {10.1145/3469720},
-  journal = {ACM Trans. Math. Softw.},
-  month   = sep,
   articleno = 33,
   numpages = 34
 }
 
 @Article{2021:neuharth.brune.ea:formation,
-  doi     = {10.1029/2020gc009615},
-  year    = 2021,
-  month   = apr,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = 22,
-  number  = 4,
   author  = {Derek Neuharth and Sascha Brune and Anne Glerum and Christian Heine and J. Kim Welford},
   title   = {Formation of Continental Microplates Through Rift Linkage: Numerical Modeling and Its Application to the Flemish Cap and Sao Paulo Plateau},
-  journal = {Geochemistry, Geophysics, Geosystems}
+  journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2021,
+  volume  = 22,
+  number  = 4,
+  month   = apr,
+  doi     = {10.1029/2020gc009615},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2021:noii.fan.ea:quasi-monolithic,
+  author  = {Nima Noii and Meng Fan and Thomas Wick and Yan Jin},
   title   = {A quasi-monolithic phase-field description for orthotropic anisotropic fracture with adaptive mesh refinement and primal-dual active set method},
   journal = {Engineering Fracture Mechanics},
+  year    = 2021,
   volume  = 258,
   pages   = 108060,
-  year    = 2021,
   issn    = {0013-7944},
   doi     = {10.1016/j.engfracmech.2021.108060},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0013794421004744},
-  author  = {Nima Noii and Meng Fan and Thomas Wick and Yan Jin}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0013794421004744}
 }
 
 @Article{2021:pacheco.schussnig.ea:efficient,
   author  = {Douglas R.Q. Pacheco and Richard Schussnig and Thomas-Peter Fries},
+  title   = {An efficient split-step framework for non-{N}ewtonian incompressible flow problems with consistent pressure boundary conditions},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2021,
+  volume  = 382,
+  pages   = 113888,
   doi     = {10.1016/j.cma.2021.113888},
   issn    = 00457825,
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  pages   = 113888,
   publisher = {Elsevier B.V.},
-  title   = {An efficient split-step framework for non-{N}ewtonian incompressible flow problems with consistent pressure boundary conditions},
-  volume  = 382,
-  url     = {https://linkinghub.elsevier.com/retrieve/pii/S0045782521002255},
-  year    = 2021
+  url     = {https://linkinghub.elsevier.com/retrieve/pii/S0045782521002255}
 }
 
 @Article{2021:pacheco.schussnig.ea:global,
   author  = {Douglas R. Q. Pacheco and Richard Schussnig and Olaf Steinbach and Thomas-Peter Fries},
+  title   = {A global residual-based stabilization for equal-order finite element approximations of incompressible flows},
+  journal = {International Journal for Numerical Methods in Engineering},
+  year    = 2021,
+  volume  = 122,
+  pages   = {2075--2094},
   doi     = {10.1002/nme.6615},
   issn    = {0029-5981},
   issue   = 8,
-  journal = {International Journal for Numerical Methods in Engineering},
-  pages   = {2075--2094},
-  title   = {A global residual-based stabilization for equal-order finite element approximations of incompressible flows},
-  volume  = 122,
-  url     = {https://onlinelibrary.wiley.com/doi/10.1002/nme.6615},
-  year    = 2021
+  url     = {https://onlinelibrary.wiley.com/doi/10.1002/nme.6615}
 }
 
 @Article{2021:pagani.dede.ea:computational,
-  doi     = {10.3389/fphys.2021.673612},
   author  = {Pagani, S. and Ded{\`{e}}, L. and Frontera, A. and Salvador, M. and Limite, L. R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. and Quarteroni, A.},
   title   = {A Computational Study of the Electrophysiological Substrate in Patients Suffering From Atrial Fibrillation},
   journal = {Frontiers in Physiology},
-  volume  = 12,
   year    = 2021,
+  volume  = 12,
+  doi     = {10.3389/fphys.2021.673612},
   publisher = {Frontiers Media SA}
 }
 
 @Article{2021:piersanti.africa.ea:modeling,
-  doi     = {10.1016/j.cma.2020.113468},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0045782520306538},
-  year    = 2021,
-  month   = jan,
-  publisher = {Elsevier},
-  volume  = 373,
-  pages   = 113468,
   author  = {Roberto Piersanti and Pasquale Claudio Africa and Marco Fedele and Christian Vergara and Luca Ded{\`{e}} and Antonio F. Corno and Alfio Quarteroni},
   title   = {Modeling cardiac muscle fibers in ventricular and atrial electrophysiology simulations},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2021,
+  volume  = 373,
+  pages   = 113468,
+  month   = jan,
+  doi     = {10.1016/j.cma.2020.113468},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0045782520306538},
+  publisher = {Elsevier}
 }
 
 @Article{2021:regazzoni.quarteroni:accelerating,
   author  = {Regazzoni, F. and Quarteroni, A.},
   title   = {Accelerating the convergence to a limit cycle in 3D cardiac electromechanical simulations through a data-driven 0D emulator},
   journal = {Computers in Biology and Medicine},
+  year    = 2021,
   volume  = 135,
   pages   = 104641,
-  year    = 2021,
   issn    = {0010-4825}
 }
 
@@ -801,14 +801,14 @@
 }
 
 @Article{2021:ross.domnguez.ea:energy,
-  doi     = {10.3389/fphys.2021.628819},
-  year    = 2021,
-  month   = apr,
-  publisher = {Frontiers Media {SA}},
-  volume  = 12,
   author  = {Stephanie A. Ross and Sebasti{\'{a}}n Dom{\'{\i}}nguez and Nilima Nigam and James M. Wakeling},
   title   = {The Energy of Muscle Contraction. {III}. Kinetic Energy During Cyclic Contractions},
-  journal = {Frontiers in Physiology}
+  journal = {Frontiers in Physiology},
+  year    = 2021,
+  volume  = 12,
+  month   = apr,
+  doi     = {10.3389/fphys.2021.628819},
+  publisher = {Frontiers Media {SA}}
 }
 
 @MastersThesis{2021:roth:proper,
@@ -822,13 +822,13 @@
 
 @Article{2021:sabanskis.plate.ea:evaluation,
   author  = {Sabanskis, Andrejs and Pl{\={a}}te, Mat{\={\i}}ss and Sattler, Andreas and Miller, Alfred and Virbulis, J{\={a}}nis},
-  journal = {Crystals},
   title   = {Evaluation of the performance of published point defect parameter sets in cone and body phase of a 300 mm {Czochralski} silicon crystal},
+  journal = {Crystals},
   year    = 2021,
-  issn    = {2073-4352},
+  volume  = 11,
   number  = 5,
   pages   = 460,
-  volume  = 11,
+  issn    = {2073-4352},
   doi     = {10.3390/cryst11050460},
   publisher = {{MDPI} {AG}}
 }
@@ -844,12 +844,12 @@
 }
 
 @Article{2021:samrock.grayver.ea:integrated,
-  title   = {Integrated magnetotelluric and petrological analysis of felsic magma reservoirs: Insights from Ethiopian rift volcanoes},
   author  = {Samrock, Friedemann and Grayver, Alexander V and Bachmann, Olivier and Karakas, {\"O}zge and Saar, Martin O},
+  title   = {Integrated magnetotelluric and petrological analysis of felsic magma reservoirs: Insights from Ethiopian rift volcanoes},
   journal = {Earth and Planetary Science Letters},
+  year    = 2021,
   volume  = 559,
   pages   = 116765,
-  year    = 2021,
   publisher = {Elsevier}
 }
 
@@ -857,24 +857,24 @@
   author  = {Saxena, Arushi and Choi, Eunseo and Powell, Christine A and Aslam, Khurram S},
   title   = {{Seismicity in the central and southeastern United States due to upper mantle heterogeneities}},
   journal = {Geophysical Journal International},
+  year    = 2021,
   volume  = 225,
   number  = 3,
   pages   = {1624--1636},
-  year    = 2021,
   month   = mar,
   doi     = {10.1093/gji/ggab051}
 }
 
 @Article{2021:schussnig.pacheco.ea:robust,
+  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   title   = {Robust stabilised finite element solvers for generalised {N}ewtonian fluid flows},
   journal = {Journal of Computational Physics},
+  year    = 2021,
   volume  = 442,
   pages   = 110436,
-  year    = 2021,
   issn    = {0021-9991},
   doi     = {10.1016/j.jcp.2021.110436},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0021999121003314},
-  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0021999121003314}
 }
 
 @Article{2021:stark:on,
@@ -891,25 +891,25 @@
   author  = {Thiele, Jan Philipp and Wick, Thomas},
   title   = {Space-time PU-DWR error control and adaptivity for the heat equation},
   journal = {PAMM},
+  year    = 2021,
   volume  = 21,
   number  = 1,
   pages   = {e202100174},
   doi     = {10.1002/pamm.202100174},
   url     = {https://onlinelibrary.wiley.com/doi/abs/10.1002/pamm.202100174},
-  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100174},
-  year    = 2021
+  eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/pamm.202100174}
 }
 
 @Article{2021:uluocak.gogus.ea:geodynamics,
-  doi     = {10.1029/2021tc007031},
-  year    = 2021,
-  month   = dec,
-  publisher = {American Geophysical Union ({AGU})},
-  volume  = 40,
-  number  = 12,
   author  = {Ebru {\c{S}}eng\"{u}l Uluocak and O{\u{g}}uz H. G\"{o}{\u{g}}\"{u}{\c{s}} and Russell N. Pysklywec and Bo Chen},
   title   = {Geodynamics of East Anatolia-Caucasus Domain: Inferences From 3D Thermo-Mechanical Models, Residual Topography, and Admittance Function Analyses},
-  journal = {Tectonics}
+  journal = {Tectonics},
+  year    = 2021,
+  volume  = 40,
+  number  = 12,
+  month   = dec,
+  doi     = {10.1029/2021tc007031},
+  publisher = {American Geophysical Union ({AGU})}
 }
 
 @Article{2021:veszelka.queisser.ea:impact,
@@ -928,22 +928,22 @@
   title   = {Adjoint-based methods for optimization and goal-oriented error control applied to fluid-structure interaction: implementation of a partition-of-unity dual-weighted residual estimator for stationary forward FSI problems in deal.II},
   booktitle = {Book of VI ECCOMAS Young Investigators Conference YIC2021},
   year    = 2021,
-  doi     = {10.4995/YIC2021.2021.12332},
+  pages   = {257--266},
   publisher = {Editorial Universitat Politecnica de Valencia},
-  pages   = {257--266}
+  doi     = {10.4995/YIC2021.2021.12332}
 }
 
 @Article{2021:wick:dual-weighted,
-  doi     = {10.1515/cmam-2020-0038},
+  author  = {Thomas Wick},
+  title   = {Dual-Weighted Residual A Posteriori Error Estimates for a Penalized Phase-Field Slit Discontinuity Problem},
+  journal = {Computational Methods in Applied Mathematics},
   year    = 2021,
-  month   = jun,
-  publisher = {Walter de Gruyter {GmbH}},
   volume  = 21,
   number  = 3,
   pages   = {693--707},
-  author  = {Thomas Wick},
-  title   = {Dual-Weighted Residual A Posteriori Error Estimates for a Penalized Phase-Field Slit Discontinuity Problem},
-  journal = {Computational Methods in Applied Mathematics}
+  month   = jun,
+  doi     = {10.1515/cmam-2020-0038},
+  publisher = {Walter de Gruyter {GmbH}}
 }
 
 @InProceedings{2021:wick:on-the-adjoint-equation-in-fluid-structure-interaction,
@@ -955,23 +955,23 @@
 }
 
 @Article{2021:wilde.kramer.ea:high-order,
-  doi     = {10.1103/physreve.104.025301},
-  year    = 2021,
-  month   = aug,
-  publisher = {American Physical Society ({APS})},
-  volume  = 104,
-  number  = 2,
   author  = {Dominik Wilde and Andreas Kr\"{a}mer and Dirk Reith and Holger Foysi},
   title   = {High-order semi-Lagrangian kinetic scheme for compressible turbulence},
-  journal = {Physical Review E}
+  journal = {Physical Review E},
+  year    = 2021,
+  volume  = 104,
+  number  = 2,
+  month   = aug,
+  doi     = {10.1103/physreve.104.025301},
+  publisher = {American Physical Society ({APS})}
 }
 
 @MastersThesis{2021:withers:modelling,
   author  = {Withers, Craig},
   title   = {Modelling slab age and crustal thickness: numerical approaches to drivers of compressive stresses in the overriding plate in Andean style subduction zone systems},
+  school  = {Durham theses},
   year    = 2021,
   publisher = {Durham University},
-  school  = {Durham theses},
   opturl  = {http://etheses.dur.ac.uk/13836/}
 }
 

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -1,109 +1,109 @@
 % Encoding: US-ASCII
 
 @Misc{2022:africa:lifex,
-  doi     = {10.48550/ARXIV.2207.14668},
   author  = {Africa, Pasquale Claudio},
   title   = {lifex: a flexible, high performance library for the numerical solution of complex finite element problems},
-  publisher = {arXiv},
-  year    = 2022
+  year    = 2022,
+  doi     = {10.48550/ARXIV.2207.14668},
+  publisher = {arXiv}
 }
 
 @Article{2022:aggul.labovsky.ea:ns-,
+  author  = {Mustafa Aggul and Alexander E. Labovsky and Kyle J. Schwiebert},
   title   = {{NS}-$\omega$ model for fluid--fluid interaction problems at high {Reynolds} numbers},
   journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2022,
   volume  = 395,
   pages   = 115052,
-  year    = 2022,
   month   = may,
   publisher = {Elsevier {BV}},
   issn    = {0045-7825},
   doi     = {10.1016/j.cma.2022.115052},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0045782522002663},
-  author  = {Mustafa Aggul and Alexander E. Labovsky and Kyle J. Schwiebert}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0045782522002663}
 }
 
 @Article{2022:ahuja.endtmayer.ea:multigoal-oriented,
   author  = {K. Ahuja and B. Endtmayer and M.C. Steinbach and T. Wick},
   title   = {Multigoal-oriented error estimation and mesh adaptivity for fluid-structure interaction},
   journal = {Journal of Computational and Applied Mathematics},
+  year    = 2022,
   volume  = 412,
   pages   = 114315,
-  year    = 2022,
   issn    = {0377-0427},
   doi     = {10.1016/j.cam.2022.114315},
   url     = {https://www.sciencedirect.com/science/article/pii/S0377042722001340}
 }
 
 @Article{2022:arndt.bangerth.ea:deal-ii,
-  title   = {The \texttt{deal.II} Library, Version 9.4},
   author  = {Daniel Arndt and Wolfgang Bangerth and Marco Feder and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Simon Sticko and Bruno Turcksin and David Wells},
+  title   = {The \texttt{deal.II} Library, Version 9.4},
   journal = {Journal of Numerical Mathematics},
-  doi     = {10.1515/jnma-2022-0054},
   year    = 2022,
   volume  = 30,
   number  = 3,
   pages   = {231--246},
+  doi     = {10.1515/jnma-2022-0054},
   url     = {https://dealii.org/deal94-preprint.pdf}
 }
 
 @Article{2022:axelsson.dravins.ea:stage-parallel,
-  title   = {Stage-parallel preconditioners for implicit Runge-Kutta methods of arbitrary high order. Linear problems},
   author  = {Owe Axelsson and Ivo Dravins and Maya Neytcheva},
+  title   = {Stage-parallel preconditioners for implicit Runge-Kutta methods of arbitrary high order. Linear problems},
   journal = {submitted},
   year    = 2022,
   url     = {http://www.it.uu.se/research/publications/reports/2022-004/2022-004-nc.pdf}
 }
 
 @Article{2022:barbeau.etienne.ea:development,
-  title   = {Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems},
   author  = {Barbeau, Lucka and {\'E}tienne, St{\'e}phane and B{\'e}guin, C{\'e}dric and Blais, Bruno},
+  title   = {Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems},
   journal = {Computers \& Fluids},
+  year    = 2022,
   volume  = 239,
   pages   = 105415,
-  year    = 2022,
   url     = {https://doi.org/10.1016/j.compfluid.2022.105415},
   publisher = {Elsevier}
 }
 
 @InCollection{2022:basava.mang.ea:adaptive,
-  doi     = {10.1007/978-3-030-92672-4_8},
-  year    = 2022,
-  publisher = {Springer International Publishing},
-  pages   = {191--215},
   author  = {Seshadri Basava and Katrin Mang and Mirjam Walloth and Thomas Wick and Winnifried Wollner},
   title   = {Adaptive and Pressure-Robust Discretization of Incompressible Pressure-Driven Phase-Field Fracture},
-  booktitle = {Non-standard Discretisation Methods in Solid Mechanics}
+  booktitle = {Non-standard Discretisation Methods in Solid Mechanics},
+  publisher = {Springer International Publishing},
+  year    = 2022,
+  pages   = {191--215},
+  doi     = {10.1007/978-3-030-92672-4_8}
 }
 
 @Article{2022:behr.holt.ea:effects,
-  doi     = {10.1093/gji/ggac075},
-  url     = {https://doi.org/10.1093/gji/ggac075},
-  year    = 2022,
-  month   = feb,
-  publisher = {Oxford University Press ({OUP})},
   author  = {Whitney M. Behr and Adam F. Holt and Thorsten W. Becker and Claudio Faccenna},
   title   = {The effects of plate interface rheology on subduction kinematics and dynamics},
-  journal = {Geophysical Journal International}
+  journal = {Geophysical Journal International},
+  year    = 2022,
+  month   = feb,
+  doi     = {10.1093/gji/ggac075},
+  url     = {https://doi.org/10.1093/gji/ggac075},
+  publisher = {Oxford University Press ({OUP})}
 }
 
 @Article{2022:comellas.farkas.ea:local,
   author  = {Comellas, Ester and Farkas, Johanna E. and Kleinberg, Giona and Lloyd, Katlyn and Mueller, Thomas and Duerr, Timothy J. and Mu{\~{n}}oz, Jose J. and Monaghan, James R. and Shefelbine, Sandra J.},
-  doi     = {10.1098/RSPB.2022.0621},
+  title   = {Local mechanical stimuli correlate with tissue growth in axolotl salamander joint morphogenesis},
   journal = {Proceedings of the Royal Society B},
+  year    = 2022,
+  volume  = 289,
   number  = 1975,
   pages   = 20220621,
-  title   = {Local mechanical stimuli correlate with tissue growth in axolotl salamander joint morphogenesis},
-  url     = {https://royalsocietypublishing.org/doi/10.1098/rspb.2022.0621},
-  volume  = 289,
-  year    = 2022
+  doi     = {10.1098/RSPB.2022.0621},
+  url     = {https://royalsocietypublishing.org/doi/10.1098/rspb.2022.0621}
 }
 
 @Article{2022:davies.kramer.ea:towards,
   author  = {Davies, D. R. and Kramer, S. C. and Ghelichkhan, S. and Gibson, A.},
   title   = {Towards automatic finite-element methods for geodynamics via {F}iredrake},
   journal = {Geoscientific Model Development},
-  volume  = 15,
   year    = 2022,
+  volume  = 15,
   number  = 13,
   pages   = {5127--5166},
   url     = {https://gmd.copernicus.org/articles/15/5127/2022/},
@@ -114,63 +114,63 @@
   author  = {Diehl, Patrick and Lipton, Robert and Wick, Thomas and Tyagi, Mayank},
   title   = {A comparative review of peridynamics and phase-field models for engineering fracture mechanics},
   journal = {Computational Mechanics},
+  year    = 2022,
   volume  = 69,
   number  = 6,
   pages   = {1259--1293},
-  year    = 2022,
   publisher = {Springer},
   doi     = {10.1007/s00466-022-02147-0}
 }
 
 @Article{2022:fang.zhang.ea:causal,
+  author  = {Gui Fang and Jian Zhang and Tianyao Hao and Miao Dong and Chenghao Jiang and Yubei He},
   title   = {The causal mechanism of the {S}angihe Forearc Thrust, {M}olucca {S}ea, northeast {I}ndonesia, from numerical simulation},
   journal = {Journal of Asian Earth Sciences},
+  year    = 2022,
   volume  = 237,
   pages   = 105350,
-  year    = 2022,
   issn    = {1367-9120},
   doi     = {10.1016/j.jseaes.2022.105350},
-  url     = {https://www.sciencedirect.com/science/article/pii/S1367912022002814},
-  author  = {Gui Fang and Jian Zhang and Tianyao Hao and Miao Dong and Chenghao Jiang and Yubei He}
+  url     = {https://www.sciencedirect.com/science/article/pii/S1367912022002814}
 }
 
 @Misc{2022:fehling.bangerth:algorithms,
-  doi     = {10.48550/ARXIV.2206.06512},
-  url     = {https://arxiv.org/abs/2206.06512},
   author  = {Fehling, Marc and Bangerth, Wolfgang},
   title   = {Algorithms for Parallel Generic $hp$-adaptive Finite Element Software},
-  publisher = {arXiv},
   year    = 2022,
+  doi     = {10.48550/ARXIV.2206.06512},
+  url     = {https://arxiv.org/abs/2206.06512},
+  publisher = {arXiv},
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
 @Misc{2022:fuest.heydari.ea:global,
   author  = {Fuest, Mario and Heydari, Shahin and Knobloch, Petr and Lankeit, Johannes and Wick, Thomas},
   title   = {Global existence of classical solutions and numerical simulations of a cancer invasion model},
+  year    = 2022,
   doi     = {10.48550/ARXIV.2205.08168},
   url     = {https://arxiv.org/abs/2205.08168},
   publisher = {arXiv},
-  year    = 2022,
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
 @Article{2022:fumagalli.vitullo.ea:image-based,
-  doi     = {10.3389/fphys.2021.787082},
-  title   = {Image-based computational hemodynamics analysis of systolic obstruction in hypertrophic cardiomyopathy},
   author  = {Fumagalli, Ivan and Vitullo, Piermario and Vergara, Christian and Fedele, Marco and Corno, Antonio F and Ippolito, Sonia and Scrofani, Roberto and Quarteroni, Alfio},
+  title   = {Image-based computational hemodynamics analysis of systolic obstruction in hypertrophic cardiomyopathy},
   journal = {Frontiers in Physiology},
+  year    = 2022,
   volume  = 12,
   pages   = 2437,
-  year    = 2022,
+  doi     = {10.3389/fphys.2021.787082},
   publisher = {Frontiers}
 }
 
 @Article{2022:golshan.munch.ea:lethe-dem,
-  title   = {Lethe-DEM: An open-source parallel discrete element solver with load balancing},
   author  = {Golshan, Shahab and Munch, Peter and Gassm{\"o}ller, Rene and Kronbichler, Martin and Blais, Bruno},
+  title   = {Lethe-DEM: An open-source parallel discrete element solver with load balancing},
   journal = {Computational Particle Mechanics},
-  pages   = {1--20},
   year    = 2022,
+  pages   = {1--20},
   doi     = {10.1007/s40571-022-00478-6},
   publisher = {Springer}
 }
@@ -178,25 +178,25 @@
 @Article{2022:guermond.kronbichler.ea:on,
   author  = {Jean-Luc~Guermond and Martin Kronbichler and Matthias Maier and Bojan Popov and Ignacio Tomas},
   title   = {On the implementation of a robust and efficient finite element-based parallel solver for the compressible Navier-stokes equations},
-  doi     = {10.1016/j.cma.2021.114250},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   year    = 2022,
   volume  = 389,
-  pages   = 114250
+  pages   = 114250,
+  doi     = {10.1016/j.cma.2021.114250}
 }
 
 @Article{2022:heyn.conrad:on,
   author  = {Heyn, Bj{\"o}rn H. and Conrad, Clinton P.},
   title   = {On the relation between basal erosion of the lithosphere and surface heat flux for continental plume tracks},
   journal = {Geophysical Research Letters},
+  year    = 2022,
   volume  = 49,
   number  = 7,
-  year    = 2022,
   pages   = {e2022GL098003},
+  note    = {e2022GL098003 2022GL098003},
   doi     = {10.1029/2022GL098003},
   url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2022GL098003},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2022GL098003},
-  note    = {e2022GL098003 2022GL098003}
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2022GL098003}
 }
 
 @InProceedings{2022:j-p-thiele:space-time,
@@ -211,38 +211,38 @@
   author  = {Janbakhsh, Payman},
   title   = {Numerical Modeling Of Tectonic Plates \& Application of Artificial Neural Networks in Earthquake Seismology},
   school  = {University of Toronto},
-  url     = {https://hdl.handle.net/1807/123260},
-  year    = 2022
+  year    = 2022,
+  url     = {https://hdl.handle.net/1807/123260}
 }
 
 @Article{2022:jingchun.chengli.ea:on,
+  author  = {Xie Jingchun and Huang Chengli and Zhang Mian},
   title   = {On the formation of thrust fault-related landforms in {M}ercury's {N}orthern {S}mooth {P}lains: {A} new mechanical model of the lithosphere},
   journal = {Icarus},
-  pages   = 115197,
   year    = 2022,
+  pages   = 115197,
   issn    = {0019-1035},
   doi     = {10.1016/j.icarus.2022.115197},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0019103522002962},
-  author  = {Xie Jingchun and Huang Chengli and Zhang Mian}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0019103522002962}
 }
 
 @Misc{2022:jodlbauer.langer.ea:matrix-free,
   author  = {Jodlbauer, Daniel and Langer, Ulrich and Wick, Thomas and Zulehner, Walter},
   title   = {Matrix-free Monolithic Multigrid Methods for Stokes and Generalized Stokes Problems},
+  year    = 2022,
   doi     = {10.48550/ARXIV.2205.15770},
   url     = {https://arxiv.org/abs/2205.15770},
   publisher = {arXiv},
-  year    = 2022,
   copyright = {Creative Commons Attribution 4.0 International}
 }
 
 @Misc{2022:khimin.steinbach.ea:computational,
   author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
   title   = {Computational performance studies for space-time phase-field fracture optimal control problems},
+  year    = 2022,
   doi     = {10.48550/ARXIV.2203.14643},
   url     = {https://arxiv.org/abs/2203.14643},
   publisher = {arXiv},
-  year    = 2022,
   copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
 }
 
@@ -250,11 +250,11 @@
   author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
   editor  = {Aldakheel, Fadi and Hudobivnik, Bla{\v{z}} and Soleimani, Meisam and Wessels, Henning and Wei{\ss}enfels, Christian and Marino, Michele},
   title   = {Optimal Control for Phase-Field Fracture: Algorithmic Concepts and Computations},
-  booktitle = {Current Trends and Open Problems in Computational Mechanics},
-  year    = 2022,
-  publisher = {Springer International Publishing},
-  address = {Cham},
   pages   = {247--255},
+  publisher = {Springer International Publishing},
+  year    = 2022,
+  address = {Cham},
+  booktitle = {Current Trends and Open Problems in Computational Mechanics},
   isbn    = {978-3-030-87312-7},
   doi     = {10.1007/978-3-030-87312-7_24}
 }
@@ -263,20 +263,20 @@
   author  = {Liu, Shangxin and King, Scott D.},
   title   = {Dynamics of the {N}orth {A}merican Plate: {L}arge-Scale Driving Mechanism From Far-Field Slabs and the Interpretation of Shallow Negative Seismic Anomalies},
   journal = {Geochemistry, Geophysics, Geosystems},
+  year    = 2022,
   volume  = 23,
   number  = 3,
   pages   = {e2021GC009808},
+  note    = {e2021GC009808 2021GC009808},
   doi     = {10.1029/2021GC009808},
   url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2021GC009808},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021GC009808},
-  note    = {e2021GC009808 2021GC009808},
-  year    = 2022
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021GC009808}
 }
 
 @Article{2022:liu.mcbride.ea:vibration,
   author  = {Zhaowei Liu and Andrew McBride and Prashant Saxena and Luca Heltai and Yilin Qu and Paul Steinmann},
-  journal = {International Journal for Numerical Methods in Engineering},
   title   = {Vibration Analysis of Piezoelectric {Kirchhoff-Love} shells based on {Catmull-Clark} Subdivision Surfaces},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = 2022,
   doi     = {10.1002/nme.7010}
 }
@@ -287,17 +287,17 @@
   school  = {Universidad de Murcia},
   year    = 2022,
   month   = jul,
-  url     = {https://github.com/Lorenc1o/University_Notes/blob/main/ComputerScience/TFG/TFG_FEM.pdf},
-  note    = {Bachelor's Thesis}
+  note    = {Bachelor's Thesis},
+  url     = {https://github.com/Lorenc1o/University_Notes/blob/main/ComputerScience/TFG/TFG_FEM.pdf}
 }
 
 @PhDThesis{2022:mang:phase-field,
-  title   = {Phase-field fracture modeling, numerical solution, and simulations for compressible and incompressible solids},
   author  = {Mang, Katrin},
+  title   = {Phase-field fracture modeling, numerical solution, and simulations for compressible and incompressible solids},
+  school  = {Hannover: Institutionelles Repositorium der Leibniz Universit{\"a}t Hannover},
   year    = 2022,
   month   = feb,
-  doi     = {10.15488/11928},
-  school  = {Hannover: Institutionelles Repositorium der Leibniz Universit{\"a}t Hannover}
+  doi     = {10.15488/11928}
 }
 
 @Article{2022:munch.dravins.ea:stage-parallel,
@@ -308,12 +308,12 @@
 }
 
 @Article{2022:munch.heister.ea:efficient,
-  doi     = {10.48550/ARXIV.2203.12292},
-  url     = {https://arxiv.org/abs/2203.12292},
   author  = {Peter Munch and Timo Heister and Laura Prieto Saavedra and Martin Kronbichler},
   title   = {Efficient distributed matrix-free multigrid methods on locally refined meshes for FEM computations},
-  publisher = {arXiv},
   year    = 2022,
+  doi     = {10.48550/ARXIV.2203.12292},
+  url     = {https://arxiv.org/abs/2203.12292},
+  publisher = {arXiv},
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
@@ -322,61 +322,61 @@
   title   = {Efficient Application of~Hanging-Node Constraints for~Matrix-Free High-Order {FEM} Computations on~{CPU} and~{GPU}},
   booktitle = {Lecture Notes in Computer Science},
   year    = 2022,
-  publisher = {Springer International Publishing},
   pages   = {133--152},
+  publisher = {Springer International Publishing},
   doi     = {10.1007/978-3-031-07312-0_7}
 }
 
 @Article{2022:murer.formica.ea:coupled,
   author  = {Murer, Mauro and Formica, Giovanni and Milicchio, Franco and Morganti, Simone and Auricchio, Ferdinando},
+  title   = {A coupled multiphase Lagrangian-Eulerian fluid-dynamics framework for numerical simulation of Laser Metal Deposition process},
   journal = {The International Journal of Advanced Manufacturing Technology},
+  year    = 2022,
+  volume  = 120,
   number  = 5,
   pages   = {3269--3286},
-  title   = {A coupled multiphase Lagrangian-Eulerian fluid-dynamics framework for numerical simulation of Laser Metal Deposition process},
-  volume  = 120,
-  year    = 2022,
   doi     = {10.1007/s00170-022-08763-7}
 }
 
 @Article{2022:negredo.van-hunen.ea:on,
+  author  = {Ana M. Negredo and Jeroen {van Hunen} and Juan Rodr\'{i}guez-Gonz\'{a}lez and Javier Fullea},
   title   = {On the origin of the {C}anary {I}slands: {I}nsights from mantle convection modelling},
   journal = {Earth and Planetary Science Letters},
+  year    = 2022,
   volume  = 584,
   pages   = 117506,
-  year    = 2022,
   issn    = {0012-821X},
   doi     = {10.1016/j.epsl.2022.117506},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X2200142X},
-  author  = {Ana M. Negredo and Jeroen {van Hunen} and Juan Rodr\'{i}guez-Gonz\'{a}lez and Javier Fullea}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0012821X2200142X}
 }
 
 @Article{2022:oneill.aulbach:destabilization,
   author  = {Craig O'Neill and Sonja Aulbach },
   title   = {Destabilization of deep oxidized mantle drove the Great Oxidation Event},
   journal = {Science Advances},
+  year    = 2022,
   volume  = 8,
   number  = 7,
   pages   = {eabg1626},
-  year    = 2022,
   doi     = {10.1126/sciadv.abg1626},
   url     = {https://www.science.org/doi/abs/10.1126/sciadv.abg1626},
   eprint  = {https://www.science.org/doi/pdf/10.1126/sciadv.abg1626}
 }
 
 @Article{2022:orlando.della-rocca.ea:efficient,
-  title   = {An efficient and accurate implicit {DG} solver for the incompressible {N}avier-{S}tokes equations},
   author  = {Orlando, G. and Della Rocca, A. and Barbante, P.F. and Bonaventura, L. and Parolini, N.},
-  doi     = {10.1002/fld.5098},
+  title   = {An efficient and accurate implicit {DG} solver for the incompressible {N}avier-{S}tokes equations},
+  journal = {International Journal for Numerical Methods in Fluids},
   year    = 2022,
-  journal = {International Journal for Numerical Methods in Fluids}
+  doi     = {10.1002/fld.5098}
 }
 
 @Article{2022:palmiotto.ficini.ea:back-arc,
   author  = {Palmiotto, Camilla and Ficini, Eleonora and Loreto, Maria Filomena and Muccini, Filippo and Cuffaro, Marco},
   title   = {Back-Arc Spreading Centers and Superfast Subduction: {T}he Case of the {N}orthern {L}au Basin ({SW} {P}acific Ocean)},
   journal = {Geosciences},
-  volume  = 12,
   year    = 2022,
+  volume  = 12,
   number  = 2,
   article-number = 50,
   url     = {https://www.mdpi.com/2076-3263/12/2/50},
@@ -386,69 +386,69 @@
 
 @Article{2022:peschka.heltai:model,
   author  = {Dirk Peschka and Luca Heltai},
-  journal = {Journal of Computational Physics},
-  pages   = 111325,
   title   = {Model hierarchies and higher-order discretisation of time-dependent thin-film free boundary problems with dynamic contact angle},
-  volume  = 464,
+  journal = {Journal of Computational Physics},
   year    = 2022,
+  volume  = 464,
+  pages   = 111325,
   doi     = {10.1016/j.jcp.2022.111325}
 }
 
 @Article{2022:piersanti.regazzoni.ea:3d-0d,
-  doi     = {10.1016/j.cma.2022.114607},
-  title   = {3D--0D closed-loop model for the simulation of cardiac biventricular electromechanics},
   author  = {Piersanti, Roberto and Regazzoni, Francesco and Salvador, Matteo and Corno, Antonio F and Vergara, Christian and Quarteroni, Alfio and others},
+  title   = {3D--0D closed-loop model for the simulation of cardiac biventricular electromechanics},
   journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2022,
   volume  = 391,
   pages   = 114607,
-  year    = 2022,
   month   = mar,
+  doi     = {10.1016/j.cma.2022.114607},
   publisher = {Elsevier}
 }
 
 @Article{2022:quarteroni.dedee.ea:modeling,
-  doi     = {10.1090/bull/1738},
-  title   = {Modeling the cardiac electromechanical function: A mathematical journey},
   author  = {Quarteroni, Alfio and Dede{\`{e}}, Luca and Regazzoni, Francesco},
+  title   = {Modeling the cardiac electromechanical function: A mathematical journey},
   journal = {Bulletin of the American Mathematical Society},
+  year    = 2022,
   volume  = 59,
   number  = 3,
   pages   = {371--403},
-  year    = 2022,
   month   = feb,
+  doi     = {10.1090/bull/1738},
   publisher = {American Mathematical Society ({AMS})}
 }
 
 @MastersThesis{2022:quiroga:numerical,
   author  = {Quiroga, David},
   title   = {Numerical Models of Lithosphere Removal in the {S}ierra {N}evada de {S}anta {M}arta, {C}olombia},
-  pages   = 178,
   school  = {University of Alberta},
   year    = 2022,
+  pages   = 178,
   doi     = {10.7939/r3-6mk4-sj26}
 }
 
 @Article{2022:regazzoni.salvador.ea:cardiac,
-  doi     = {10.1016/j.jcp.2022.111083},
   author  = {F. Regazzoni and M. Salvador and P.C. Africa and M. Fedele and L. Dede{\`{e}} and A. Quarteroni},
   title   = {A cardiac electromechanical model coupled with a lumped-parameter model for closed-loop blood circulation},
   journal = {Journal of Computational Physics},
+  year    = 2022,
   volume  = 457,
   pages   = 111083,
-  year    = 2022,
   month   = may,
+  doi     = {10.1016/j.jcp.2022.111083},
   publisher = {Elsevier {BV}}
 }
 
 @Article{2022:regazzoni.salvador.ea:machine,
-  doi     = {10.1016/j.cma.2022.114825},
-  title   = {A machine learning method for real-time numerical simulations of cardiac electromechanics},
   author  = {Regazzoni, Francesco and Salvador, Matteo and Ded{\`{e}}, Luca and Quarteroni, Alfio},
+  title   = {A machine learning method for real-time numerical simulations of cardiac electromechanics},
   journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = 2022,
   volume  = 393,
   pages   = 114825,
-  year    = 2022,
   month   = apr,
+  doi     = {10.1016/j.cma.2022.114825},
   publisher = {Elsevier}
 }
 
@@ -456,8 +456,8 @@
   author  = {Root, B. C. and Sebera, J. and Szwillus, W. and Thieulot, C. and Martinec, Z. and Fullea, J.},
   title   = {Benchmark forward gravity schemes: the gravity field of a realistic lithosphere model {WINTERC-G}},
   journal = {Solid Earth},
-  volume  = 13,
   year    = 2022,
+  volume  = 13,
   number  = 5,
   pages   = {849--873},
   url     = {https://se.copernicus.org/articles/13/849/2022/},
@@ -469,112 +469,112 @@
   title   = {Neural network guided adjoint computations in dual weighted residual error estimation},
   journal = {SN Applied Sciences},
   year    = 2022,
-  month   = jan,
-  day     = 31,
   volume  = 4,
   number  = 2,
   pages   = 62,
+  month   = jan,
+  day     = 31,
   issn    = {2523-3971},
   doi     = {10.1007/s42452-022-04938-9}
 }
 
 @Article{2022:sabanskis.dadzis.ea:application,
-  doi     = {10.3390/cryst12020174},
+  author  = {Andrejs Sabanskis and Kaspars Dadzis and Robert Menzel and J{\={a}}nis Virbulis},
+  title   = {Application of the {A}lexander{\textendash}{H}aasen Model for Thermally Stimulated Dislocation Generation in {FZ} Silicon Crystals},
+  journal = {Crystals},
   year    = 2022,
-  month   = jan,
-  publisher = {{MDPI} {AG}},
   volume  = 12,
   number  = 2,
   pages   = 174,
-  author  = {Andrejs Sabanskis and Kaspars Dadzis and Robert Menzel and J{\={a}}nis Virbulis},
-  title   = {Application of the {A}lexander{\textendash}{H}aasen Model for Thermally Stimulated Dislocation Generation in {FZ} Silicon Crystals},
-  journal = {Crystals}
+  month   = jan,
+  doi     = {10.3390/cryst12020174},
+  publisher = {{MDPI} {AG}}
 }
 
 @Article{2022:salvador.regazzoni.ea:role,
-  doi     = {10.1016/j.compbiomed.2021.105203},
-  title   = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
   author  = {Salvador, Matteo and Regazzoni, Francesco and Pagani, Stefano and Ded{\`{e}}, Luca and Trayanova, Natalia and Quarteroni, Alfio},
+  title   = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
   journal = {Computers in Biology and Medicine},
+  year    = 2022,
   volume  = 142,
   pages   = 105203,
-  year    = 2022,
   month   = mar,
+  doi     = {10.1016/j.compbiomed.2021.105203},
   publisher = {Elsevier}
 }
 
 @Article{2022:schussnig.pacheco.ea:efficient,
+  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   title   = {Efficient split-step schemes for fluid--structure interaction involving incompressible generalised {N}ewtonian flows},
   journal = {Computers \& Structures},
+  year    = 2022,
   volume  = 260,
   pages   = 106718,
-  year    = 2022,
   issn    = {0045-7949},
   doi     = {10.1016/j.compstruc.2021.106718},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0045794921002406},
-  author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0045794921002406}
 }
 
 @Article{2022:stein.comeau.ea:numerical,
+  author  = {Claudia Stein and Matthew Comeau and Michael Becken and Ulrich Hansen},
   title   = {Numerical study on the style of delamination},
   journal = {Tectonophysics},
-  pages   = 229276,
   year    = 2022,
+  pages   = 229276,
   issn    = {0040-1951},
   doi     = {10.1016/j.tecto.2022.229276},
-  url     = {https://www.sciencedirect.com/science/article/pii/S0040195122000701},
-  author  = {Claudia Stein and Matthew Comeau and Michael Becken and Ulrich Hansen}
+  url     = {https://www.sciencedirect.com/science/article/pii/S0040195122000701}
 }
 
 @Article{2022:tsagkari.connelly.ea:role,
-  doi     = {10.1038/s41522-022-00300-4},
-  year    = 2022,
-  month   = apr,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume  = 8,
-  number  = 1,
   author  = {Erifyli Tsagkari and Stephanie Connelly and Zhaowei Liu and Andrew McBride and William T. Sloan},
   title   = {The role of shear dynamics in biofilm formation},
-  journal = {npj Biofilms and Microbiomes}
+  journal = {npj Biofilms and Microbiomes},
+  year    = 2022,
+  volume  = 8,
+  number  = 1,
+  month   = apr,
+  doi     = {10.1038/s41522-022-00300-4},
+  publisher = {Springer Science and Business Media {LLC}}
 }
 
 @Article{2022:vergara.stella.ea:computational,
   author  = {Vergara, Christian and Stella, Simone and Maines, Massimiliano and Africa, Pasquale Claudio and Catanzariti, Domenico and Dematt\`{e}, Cristina and Centonze, Maurizio and Nobile, Fabio and Quarteroni, Alfio and Del Greco, Maurizio},
   title   = {Computational electrophysiology of the coronary sinus branches based on electro-anatomical mapping for the prediction of the latest activated region},
   journal = {Medical \& Biological Engineering \& Computing},
+  year    = 2022,
   volume  = 60,
   number  = 8,
   pages   = {2307--2319},
-  year    = 2022,
   month   = jun,
   doi     = {10.1007/s11517-022-02610-3}
 }
 
 @MastersThesis{2022:wik:high-performance,
   author  = {Wik, Niklas},
-  pages   = 60,
-  school  = {Uppsala University, Division of Scientific Computing},
   title   = {High-performance implementation of H(div)-conforming elements for incompressible flows},
+  school  = {Uppsala University, Division of Scientific Computing},
+  year    = 2022,
+  month   = jun,
+  pages   = 60,
   series  = {UPTEC F},
   issn    = {1401-5757},
   number  = 22027,
-  url     = {http://urn.kb.se/resolve?urn=urn:nbn:se:uu:diva-478600},
-  year    = 2022,
-  month   = jun
+  url     = {http://urn.kb.se/resolve?urn=urn:nbn:se:uu:diva-478600}
 }
 
 @Article{2022:zha.lin.ea:effects,
   author  = {Zha, Caicai and Lin, Jian and Zhou, Zhiyuan and Xu, Min and Zhang, Xubo},
   title   = {Effects of Hotspot-Induced Long-Wavelength Mantle Melting Variations on Magmatic Segmentation at the {R}eykjanes Ridge: Insights From 3D Geodynamic Modeling},
   journal = {Journal of Geophysical Research: Solid Earth},
+  year    = 2022,
   volume  = 127,
   number  = 3,
   pages   = {e2021JB023244},
+  note    = {e2021JB023244 2021JB023244},
   doi     = {10.1029/2021JB023244},
   url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2021JB023244},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021JB023244},
-  note    = {e2021JB023244 2021JB023244},
-  year    = 2022
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021JB023244}
 }
 
 @Article{2022:zhang.shahabad.ea:3-dimensional,
@@ -587,12 +587,12 @@
 }
 
 @Misc{2022:zingaro.bucelli.ea:modeling,
-  doi     = {10.48550/ARXIV.2208.09435},
-  url     = {https://arxiv.org/abs/2208.09435},
   author  = {Zingaro, Alberto and Bucelli, Michele and Fumagalli, Ivan and Ded{\`{e}}, Luca and Quarteroni, Alfio},
   title   = {Modeling isovolumetric phases in cardiac flows by an Augmented Resistive Immersed Implicit Surface Method},
-  publisher = {arXiv},
   year    = 2022,
+  doi     = {10.48550/ARXIV.2208.09435},
+  url     = {https://arxiv.org/abs/2208.09435},
+  publisher = {arXiv},
   copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
 }
 
@@ -600,10 +600,10 @@
   author  = {Zingaro, Alberto and Fumagalli, Ivan and Fedele, Marco and Africa, Pasquale Claudio and Ded{\`{e}}, Luca and Quarteroni, Alfio and Corno, Antonio Francesco},
   title   = {A geometric multiscale model for the numerical simulation of blood flow in the human left heart},
   journal = {Discrete and Continuous Dynamical Systems - S},
+  year    = 2022,
   volume  = 15,
   number  = 8,
   pages   = {2391--2427},
-  year    = 2022,
   doi     = {10.3934/dcdss.2022052}
 }
 


### PR DESCRIPTION
Part of #389.

Second to last resource I would like to incorporate in our publication list. This sorts the fields inside each bibtex entry.
https://github.com/ge-ne/bibtool/blob/master/lib/sort_fld.rsc

Again, this is an entirely subjective change with the goal to have a more uniform publication list. We can adjust the order in which we want to sort the fields ourselves -- this is just the default that the author of bibtool thinks looks nice.

This patch just moves fields around. You can see that the number of line additions is similar to the number of line deletions (with the difference being the 3 lines in the configuration file).