### PR TITLE
bibtool: semantic checks for year fields.

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -15,6 +15,9 @@ print.wide.equal = on
 % use braces instead of double quotes as delimiters
 resource braces
 
+% semantic checks for year fields
+resource check_y
+
 % style improvements: no empty fields, fix page ranges, pure numerical fields
 resource improve
 


### PR DESCRIPTION
Part of #389.

The resource checks for semantic issues with the year field.
https://github.com/ge-ne/bibtool/blob/master/lib/check_y.rsc

So the current form of our publication list has no issues with the year field as bibtool didn't complain about any.