### PR TITLE
bibtool: added year to citekey

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -1,7 +1,8 @@
 delete.field = {keywords}
 delete.field = {abstract}
 
-key.format = short
+% generate citekeys using year, author, and title field
+key.format = {%d(year):%-2n(author):%-W(title)}
 key.generation = on
 
 print.align = 12

--- a/publications-1998.bib
+++ b/publications-1998.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@MastersThesis{bangerth:adaptive,
+@MastersThesis{1998:bangerth:adaptive,
   author  = {W. Bangerth},
   title   = {Adaptive Finite-Elemente-Methoden zur L\"{o}sung der Wellengleichung mit Anwendung in der Physik der Sonne},
   school  = {University of Heidelberg},

--- a/publications-1999.bib
+++ b/publications-1999.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@TechReport{bangerth.kanschat:concepts,
+@TechReport{1999:bangerth.kanschat:concepts,
   author  = {W. Bangerth and G. Kanschat},
   title   = {Concepts for object-oriented finite element software - the \texttt{deal.II} library},
   institution = {IWR Heidelberg},
@@ -9,7 +9,7 @@
   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.136.7882&rep=rep1&type=pdf}
 }
 
-@Article{bangerth.rannacher:adaptive,
+@Article{1999:bangerth.rannacher:adaptive,
   author  = {W. Bangerth and R. Rannacher},
   title   = {Adaptive finite element approximation of the acoustic wave equation: Error estimation and mesh adaptation},
   journal = {East-West Journal of Numerical Mathematics},
@@ -19,7 +19,7 @@
   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.220.6982&rep=rep1&type=pdf}
 }
 
-@MastersThesis{nauber:adaptive,
+@MastersThesis{1999:nauber:adaptive,
   author  = {S. Nauber},
   title   = {Adaptive Finite Elemente Verfahren f\"{u}r selbstadjungierte Eigenwertprobleme},
   school  = {University of Heidelberg},

--- a/publications-2000.bib
+++ b/publications-2000.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@InProceedings{bangerth:mesh,
+@InProceedings{2000:bangerth:mesh,
   author  = {W. Bangerth},
   title   = {Mesh Adaptivity and Error Control for a Finite Element Approximation of the Elastic Wave Equation},
   booktitle = {Fifth International Conference on Mathematical and Numerical Aspects of Wave Propagation},
@@ -9,7 +9,7 @@
   url     = {http://www.math.colostate.edu/~bangerth/publications/2000-waves2000.pdf}
 }
 
-@TechReport{bangerth:multi-threading,
+@TechReport{2000:bangerth:multi-threading,
   author  = {W. Bangerth},
   title   = {Multi-threading support in deal.II},
   institution = {IWR Heidelberg},
@@ -17,7 +17,7 @@
   number  = {Preprint 2000-11 (SFB 359)}
 }
 
-@InProceedings{bangerth:using,
+@InProceedings{2000:bangerth:using,
   author  = {W. Bangerth},
   title   = {Using Modern Features of C++ for Adaptive Finite Element Methods: Dimension-Independent Programming in deal.II},
   booktitle = {Proceedings of the 16th IMACS World Congress},
@@ -27,7 +27,7 @@
   url     = {http://www.math.colostate.edu/~bangerth/publications/2000-imacs.pdf}
 }
 
-@MastersThesis{mohamed:interaction,
+@MastersThesis{2000:mohamed:interaction,
   author  = {F. Mohamed},
   title   = {Interaction of vortices in superconductors with kappa close to 1/sqrt(2)},
   school  = {ETH Zurich},

--- a/publications-2001.bib
+++ b/publications-2001.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{bangerth.rannacher:adaptive,
+@Article{2001:bangerth.rannacher:adaptive,
   author  = {Wolfgang Bangerth and Rolf Rannacher},
   title   = {Adaptive finite element techniques for the acoustic wave equation},
   journal = {Journal of Computational Acoustics},
@@ -13,7 +13,7 @@
   publisher = {World Scientific Pub Co Pte Lt}
 }
 
-@Article{barinka.barsch.ea:adaptive,
+@Article{2001:barinka.barsch.ea:adaptive,
   author  = {Arne Barinka and Titus Barsch and Philippe Charton and Albert Cohen and Stephan Dahlke and Wolfgang Dahmen and Karsten Urban},
   title   = {Adaptive Wavelet Schemes for Elliptic Problems---Implementation and Numerical Experiments},
   journal = {{SIAM} Journal on Scientific Computing},
@@ -26,7 +26,7 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@Article{becker.rannacher:optimal,
+@Article{2001:becker.rannacher:optimal,
   author  = {Roland Becker and Rolf Rannacher},
   title   = {An optimal control approach to a posteriori error estimation in finite element methods},
   journal = {Acta Numerica},
@@ -38,7 +38,7 @@
   publisher = {Cambridge University Press ({CUP})}
 }
 
-@Article{cockburn.kanschat.ea:superconvergence,
+@Article{2001:cockburn.kanschat.ea:superconvergence,
   author  = {Bernardo Cockburn and Guido Kanschat and Ilaria Perugia and Dominik Sch\"{o}tzau},
   title   = {Superconvergence of the Local Discontinuous Galerkin Method for Elliptic Problems on Cartesian Grids},
   journal = {{SIAM} Journal on Numerical Analysis},
@@ -51,7 +51,7 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@InProceedings{hartmann:adaptive,
+@InProceedings{2001:hartmann:adaptive,
   author  = {R. Hartmann},
   title   = {Adaptive FE-Methods for Conservation Equations},
   booktitle = {Hyperbolic Problems: Theory, Numerics, Applications},
@@ -63,7 +63,7 @@
   doi     = {10.1007/978-3-0348-8372-6_3}
 }
 
-@MastersThesis{richter:funktionalorientierte,
+@MastersThesis{2001:richter:funktionalorientierte,
   author  = {T. Richter},
   title   = {Funktionalorientierte Gitteroptimierung bei der Finite-Elemente Approximation elliptischer Differentialgleichungen},
   school  = {University of Heidelberg},

--- a/publications-2002.bib
+++ b/publications-2002.bib
@@ -1,20 +1,20 @@
 % Encoding: US-ASCII
 
-@PhDThesis{bangerth:adaptive,
+@PhDThesis{2002:bangerth:adaptive,
   author  = {W. Bangerth},
   title   = {Adaptive Finite Element Methods for the Identification of Distributed Parameters in Partial Differential Equations},
   year    = 2002,
   school  = {University of Heidelberg}
 }
 
-@MastersThesis{benkler:numerical,
+@MastersThesis{2002:benkler:numerical,
   author  = {S. Benkler},
   title   = {Numerical solution of the nonlinear Hartree equation.},
   year    = 2002,
   school  = {ETH Zurich, Switzerland}
 }
 
-@InProceedings{cockburn.kanschat.ea:local,
+@InProceedings{2002:cockburn.kanschat.ea:local,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {The local discontinuous Galerkin method in incompressible fluid flow},
   booktitle = {Proceedings of the Fifth World Congress on Computational Mechanics (WCCM V)},
@@ -23,7 +23,7 @@
   year    = 2002
 }
 
-@Article{cockburn.kanschat.ea:local*1,
+@Article{2002:cockburn.kanschat.ea:local*1,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau and C. Schwab},
   title   = {Local discontinuous Galerkin methods for the Stokes system},
   journal = {SIAM J. Numer. Anal.},
@@ -34,7 +34,7 @@
   doi     = {10.1137/S0036142900380121}
 }
 
-@Article{hartmann.houston:adaptive,
+@Article{2002:hartmann.houston:adaptive,
   author  = {R. Hartmann and P. Houston},
   title   = {Adaptive Discontinuous Galerkin Finite Element Methods for the Compressible Euler Equations},
   journal = {J. Comput. Phys.},
@@ -44,7 +44,7 @@
   doi     = {10.1006/jcph.2002.7206}
 }
 
-@PhDThesis{hartmann:adaptive,
+@PhDThesis{2002:hartmann:adaptive,
   author  = {R. Hartmann},
   title   = {Adaptive Finite Element Methods for the Compressible Euler Equations},
   year    = 2002,
@@ -52,7 +52,7 @@
   doi     = {10.11588/heidok.00002488}
 }
 
-@Article{kanschat.rannacher:local,
+@Article{2002:kanschat.rannacher:local,
   author  = {G. Kanschat and Rolf Rannacher},
   title   = {Local error analysis of the interior penalty discontinuous Galerkin method for second order elliptic problems},
   journal = {J. Numer. Math.},
@@ -61,7 +61,7 @@
   pages   = {249--274}
 }
 
-@Article{mohamed.troyer.ea:interaction,
+@Article{2002:mohamed.troyer.ea:interaction,
   author  = {F. Mohamed and M. Troyer and G. Blatter},
   title   = {Interaction of vortices in superconductors with kappa close to 1/sqrt(2),},
   journal = {Phys. Rev. B, article 224504},
@@ -69,7 +69,7 @@
   volume  = 65
 }
 
-@Article{shardlow:coupled,
+@Article{2002:shardlow:coupled,
   author  = {T. Shardlow},
   title   = {A coupled Cahn-Hilliard particle system},
   journal = {Electronic Journal of Differential Equations, No. 73},
@@ -78,7 +78,7 @@
   pages   = {1--21}
 }
 
-@Article{stadler.holzapfel:novel,
+@Article{2002:stadler.holzapfel:novel,
   author  = {M. Stadler and G. A. Holzapfel},
   title   = {A novel approach for smooth contact surfaces using NURBS: application to the FE simulation of stenting},
   journal = {Proceedings of the 13th Conference of the European Society of Biomechanics, 1-4 September 2002, Wroclaw, Poland},

--- a/publications-2003.bib
+++ b/publications-2003.bib
@@ -1,20 +1,20 @@
 % Encoding: US-ASCII
 
-@PhDThesis{achatz:adaptive,
+@PhDThesis{2003:achatz:adaptive,
   author  = {S. Achatz},
   title   = {Adaptive finite D\"{u}nngitter-Elemente h\"{o}herer Ordnung f\"{u}r elliptische partielle Differentialgleichungen mit variablen Koeffizienten},
   year    = 2003,
   school  = {TU Munich}
 }
 
-@Article{bangerth.rannacher:adaptive,
+@Article{2003:bangerth.rannacher:adaptive,
   author  = {W. Bangerth and R. Rannacher},
   title   = {Adaptive Finite Element Methods for Solving Differential Equations},
   journal = {Book, Birkh\"{a}user},
   year    = 2003
 }
 
-@Article{bangerth:starting,
+@Article{2003:bangerth:starting,
   author  = {W. Bangerth},
   title   = {Starting threads in a C++ compatible fashion},
   journal = {C/C++ Users Journal},
@@ -22,28 +22,28 @@
   pages   = {21--24}
 }
 
-@PhDThesis{calhoun-lopez:numerical,
+@PhDThesis{2003:calhoun-lopez:numerical,
   author  = {M. Calhoun-Lopez},
   title   = {Numerical solutions of hyperbolic conservation laws: Incorporating multi-resolution viscosity methods into the finite element framework},
   year    = 2003,
   school  = {Iowa State University}
 }
 
-@PhDThesis{carnes:adaptive,
+@PhDThesis{2003:carnes:adaptive,
   author  = {B. Carnes},
   title   = {Adaptive finite elements for nonlinear transport equations},
   year    = 2003,
   school  = {ICES, The University of Texas at Austin}
 }
 
-@Article{cockburn.kanschat.ea:ldg,
+@Article{2003:cockburn.kanschat.ea:ldg,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {LDG methods for Stokes flow problems},
   journal = {in Brezzi, Buffa, Corsaro, Murli: Numerical Mathematics and Advanced Applications: ENUMATH 2001, Springer Italia},
   year    = 2003
 }
 
-@Article{cockburn.kanschat.ea:local,
+@Article{2003:cockburn.kanschat.ea:local,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {The Local Discontinuous Galerkin Method for the Oseen Equations},
   journal = {Math. Comput.},
@@ -52,7 +52,7 @@
   pages   = {569--593}
 }
 
-@Article{gopalakrishnan.kanschat:application,
+@Article{2003:gopalakrishnan.kanschat:application,
   author  = {J. Gopalakrishnan and G. Kanschat},
   title   = {Application of unified DG analysis to preconditioning DG methods},
   journal = {in Bathe: Computational Fluid and Solid Mechanics},
@@ -60,14 +60,14 @@
   pages   = {1943--1945}
 }
 
-@Article{gopalakrishnan.kanschat:multi-level,
+@Article{2003:gopalakrishnan.kanschat:multi-level,
   author  = {J. Gopalakrishnan and G. Kanschat},
   title   = {Multi-level Preconditioners for the interior penalty method},
   journal = {in Brezzi, Buffa, Corsaro, Murli: Numerical Mathematics and Advanced Applications: ENUMATH 2001, Springer Italia},
   year    = 2003
 }
 
-@Article{gopalakrishnan.kanschat:multilevel,
+@Article{2003:gopalakrishnan.kanschat:multilevel,
   author  = {J. Gopalakrishnan and G. Kanschat},
   title   = {A Multilevel Discontinuous Galerkin Method},
   journal = {Numer. Math.},
@@ -76,7 +76,7 @@
   pages   = {527--550}
 }
 
-@Article{hartmann.houston:adaptive,
+@Article{2003:hartmann.houston:adaptive,
   author  = {R. Hartmann and P. Houston},
   title   = {Adaptive Discontinuous Galerkin Finite Element Methods for Nonlinear Hyperbolic Conservation Laws},
   journal = {SIAM J. Sci. Comput.},
@@ -87,7 +87,7 @@
   doi     = {10.1137/S1064827501389084}
 }
 
-@InProceedings{hartmann.houston:goal-oriented,
+@InProceedings{2003:hartmann.houston:goal-oriented,
   author  = {Hartmann, R. and Houston, P.},
   title   = {Goal-Oriented A Posteriori Error Estimation for Compressible Fluid Flows},
   booktitle = {Numerical Mathematics and Advanced Applications},
@@ -97,7 +97,7 @@
   doi     = {10.1007/978-88-470-2089-4_70}
 }
 
-@InProceedings{hartmann.houston:goal-oriented*1,
+@InProceedings{2003:hartmann.houston:goal-oriented*1,
   author  = {Hartmann, Ralf and Houston, Paul},
   title   = {Goal-Oriented A Posteriori Error Estimation for Multiple Target Functionals},
   booktitle = {Hyperbolic Problems: Theory, Numerics, Applications},
@@ -108,14 +108,14 @@
   doi     = {10.1007/978-3-642-55711-8_54}
 }
 
-@Article{kanschat:discontinuous,
+@Article{2003:kanschat:discontinuous,
   author  = {G. Kanschat},
   title   = {Discontinuous Galerkin Finite Element Methods for Advection-Diffusion Problems},
   journal = {Habilitationsschrift, Universit\"{a}t Heidelberg},
   year    = 2003
 }
 
-@InProceedings{kanschat:preconditioning,
+@InProceedings{2003:kanschat:preconditioning,
   author  = {G. Kanschat},
   title   = {Preconditioning discontinuous Galerkin saddle point systems},
   editor  = {K.J. Bathe},
@@ -125,7 +125,7 @@
   doi     = {10.1016/B978-008044046-0.50494-2}
 }
 
-@Article{kanschat:preconditioning*1,
+@Article{2003:kanschat:preconditioning*1,
   author  = {G. Kanschat},
   title   = {Preconditioning methods for local discontinuous {G}alerkin Discretizations},
   journal = {SIAM J. Sci. Comput.},
@@ -136,7 +136,7 @@
   doi     = {10.1137/S1064827502410657}
 }
 
-@Article{schneebeli.schotzau:mixed,
+@Article{2003:schneebeli.schotzau:mixed,
   author  = {A. Schneebeli and D. Sch\"{o}tzau},
   title   = {Mixed finite elements for incompressible magneto-hydrodynamics},
   journal = {Comptes Rendus Mathematique},
@@ -145,7 +145,7 @@
   pages   = {71--74}
 }
 
-@Article{stadler.holzapfel.ea:cn,
+@Article{2003:stadler.holzapfel.ea:cn,
   author  = {M. Stadler and G. A. Holzapfel and J. Korelc},
   title   = {C$^{n}$ continuous modelling of smooth contact surfaces using NURBS and application to 2D problems},
   journal = {International Journal for Numerical Methods in Engineering},

--- a/publications-2004.bib
+++ b/publications-2004.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{bangerth.grote.ea:finite,
+@Article{2004:bangerth.grote.ea:finite,
   author  = {W. Bangerth and M. Grote and C. Hohenegger},
   title   = {Finite Element Method For Time Dependent Scattering: Nonreflecting Boundary Condition, Adaptivity, and Energy Decay},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -9,14 +9,14 @@
   pages   = {2453--2482}
 }
 
-@Article{bangerth:framework,
+@Article{2004:bangerth:framework,
   author  = {W. Bangerth and },
   title   = {A framework for the adaptive finite element solution of large inverse problems. I. Basic techniques},
   journal = {ICES Report 2004-39},
   year    = 2004
 }
 
-@Article{boffi.gastaldi.ea:finite,
+@Article{2004:boffi.gastaldi.ea:finite,
   author  = {D. Boffi and L. Gastaldi and L. Heltai},
   title   = {A finite element approach to the immersed boundary method},
   journal = {Progress in Engineering Computational Technology},
@@ -25,7 +25,7 @@
   pages   = {271--298}
 }
 
-@Article{carey.anderson.ea:some,
+@Article{2004:carey.anderson.ea:some,
   author  = {G. Carey and M. Anderson and B. Carnes and B. Kirk},
   title   = {Some aspects of adaptive grid technology related to boundary and interior layers},
   journal = {Journal of Computational and Applied Mathematics},
@@ -34,7 +34,7 @@
   pages   = {55--86}
 }
 
-@Article{carey.barth.ea:modeling,
+@Article{2004:carey.barth.ea:modeling,
   author  = {G. Carey and W. Barth and J. A. Woods and B. Kirk and M. Anderson and S. Chow and W. Bangerth},
   title   = {Modeling error and constitutive relations in simulation of flow and transport},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -43,7 +43,7 @@
   pages   = {1211--1236}
 }
 
-@Article{chow.carey.ea:finite,
+@Article{2004:chow.carey.ea:finite,
   author  = {S. Chow and G. F. Carey and M. L. Anderson},
   title   = {Finite element approximations of a glaciology problem.},
   journal = {ESAIM: Mathematical Modelling and Numerical Analysis (M2AN)},
@@ -52,14 +52,14 @@
   pages   = {741--756}
 }
 
-@MastersThesis{frobel:tikhonov-regularisierung,
+@MastersThesis{2004:frobel:tikhonov-regularisierung,
   author  = {C. Fr\"{o}bel},
   title   = {Tikhonov-Regularisierung zur Parameteridentifikation bei elliptischen und parabolischen Modellgleichungen.},
   year    = 2004,
   school  = {Universit\"{a}t Bremen, Germany}
 }
 
-@Article{hasler.schneebeli.ea:mixed,
+@Article{2004:hasler.schneebeli.ea:mixed,
   author  = {U. Hasler and A. Schneebeli and D. Sch\"{o}tzau},
   title   = {Mixed finite element approximation of incompressible MHD problems based on weighted regularization},
   journal = {Applied Numerical Mathematics},
@@ -68,7 +68,7 @@
   pages   = {19--45}
 }
 
-@Article{joshi.bangerth.ea:adaptive,
+@Article{2004:joshi.bangerth.ea:adaptive,
   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
   title   = {Adaptive finite element based tomography for fluorescence optical imaging in tissue},
   journal = {Optics Express},
@@ -80,7 +80,7 @@
   doi     = {10.1364/OPEX.12.005402}
 }
 
-@InProceedings{joshi.bangerth.ea:adaptive*1,
+@InProceedings{2004:joshi.bangerth.ea:adaptive*1,
   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca},
   title   = {Adaptive finite element methods for fluorescence enhanced frequency domain optical tomography: Forward imaging problem},
   booktitle = {2nd IEEE International Symposium on Biomedical Imaging: Nano to Macro (IEEE Cat No. 04EX821)},
@@ -89,14 +89,14 @@
   doi     = {10.1109/ISBI.2004.1398735}
 }
 
-@Article{joshi.thompson.ea:adaptive,
+@Article{2004:joshi.thompson.ea:adaptive,
   author  = {A. Joshi and A. B. Thompson and W. Bangerth and E. Sevick-Muraca},
   title   = {Adaptive finite element methods for forward modeling in fluorescence enhanced frequency domain optical tomography},
   journal = {Proceedings of the 2004 OSA Biomedical Topical Meetings},
   year    = 2004
 }
 
-@Article{kanschat.meinkohn:multi-model,
+@Article{2004:kanschat.meinkohn:multi-model,
   author  = {G. Kanschat and E. Meinkohn},
   title   = {Multi-model preconditioning for radiative transfer problems, 2004.},
   journal = {IWR, University of Heidelberg, Preprint 2004-33},
@@ -104,7 +104,7 @@
   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.87.169&rep=rep1&type=pdf}
 }
 
-@Article{kanschat:multi-level,
+@Article{2004:kanschat:multi-level,
   author  = {G. Kanschat},
   title   = {Multi-level methods for discontinuous Galerkin FEM on locally refined meshes},
   journal = {Comput. \& Struct.},
@@ -113,7 +113,7 @@
   pages   = {2437--2445}
 }
 
-@Article{ramirez.laso:micro-macro,
+@Article{2004:ramirez.laso:micro-macro,
   author  = {J. Ramirez and M. Laso},
   title   = {Micro-macro simulations of three-dimensional plane contraction flow},
   journal = {Modelling Simul. Mater. Sci. Eng.},
@@ -122,14 +122,14 @@
   pages   = {1293--1306}
 }
 
-@Article{schulz.bangerth.ea:independent,
+@Article{2004:schulz.bangerth.ea:independent,
   author  = {R. B. Schulz and W. Bangerth and J. Peter and W. Semmler},
   title   = {Independent modeling of fluorescence excitation and emission with the finite element method},
   journal = {Proceedings of the OSA BIOMED topical meeting, Miami, Florida, 14-18 April },
   year    = 2004
 }
 
-@Article{zander.weimar.ea:simulation,
+@Article{2004:zander.weimar.ea:simulation,
   author  = {E. Zander and J. R. Weimar and H. G. Mathies},
   title   = {Simulation of High-Frequency Atmospheric Gas Discharges},
   journal = {PAMM},

--- a/publications-2005.bib
+++ b/publications-2005.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{anderson.bangerth.ea:analysis,
+@Article{2005:anderson.bangerth.ea:analysis,
   author  = {M. Anderson and W. Bangerth and G. Carey},
   title   = {Analysis of parameter sensitivity and experimental design for a class of nonlinear partial differential equations},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -9,7 +9,7 @@
   pages   = {583--605}
 }
 
-@Article{bangerth.joshi.ea:adaptive,
+@Article{2005:bangerth.joshi.ea:adaptive,
   author  = {W. Bangerth and A. Joshi and E. Sevick-Muraca},
   title   = {Adaptive finite element methods for increased resolution in fluorescence optical tomography},
   journal = {Progress in Biomedical Optics and Imaging},
@@ -18,14 +18,14 @@
   pages   = {318--329}
 }
 
-@Article{boffi.gastaldi.ea:finite,
+@Article{2005:boffi.gastaldi.ea:finite,
   author  = {D. Boffi and L. Gastaldi and L. Heltai},
   title   = {The finite element immersed boundary method: model, stability, and numerical results},
   journal = {In Schrefler Papadrakakis, Onate, eds., Computational Methods for Coupled Problems in Science and Engineering},
   year    = 2005
 }
 
-@Article{calhoun-lopez.gunzburger:finite,
+@Article{2005:calhoun-lopez.gunzburger:finite,
   author  = {M. Calhoun-Lopez and M. D. Gunzburger},
   title   = {A Finite Element, Multiresolution Viscosity Method for Hyperbolic Conservation Laws},
   journal = {SIAM J. Numer. Anal.},
@@ -34,7 +34,7 @@
   pages   = {1988--2011}
 }
 
-@Article{carnes.djilali:systematic,
+@Article{2005:carnes.djilali:systematic,
   author  = {B. Carnes and N. Djilali},
   title   = {Systematic parameter estimation for PEM fuel cell models},
   journal = {Journal of Power Sources},
@@ -43,7 +43,7 @@
   pages   = {83--93}
 }
 
-@Article{cockburn.kanschat.ea:local,
+@Article{2005:cockburn.kanschat.ea:local,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {The Local Discontinuous Galerkin Method for Linear Incomressible Fluid Flow: a Review},
   journal = {Comput. \& Fluids},
@@ -53,7 +53,7 @@
   doi     = {10.1016/j.compfluid.2003.08.005}
 }
 
-@Article{cockburn.kanschat.ea:locally,
+@Article{2005:cockburn.kanschat.ea:locally,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {A locally conservative LDG method for the incompressible Navier-Stokes equations},
   journal = {Math. Comput.},
@@ -62,14 +62,14 @@
   pages   = {1067--1095}
 }
 
-@Article{hartmann:discontinuous,
+@Article{2005:hartmann:discontinuous,
   author  = {R. Hartmann},
   title   = {Discontinuous Galerkin methods for compressible flows: higher order accuracy, error estimation and adaptivity},
   journal = {In H. Deconinck and M. Ricchiuto, editors, VKI LS 2006-01: CFD - Higher Order Discretization Methods, November 14-18, 2005, Rhode Saint Genese, Belgium. von Karman Institute for Fluid Dynamics},
   year    = 2005
 }
 
-@Article{joshi.bangerth.ea:experimental,
+@Article{2005:joshi.bangerth.ea:experimental,
   author  = {A. Joshi and W. Bangerth and A. B. Thompson and E. Sevick-Muraca},
   title   = {Experimental fluorescence optical tomography using adaptive finite elements and planar illumination with modulated excitation light},
   journal = {Progress in Biomedical Optics and Imaging},
@@ -78,14 +78,14 @@
   pages   = {351--358}
 }
 
-@PhDThesis{joshi:adaptive,
+@PhDThesis{2005:joshi:adaptive,
   author  = {A. Joshi},
   title   = {Adaptive finite element methods for fluorescence enhanced optical tomography},
   year    = 2005,
   school  = {Texas A\&M University}
 }
 
-@Article{kanschat:block,
+@Article{2005:kanschat:block,
   author  = {G. Kanschat},
   title   = {Block Preconditioners for LDG Discretizations of Linear Incompressible Flow Problems},
   journal = {J. Sci. Comput., -23},
@@ -95,7 +95,7 @@
   url     = {http://link.springer.com/article/10.1007/s10915-004-4144-6#page-1}
 }
 
-@Article{kayser-herold.matthies:least,
+@Article{2005:kayser-herold.matthies:least,
   author  = {O. Kayser-Herold and H. G. Matthies},
   title   = {Least squares finite element methods for fluid-structure interaction problems},
   journal = {Computers \& Structures},
@@ -104,7 +104,7 @@
   pages   = {191--207}
 }
 
-@Article{li:on,
+@Article{2005:li:on,
   author  = {R. Li},
   title   = {On multi-mesh h-adaptive methods},
   journal = {J. Sci. Comput.},
@@ -113,7 +113,7 @@
   pages   = {321--341}
 }
 
-@Article{mu:pde,
+@Article{2005:mu:pde,
   author  = {M. Mu},
   title   = {PDE.MART: A network-based problem-solving environment for PDEs},
   journal = {ACM Trans. Math. Software},
@@ -122,7 +122,7 @@
   pages   = {508--531}
 }
 
-@Article{nestler.danilov.ea:crystal,
+@Article{2005:nestler.danilov.ea:crystal,
   author  = {B. Nestler and D. Danilov and P. Galenko},
   title   = {Crystal growth of pure substances: Phase-field simulations in comparison with analytical and experimental results},
   journal = {Journal of Computational Physics},
@@ -131,7 +131,7 @@
   pages   = {221--239}
 }
 
-@Article{nielsen.koehler.ea:fully,
+@Article{2005:nielsen.koehler.ea:fully,
   author  = {T. Nielsen and T. Koehler and M. van der Mark and G. t'Hooft},
   title   = {Fully 3D reconstruction of attenuation for diffuse optical tomography using a finite element model},
   journal = {Nuclear Science Symposium Record},
@@ -140,7 +140,7 @@
   pages   = {2283--2285}
 }
 
-@Article{ouyang.xiu:simulation,
+@Article{2005:ouyang.xiu:simulation,
   author  = {Q. Ouyang and K. Xiu},
   title   = {Simulation Study of Reduced Self-Heating in Novel Thin-SOI Vertical Bipolar Transistors},
   journal = {Simulation of Semiconductor Processes and Devices},
@@ -148,14 +148,14 @@
   pages   = {55--58}
 }
 
-@PhDThesis{polner:galerkin,
+@PhDThesis{2005:polner:galerkin,
   author  = {M. Polner},
   title   = {Galerkin least-squares stabilization operators for the Navier-Stokes equations, A unified approach},
   year    = 2005,
   school  = {University of Twente, The Netherlands}
 }
 
-@Article{schulz.echner.ea:development,
+@Article{2005:schulz.echner.ea:development,
   author  = {R. B. Schulz and G. Echner and H. Ruehle and W. Stroh and J. Vierling and T. Vogt and J. Peter and W. Semmler},
   title   = {Development of a fully rotational non-contact fluorescence tomographer for small animals},
   journal = {IEEE Micro-imaging Conference, IEEE Nuclear Science Symposium Conference Record},
@@ -163,7 +163,7 @@
   pages   = {2391--2393}
 }
 
-@Article{schulz.peter.ea:quantifiability,
+@Article{2005:schulz.peter.ea:quantifiability,
   author  = {R. B. Schulz and J. Peter and W. Semmler and C. D'andrea and G. Valentini and R. Cubeddu},
   title   = {Quantifiability and Image Quality in Noncontact Fluorescence Tomography},
   journal = {in: Photon Migration and Diffuse-Light Imaging II, K. Licha and R. Cubeddu (eds.), SPIE press},

--- a/publications-2006.bib
+++ b/publications-2006.bib
@@ -1,13 +1,13 @@
 % Encoding: US-ASCII
 
-@MastersThesis{allmaras:optimal,
+@MastersThesis{2006:allmaras:optimal,
   author  = {M. Allmaras},
   title   = {Optimal Design of Periodic Microstructures by the Inverse Homogenization Method},
   year    = 2006,
   school  = {Technical University Munich, Germany}
 }
 
-@Article{antonic.vrdoljak:sequential,
+@Article{2006:antonic.vrdoljak:sequential,
   author  = {N. Antonic and M. Vrdoljak},
   title   = {Sequential laminates in multiple state optimal design problems},
   journal = {Mathematical Problems in Engineering},
@@ -16,7 +16,7 @@
   pages   = {1--14}
 }
 
-@TechReport{bangtsson.lund:comparison,
+@TechReport{2006:bangtsson.lund:comparison,
   author  = {E. B\"{a}ngtsson and B. Lund},
   title   = {A comparison between two approaches to solve the equations of isostasy},
   year    = 2006,
@@ -27,7 +27,7 @@
   url     = {http://bis-21pp.acad.bg/private/EricB-TRreport-final.pdf}
 }
 
-@Article{bangtsson.neytcheva:agglomerate,
+@Article{2006:bangtsson.neytcheva:agglomerate,
   author  = {E. B\"{a}ngtsson and M. Neytcheva},
   title   = {An agglomerate multilevel preconditioner for linear isostasy saddle point problems},
   journal = {Proceedings of Large-Scale Scientific Computing: 5th International Conference (I. Lirkov, S. Margenov, J. Wasniewski, eds)},
@@ -35,7 +35,7 @@
   pages   = {113--120}
 }
 
-@Article{bangtsson.neytcheva:numerical,
+@Article{2006:bangtsson.neytcheva:numerical,
   author  = {E. B\"{a}ngtsson and M. Neytcheva},
   title   = {Numerical simulations of glacial rebound using preconditioned iterative solution methods},
   journal = {Applications of Mathematics},
@@ -44,7 +44,7 @@
   pages   = {183--201}
 }
 
-@Article{boffi.gastaldi.ea:stability,
+@Article{2006:boffi.gastaldi.ea:stability,
   author  = {D. Boffi and L. Gastaldi and L. Heltai},
   title   = {Stability Results and Algorithmic Strategies for the Finite Element Approach to the Immersed Boundary Method},
   journal = {Numerical Mathematics and Advanced Applications},
@@ -53,7 +53,7 @@
   url     = {http://link.springer.com/chapter/10.1007/978-3-540-34288-5_54}
 }
 
-@Article{danilov.nestler:phase-field,
+@Article{2006:danilov.nestler:phase-field,
   author  = {D. Danilov and B. Nestler},
   title   = {Phase-field simulations of eutectic solidification using an adaptive finite element method},
   journal = {International Journal of Modern Physics B},
@@ -62,7 +62,7 @@
   pages   = {853--867}
 }
 
-@Article{grote.schneebeli.ea:discontinuous,
+@Article{2006:grote.schneebeli.ea:discontinuous,
   author  = {M. Grote and A. Schneebeli and D. Sch\"{o}tzau},
   title   = {Discontinuous Galerkin Finite Element Method for the Wave Equation},
   journal = {SIAM J. Numer. Anal},
@@ -71,7 +71,7 @@
   pages   = {2408--2431}
 }
 
-@Article{ha.shin:two,
+@Article{2006:ha.shin:two,
   author  = {T. Ha and C. Shin},
   title   = {Two dimensional magnetotelluric inversion via reverse time migration algorithm},
   journal = {Abstracts of the SEG Annual Meeting in New Orleans},
@@ -79,7 +79,7 @@
   pages   = {830--835}
 }
 
-@Article{hartmann.houston:symmetric,
+@Article{2006:hartmann.houston:symmetric,
   author  = {R. Hartmann and P. Houston},
   title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations I: Method Formulation},
   journal = {Int. J. Numer. Anal. Model.},
@@ -90,7 +90,7 @@
   url     = {http://www.math.ualberta.ca/ijnam/Volume-3-2006/No-1-06/2006-01-01.pdf}
 }
 
-@Article{hartmann.houston:symmetric*1,
+@Article{2006:hartmann.houston:symmetric*1,
   author  = {R. Hartmann and P. Houston},
   title   = {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations II: Goal-Oriented A Posteriori Error Estimation},
   journal = {Int. J. Numer. Anal. Model.},
@@ -101,7 +101,7 @@
   url     = {http://www.math.ualberta.ca/ijnam/Volume-3-2006/No-2-06/2006-02-02.pdf}
 }
 
-@Article{hartmann:adaptive,
+@Article{2006:hartmann:adaptive,
   author  = {R. Hartmann},
   title   = {Adaptive discontinuous Galerkin methods with shock-capturing for the compressible Navier-Stokes equations},
   journal = {Int. J. Numer. Meth. Fluids},
@@ -110,28 +110,28 @@
   pages   = {1131--1156}
 }
 
-@Article{hartmann:derivation,
+@Article{2006:hartmann:derivation,
   author  = {R. Hartmann},
   title   = {Derivation of an adjoint consistent discontinuous Galerkin discretization of the compressible Euler equations},
   journal = {In G. Lube and G. Rapin, eds., Proceedings of the BAIL 2006 Conference},
   year    = 2006
 }
 
-@Article{hartmann:error,
+@Article{2006:hartmann:error,
   author  = {R. Hartmann},
   title   = {Error estimation and adjoint-based adaptation in aerodynamics},
   journal = {In P. Wesseling, E. Onate, J. Periaux, eds., Proceedings of the ECCOMAS CFD 2006, Sept. 5-8, Egmond aan Zee, The Netherlands},
   year    = 2006
 }
 
-@PhDThesis{heltai:finite,
+@PhDThesis{2006:heltai:finite,
   author  = {L. Heltai},
   title   = {The Finite Element Immersed Boundary Method},
   year    = 2006,
   school  = {Universit\`{a} di Pavia, Dipartimento di Matematica ``F. Casorati''}
 }
 
-@Article{hwang.pan.ea:influence,
+@Article{2006:hwang.pan.ea:influence,
   author  = {K. Hwang and T. Pan and A. Joshi and J. C. Rasmussen and W. Bangerth and E. Sevick-Muraca},
   title   = {Influence of excitation light rejection on forward model mismatch in optical tomography},
   journal = {Phys. Med. Biol.},
@@ -140,7 +140,7 @@
   pages   = {5889--5902}
 }
 
-@Article{joshi.bangerth.ea:fully,
+@Article{2006:joshi.bangerth.ea:fully,
   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
   title   = {Fully adaptive FEM based fluorescence optical tomography from time-dependent measurements with area illumination and detection},
   journal = {Med. Phys.},
@@ -149,7 +149,7 @@
   pages   = {1299--1310}
 }
 
-@InProceedings{joshi.bangerth.ea:non-contact,
+@InProceedings{2006:joshi.bangerth.ea:non-contact,
   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
   title   = {Non-contact fluorescence optical tomography with scanning area illumination},
   booktitle = {3rd IEEE International Symposium on Biomedical Imaging: Nano to Macro, 2006.},
@@ -160,7 +160,7 @@
   doi     = {10.1109/ISBI.2006.1624983}
 }
 
-@Article{joshi.bangerth.ea:non-contact*1,
+@Article{2006:joshi.bangerth.ea:non-contact*1,
   author  = {A. Joshi and W. Bangerth and E. Sevick-Muraca},
   title   = {Non-contact fluorescence optical tomography with scanning patterned illumination},
   journal = {Optics Express},
@@ -171,7 +171,7 @@
   doi     = {10.1364/OE.14.006516}
 }
 
-@Article{joshi.bangerth.ea:plane,
+@Article{2006:joshi.bangerth.ea:plane,
   author  = {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen and E. Sevick-Muraca},
   title   = {Plane wave fluorescence tomography with adaptive finite elements},
   journal = {Optics Letters},
@@ -180,7 +180,7 @@
   pages   = {193--195}
 }
 
-@PhDThesis{kayser-herold:least-squares,
+@PhDThesis{2006:kayser-herold:least-squares,
   author  = {O. Kayser-Herold},
   title   = {Least-Squares Methods for the Solution of Fluid-Structure Interaction Problems},
   year    = 2006,
@@ -188,7 +188,7 @@
   url     = {http://www.digibib.tu-bs.de/?docid=00000035}
 }
 
-@MastersThesis{leicht:anisotropic,
+@MastersThesis{2006:leicht:anisotropic,
   author  = {T. Leicht},
   title   = {Anisotropic Mesh Refinement for Discontinuous Galerkin Methods in Aerodynamic Flow Simulations},
   year    = 2006,
@@ -196,7 +196,7 @@
   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/publications/publications.html#supervised}
 }
 
-@Article{nielsen.kohler:impact,
+@Article{2006:nielsen.kohler:impact,
   author  = {T. Nielsen and T. Kohler},
   title   = {Impact of noise on image reconstruction for diffuse optical tomography},
   journal = {Phys. of Med. Imag., Proceedings of SPIE, doi: 10.1117/12.651297, Vol. 6142, 61420M},
@@ -204,14 +204,14 @@
   url     = {http://reviews.spiedigitallibrary.org/data/Conferences/SPIEP/3323/61420M_1.pdf}
 }
 
-@PhDThesis{oeltz:raum-zeit,
+@PhDThesis{2006:oeltz:raum-zeit,
   author  = {D. Oeltz},
   title   = {Ein Raum-Zeit D\"{u}nngitterverfahren zur Diskretisierung parabolischer Differentialgleichungen},
   year    = 2006,
   school  = {University of Bonn, Germany}
 }
 
-@Article{schmidt:low-dimensional,
+@Article{2006:schmidt:low-dimensional,
   author  = {M. Schmidt},
   title   = {Low-dimensional I/O modeling of distributed parameter systems},
   journal = {Proc. Appl. Math. Mech.},
@@ -220,7 +220,7 @@
   pages   = {15--18}
 }
 
-@Article{ziegler.kohler.ea:spatial,
+@Article{2006:ziegler.kohler.ea:spatial,
   author  = {R. Ziegler and T. Kohler and T. Nielsen and O. Steinkellner and D. Grosenick and H. Rinneberg},
   title   = {Spatial Resolution for Time-Resolved Optical Tomography in Slab Geometry},
   journal = {Nucl. Sci. Symp. Conf. IEEE, Vol. 4, pp: 2578 - 2583},

--- a/publications-2007.bib
+++ b/publications-2007.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{antonic.vrdoljak:gradient,
+@Article{2007:antonic.vrdoljak:gradient,
   author  = {N. Antonic and M. Vrdoljak},
   title   = {Gradient methods for multiple state optimal design problems},
   journal = {Ann. Univ. Ferrara},
@@ -9,7 +9,7 @@
   pages   = {177--187}
 }
 
-@Article{antonietti.heltai:numerical,
+@Article{2007:antonietti.heltai:numerical,
   author  = {P. F. Antonietti and L. Heltai},
   title   = {Numerical validation of a class of mixed discontinuous Galerkin methods for Darcy flow},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -18,14 +18,14 @@
   pages   = {4505--4520}
 }
 
-@PhDThesis{antonietti:domain,
+@PhDThesis{2007:antonietti:domain,
   author  = {P. F. Antonietti},
   title   = {Domain decomposition, spectral correctness and numerical testing of discontinuous Galerkin methods},
   year    = 2007,
   school  = {University of Pavia, Italy}
 }
 
-@Article{bangerth.hartmann.ea:deal,
+@Article{2007:bangerth.hartmann.ea:deal,
   author  = {W. Bangerth and R. Hartmann and G. Kanschat},
   title   = {deal.II -- a general-purpose object-oriented finite element library},
   journal = {ACM Transactions on Mathematical Software},
@@ -35,7 +35,7 @@
   doi     = {10.1145/1268776.1268779}
 }
 
-@Article{bangerth.joshi.ea:inverse,
+@Article{2007:bangerth.joshi.ea:inverse,
   author  = {W. Bangerth and A. Joshi and E. Sevick},
   title   = {Inverse biomedical imaging using separately adapted meshes for parameters and forward model variables},
   journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
@@ -43,14 +43,14 @@
   pages   = {1368--1371}
 }
 
-@Article{bangtsson.neytcheva:finite,
+@Article{2007:bangtsson.neytcheva:finite,
   author  = {E. B\"{a}ngtsson and M. Neytcheva},
   title   = {Finite Element Block-Factorized Preconditioners},
   journal = {Technical Report 2007-008, Uppsala University, Sweden},
   year    = 2007
 }
 
-@Article{boffi.gastaldi.ea:numerical,
+@Article{2007:boffi.gastaldi.ea:numerical,
   author  = {D. Boffi and L. Gastaldi and L. Heltai},
   title   = {Numerical stability of the finite element immersed boundary method},
   journal = {Mathematical Models and Methods in Applied Sciences},
@@ -59,7 +59,7 @@
   pages   = {1479--1505}
 }
 
-@Article{boffi.gastaldi.ea:on,
+@Article{2007:boffi.gastaldi.ea:on,
   author  = {D. Boffi and L. Gastaldi and L. Heltai},
   title   = {On the CFL condition for the finite element immersed boundary method},
   journal = {Computers \& Structures},
@@ -69,7 +69,7 @@
   doi     = {10.1016/j.compstruc.2007.01.009}
 }
 
-@Article{calhoun-lopez.gunzburger:efficient,
+@Article{2007:calhoun-lopez.gunzburger:efficient,
   author  = {M. Calhoun-Lopez and M. D. Gunzburger},
   title   = {The efficient implementation of a finite element, multi-resolution viscosity method for hyperbolic conservation laws},
   journal = {Journal of Computational Physics},
@@ -78,7 +78,7 @@
   pages   = {1288--1313}
 }
 
-@Article{carnes.carey:estimating,
+@Article{2007:carnes.carey:estimating,
   author  = {B. R. Carnes and G. F. Carey},
   title   = {Estimating spatial and parameter error in parameterized nonlinear reaction-diffusion equations},
   journal = {Communications in Numerical Methods in Engineering},
@@ -88,7 +88,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/cnm.928/abstract}
 }
 
-@Article{carnes.djilali:analysis,
+@Article{2007:carnes.djilali:analysis,
   author  = {B. Carnes and N. Djilali},
   title   = {Analysis of coupled proton and water transport in a PEM fuel cell using the binary friction membrane model},
   journal = {Electrochimica Acta},
@@ -97,7 +97,7 @@
   pages   = {1038--1052}
 }
 
-@Article{cockburn.kanschat.ea:note,
+@Article{2007:cockburn.kanschat.ea:note,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {A note on discontinuous Galerkin divergence-free solutions of the Navier-Stokes equations},
   journal = {Journal of Scientific Computing},
@@ -106,7 +106,7 @@
   pages   = {61--73}
 }
 
-@Article{douglas.cole.ea:dynamically,
+@Article{2007:douglas.cole.ea:dynamically,
   author  = {C. C. Douglas and M. J. Cole and P. Dostert and Y. Efendiev and R. E. Ewing and G. Haase and J. Hatcher and M. Iskandarani and C. R. Johnson and R. A. Lodder},
   title   = {Dynamically identifying and tracking contaminants in water bodies},
   journal = {International Conference on Computational Science ICCS 2007, of Springer Lecture Notes in Computer Science},
@@ -115,14 +115,14 @@
   pages   = {1002--1009}
 }
 
-@Article{freddi.fremond:collision,
+@Article{2007:freddi.fremond:collision,
   author  = {F. Freddi and M. Fr\'{e}mond},
   title   = {Collision and Fractures: a predictive theory},
   journal = {Proceedings of the EuroSim Conference, Lubiana, Slovenia, 9-13 September},
   year    = 2007
 }
 
-@Article{galenko.reutzel.ea:modelling,
+@Article{2007:galenko.reutzel.ea:modelling,
   author  = {P. K. Galenko and S. Reutzel and D. M. Herlach and D. Danilov and B. Nestler},
   title   = {Modelling of dendritic solidification in undercooled dilute Ni-Zr melts},
   journal = {Acta Materialia},
@@ -131,7 +131,7 @@
   pages   = {6834--6842}
 }
 
-@Article{ha.shin:magnetotelluric,
+@Article{2007:ha.shin:magnetotelluric,
   author  = {T. Ha and C. Shin},
   title   = {Magnetotelluric inversion via reverse time migration algorithm of seimic data},
   journal = {J. Comput. Phys.},
@@ -140,7 +140,7 @@
   pages   = {237--262}
 }
 
-@Article{hartmann:adjoint,
+@Article{2007:hartmann:adjoint,
   author  = {R. Hartmann},
   title   = {Adjoint consistency analysis of Discontinuous Galerkin discretizations},
   journal = {SIAM J. Numer. Anal., no. 6},
@@ -149,7 +149,7 @@
   pages   = {2671--2696}
 }
 
-@Article{hartmann:dg,
+@Article{2007:hartmann:dg,
   author  = {R. Hartmann},
   title   = {DG discretizations for compressible flows: Adjoint consistency analysis, error estimation and adaptivity},
   journal = {In R. Rannacher, E. S\"{u}li, and R. Verf\"{u}hrt, eds., Adaptive Numerical Methods for PDEs, Mathematisches Forschungsinstitut Oberwolfach Report 29/2007},
@@ -157,7 +157,7 @@
   pages   = {26--30}
 }
 
-@Article{hartmann:error,
+@Article{2007:hartmann:error,
   author  = {R. Hartmann},
   title   = {Error estimation and adjoint based refinement for an adjoint consistent DG discretization of the compressible Euler equations},
   journal = {Int. J. Computing Science and Mathematics},
@@ -166,21 +166,21 @@
   pages   = {207--220}
 }
 
-@MastersThesis{hepperger:pod-basierter,
+@MastersThesis{2007:hepperger:pod-basierter,
   author  = {P. Hepperger},
   title   = {Ein POD-basierter Ansatz zur numerischen L\"{o}sung eines Datenassimilationsproblems am Beispiel einer linearen Diffusions-Konvektions-Gleichung},
   year    = 2007,
   school  = {Technical University of Munich, Germany}
 }
 
-@MastersThesis{janssen:vergleich,
+@MastersThesis{2007:janssen:vergleich,
   author  = {B. Janssen and },
   title   = {Vergleich verschiedener Finite-Elemente-Approximationen zur numerischen L\"{o}sung der Plattengleichung},
   year    = 2007,
   school  = {University of Heidelberg, Germany}
 }
 
-@Article{joshi.bangerth.ea:molecular,
+@Article{2007:joshi.bangerth.ea:molecular,
   author  = {A. Joshi and W. Bangerth and R. Sharma and J. Rasmussen and W. Wang and E. Sevick},
   title   = {Molecular tomographic imaging of lymph nodes with NIR fluorescence},
   journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
@@ -188,14 +188,14 @@
   pages   = {564--567}
 }
 
-@MastersThesis{kamm:posteriori,
+@MastersThesis{2007:kamm:posteriori,
   author  = {C. D. Kamm},
   title   = {A posteriori error estimation in numerical methods for solving self-adjoint eigenvalue problems},
   year    = 2007,
   school  = {TU Berlin, Germany}
 }
 
-@Article{kayser-herold.matthies:unified,
+@Article{2007:kayser-herold.matthies:unified,
   author  = {O. Kayser-Herold and H.G. Matthies},
   title   = {A unified least-squares formulation for fluid-structure interaction problems},
   journal = {Computers and Structures},
@@ -204,7 +204,7 @@
   pages   = {998--1011}
 }
 
-@Article{nestler.danilov.ea:metallic,
+@Article{2007:nestler.danilov.ea:metallic,
   author  = {B. Nestler and D. Danilov and A. Bracchi and Y.-L. Huang and T. Niermann and M. Seibt and S. Schneider},
   title   = {A metallic glass composite: Phase-field simulations and experimental analysis of microstructure evolution},
   journal = {Materials Science and Engineering: A, -453},
@@ -213,7 +213,7 @@
   pages   = {8--14}
 }
 
-@Article{nielsen.brendel.ea:image,
+@Article{2007:nielsen.brendel.ea:image,
   author  = {T. Nielsen and B. Brendel and T. Koehler and R. Ziegler and A. Ziegler and L. Bakker and M. van Beek and M. van der Mark and M. van der Voort and R. Harbers and K. Licha and M. Pessel and F. Schippers and J. P. Meeuwse and A. Feuerabend and D. van Pijkeren and S. Deckers},
   title   = {Image reconstruction and evaluation of system performance for optical fluorescence tomography},
   journal = {Multimodal Biomedical Imaging II, Proc. SPIE },
@@ -222,14 +222,14 @@
   url     = {http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=1296529}
 }
 
-@PhDThesis{nigro:discontinuous,
+@PhDThesis{2007:nigro:discontinuous,
   author  = {A. Nigro},
   title   = {Discontinuous Galerkin Methods for inviscid low Mach number flows},
   year    = 2007,
   school  = {University of Calabria}
 }
 
-@Article{phillips.wheeler:coupling,
+@Article{2007:phillips.wheeler:coupling,
   author  = {P. J. Phillips and M. F. Wheeler},
   title   = {A coupling of mixed and continuous Galerkin finite element methods for poroelasticity II: the discrete-in-time case},
   journal = {Computational Geosciences},
@@ -238,7 +238,7 @@
   pages   = {145--158}
 }
 
-@Article{reinhardt.frohne:on,
+@Article{2007:reinhardt.frohne:on,
   author  = {H. J. Reinhardt and J. Frohne},
   title   = {On Multidimensional Inverse Heat Conduction Problems},
   journal = {International Conference ''Inverse and Ill-Posed Problems of Mathematical Physics'', Russia},
@@ -246,7 +246,7 @@
   url     = {http://www.math.nsc.ru/conference/ipmp07/abstracts/Section3/ReinhardtHJ.pdf}
 }
 
-@Article{reinhardt.hao.ea:numerical,
+@Article{2007:reinhardt.hao.ea:numerical,
   author  = {H. J. Reinhardt and D. N. H\`{a}o and J. Frohne and F.-T. Suttmeier},
   title   = {Numerical solution of Inverse Heat Conduction Problems in two spatial dimensions},
   journal = {J. Inverse and Ill-Posed Problems},
@@ -255,28 +255,28 @@
   pages   = {19--36}
 }
 
-@PhDThesis{renda:discontinuous,
+@PhDThesis{2007:renda:discontinuous,
   author  = {S. M. Renda},
   title   = {Discontinuous Galerkin Methods for all speed flows},
   year    = 2007,
   school  = {University of Calabria}
 }
 
-@MastersThesis{rohe:residuale,
+@MastersThesis{2007:rohe:residuale,
   author  = {L. R\"{o}he},
   title   = {Residuale Stabilisierung f\"{u}r Finite Elemente Verfahren bei inkompressiblen Str\"{o}mungen},
   year    = 2007,
   school  = {University of G\"{o}ttingen, Germany}
 }
 
-@PhDThesis{schmidt:systematic,
+@PhDThesis{2007:schmidt:systematic,
   author  = {M. Schmidt},
   title   = {Systematic discretization of input/output maps and other contributions to the control of distributed parameter systems},
   year    = 2007,
   school  = {TU Berlin, Germany}
 }
 
-@Article{schulz.schweiger.ea:applying,
+@Article{2007:schulz.schweiger.ea:applying,
   author  = {R. B. Schulz and M. Schweiger and C. D'Andrea and G. Valentini and J. Peter and R. Cubeddu and S. Arridge and W. Semmler},
   title   = {Applying Time-Dependent Data for Fluorescence Tomography},
   journal = {European Conference on Biomedical Optics, Munich Germany},
@@ -285,7 +285,7 @@
   doi     = {10.1364/ECBO.2007.6626_19}
 }
 
-@Article{secanell.carnes.ea:numerical,
+@Article{2007:secanell.carnes.ea:numerical,
   author  = {M. Secanell and B. Carnes and A. Suleman and N. Djilali},
   title   = {Numerical optimization of proton exchange membrane fuel cell cathodes},
   journal = {Electrochimica Acta},
@@ -294,7 +294,7 @@
   pages   = {2668--2682}
 }
 
-@Article{secanell.karan.ea:multi-variable,
+@Article{2007:secanell.karan.ea:multi-variable,
   author  = {M. Secanell and K. Karan and A. Suleman and N. Djilali},
   title   = {Multi-variable optimization of PEMFC cathodes using an agglomerate model},
   journal = {Electrochimica Acta},
@@ -303,7 +303,7 @@
   pages   = {6318--6337}
 }
 
-@Article{steigemann.fulland.ea:simulation,
+@Article{2007:steigemann.fulland.ea:simulation,
   author  = {M. Steigemann and M. Fulland and M. Specovius-Neugebauer and H. A. Richard},
   title   = {Simulation of crack paths in functionally graded materials},
   journal = {PAMM},
@@ -312,7 +312,7 @@
   pages   = {4030029--4030030}
 }
 
-@Article{steigemann.fulland:on,
+@Article{2007:steigemann.fulland:on,
   author  = {M. Steigemann and M. Fulland},
   title   = {On the computation of the pure Neumann problem in 2-dimensional elasticity},
   journal = {International Journal of Fracture},
@@ -321,7 +321,7 @@
   pages   = {265--277}
 }
 
-@Article{ziegler.nielsen.ea:reconstruction,
+@Article{2007:ziegler.nielsen.ea:reconstruction,
   author  = {R. Ziegler and T. Nielsen and T. Koehler and D. Grosenick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg},
   title   = {Reconstruction of absorption and fluorescence contrast for scanning time-domain fluorescence mammography},
   journal = {Optical Tomography and Spectroscopy of Tissue VII, Proc. SPIE 64340H/1-11},

--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{bangerth.joshi:adaptive,
+@Article{2008:bangerth.joshi:adaptive,
   author  = {W. Bangerth and A. Joshi},
   title   = {Adaptive finite element methods for the solution of inverse problems in optical tomography},
   journal = {Inverse Problems, article 034011 (23 pages)},
@@ -8,7 +8,7 @@
   volume  = 24
 }
 
-@Article{bangerth:framework,
+@Article{2008:bangerth:framework,
   author  = {W. Bangerth},
   title   = {A framework for the adaptive finite element solution of large-scale inverse problems},
   journal = {SIAM J. Sci. Comput},
@@ -17,7 +17,7 @@
   pages   = {2965--2989}
 }
 
-@Article{bangtsson.lund:comparison,
+@Article{2008:bangtsson.lund:comparison,
   author  = {E. B\"{a}ngtsson and B. Lund},
   title   = {A comparison between two solution techniques to solve the equations of glacially induced deformation of an elastic Earth},
   journal = {Int. J. Numer. Meth. Engrg.},
@@ -26,14 +26,14 @@
   pages   = {479--502}
 }
 
-@Article{bartels.joshi.ea:post-image,
+@Article{2008:bartels.joshi.ea:post-image,
   author  = {M. Bartels and A. Joshi and J. C. Rasmussen and E. M. Sevick-Muraca and W. Bangerth},
   title   = {Post-image acquisition excitation light mitigation in NIR fluorescent tomography},
   journal = {Proceedings of the IEEE International Symposium on Biomedical Imaging, Arlington, VA},
   year    = 2008
 }
 
-@Article{boffi.gastaldi.ea:on,
+@Article{2008:boffi.gastaldi.ea:on,
   author  = {D. Boffi and L. Gastaldi and L. Heltai and C. S. Peskin},
   title   = {On the hyper-elastic formulation of the immersed boundary method},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -42,7 +42,7 @@
   pages   = {2210--2231}
 }
 
-@Article{brendel.ziegler.ea:algebraic,
+@Article{2008:brendel.ziegler.ea:algebraic,
   author  = {B. Brendel and R. Ziegler and T. Nielsen},
   title   = {Algebraic reconstruction techniques for spectral reconstruction in diffuse optical tomography},
   journal = {Applied Optics},
@@ -51,7 +51,7 @@
   pages   = {6392--6403}
 }
 
-@Article{carnes.carey:local,
+@Article{2008:carnes.carey:local,
   author  = {B. Carnes and G. F. Carey},
   title   = {Local boundary value problems for the error in FE approximation of non-linear diffusion systems},
   journal = {Int. J. for Numer. Methods Engrg.},
@@ -60,7 +60,7 @@
   pages   = {665--684}
 }
 
-@Article{djilali.sui:transport,
+@Article{2008:djilali.sui:transport,
   author  = {N. Djilali and P. C. Sui},
   title   = {Transport phenomena in fuel cells: from microscale to macroscale},
   journal = {Int. J. of Comput. Fluid Dynam.},
@@ -69,7 +69,7 @@
   pages   = {115--133}
 }
 
-@Article{fosdick.freddi.ea:bifurcation,
+@Article{2008:fosdick.freddi.ea:bifurcation,
   author  = {R. Fosdick and F. Freddi and G. Royer-Carfagni},
   title   = {Bifurcation instability in linear elasticity with the constraint of local injectivity},
   journal = {J. of Elasticity},
@@ -78,21 +78,21 @@
   pages   = {99--126}
 }
 
-@MastersThesis{geiger:vergleich,
+@MastersThesis{2008:geiger:vergleich,
   author  = {M. Geiger},
   title   = {Vergleich dreier Zeitschrittverahren zur numerischen L\"{o}sung der akustischen Wellengleichung},
   year    = 2008,
   school  = {University of Heidelberg, Germany}
 }
 
-@Article{ghysels.samaey.ea:multi-scale,
+@Article{2008:ghysels.samaey.ea:multi-scale,
   author  = {P. Ghysels and G. Samaey and B. Tijskens and H. Ramon and D. Roose},
   title   = {Multi-scale simulation of plant tissue deformation using a model for individual cell behavior},
   journal = {Report TW 522, Department of Computer Science, K.U. Leuven, Belgium, 2008.},
   year    = 2008
 }
 
-@Article{giavarini.santarelli.ea:non-linear,
+@Article{2008:giavarini.santarelli.ea:non-linear,
   author  = {C. Giavarini and M.L. Santarelli and R. Natalini and F. Freddi},
   title   = {A non-linear model of sulphation of porous stones: Numerical simulations and preliminary laboratory assessments},
   journal = {J. of Cultural Heritage},
@@ -102,7 +102,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S1296207407001422}
 }
 
-@Article{grote.schneebeli.ea:interior,
+@Article{2008:grote.schneebeli.ea:interior,
   author  = {M. Grote and A. Schneebeli and D. Sch\"{o}tzau},
   title   = {Interior penalty discontinuous Galerkin method for Maxwell's equations: optimal L$^{2}$-norm estimates},
   journal = {IMA J. Numer. Anal.},
@@ -111,7 +111,7 @@
   pages   = {440--468}
 }
 
-@Article{hartmann.houston:optimal,
+@Article{2008:hartmann.houston:optimal,
   author  = {R. Hartmann and P. Houston},
   title   = {An optimal order interior penalty discontinuous Galerkin discretization of the compressible Navier-Stokes equations},
   journal = {J. Comput. Phys., no. 22},
@@ -120,7 +120,7 @@
   pages   = {9670--9685}
 }
 
-@Article{hartmann:error,
+@Article{2008:hartmann:error,
   author  = {R. Hartmann},
   title   = {Error estimation and adjoint-based refinement for multiple force coefficients in aerodynamic flow simulations},
   journal = {8th. World Congress on Computational Mechanics (WCCM8)},
@@ -128,7 +128,7 @@
   url     = {http://elib.dlr.de/57075}
 }
 
-@Article{hartmann:multitarget,
+@Article{2008:hartmann:multitarget,
   author  = {R. Hartmann},
   title   = {Multitarget error estimation and adaptivity in aerodynamic flow simulations},
   journal = {SIAM J. Sci. Comput., no. 1},
@@ -137,21 +137,21 @@
   pages   = {708--731}
 }
 
-@Article{hartmann:numerical,
+@Article{2008:hartmann:numerical,
   author  = {R. Hartmann},
   title   = {Numerical Analysis of Higher Order Discontinuous Galerkin Finite Element Methods},
   journal = {In H. Deconinck, editor, VKI LS 2008-08: 35th CFD/ADIGMA course on very high order discretization methods, Oct. 13-17, 2008. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium},
   year    = 2008
 }
 
-@MastersThesis{heister:vorkonditionierunsstrategien,
+@MastersThesis{2008:heister:vorkonditionierunsstrategien,
   author  = {T. Heister},
   title   = {Vorkonditionierunsstrategien f\"{u}r das stabilisierte Oseen-Problem},
   year    = 2008,
   school  = {University of G\"{o}ttingen, Germany}
 }
 
-@Article{heltai:on,
+@Article{2008:heltai:on,
   author  = {L. Heltai},
   title   = {On the stability of the finite element immersed boundary method},
   journal = {Computers and Structures},
@@ -160,7 +160,7 @@
   pages   = {598--617}
 }
 
-@Article{joshi.bangerth.ea:non-contact,
+@Article{2008:joshi.bangerth.ea:non-contact,
   author  = {A. Joshi and W. Bangerth and E. Sevick},
   title   = {Non-Contact Fluorescence Optical Tomography with Adaptive Finite Element Methods},
   journal = {In: Mathematical Methods in Biomedical Imaging and Intensity-Modulated Radiation Therapy (IMRT), Y. Censor, M. Jiang and A.K. Louis (eds.), Birkh\"{a}user},
@@ -168,7 +168,7 @@
   pages   = {185--200}
 }
 
-@Article{kanschat.schotzau:energy,
+@Article{2008:kanschat.schotzau:energy,
   author  = {G. Kanschat and D. Sch\"{o}tzau},
   title   = {Energy norm a-posteriori error estimation for divergence-free discontinuous Galerkin approximations of the Navier-Stokes equations},
   journal = {Int. J. Numer. Methods Fluids},
@@ -178,7 +178,7 @@
   doi     = {10.1002/fld.1795}
 }
 
-@Article{kanschat:robust,
+@Article{2008:kanschat:robust,
   author  = {G. Kanschat},
   title   = {Robust smoothers for high order discontinuous Galerkin discretizations of advection-diffusion problems},
   journal = {J. Comput. Appl. Math.},
@@ -188,7 +188,7 @@
   url     = {http://www.isc.tamu.edu/publications-reports/tr/0701.pdf}
 }
 
-@Article{khalmanova.costanzo:space-time,
+@Article{2008:khalmanova.costanzo:space-time,
   author  = {D. K. Khalmanova and F. Costanzo},
   title   = {A space-time discontinuous Galerkin finite element method for fully coupled linear thermo-elasto-dynamic problems with strain and heat flux discontinuities},
   journal = {Comput. Meth. Appl. Mech. Engrg.},
@@ -197,14 +197,14 @@
   pages   = {1323--1342}
 }
 
-@PhDThesis{khasina:mathematische,
+@PhDThesis{2008:khasina:mathematische,
   author  = {L. Khasina},
   title   = {Mathematische Behandlung von Mischungen elastoplastischer Substanzen},
   year    = 2008,
   school  = {University of Bonn, Germany}
 }
 
-@InProceedings{kronbichler.kreiss:hybrid,
+@InProceedings{2008:kronbichler.kreiss:hybrid,
   author  = {Martin Kronbichler and Gunilla Kreiss},
   title   = {A hybrid level-set {Cahn--Hilliard} model for two-phase flow},
   journal = {Proceedings of the 1st European Conference on Microfluidics},
@@ -214,7 +214,7 @@
   url     = {http://urn.kb.se/resolve?urn=urn:nbn:se:uu:diva-104899}
 }
 
-@Article{leicht.hartmann:anisotropic,
+@Article{2008:leicht.hartmann:anisotropic,
   author  = {T. Leicht and R. Hartmann},
   title   = {Anisotropic mesh refinement for discontinuous Galerkin methods in two-dimensional aerodynamic flow simulations},
   journal = {Int. J. Numer. Meth. Fluids, no. 11},
@@ -223,14 +223,85 @@
   pages   = {2111--2138}
 }
 
-@MastersThesis{lowe:stabilisierung,
+@MastersThesis{2008:lowe:stabilisierung,
   author  = {J. L\"{o}we},
   title   = {Stabilisierung durch lokale Projektion f\"{u}r inkompressible Str\"{o}mungsprobleme},
   year    = 2008,
   school  = {University of G\"{o}ttingen, Germany}
 }
 
-@Article{lube.tews:optimal,
+@Article{2008:neytcheva.bangtsson:preconditioning,
+  author  = {M. Neytcheva and E. B\"{a}ngtsson},
+  title   = {Preconditioning of nonsymmetric saddle point systems as arising in modelling of viscoelastic problems},
+  journal = {ETNA},
+  year    = 2008,
+  volume  = 29,
+  pages   = {193--211}
+}
+
+@Article{2008:pitt.costanzo:theory,
+  author  = {J. S. Pitt and F. Costanzo},
+  title   = {Theory and simulation of a brittle damage model in thermoelastodynamics},
+  journal = {Proceedings of the 8th World Congress on Computational Mechanics (WCCM 8), Venice, Italy},
+  year    = 2008
+}
+
+@MastersThesis{2008:schmid:theory,
+  author  = {K. Schmid},
+  title   = {Theory and numerics of a reconstruction algorithm for a problem from acoustic microscopy},
+  year    = 2008,
+  school  = {Technical University of Munich, Germany}
+}
+
+@Article{2008:secanell.karan.ea:optimal,
+  author  = {M. Secanell and K. Karan and A. Suleman and N. Djilali},
+  title   = {Optimal design of ultralow-platinum PEMFC anode electrodes},
+  journal = {Journal of The Electrochemical Society, pp. B125-B134},
+  year    = 2008,
+  volume  = 155
+}
+
+@Article{2008:secanell.songprakorp.ea:multi-objective,
+  author  = {M. Secanell and R. Songprakorp and A. Suleman and N. Djilali},
+  title   = {Multi-objective optimization of a polymer electrolyte fuel cell membrane electrode assembly},
+  journal = {Energy \& Environmental Science},
+  year    = 2008,
+  volume  = 1,
+  pages   = {378--388}
+}
+
+@Article{2008:white.borja:stabilized,
+  author  = {J. A. White and R. I. Borja},
+  title   = {Stabilized low-order finite elements for coupled solid-deformation/fluid-diffusion and their application to fault zone transients},
+  journal = {Comput. Meth. Appl. Mech. Engrg.},
+  year    = 2008,
+  volume  = 197,
+  pages   = {4353--4366}
+}
+
+@MastersThesis{2008:wick:untersuchung,
+  author  = {T. Wick},
+  title   = {Untersuchung von Kopplungsmechanismen von Fluid-Struktur-Interaktion},
+  year    = 2008,
+  school  = {Universit\"{a}t Siegen, Germany}
+}
+
+@Article{2008:ziegler.brendel.ea:nonlinear,
+  author  = {R. Ziegler and B. Brendel and A. Ziegler and T. Nielsen and H. Rinneberg},
+  title   = {Nonlinear Reconstruction of Continuous Wave Diffuse Optical Tomography Using Fitted Diffusion Coefficients},
+  journal = {Doi: 10.1364/BIOMED.2008.BSuE44, Biomedical Optics . Florida, USA},
+  year    = 2008,
+  url     = {https://www.osapublishing.org/abstract.cfm?uri=BIOMED-2008-BSuE44}
+}
+
+@PhDThesis{2008:ziegler:modeling,
+  author  = {R. Ziegler},
+  title   = {Modeling photon transport and reconstruction of optical properties for performance assessment of laser and fluorescence mammographs and analysis of clinical data},
+  year    = 2008,
+  school  = {Freie Universit\"{a}t Berlin}
+}
+
+@Article{2010:lube.tews:optimal,
   author  = {G. Lube and B. Tews},
   title   = {Optimal control of singularly perturbed advection-diffusion-reaction problems},
   journal = {Math. Model. Meths. Appl. Sc.},
@@ -240,77 +311,6 @@
   pages   = {375--395},
   doi     = {10.1142/S0218202510004271},
   comment = {Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G\"{o}ttingen, Germany}
-}
-
-@Article{neytcheva.bangtsson:preconditioning,
-  author  = {M. Neytcheva and E. B\"{a}ngtsson},
-  title   = {Preconditioning of nonsymmetric saddle point systems as arising in modelling of viscoelastic problems},
-  journal = {ETNA},
-  year    = 2008,
-  volume  = 29,
-  pages   = {193--211}
-}
-
-@Article{pitt.costanzo:theory,
-  author  = {J. S. Pitt and F. Costanzo},
-  title   = {Theory and simulation of a brittle damage model in thermoelastodynamics},
-  journal = {Proceedings of the 8th World Congress on Computational Mechanics (WCCM 8), Venice, Italy},
-  year    = 2008
-}
-
-@MastersThesis{schmid:theory,
-  author  = {K. Schmid},
-  title   = {Theory and numerics of a reconstruction algorithm for a problem from acoustic microscopy},
-  year    = 2008,
-  school  = {Technical University of Munich, Germany}
-}
-
-@Article{secanell.karan.ea:optimal,
-  author  = {M. Secanell and K. Karan and A. Suleman and N. Djilali},
-  title   = {Optimal design of ultralow-platinum PEMFC anode electrodes},
-  journal = {Journal of The Electrochemical Society, pp. B125-B134},
-  year    = 2008,
-  volume  = 155
-}
-
-@Article{secanell.songprakorp.ea:multi-objective,
-  author  = {M. Secanell and R. Songprakorp and A. Suleman and N. Djilali},
-  title   = {Multi-objective optimization of a polymer electrolyte fuel cell membrane electrode assembly},
-  journal = {Energy \& Environmental Science},
-  year    = 2008,
-  volume  = 1,
-  pages   = {378--388}
-}
-
-@Article{white.borja:stabilized,
-  author  = {J. A. White and R. I. Borja},
-  title   = {Stabilized low-order finite elements for coupled solid-deformation/fluid-diffusion and their application to fault zone transients},
-  journal = {Comput. Meth. Appl. Mech. Engrg.},
-  year    = 2008,
-  volume  = 197,
-  pages   = {4353--4366}
-}
-
-@MastersThesis{wick:untersuchung,
-  author  = {T. Wick},
-  title   = {Untersuchung von Kopplungsmechanismen von Fluid-Struktur-Interaktion},
-  year    = 2008,
-  school  = {Universit\"{a}t Siegen, Germany}
-}
-
-@Article{ziegler.brendel.ea:nonlinear,
-  author  = {R. Ziegler and B. Brendel and A. Ziegler and T. Nielsen and H. Rinneberg},
-  title   = {Nonlinear Reconstruction of Continuous Wave Diffuse Optical Tomography Using Fitted Diffusion Coefficients},
-  journal = {Doi: 10.1364/BIOMED.2008.BSuE44, Biomedical Optics . Florida, USA},
-  year    = 2008,
-  url     = {https://www.osapublishing.org/abstract.cfm?uri=BIOMED-2008-BSuE44}
-}
-
-@PhDThesis{ziegler:modeling,
-  author  = {R. Ziegler},
-  title   = {Modeling photon transport and reconstruction of optical properties for performance assessment of laser and fluorescence mammographs and analysis of clinical data},
-  year    = 2008,
-  school  = {Freie Universit\"{a}t Berlin}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2008.bib
+++ b/publications-2008.bib
@@ -301,16 +301,4 @@
   school  = {Freie Universit\"{a}t Berlin}
 }
 
-@Article{2010:lube.tews:optimal,
-  author  = {G. Lube and B. Tews},
-  title   = {Optimal control of singularly perturbed advection-diffusion-reaction problems},
-  journal = {Math. Model. Meths. Appl. Sc.},
-  year    = 2010,
-  volume  = 20,
-  number  = 3,
-  pages   = {375--395},
-  doi     = {10.1142/S0218202510004271},
-  comment = {Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G\"{o}ttingen, Germany}
-}
-
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2009.bib
+++ b/publications-2009.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{abaimov.roy.ea:damage,
+@Article{2009:abaimov.roy.ea:damage,
   author  = {S. G. Abaimov and A. Roy and J.P. Cusumano},
   title   = {Damage nucleation phenomena: Statistics of times to failure},
   journal = {arXiv:0910.5179},
@@ -8,14 +8,14 @@
   url     = {http://arxiv.org/abs/0910.5179}
 }
 
-@Article{bangerth.joshi:adaptive,
+@Article{2009:bangerth.joshi:adaptive,
   author  = {W. Bangerth and A. Joshi},
   title   = {Adaptive finite element methods for nonlinear inverse problems},
   journal = {Proceedings of the 2009 ACM Symposium on Applied Computing},
   year    = 2009
 }
 
-@Article{bangerth.kayser-herold:data,
+@Article{2009:bangerth.kayser-herold:data,
   author  = {W. Bangerth and O. Kayser-Herold},
   title   = {Data Structures and Requirements for hp Finite Element Software},
   journal = {ACM Trans. Math. Softw., pp. 4/1-31},
@@ -23,7 +23,7 @@
   volume  = 36
 }
 
-@Article{bartle.mcbride.ea:discontinuous,
+@Article{2009:bartle.mcbride.ea:discontinuous,
   author  = {S. Bartle and A. McBride and B. D. Reddy},
   title   = {A discontinuous Galerkin formulation of a model of gradient plasticity at finite strains},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -32,14 +32,14 @@
   pages   = {1805--1820}
 }
 
-@MastersThesis{bartle:shell,
+@MastersThesis{2009:bartle:shell,
   author  = {S. Bartle},
   title   = {Shell finite elements with applications in biomechanics},
   year    = 2009,
   school  = {University of Cape Town, South Africa}
 }
 
-@Article{bassi.bartolo.ea:discontinuous,
+@Article{2009:bassi.bartolo.ea:discontinuous,
   author  = {F. Bassi and C. De Bartolo and R. Hartmann and A. Nigro},
   title   = {A discontinuous Galerkin method for inviscid low Mach number flows},
   journal = {J. Comput. Phys., no. 11},
@@ -48,7 +48,7 @@
   pages   = {3996--4011}
 }
 
-@Article{brendel.nielsen:selection,
+@Article{2009:brendel.nielsen:selection,
   author  = {B. Brendel and T. Nielsen},
   title   = {Selection of optimal wavelengths for spectral reconstruction in diffuse optical tomography},
   journal = {J. Biomed. Optics, 034041/1-034041/10},
@@ -56,7 +56,7 @@
   volume  = 14
 }
 
-@Article{capek:metoda,
+@Article{2009:capek:metoda,
   author  = {\v{C}apek, Marek},
   title   = {Metoda vrstevnic a modelov\'{a}n\'{i} proud\v{e}n\'{i} nem\'{i}siteln\'{y}ch nestla\v{c}iteln\'{y}ch tekutin},
   journal = {PhD dissertation, Charles University, Prague, Czech Republic},
@@ -64,7 +64,7 @@
   url     = {https://dspace.cuni.cz/handle/20.500.11956/22847}
 }
 
-@Article{clason.hepperger:forward,
+@Article{2009:clason.hepperger:forward,
   author  = {C. Clason and P. Hepperger},
   title   = {A forward approach to numerical data assimilation},
   journal = {SIAM J. Sc. Comput.},
@@ -73,7 +73,7 @@
   pages   = {3090--3115}
 }
 
-@Article{cockburn.kanschat.ea:equal-order,
+@Article{2009:cockburn.kanschat.ea:equal-order,
   author  = {B. Cockburn and G. Kanschat and D. Sch\"{o}tzau},
   title   = {An equal-order DG method for the incompressible Navier-Stokes equations},
   journal = {J. Sci. Comput.},
@@ -83,14 +83,14 @@
   doi     = {10.1007/s10915-008-9261-1}
 }
 
-@Article{desimone.heltai.ea:tools,
+@Article{2009:desimone.heltai.ea:tools,
   author  = {A. DeSimone and L. Heltai and C. Manigrasso},
   title   = {Tools for the Solution of PDEs Defined on Curved Manifolds with the deal.II Library},
   journal = {Prep. SISSA 42/2009/M},
   year    = 2009
 }
 
-@Article{freddi.royer-carfagni:from,
+@Article{2009:freddi.royer-carfagni:from,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {From Non-Linear Elasticity to Linearized Theory: Examples Defying Intuition},
   journal = {J. of Elasticity},
@@ -99,28 +99,28 @@
   pages   = {1--26}
 }
 
-@Article{freddi.royer-carfagni:variational,
+@Article{2009:freddi.royer-carfagni:variational,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {Variational models for cleavage and shear fractures},
   journal = {Proceedings of the XIX Congresso Aimeta, Ancona},
   year    = 2009
 }
 
-@MastersThesis{frohne:numerische,
+@MastersThesis{2009:frohne:numerische,
   author  = {J. Frohne},
   title   = {Numerische L\"{o}sung des inversen W\"{a}rmeleitproblems in zwei Ortsdimensionen zur Identifizierung von Randbedingungen},
   year    = 2009,
   school  = {Universit\"{a}t Siegen, Germany}
 }
 
-@Article{george.gupta.ea:empirical,
+@Article{2009:george.gupta.ea:empirical,
   author  = {T. George and A. Gupta and V. Sarin},
   title   = {An empirical analysis of the performance of iterative solvers for SPD systems},
   journal = {IBM TJ Watson Research Center, Tech. Rep. RC24737},
   year    = 2009
 }
 
-@Article{ghysels.samaey.ea:multi-scale,
+@Article{2009:ghysels.samaey.ea:multi-scale,
   author  = {P. Ghysels and G. Samaey and B. Tijskens and P. Van Liedekerke and H. Ramon and D. Roose},
   title   = {Multi-scale simulation of plant tissue deformation using a model for individual cell mechanics},
   journal = {Phys. Biol., pp. 016009/1-14},
@@ -128,7 +128,7 @@
   volume  = 6
 }
 
-@Article{gladkov.stiemer.ea:phase-field-based,
+@Article{2009:gladkov.stiemer.ea:phase-field-based,
   author  = {S. Gladkov and M. Stiemer and B. Svendsen},
   title   = {Phase-field-based modeling and simulation of solidification and deformation behavior of technological alloys},
   journal = {PAMM},
@@ -137,7 +137,7 @@
   pages   = {10547--10548}
 }
 
-@Article{hartmann.lukacova-medvidova.ea:efficient,
+@Article{2009:hartmann.lukacova-medvidova.ea:efficient,
   author  = {R. Hartmann and M. Lukacova-Medvidova and F. Prill},
   title   = {Efficient preconditioning for the discontinuous Galerkin finite element method by low-order elements},
   journal = {Appl. Numer. Math., no. 8},
@@ -146,7 +146,7 @@
   pages   = {1737--1753}
 }
 
-@Article{henke:nichtlineare,
+@Article{2009:henke:nichtlineare,
   author  = {C. Henke},
   title   = {Nichtlineare, mehrskalige kunstliche Diffusion und L$^{\infty}$(L$^{\infty}$)-Beschr\"{a}nktheit bei DG-L\"{o}sungen h\"{o}herer Ordnung von Erhaltungsgleichungen},
   journal = {PhD dissertation, Technischen Universit\"{a}t Clausthal},
@@ -154,7 +154,7 @@
   url     = {http://d-nb.info/1001190246/34/}
 }
 
-@Article{hesse.kanschat:mesh,
+@Article{2009:hesse.kanschat:mesh,
   author  = {H. K. Hesse and G. Kanschat},
   title   = {Mesh Adaptive Multiple Shooting for Partial Differential Equations. Part I: Linear Quadratic Optimal Control Problems},
   journal = {Journal of Numerical Mathematics},
@@ -163,7 +163,7 @@
   pages   = {195--217}
 }
 
-@Article{hyde.schulz.ea:performance,
+@Article{2009:hyde.schulz.ea:performance,
   author  = {D. Hyde and R. Schulz and D. Brooks and E. Miller and V. Ntziachristos},
   title   = {Performance dependence of hybrid x-ray computed tomography/fluorescence molecular tomography on the optical forward problem},
   journal = {J. Optical Soc. Amer.},
@@ -172,7 +172,7 @@
   pages   = {919--923}
 }
 
-@Article{jetzfellner.razansky.ea:performance,
+@Article{2009:jetzfellner.razansky.ea:performance,
   author  = {T. Jetzfellner and D. Razansky and A. Rosenthal and R. Schulz and K.-H. Englmeier and V. Ntziachristos},
   title   = {Performance of iterative optoacoustic tomography with experimental data},
   journal = {Appl. Phys. Lett., pp. 013703/1-3},
@@ -180,14 +180,14 @@
   volume  = 95
 }
 
-@MastersThesis{jung:mehrgitterverfahren,
+@MastersThesis{2009:jung:mehrgitterverfahren,
   author  = {J. Jung},
   title   = {Mehrgitterverfahren f\"{u}r FE-Modelle 4. Ordnung},
   year    = 2009,
   school  = {Universit\"{a}t Siegen, Germany}
 }
 
-@Article{kim.pasciak:computation,
+@Article{2009:kim.pasciak:computation,
   author  = {S. Kim and J. E. Pasciak},
   title   = {The computation of resonances in open systems using a perfectly matched layer},
   journal = {Math. Comp.},
@@ -196,21 +196,21 @@
   pages   = {1375--1398}
 }
 
-@PhDThesis{kim:analysis,
+@PhDThesis{2009:kim:analysis,
   author  = {S. Kim},
   title   = {Analysis of a PML method applied to computation of resonances in open systems and acoustic scattering problems},
   year    = 2009,
   school  = {Texas A\&M University}
 }
 
-@MastersThesis{klein:modelladaptive,
+@MastersThesis{2009:klein:modelladaptive,
   author  = {N. Klein},
   title   = {Modelladaptive FE-Techniken bei Elastizit\"{a}tsproblemen mit gro{\ss}en Verformungen},
   year    = 2009,
   school  = {Universit\"{a}t Siegen, Germany}
 }
 
-@Article{kronbichler:numerical,
+@Article{2009:kronbichler:numerical,
   author  = {M. Kronbichler},
   title   = {Numerical Methods for the Navier-Stokes Equations applied to Turbulent Flow and to Multi-Phase Flow},
   journal = {Dissertation for the degree of Licentiate of Philosophy in Scientific Computing with specialization in Numerical Analysis, Uppsala University},
@@ -218,14 +218,14 @@
   url     = {http://uu.diva-portal.org/smash/get/diva2:275573/FULLTEXT01.pdf}
 }
 
-@MastersThesis{lorentzon:fluid-structure,
+@MastersThesis{2009:lorentzon:fluid-structure,
   author  = {J. Lorentzon},
   title   = {Fluid-structure interaction (FSI) case study of a cantilever using OpenFOAM and DEAL.II with application to VIV},
   year    = 2009,
   school  = {Lunds Institute of Technology, Sweden}
 }
 
-@Article{matthies.lube.ea:some,
+@Article{2009:matthies.lube.ea:some,
   author  = {G. Matthies and G. Lube and L. R\"{o}he},
   title   = {Some remarks on streamline-diffusion methods for inf-sup stable discretisations of the generalised Oseen problem},
   journal = {Comp. Meths. Appl. Math. Vol. 9 },
@@ -233,14 +233,14 @@
   pages   = {1--23}
 }
 
-@MastersThesis{mcmahon:modelling,
+@MastersThesis{2009:mcmahon:modelling,
   author  = {A. M. McMahon},
   title   = {Modelling the Flow Behaviour of Gas Bubbles in a Bubble Column},
   year    = 2009,
   school  = {University of Cape Town, South Africa}
 }
 
-@Article{miller.costanzo:numerical,
+@Article{2009:miller.costanzo:numerical,
   author  = {S. T. Miller and F. Costanzo},
   title   = {A numerical verification for an unconditionally stable FEM for elastodynamics},
   journal = {Comp. Mech.},
@@ -249,7 +249,7 @@
   pages   = {223--237}
 }
 
-@Article{olshanskii.lube.ea:grad-div,
+@Article{2009:olshanskii.lube.ea:grad-div,
   author  = {M. Olshanskii and G. Lube and T. Heister and J. L\"{o}we},
   title   = {Grad-div stabilization and subgrid pressure models for the incompressible Navier--Stokes equations},
   journal = {Comp. Meth. Appl. Mech. Eng. V. 198},
@@ -257,7 +257,7 @@
   pages   = {3975--3988}
 }
 
-@Article{pitt.costanzo:adaptive,
+@Article{2009:pitt.costanzo:adaptive,
   author  = {J. S. Pitt and F. Costanzo},
   title   = {An adaptive h-refinement algorithm for local damage models},
   journal = {Algorithms},
@@ -266,21 +266,21 @@
   pages   = {1281--1300}
 }
 
-@Article{plagne.hulsemann.ea:parallel,
+@Article{2009:plagne.hulsemann.ea:parallel,
   author  = {L. Plagne and F. H\"{u}lsemann and D. Barthou and J. Jaeger},
   title   = {Parallel expression template for large vectors},
   journal = {Proceedings of the 8th workshop on Parallel/High-Performance Object-Oriented Scientific Computing, European Conference on Object-Oriented Programming},
   year    = 2009
 }
 
-@Article{prill.lukacova-medvidova.ea:multilevel,
+@Article{2009:prill.lukacova-medvidova.ea:multilevel,
   author  = {F. Prill and M. Lukacova-Medvidova and R. Hartmann},
   title   = {A multilevel discontinuous Galerkin method for the compressible Navier-Stokes equations},
   journal = {In A. Handlovicova, P. Frolkovic, K. Mikula and D. Sevcovic, eds., Proceedings of ALGORITMY 2009. 18th Conference on Scientific Computing Vysoke Tatry - Podbanske, Slovakia, March 15 - 20},
   year    = 2009
 }
 
-@Article{prill.lukacova-medvidova.ea:smoothed,
+@Article{2009:prill.lukacova-medvidova.ea:smoothed,
   author  = {F. Prill and M. Lukacova-Medvidova and R. Hartmann},
   title   = {Smoothed aggregation multigrid for the discontinuous Galerkin method},
   journal = {SIAM J. Sci. Comput., no. 5},
@@ -289,14 +289,14 @@
   pages   = {3503--3528}
 }
 
-@MastersThesis{raeini:fractured,
+@MastersThesis{2009:raeini:fractured,
   author  = {A. Q. Raeini},
   title   = {Fractured reservoir simulation using finite element method with logarithmic shape functions (in Persian)},
   year    = 2009,
   school  = {Sharif University of Technology, Iran}
 }
 
-@Article{ramay.vendelin:diffusion,
+@Article{2009:ramay.vendelin:diffusion,
   author  = {H. R. Ramay and M. Vendelin},
   title   = {Diffusion restrictions surrounding mitochondria: a mathematical model of heart muscle fibers},
   journal = {Biophys. J.},
@@ -305,7 +305,7 @@
   pages   = {443--452}
 }
 
-@Article{rannacher:adaptive,
+@Article{2009:rannacher:adaptive,
   author  = {R. Rannacher},
   title   = {Adaptive Finite Element Discretization of Flow Problems for Goal-Oriented Model Reduction},
   journal = {In: Computational Fluid Dynamics 2008 (H. Choi, H. G. Choi and J. Y. Yoo, eds.), Springer},
@@ -313,7 +313,7 @@
   pages   = {31--45}
 }
 
-@Article{ruger.joos.ea:3d,
+@Article{2009:ruger.joos.ea:3d,
   author  = {B. R\"{u}ger and J. Joos and T. Carraro and A. Weber and E. Ivers-Tiff\'{e}e},
   title   = {3D Electrode Microstructure Reconstruction and Modelling},
   journal = {ECS Trans. 25},
@@ -321,7 +321,7 @@
   pages   = {1211--1220}
 }
 
-@Article{schotzau.zhu:robust,
+@Article{2009:schotzau.zhu:robust,
   author  = {D. Sch\"{o}tzau and L. Zhu},
   title   = {A robust a-posteriori error estimator for discontinuous Galerkin methods for convection-diffusion equations},
   journal = {Appl. Numer. Math.},
@@ -330,14 +330,14 @@
   pages   = {2236--2255}
 }
 
-@MastersThesis{schroder:simulation,
+@MastersThesis{2009:schroder:simulation,
   author  = {N. Schr\"{o}der},
   title   = {Simulation eines mikrofluidischen Kanals mit deal.II},
   year    = 2009,
   school  = {Universit\"{a}t Siegen, Germany}
 }
 
-@Article{wang.bangerth.ea:three-dimensional,
+@Article{2009:wang.bangerth.ea:three-dimensional,
   author  = {Y. Wang and W. Bangerth and J. Ragusa},
   title   = {Three-dimensional h-adaptivity for the multigroup neutron diffusion equations},
   journal = {Progress in Nuclear Energy},
@@ -346,42 +346,42 @@
   pages   = {543--555}
 }
 
-@PhDThesis{wang:adaptive,
+@PhDThesis{2009:wang:adaptive,
   author  = {Y. Wang},
   title   = {Adaptive mesh refinement solution techniques for the multigrid S$_{\textnormal{N}}$ transport equation using a higher-order discontinuous finite element method},
   year    = 2009,
   school  = {Texas A\&M University}
 }
 
-@MastersThesis{wanka:grundkonzepte,
+@MastersThesis{2009:wanka:grundkonzepte,
   author  = {S. Wanka},
   title   = {Grundkonzepte zur Modelladaptivit\"{a}t bei Hindernisproblemen},
   year    = 2009,
   school  = {Universit\"{a}t Siegen, Germany}
 }
 
-@PhDThesis{white:stabilized,
+@PhDThesis{2009:white:stabilized,
   author  = {J. White},
   title   = {Stabilized finite element methods for coupled flow and geomechanics},
   year    = 2009,
   school  = {Stanford University}
 }
 
-@PhDThesis{willems:numerical,
+@PhDThesis{2009:willems:numerical,
   author  = {J. Willems},
   title   = {Numerical upscaling for multiscale flow problems - Analysis and Algorithms},
   year    = 2009,
   school  = {University of Kaiserslautern, Germany}
 }
 
-@Article{young.romero.ea:finite,
+@Article{2009:young.romero.ea:finite,
   author  = {T. D. Young and E. Romero and J. E. Roman},
   title   = {Finite element solution of the stationary Schr\"{o}dinger equation using standard computational tools},
   journal = {In Proceedings of the International Conference on Computational and Mathematical Methods in Science and Engineering 2009, Gijon Asturias, Spain, July },
   year    = 2009
 }
 
-@Article{young:exemplifying,
+@Article{2009:young:exemplifying,
   author  = {T. D. Young},
   title   = {Exemplifying quantum systems in a finite element basis},
   journal = {AIP Conf. Proc.},
@@ -390,7 +390,7 @@
   pages   = {285--289}
 }
 
-@Article{ziegler.brendel.ea:investigation,
+@Article{2009:ziegler.brendel.ea:investigation,
   author  = {R. Ziegler and B. Brendel and A. Schipper and R. Harbers and M. van Beek and H. Rinneberg and T. Nielsen},
   title   = {Investigation of detection limits for diffuse optical tomography systems: I. Theory and experiment},
   journal = {Phys. Med. Biol.},
@@ -401,7 +401,7 @@
   doi     = {10.1088/0031-9155/54/2/015}
 }
 
-@Article{ziegler.brendel.ea:investigation*1,
+@Article{2009:ziegler.brendel.ea:investigation*1,
   author  = {R. Ziegler and B. Brendel and H. Rinneberg and T. Nielsen},
   title   = {Investigation of detection limits for diffuse optical tomography systems: II. Analysis of slab and cup geometry for breast imaging},
   journal = {Phys. Med. Biol.},
@@ -412,7 +412,7 @@
   doi     = {10.1088/0031-9155/54/2/016 }
 }
 
-@Article{ziegler.nielsen.ea:nonlinear,
+@Article{2009:ziegler.nielsen.ea:nonlinear,
   author  = {R. Ziegler and T. Nielsen and T. Koehler and D. Grosnick and O. Steinkellner and A. Hagen and R. Macdonald and H. Rinneberg},
   title   = {Nonlinear reconstruction of absorption and fluorescence contrast from measured diffuse transmittance and reflectance of a compressed-breast-simulating phantom},
   journal = {Applied Optics},
@@ -421,7 +421,7 @@
   pages   = {4651--4662}
 }
 
-@Article{zingan:discontinuous,
+@Article{2009:zingan:discontinuous,
   author  = {V. N. Zingan},
   title   = {Discontinuous Galerkin Finite Element Method for the Nonlinear Hyperbolic Problems with Entropy-Bases Artificial Viscosity Stabilization},
   journal = {PhD dissertation, Texas A\&M University},

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -1,13 +1,13 @@
 % Encoding: US-ASCII
 
-@Article{alexe.sandu:space-time,
+@Article{2010:alexe.sandu:space-time,
   author  = {M. Alexe and A. Sandu},
   title   = {Space-time adaptive solution of inverse problems with the discrete adjoint method},
   journal = {Technical Report TR-10-14, Computational Science Laboratory, Department of Computer Science, Virginia Tech},
   year    = 2010
 }
 
-@Article{alns.mardal:on,
+@Article{2010:alns.mardal:on,
   author  = {M. S. Aln\ae{}s and K.-A. Mardal},
   title   = {On the efficiency of symbolic computations combined with code generation for finite element methods},
   journal = {ACM Transactions on Mathematical Software, 8/1-26},
@@ -15,7 +15,7 @@
   volume  = 37
 }
 
-@Article{arroyo.desimone.ea:role,
+@Article{2010:arroyo.desimone.ea:role,
   author  = {M. Arroyo and A. DeSimone and L. Heltai},
   title   = {The role of membrane viscosity in the dynamics of fluid membranes},
   journal = {arXiv:1007.4934},
@@ -23,7 +23,7 @@
   url     = {http://arxiv.org/abs/1007.4934}
 }
 
-@Article{balzera.werlingb:principles,
+@Article{2010:balzera.werlingb:principles,
   author  = {J. Balzera and S. Werlingb},
   title   = {Principles of Shape from Specular Reflection},
   journal = {Measurement, issue 10, pp. 1305--1317},
@@ -32,7 +32,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0263224110001570}
 }
 
-@Article{bangerth.geiger.ea:adaptive,
+@Article{2010:bangerth.geiger.ea:adaptive,
   author  = {W. Bangerth and M. Geiger and R. Rannacher},
   title   = {Adaptive Galerkin finite element methods for the wave equation},
   journal = {Computational Methods in Applied Mathematics},
@@ -41,14 +41,14 @@
   pages   = {3--48}
 }
 
-@Article{bartle.mcbride.ea:shell,
+@Article{2010:bartle.mcbride.ea:shell,
   author  = {S. Bartle and A. McBride and B. D. Reddy},
   title   = {Shell finite elements, with applications in biomechanics},
   journal = {In: Kok, S. (Ed.): Proceedings of 7th South African Conference on Computational and Applied Mechanics (University of Pretoria, Pretoria, South Africa)},
   year    = 2010
 }
 
-@Article{cangiani.natalini:spatial,
+@Article{2010:cangiani.natalini:spatial,
   author  = {A. Cangiani and R. Natalini},
   title   = {A spatial model of cellular molecular trafficking including active transport along microtubules},
   journal = {Journal of Theoretical Biology},
@@ -57,7 +57,7 @@
   pages   = {614--625}
 }
 
-@Article{chauvin.saramito.ea:convergence,
+@Article{2010:chauvin.saramito.ea:convergence,
   author  = {C. Chauvin and P. Saramito and C. Trophime},
   title   = {Convergence properties and numerical simulation by an adaptive FEM of the thermistor problem},
   journal = {hal-00449960, version 1},
@@ -65,7 +65,7 @@
   url     = {https://hal.archives-ouvertes.fr/hal-00449960/}
 }
 
-@Article{chueh.secanell.ea:multi-level,
+@Article{2010:chueh.secanell.ea:multi-level,
   author  = {C. C. Chueh and M. Secanell and W. Bangerth and N. Djilali},
   title   = {Multi-level Adaptive Simulation of Transient Two-phase Flow in Heterogeneous Porous Media},
   journal = {Computers and Fluids},
@@ -74,21 +74,21 @@
   pages   = {1585--1596}
 }
 
-@PhDThesis{chueh:integrated,
+@PhDThesis{2010:chueh:integrated,
   author  = {C. C. Chueh},
   title   = {Integrated adaptive numerical methods for transient two-phase flow in heterogeneous porous medi},
   year    = 2010,
   school  = {University of Victoria}
 }
 
-@MastersThesis{dally:fe-modelladaptivitat,
+@MastersThesis{2010:dally:fe-modelladaptivitat,
   author  = {T. Dally},
   title   = {FE-Modelladaptivit\"{a}t f\"{u}r P-Laplace},
   year    = 2010,
   school  = {Universit\"{a}t Siegen, Germany}
 }
 
-@Article{freddi.fremond:collision,
+@Article{2010:freddi.fremond:collision,
   author  = {F. Freddi and M. Fr\'{e}mond},
   title   = {Collision and Fractures: a predictive theory},
   journal = {European Journal of Mechanics - A/Solids},
@@ -97,7 +97,7 @@
   pages   = {998--1007}
 }
 
-@Article{freddi.royer-carfagni:regularized,
+@Article{2010:freddi.royer-carfagni:regularized,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {Regularized Variational Theories of Fracture: a Unified Approach},
   journal = {Journal of the Mechanics and Physics of Solids},
@@ -106,7 +106,7 @@
   pages   = {1154--1174}
 }
 
-@Article{freddi.royer-carfagni:variational,
+@Article{2010:freddi.royer-carfagni:variational,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {A variational formulation for smeared fixed-crack models},
   journal = {Proceedings of the IGF Workshop ``Problematiche di Frattura nei Materiali per l'Ingegneria'', Giornata IGF Forni di Sopra},
@@ -114,7 +114,7 @@
   pages   = {133--142}
 }
 
-@Article{freyer.ale.ea:fast,
+@Article{2010:freyer.ale.ea:fast,
   author  = {M. Freyer and A. Ale and R. Schulz and M. Zientkowska and V. Ntziachristos and K.-H. Englmeier},
   title   = {Fast automatic segmentation of anatomical structures in x-ray computed tomography images to improve fluorescence molecular tomography reconstruction},
   journal = {Journal of Biomedical Optics, pp. 036006/1-8},
@@ -122,7 +122,7 @@
   volume  = 15
 }
 
-@Article{garny.cooper.ea:toward,
+@Article{2010:garny.cooper.ea:toward,
   author  = {A. Garny and J. Cooper and P. J. Hunt},
   title   = {Toward a VPH/Physiome ToolKit},
   journal = {Wiley Interdisciplinary Reviews: Systems Biology and Medicine},
@@ -131,7 +131,7 @@
   pages   = {134--147}
 }
 
-@Article{ghysels.samaey.ea:coarse,
+@Article{2010:ghysels.samaey.ea:coarse,
   author  = {P. Ghysels and G. Samaey and P. Van Liedekerke and E. Tijskens and H. Ramon and D. Roose},
   title   = {Coarse implicit time integration of a cellular scale particle model for plant tissue deformation},
   journal = {Int. J. Multisc. Comput. Engrg.},
@@ -140,7 +140,7 @@
   pages   = {411--422}
 }
 
-@Article{ghysels.samaey.ea:multiscale,
+@Article{2010:ghysels.samaey.ea:multiscale,
   author  = {P. Ghysels and G. Samaey and P. Van Liedekerke and E. Tijskens and H. Ramon and D. Roose},
   title   = {Multiscale modeling of viscoelastic plant tissue},
   journal = {Int. J. Multisc. Comput. Engrg.},
@@ -149,7 +149,7 @@
   pages   = {379--396}
 }
 
-@Article{girault.murat.ea:finite,
+@Article{2010:girault.murat.ea:finite,
   author  = {V. Girault and F. Murat and A. Salgado},
   title   = {Finite element discretization of Darcy's equations with pressure dependent porosity.},
   journal = {M2AN},
@@ -158,7 +158,7 @@
   pages   = {1155--1191}
 }
 
-@Article{guven.reilly-raska.ea:discretization,
+@Article{2010:guven.reilly-raska.ea:discretization,
   author  = {M. Guven and L. Reilly-Raska and L. Zhou and B. Yazici},
   title   = {Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography: Part I},
   journal = {IEEE Trans. Medical Imaging},
@@ -167,7 +167,7 @@
   pages   = {217--229}
 }
 
-@Article{guven.zhou.ea:discretization,
+@Article{2010:guven.zhou.ea:discretization,
   author  = {M. Guven and L. Zhou and L. Reilly-Raska and B. Yazici},
   title   = {Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography: Part II},
   journal = {IEEE Trans. Medical Imaging},
@@ -176,7 +176,7 @@
   pages   = {230--245}
 }
 
-@Article{hartmann.held.ea:discontinuous,
+@Article{2010:hartmann.held.ea:discontinuous,
   author  = {R. Hartmann and J. Held and T. Leicht and F. Prill},
   title   = {Discontinuous Galerkin methods for computational aerodynamics -- 3D adaptive flow simulation with the DLR PADGE code},
   journal = {Aerospace Science and Technology},
@@ -186,7 +186,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S1270963810000441}
 }
 
-@Article{hartmann.held.ea:error,
+@Article{2010:hartmann.held.ea:error,
   author  = {R. Hartmann and J. Held and T. Leicht and F. Prill},
   title   = {Error estimation and adaptive mesh refinement for aerodynamic flows},
   journal = {In N. Kroll, H. Bieler, H. Deconinck, V. Couallier, H. van der Ven and K. Sorensen, editors, ADIGMA - A European Initiative on the Development of Adaptive Higher-Order Variational Methods for Aerospace Applications, of Notes on numerical fluid mechanics and multidisciplinary design, Springer},
@@ -195,28 +195,28 @@
   pages   = {339--353}
 }
 
-@Article{hartmann.houston:error,
+@Article{2010:hartmann.houston:error,
   author  = {R. Hartmann and P. Houston},
   title   = {Error estimation and adaptive mesh refinement for aerodynamic flows},
   journal = {In H. Deconinck, editor, VKI LS 2010-01: 36th CFD/ADIGMA course on hp-adaptive and hp-multigrid methods, Oct. 26-30, 2009. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium},
   year    = 2010
 }
 
-@Article{hartmann.leicht:discontinuous,
+@Article{2010:hartmann.leicht:discontinuous,
   author  = {R. Hartmann and T. Leicht},
   title   = {Discontinuous Galerkin Verfahren in der Aerodynamik: H\"{o}here Ordnung, Fehlersch\"{a}tzung und Gitteradaption},
   journal = {STAB Mitteilungen. 17. DGLR-Fach-Symposium der STAB, 9.-10. Nov. 2010, Berlin},
   year    = 2010
 }
 
-@Article{heister.kronbichler.ea:generic,
+@Article{2010:heister.kronbichler.ea:generic,
   author  = {T. Heister and M. Kronbichler and W. Bangerth},
   title   = {Generic Finite Element programming for massively parallel flow simulations},
   journal = {Eccomas CFD 2010 proceedings},
   year    = 2010
 }
 
-@Article{heister.kronbichler.ea:massively,
+@Article{2010:heister.kronbichler.ea:massively,
   author  = {T. Heister and M. Kronbichler and W. Bangerth},
   title   = {Massively Parallel Finite Element Programming},
   journal = {Recent Advances in the Message Passing Interface, Lecture Notes in Computer Science, /2010},
@@ -225,21 +225,21 @@
   pages   = {122--131}
 }
 
-@Article{heister.lube.ea:on,
+@Article{2010:heister.lube.ea:on,
   author  = {T. Heister and G. Lube and G. Rapin},
   title   = {On robust parallel preconditioning for incompressible flow problems},
   journal = {In Numerical Mathematics and Advanced Applications, ENUMATH 2009. Springer, Berlin},
   year    = 2010
 }
 
-@Article{hinze.kunkel:residual,
+@Article{2010:hinze.kunkel:residual,
   author  = {M. Hinze and M. Kunkel},
   title   = {Residual Based Sampling in POD Model Order Reduction of Drift-Diffusion Equations in Parametrized Electrical Networks},
   journal = {arXiv:1003.0551v1 [math.NA]},
   year    = 2010
 }
 
-@Article{iliev.lazarov.ea:discontinuous,
+@Article{2010:iliev.lazarov.ea:discontinuous,
   author  = {O. P. Iliev and R. D. Lazarov and J. Willems},
   title   = {Discontinuous Galerkin Subgrid Finite Element Method for Heterogeneous Brinkman Equations},
   journal = {Large-Scale Scientific Computing, Lectures Notes in Computer Science},
@@ -248,7 +248,7 @@
   pages   = {14--25}
 }
 
-@Article{iliev.lazarov.ea:fast,
+@Article{2010:iliev.lazarov.ea:fast,
   author  = {O. P. Iliev and R. D. Lazarov and J. Willems},
   title   = {Fast numerical upscaling of heat equation for fibrous materials},
   journal = {J. Computing and Visualization in Science},
@@ -257,14 +257,14 @@
   pages   = {275--285}
 }
 
-@Article{janssen.wick:block,
+@Article{2010:janssen.wick:block,
   author  = {B. Janssen and T. Wick},
   title   = {Block preconditioning with Schur complements for monolithic fluid-structure interactions},
   journal = {Proceedings of the Eccomas CFD 2010 conference, J. C. F. Pereira and A. Sequeira (eds.)},
   year    = 2010
 }
 
-@Article{joos.ruger.ea:electrode,
+@Article{2010:joos.ruger.ea:electrode,
   author  = {J. Joos and B. R\"{u}ger and T. Carraro and A. Weber and E. Ivers-Tiff\'{e}e},
   title   = {Electrode Reconstruction by FIB/SEM and Microstructure Modeling},
   journal = {ECS Trans. 28},
@@ -272,7 +272,7 @@
   pages   = {81--91}
 }
 
-@Article{kanschat.riviere:strongly,
+@Article{2010:kanschat.riviere:strongly,
   author  = {G. Kanschat and B. Rivi\`{e}re},
   title   = {A strongly conservative finite element method for the coupling of Stokes and Darcy flow},
   journal = {J. Computational Physics},
@@ -281,7 +281,7 @@
   pages   = {5933--5943}
 }
 
-@Article{keller.feist.ea:investigation,
+@Article{2010:keller.feist.ea:investigation,
   author  = {F. Keller and M. Feist and H. Nirschl and W. D\"{o}rfler},
   title   = {Investigation of the nonlinear effects during the sedimentation process of a charged colloidal particle by direct numerical simulation},
   journal = {Journal of Colloid and Interface Science},
@@ -290,7 +290,7 @@
   pages   = {228--236}
 }
 
-@Article{kim.pasciak:analysis,
+@Article{2010:kim.pasciak:analysis,
   author  = {S. Kim and J. E. Pasciak},
   title   = {Analysis of a Cartesian PML approximation to acoustic scattering problems in R$^{2}$},
   journal = {J. Math. Anal. Appl.},
@@ -299,7 +299,7 @@
   pages   = {168--186}
 }
 
-@Article{king.mehrmann.ea:active,
+@Article{2010:king.mehrmann.ea:active,
   author  = {R. King and V. Mehrmann and W. Nitsche},
   title   = {Active Flow Control--A Mathematical Challenge},
   journal = {Production Factor Mathematics, Part 1},
@@ -307,7 +307,7 @@
   pages   = {73--80}
 }
 
-@Article{king.mehrmann.ea:aktive,
+@Article{2010:king.mehrmann.ea:aktive,
   author  = {R. King and V. Mehrmann and W. Nitsche},
   title   = {Aktive Str\"{o}mungsbeeinflussung -- Eine Mathematische Herausforderung},
   journal = {Produktionsfaktor Mathematik, Part 2},
@@ -315,7 +315,7 @@
   pages   = {99--109}
 }
 
-@Article{krakowian.lekszycki:investigation,
+@Article{2010:krakowian.lekszycki:investigation,
   author  = {P. Krakowian and T. Lekszycki},
   title   = {Investigation and Modeling of Bone Fracture Healing},
   journal = {5th International Conference on Advances in Mechanical Engineering and Mechanics, ICAMEM 2010, Tunisia},
@@ -323,7 +323,7 @@
   url     = {http://www.ippt.pan.pl/Repository/o462.pdf}
 }
 
-@Article{leicht.hartmann:error,
+@Article{2010:leicht.hartmann:error,
   author  = {T. Leicht and R. Hartmann},
   title   = {Error estimation and anisotropic mesh refinement for 3d laminar aerodynamic flow simulations},
   journal = {J. Comput. Phys.},
@@ -334,7 +334,7 @@
   doi     = {10.1016/j.jcp.2010.06.019}
 }
 
-@InProceedings{leicht.hartmann:error*1,
+@InProceedings{2010:leicht.hartmann:error*1,
   author  = {Leicht, Tobias and Hartmann, Ralf},
   title   = {Error estimation and anisotropic mesh refinement for aerodynamic flow simulations},
   booktitle = {Numerical Mathematics and Advanced Applications ENUMATH 2009},
@@ -344,7 +344,7 @@
   doi     = {10.1007/978-3-642-11795-4_62}
 }
 
-@Article{michoski.evans.ea:modeling,
+@Article{2010:michoski.evans.ea:modeling,
   author  = {C. E. Michoski and J. A. Evans and P. G. Schmitz},
   title   = {Modeling Chemical Reactors I: Quiescent Reactors},
   journal = {arXiv:1012.5682},
@@ -352,7 +352,7 @@
   url     = {http://arxiv.org/abs/1012.5682}
 }
 
-@PhDThesis{muehl:techniques,
+@PhDThesis{2010:muehl:techniques,
   author  = {J. K. Muehl},
   title   = {Techniques for Interdisciplinary Validation by Visualization in Physiological Modeling Liver Radiofrequency Ablation},
   year    = 2010,
@@ -360,7 +360,7 @@
   url     = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.419.3812&rep=rep1&type=pdf}
 }
 
-@Article{myers.fu.ea:experimental,
+@Article{2010:myers.fu.ea:experimental,
   author  = {M. Myers and E.G. Fu and Michelle Myers and H. Wang and G. Xie and X. Wang and W-K. Chue and L. Shao},
   title   = {An experimental and modeling study on the role of damage cascade formation in nanocrystalization of ion-irradiated Ni52.5Nb10Zr15Ti15Pt7.5 metallic glass},
   journal = {Scripta Materialia, Vol. 63 (11), pp: 1045--1048},
@@ -368,14 +368,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S1359646210005002}
 }
 
-@MastersThesis{neuen:multiscale,
+@MastersThesis{2010:neuen:multiscale,
   author  = {C. P. T. Neuen},
   title   = {A multiscale approach to the Poisson-Nernst-Planck equation},
   year    = 2010,
   school  = {University of Bonn, Germany}
 }
 
-@Article{nigro.bartolo.ea:discontinuous,
+@Article{2010:nigro.bartolo.ea:discontinuous,
   author  = {A. Nigro and C. De Bartolo and R. Hartmann and F. Bassi},
   title   = {Discontinuous Galerkin solution of preconditioned Euler equations for very low Mach number flows},
   journal = {Int. J. Numer. Meth. Fluids, no. 4},
@@ -384,14 +384,14 @@
   pages   = {449--467}
 }
 
-@PhDThesis{prill:diskontinuierliche,
+@PhDThesis{2010:prill:diskontinuierliche,
   author  = {F. Prill},
   title   = {Diskontinuierliche Galerkin-Methoden und schnelle iterative L\"{o}ser zur Simulation kompressibler Str\"{o}mungen},
   year    = 2010,
   school  = {TU Hamburg-Harburg}
 }
 
-@Article{rapson.tapson:capturing,
+@Article{2010:rapson.tapson:capturing,
   author  = {M. J. Rapson and J. C. Tapson},
   title   = {Capturing low-frequency cochlear impedance in time domain models: The role of viscosity},
   journal = {J. Acoust. Soc. Am. Vol. 127, Issue 3},
@@ -399,7 +399,7 @@
   pages   = {1869--1869}
 }
 
-@Article{rees.stoll.ea:all-at-once,
+@Article{2010:rees.stoll.ea:all-at-once,
   author  = {T. Rees and M. Stoll and A. Wathen},
   title   = {All-at-once preconditioning in PDE-constrained optimization},
   journal = {Kybernetica},
@@ -408,7 +408,7 @@
   pages   = {341--360}
 }
 
-@Article{richter.wick:finite,
+@Article{2010:richter.wick:finite,
   author  = {T. Richter and T. Wick},
   title   = {Finite Elements for Fluid-Structure Interaction in ALE and Fully Eulerian Coordinates},
   journal = {Comput. Meth. Appl. Mech. Engrg.},
@@ -417,7 +417,7 @@
   pages   = {2633--2642}
 }
 
-@Article{rohe.lube:analysis,
+@Article{2010:rohe.lube:analysis,
   author  = {L. R\"{o}he and G. Lube},
   title   = {Analysis of a variational multiscale method for large-eddy simulation and its application to homogeneous isotropic turbulence},
   journal = {Comput. Meth. Appl. Mech. Engrg.},
@@ -426,21 +426,21 @@
   pages   = {2331--2342}
 }
 
-@Article{rupp:symbolic,
+@Article{2010:rupp:symbolic,
   author  = {K. Rupp},
   title   = {Symbolic integration at compile time in finite element methods},
   journal = {Proceedings of the 2010 International Symposium on Symbolic and Algebraic Computation, 347-354},
   year    = 2010
 }
 
-@PhDThesis{salgado:approximation,
+@PhDThesis{2010:salgado:approximation,
   author  = {A. J. Salgado},
   title   = {Approximation Techniques for Incompressible Flows with Heterogeneous Properties},
   year    = 2010,
   school  = {Texas A\&M University}
 }
 
-@Article{schulz.ale.ea:hybrid,
+@Article{2010:schulz.ale.ea:hybrid,
   author  = {R. Schulz and A. Ale and A. Sarantopoulos and M. Freyer and E. Soehngen and M. Zientkowska and V. Ntziachristos},
   title   = {Hybrid System for Simultaneous Fluorescence and X-Ray Computed Tomography},
   journal = {IEEE Trans. Medical Imaging},
@@ -449,7 +449,7 @@
   pages   = {465--473}
 }
 
-@Article{secanell.songprakorp.ea:optimization,
+@Article{2010:secanell.songprakorp.ea:optimization,
   author  = {M. Secanell and R. Songprakorp and N. Djilali and A. Suleman},
   title   = {Optimization of a proton exchange membrane fuel cell membrane electrode assembly},
   journal = {Structural and Multidisciplinary Optimization, issue 1-6, pp 563-583},
@@ -458,7 +458,7 @@
   url     = {http://link.springer.com/article/10.1007/s00158-009-0387-z}
 }
 
-@Article{steigemann.specovius-neugebauer.ea:simulation,
+@Article{2010:steigemann.specovius-neugebauer.ea:simulation,
   author  = {M. Steigemann and M. Specovius-Neugebauer and M. Fulland and H. A. Richard},
   title   = {Simulation of crack paths in functionally graded materials},
   journal = {Engineering Fracture Mechanics},
@@ -467,14 +467,14 @@
   pages   = {2145--2157}
 }
 
-@Article{stoll.wathen:all-at-once,
+@Article{2010:stoll.wathen:all-at-once,
   author  = {M. Stoll and A. Wathen},
   title   = {All-at-once preconditioning of time-dependent PDE-constrained optimization problems},
   journal = {Preprint 1017, University of Oxford},
   year    = 2010
 }
 
-@Article{turcksin.ragusa.ea:goal-oriented,
+@Article{2010:turcksin.ragusa.ea:goal-oriented,
   author  = {B. Turcksin and J. C. Ragusa and W. Bangerth},
   title   = {Goal-oriented h-adaptivity for the multigroup SP$_{\textnormal{N}}$ equations},
   journal = {Nuclear Science and Engineering},
@@ -483,7 +483,7 @@
   pages   = {305--319}
 }
 
-@Article{vdroljak:on,
+@Article{2010:vdroljak:on,
   author  = {M. Vdroljak},
   title   = {On Hashin-Shtrikman bounds for mixtures of two isotropic materials},
   journal = {Nonlinear Analysis: Real world applications},
@@ -492,14 +492,14 @@
   pages   = {4597--4606}
 }
 
-@MastersThesis{weiler:stromfunktionsformulierung,
+@MastersThesis{2010:weiler:stromfunktionsformulierung,
   author  = {C. Weiler},
   title   = {Stromfunktionsformulierung der Navier-Stokes-Gleichungen und Methoden der Druckrekonstruktion},
   year    = 2010,
   school  = {University of Heidelberg, Germany}
 }
 
-@Article{young.armiento:strategies,
+@Article{2010:young.armiento:strategies,
   author  = {T. D. Young and R. Armiento},
   title   = {Strategies for $h$-adaptive refinement for a finite element treatment of harmonic oscillator Schr\"{o}dinger eigenproblem},
   journal = {Commun. Theor. Phys. (Beijing, China), (6)},
@@ -508,7 +508,7 @@
   pages   = {1017--1023}
 }
 
-@Article{zhou:adaptive,
+@Article{2010:zhou:adaptive,
   author  = {L. Zhou},
   title   = {Adaptive finite element methods for fluorescence diffuse optical tomography},
   journal = {PhD dissertation, Rensselaer Polytechnic Institute},
@@ -516,7 +516,7 @@
   url     = {http://gradworks.umi.com/34/35/3435879.html}
 }
 
-@PhDThesis{zhu:robust,
+@PhDThesis{2010:zhu:robust,
   author  = {L. Zhu},
   title   = {Robust a posteriori error estimation for discontinuous Galerkin methods for convection-diffusion equations},
   year    = 2010,

--- a/publications-2010.bib
+++ b/publications-2010.bib
@@ -344,6 +344,19 @@
   doi     = {10.1007/978-3-642-11795-4_62}
 }
 
+@Article{2010:lube.tews:optimal,
+  author  = {G. Lube and B. Tews},
+  title   = {Optimal control of singularly perturbed advection-diffusion-reaction problems},
+  journal = {Math. Model. Meths. Appl. Sc.},
+  year    = 2010,
+  month   = mar,
+  volume  = 20,
+  number  = 3,
+  pages   = {375--395},
+  doi     = {10.1142/S0218202510004271},
+  comment = {Preprint 2008-15, Institute for Numerical and Applied Mathematics, University of G\"{o}ttingen, Germany}
+}
+
 @Article{2010:michoski.evans.ea:modeling,
   author  = {C. E. Michoski and J. A. Evans and P. G. Schmitz},
   title   = {Modeling Chemical Reactors I: Quiescent Reactors},

--- a/publications-2011.bib
+++ b/publications-2011.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{adeniran.mcpate.ea:increased,
+@Article{2011:adeniran.mcpate.ea:increased,
   author  = {I. Adeniran and M. J. McPate and H. J. Wichtel and J. C. Hancox and H. Zhang},
   title   = {Increased vulnerability of human ventricle to re-entrant excitation in hERG-linked variant 1 short QT syndrome},
   journal = {PLoS Computational Biology, e1002313},
@@ -8,7 +8,7 @@
   volume  = 7
 }
 
-@Article{allmaras.bangerth:reconstructions,
+@Article{2011:allmaras.bangerth:reconstructions,
   author  = {M. Allmaras and W. Bangerth},
   title   = {Reconstructions in ultrasound modulated optical tomography},
   journal = {J. Inverse and Ill-posed Problems},
@@ -17,14 +17,14 @@
   pages   = {801--823}
 }
 
-@PhDThesis{allmaras:modeling,
+@PhDThesis{2011:allmaras:modeling,
   author  = {M. Allmaras},
   title   = {Modeling aspects and computational methods for some recent problems of tomographic imaging},
   year    = 2011,
   school  = {Texas A\&M University}
 }
 
-@Article{alouges.desimone.ea:numerical,
+@Article{2011:alouges.desimone.ea:numerical,
   author  = {F. Alouges and A. DeSimone and L. Heltai},
   title   = {Numerical strategies for stroke optimization of axisymmetric microswimmers},
   journal = {Mathematical Models and Methods in Applied Sciences},
@@ -33,7 +33,7 @@
   pages   = {361--387}
 }
 
-@Article{bangerth.burstedde.ea:algorithms,
+@Article{2011:bangerth.burstedde.ea:algorithms,
   author  = {W. Bangerth and C. Burstedde and T. Heister and M. Kronbichler},
   title   = {Algorithms and Data Structures for Massively Parallel Generic Finite Element Codes},
   journal = {ACM Transactions on Mathematical Software, article 124},
@@ -41,14 +41,14 @@
   volume  = 38
 }
 
-@Article{benzarti.freddi.ea:damage,
+@Article{2011:benzarti.freddi.ea:damage,
   author  = {K. Benzarti and F. Freddi and M. Fr\'{e}mond},
   title   = {A damage model to predict the durability of bonded assemblies. Part I: Debonding behavior of FRP strengthened concrete structures},
   journal = {Construction and Building Materials, 25(2), 547-555},
   year    = 2011
 }
 
-@Article{buehler.rosenthal.ea:model-based,
+@Article{2011:buehler.rosenthal.ea:model-based,
   author  = {A. Buehler and A. Rosenthal and T. Jetzfellner and A. Dima and D. Razansky and V. Ntziachristos},
   title   = {Model-based optoacoustic inversions with incomplete projection data},
   journal = {Med. Phys.},
@@ -57,7 +57,7 @@
   pages   = {1694--1704}
 }
 
-@Article{burg.dorfler:convergence,
+@Article{2011:burg.dorfler:convergence,
   author  = {M. B\"{u}rg and W. D\"{o}rfler},
   title   = {Convergence of an adaptive hp finite element strategy in higher space-dimensions},
   journal = {Appl. Numer. Math. 61},
@@ -65,7 +65,7 @@
   pages   = {1132--1146}
 }
 
-@Article{burg:hp-efficient,
+@Article{2011:burg:hp-efficient,
   author  = {M. B\"{u}rg},
   title   = {An hp-Efficient Residual-Based A Posteriori Error Estimator for Maxwell's Equations},
   journal = {Proc. Appl. Math. Mech. Vol. 11, pp: 869 -- 870},
@@ -73,14 +73,14 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201110421/abstract}
 }
 
-@Article{cangiani.georgoulis.ea:discontinuous,
+@Article{2011:cangiani.georgoulis.ea:discontinuous,
   author  = {A. Cangiani and E. Georgoulis and M. Jensen},
   title   = {Discontinuous Galerkin methods for convection-diffusion problems modelling mass transfer through semipermeable membranes.},
   journal = {Proceedings of the Congress on Numerical Methods in Engineering, Coimbra},
   year    = 2011
 }
 
-@Article{carrara.ferretti.ea:shear,
+@Article{2011:carrara.ferretti.ea:shear,
   author  = {P. Carrara and D. Ferretti and F. Freddi and G. Rosati},
   title   = {Shear tests of carbon fiber plates bonded to concrete with control of snap-back},
   journal = {Engineering Fracture Mechanics},
@@ -89,7 +89,7 @@
   pages   = {2663--2678}
 }
 
-@Article{chandrasekaran.jayaraman.ea:msnfd,
+@Article{2011:chandrasekaran.jayaraman.ea:msnfd,
   author  = {S. Chandrasekaran and K. R. Jayaraman and M. Gu and H. N. Mhaskar and J. Moffitt},
   title   = {MSNFD: A Higher Order Finite Difference Method for Solving Elliptic PDEs on scattered points (An Extended version of our paper submitted to ICCS 2011)},
   note    = {Submitted},
@@ -97,14 +97,14 @@
   url     = {http://scg.ece.ucsb.edu/msnpub.html}
 }
 
-@PhDThesis{crestel:moving,
+@PhDThesis{2011:crestel:moving,
   author  = {B. Crestel},
   title   = {Moving meshes on general surfaces},
   year    = 2011,
   school  = {Simon Fraser University}
 }
 
-@MastersThesis{dobson:investigation,
+@MastersThesis{2011:dobson:investigation,
   author  = {P. Dobson},
   title   = {Investigation of the polymer electrolyte membrane fuel cell catalyst layer microstructure },
   year    = 2011,
@@ -112,14 +112,14 @@
   url     = {https://era.library.ualberta.ca/public/datastream/get/uuid:30e76f20-e819-4c0e-b3e4-063dbdca6319/DS1/Dobson_Peter_Fall_2011.pdf}
 }
 
-@Article{emmrich.siska:full,
+@Article{2011:emmrich.siska:full,
   author  = {E. Emmrich and D. \v{S}i\v{s}ka},
   title   = {Full discretization of second-order nonlinear evolution equations: Strong convergence and applications},
   journal = {Preprint, University of Bielefeld},
   year    = 2011
 }
 
-@InProceedings{freddi.royer-carfagni:variational,
+@InProceedings{2011:freddi.royer-carfagni:variational,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {A variational approach to plasticity. Numerical experiments},
   booktitle = {Proceedings, Atti XX Congresso Nazionale AIMETA},
@@ -127,7 +127,7 @@
   year    = 2011
 }
 
-@Article{freddi.royer-carfagni:variational*1,
+@Article{2011:freddi.royer-carfagni:variational*1,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {Variational fracture mechanics for compressive splitting of masonry-like materials},
   journal = {Annals of Solid and Structural Mechanics},
@@ -137,21 +137,21 @@
   doi     = {10.1007/s12356-011-0018-4}
 }
 
-@PhDThesis{freyer:automatische,
+@PhDThesis{2011:freyer:automatische,
   author  = {M. Freyer},
   title   = {Automatische Segmentierung anatomischer Strukturen in CT-Bildern eines hybriden FMT/XCT-Systems zur Verbesserung der optischen Bildgebung},
   year    = 2011,
   school  = {Ludwig-Maximilians-University Munich, Germany}
 }
 
-@PhDThesis{frohne:fem-simulation,
+@PhDThesis{2011:frohne:fem-simulation,
   author  = {J. Frohne},
   title   = {FEM-Simulation der Umformtechnik metallischer Oberfl\"{a}chen im Mikrokosmos},
   year    = 2011,
   school  = {University of Siegen, Germany}
 }
 
-@Article{george.gupta.ea:empirical,
+@Article{2011:george.gupta.ea:empirical,
   author  = {T. George and A. Gupta and V. Sarin},
   title   = {An empirical analysis of the performance of iterative solvers for SPD systems},
   journal = {ACM Trans. Math. Softw., 2011. IBM Research Report RC 24737},
@@ -159,14 +159,14 @@
   note    = {Submitted}
 }
 
-@Article{ginzburg:introduction,
+@Article{2011:ginzburg:introduction,
   author  = {A. Ginzburg},
   title   = {Introduction to Geophysics (in Hebrew)},
   journal = {The Open University of Israel},
   year    = 2011
 }
 
-@Article{gladkov.kayser.ea:fe-modeling,
+@Article{2011:gladkov.kayser.ea:fe-modeling,
   author  = {S. Gladkov and T. Kayser and B. Svendsen},
   title   = {FE-modeling of ideal grain growth based on preprocessed EBSD data},
   journal = {PAMM},
@@ -175,7 +175,7 @@
   pages   = {471--472}
 }
 
-@Article{guermond.salgado:error,
+@Article{2011:guermond.salgado:error,
   author  = {J. L. Guermond and A. Salgado},
   title   = {Error analysis of a fractional time-stepping technique for incompressible flows with variable density.},
   journal = {SIAM J. of Numerical Analysis},
@@ -184,7 +184,7 @@
   pages   = {917--944}
 }
 
-@Article{hartmann.held.ea:adjoint-based,
+@Article{2011:hartmann.held.ea:adjoint-based,
   author  = {R. Hartmann and J. Held and T. Leicht},
   title   = {Adjoint-based error estimation and adaptive mesh refinement for the RANS and k-$\omega$ turbulence model equations},
   journal = {J. Comput. Phys.},
@@ -193,14 +193,14 @@
   pages   = {4268--4284}
 }
 
-@PhDThesis{heister:massively,
+@PhDThesis{2011:heister:massively,
   author  = {T. Heister},
   title   = {A Massively Parallel Finite Element Framework with Application to Incompressible Flows},
   year    = 2011,
   school  = {University of G\"{o}ttingen, Germany}
 }
 
-@Article{hepperger:pricing,
+@Article{2011:hepperger:pricing,
   author  = {P. T. Hepperger},
   title   = {Pricing and Hedging under High-Dimensional Jump-Diffusion Models using Partial Dierential Equations},
   journal = {PhD dissertation, Technische Universit at Munchen},
@@ -208,7 +208,7 @@
   url     = {http://mediatum.ub.tum.de/doc/1006896/1006896.pdf}
 }
 
-@Article{hinze.kunkel.ea:model,
+@Article{2011:hinze.kunkel.ea:model,
   author  = {M. Hinze and M. Kunkel and U. Matthes and M. Vierling},
   title   = {Model order reduction of integrated circuits in electrical networks},
   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik},
@@ -218,7 +218,7 @@
   url     = {https://preprint.math.uni-hamburg.de/public/papers/hbam/hbam2011-14.pdf}
 }
 
-@Article{hinze.kunkel.ea:model*1,
+@Article{2011:hinze.kunkel.ea:model*1,
   author  = {M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel},
   title   = {Model order reduction of coupled circuit-device systems},
   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik},
@@ -228,7 +228,7 @@
   url     = {https://preprint.math.uni-hamburg.de/public/papers/hbam/hbam2011-08.pdf}
 }
 
-@Article{hinze.kunkel.ea:pod,
+@Article{2011:hinze.kunkel.ea:pod,
   author  = {M. Hinze and M. Kunkel and M. Vierling},
   title   = {POD model order reduction of drift-diffusion equations in electrical networks},
   journal = {in: Model Reduction for Circuit Simulation, P. Benner, M. Hinze, and J. ter Maten (eds.), Lecture Notes in Electrical Engineering, Berlin-Heidelberg: Springer-Verlag, p. 177--192},
@@ -236,7 +236,7 @@
   volume  = 74
 }
 
-@Article{iliev.lazarov.ea:variational,
+@Article{2011:iliev.lazarov.ea:variational,
   author  = {O. P. Iliev and R. D. Lazarov and J. Willems},
   title   = {Variational multiscale finite element method for flows in highly porous media},
   journal = {Multiscale Modeling and Simulation},
@@ -245,14 +245,14 @@
   pages   = {1350--1372}
 }
 
-@Article{janssen.kanschat:adaptive,
+@Article{2011:janssen.kanschat:adaptive,
   author  = {B. Janssen and G. Kanschat},
   title   = {Adaptive multilevel methods with local smoothing},
   journal = {SIAM J. Sci. Comput. 33(4) 2095-2114},
   year    = 2011
 }
 
-@Article{jegert.kersch.ea:monte,
+@Article{2011:jegert.kersch.ea:monte,
   author  = {G. Jegert and A. Kersch and W. Weinreich and P. Lugli},
   title   = {Monte Carlo Simulation of Leakage Currents in TiN/ZrO$_{2}$/TiN Capacitors},
   journal = {IEEE Transactions on Electron Devices},
@@ -261,7 +261,7 @@
   pages   = {327--334}
 }
 
-@Article{jepihhina.beraud.ea:permeabilized,
+@Article{2011:jepihhina.beraud.ea:permeabilized,
   author  = {N. Jepihhina and N. Beraud and M. Sepp and R. Birkedal and M. Vendelin},
   title   = {Permeabilized Rat Cardiomyocyte Response Demonstrates Intracellular Origin of Diffusion Obstacles},
   journal = {Biophysical Journal , Vol. 101(9), pp: 2112--2121},
@@ -269,14 +269,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S000634951101085X}
 }
 
-@MastersThesis{johansson:implementation,
+@MastersThesis{2011:johansson:implementation,
   author  = {N. Johansson},
   title   = {Implementation of a standard level set method for incompressible two-phase flow simulations},
   year    = 2011,
   school  = {Uppsala University, Uppsala, Sweden}
 }
 
-@Article{joos.carraro.ea:detailed,
+@Article{2011:joos.carraro.ea:detailed,
   author  = {J. Joos and T. Carraro and M. Ender and B. R\"{u}ger and A. Weber and E. Ivers-Tiff\'{e}e},
   title   = {Detailed Microstructure Analysis and 3D Simulations of Porous Electrodes},
   journal = {ECS Trans. 35},
@@ -284,7 +284,7 @@
   pages   = {2357--2368}
 }
 
-@Article{keller.nirschl.ea:primary,
+@Article{2011:keller.nirschl.ea:primary,
   author  = {F. Keller and H. Nirschl and W. D\"{o}rfler},
   title   = {Primary charge effects on prolate spheroids with moderate aspect ratios},
   journal = {Journal of Colloid and Interface Science},
@@ -293,7 +293,7 @@
   pages   = {690--702}
 }
 
-@Article{kormann.kronbichler:parallel,
+@Article{2011:kormann.kronbichler:parallel,
   author  = {K. Kormann and M. Kronbichler},
   title   = {Parallel finite element operator application: Graph partitioning and coloring},
   journal = {In proceedings of the 2011 IEEE 7th international conference on e-Science},
@@ -301,21 +301,21 @@
   pages   = {332--339}
 }
 
-@Article{kronbichler.walker.ea:multiscale,
+@Article{2011:kronbichler.walker.ea:multiscale,
   author  = {M. Kronbichler and C. Walker and G. Kreiss and B. M\"{u}ller},
   title   = {Multiscale modeling of capillary-driven contact line dynamics},
   note    = {Submitted},
   year    = 2011
 }
 
-@PhDThesis{kronbichler:computational,
+@PhDThesis{2011:kronbichler:computational,
   author  = {M. Kronbichler},
   title   = {Computational Techniques for Coupled Flow-Transport Problems},
   year    = 2011,
   school  = {Uppsala University, Uppsala, Sweden}
 }
 
-@Article{layton.rohe.ea:explicitly,
+@Article{2011:layton.rohe.ea:explicitly,
   author  = {W. Layton and L. R\"{o}he and H. Tran},
   title   = {Explicitly uncoupled VMS stabilization of fluid flow},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -324,7 +324,7 @@
   pages   = {3183--3199}
 }
 
-@Article{leicht.hartmann:error,
+@Article{2011:leicht.hartmann:error,
   author  = {T. Leicht and R. Hartmann},
   title   = {Error estimation and hp-adaptive mesh refinement for discontinuous Galerkin methods},
   journal = {In Z. J. Wang, editor, Adaptive High-Order Methods in Computational Fluid Dynamics - with applications in aerospace engineering, World Science Books},
@@ -332,14 +332,14 @@
   pages   = {67--94}
 }
 
-@Article{leicht.hartmann:goal-oriented,
+@Article{2011:leicht.hartmann:goal-oriented,
   author  = {T. Leicht and R. Hartmann},
   title   = {Goal-oriented error estimation and hp-adaptive mesh refinement for aerodynamic flows.},
   journal = {49$^{\textnormal{th}}$ AIAA Aerospace Sciences Meeting AIAA 2011-212},
   year    = 2011
 }
 
-@Article{leonard:multiphase,
+@Article{2011:leonard:multiphase,
   author  = {K. Leonard},
   title   = {Multiphase Modelling of Tissue Engineering},
   journal = {Proceedings of the University of Oxford Department of Computer Science Student Conference 2011},
@@ -347,7 +347,7 @@
   pages   = {18--19}
 }
 
-@Article{lowe.lube.ea:projection-based,
+@Article{2011:lowe.lube.ea:projection-based,
   author  = {J. L\"{o}we and G. Lube and L. R\"{o}he},
   title   = {A Projection-Based Variational Multiscale Method for the Incompressible Navier--Stokes/Fourier Model},
   journal = {BAIL 2010 - Boundary and Interior Layers, Computational and Asymptitic Methods. Lecture Notes in Computational Science and Engineering, Vol. 81},
@@ -355,7 +355,7 @@
   pages   = {165--175}
 }
 
-@PhDThesis{lowe:finite-elemente-methode,
+@PhDThesis{2011:lowe:finite-elemente-methode,
   author  = {J. L\"{o}we},
   title   = {Eine Finite-Elemente-Methode f\"{u}r nicht-isotherme inkompressible Str\"{o}mungsprobleme },
   year    = 2011,
@@ -363,7 +363,7 @@
   url     = {http://num.math.uni-goettingen.de/picap/pdf/E675.pdf}
 }
 
-@Article{myers.sencer.ea:multi-scale,
+@Article{2011:myers.sencer.ea:multi-scale,
   author  = {M. T. Myers and B. H. Sencer and L. Shao},
   title   = {Multi-scale modeling of localized heating caused by ion bombardment},
   journal = {Nuclear Instruments and Methods in Physics Research Section B: Beam Interactions with Materials and Atoms},
@@ -372,14 +372,14 @@
   note    = {In press}
 }
 
-@Article{nigro.renda.ea:discontinuous,
+@Article{2011:nigro.renda.ea:discontinuous,
   author  = {A. Nigro and S. Renda and C. De Bartolo and R. Hartmann and F. Bassi},
   title   = {A discontinuous Galerkin method for laminar low Mach number flows},
   journal = {66th National Congress ATI in Rende, Italy, 5-9 Sept. 2011. University of Calabria},
   year    = 2011
 }
 
-@Article{norato.johnson:computational,
+@Article{2011:norato.johnson:computational,
   author  = {J. A. Norato and A. J. Wagoner Johnson},
   title   = {A Computational and Cellular Solids Approach to the Stiffness-Based Design of Bone Scaffolds},
   journal = {J. Biomech. Eng., 091003/1-8},
@@ -387,7 +387,7 @@
   volume  = 133
 }
 
-@Article{pilipenko.fleck.ea:on,
+@Article{2011:pilipenko.fleck.ea:on,
   author  = {D. Pilipenko and M. Fleck and H. Emmerich},
   title   = {On numerical aspects of phase field fracture modelling},
   journal = {European Phys. J. Plus, 100/1-16},
@@ -395,14 +395,14 @@
   volume  = 126
 }
 
-@PhDThesis{raghuram:higher,
+@PhDThesis{2011:raghuram:higher,
   author  = {K. J. Raghuram},
   title   = {Higher Order Numerical Discretization on Scattered Grids},
   year    = 2011,
   school  = {University of California, Santa Barbara}
 }
 
-@Article{richter.wick:fluid-structure,
+@Article{2011:richter.wick:fluid-structure,
   author  = {T. Richter and T. Wick},
   title   = {Fluid-Structure Interactions in ALE and Fully Eulerian Coordinates},
   journal = {PAMM},
@@ -411,14 +411,14 @@
   pages   = {487--488}
 }
 
-@MastersThesis{riedlbauer:thermomechanical,
+@MastersThesis{2011:riedlbauer:thermomechanical,
   author  = {D. Riedlbauer},
   title   = {Thermomechanical Modelling and Simulation of Electron Beam Melting},
   year    = 2011,
   school  = {Friedrich-Alexander-University, Erlangen-Nuremberg}
 }
 
-@Article{rohe.lube:large-eddy,
+@Article{2011:rohe.lube:large-eddy,
   author  = {L. R\"{o}he and G. Lube},
   title   = {Large-Eddy Simulation of Wall-Bounded Turbulent Flows: Layer-Adapted Meshes vs. Weak Dirichlet Boundary Conditions},
   journal = {BAIL 2010 - Boundary and Interior Layers, Computational and Asymptitic Methods. Lecture Notes in Computational Science and Engineering, Vol. 81},
@@ -426,7 +426,7 @@
   pages   = {197--205}
 }
 
-@Article{steigemann:simulation,
+@Article{2011:steigemann:simulation,
   author  = {M. Steigemann},
   title   = {Simulation of Quasi-static Crack Propagation in Functionally Graded Materials},
   journal = {Dept. of Math. and Natural Sci., Inst. of Anal. and Appl. Math., University of Kassel},
@@ -434,7 +434,7 @@
   url     = {http://www.martin-steigemann.net/downloads/preprint_steigemann_simulation_of_quasi-static_crack_propagation_in_fgms.pdf}
 }
 
-@Article{stoll.pearson.ea:preconditioners,
+@Article{2011:stoll.pearson.ea:preconditioners,
   author  = {M. Stoll and J. Pearson and A. Wathen},
   title   = {Preconditioners for state constrained optimal control problems with Moreau-Yosida penalty function},
   journal = {Numerical Linear Algebra with Applications},
@@ -443,7 +443,7 @@
   note    = {Submitted}
 }
 
-@Article{white.borja:block-preconditioned,
+@Article{2011:white.borja:block-preconditioned,
   author  = {J. White and R. I. Borja},
   title   = {Block-preconditioned Newton--Krylov solvers for fully coupled flow and geomechanics},
   journal = {Comp. Geosc.},
@@ -452,14 +452,14 @@
   pages   = {647--659}
 }
 
-@PhDThesis{wick:adaptive,
+@PhDThesis{2011:wick:adaptive,
   author  = {T. Wick},
   title   = {Adaptive finite element simulation of fluid-structure interaction},
   year    = 2011,
   school  = {University of Heidelberg, Germany}
 }
 
-@Article{wick:fluid-structure,
+@Article{2011:wick:fluid-structure,
   author  = {T. Wick},
   title   = {Fluid-structure interactions using different mesh motion techniques},
   journal = {Computers and Structures},
@@ -468,14 +468,14 @@
   pages   = {1456--1467}
 }
 
-@Article{young:qualitative,
+@Article{2011:young:qualitative,
   author  = {T. D. Young},
   title   = {A qualitative semi-classical treatment of an isolated semi-polar quantum dot},
   journal = {J. Phys.: Conf. Ser., 28(10)},
   year    = 2011
 }
 
-@Article{zahedi.kronbichler.ea:spurious,
+@Article{2011:zahedi.kronbichler.ea:spurious,
   author  = {S. Zahedi and M. Kronbichler and G. Kreiss},
   title   = {Spurious currents in finite element based level set methods for two-phase flow},
   journal = {Int. J. Numer. Meth. Fluids.},
@@ -484,7 +484,7 @@
   pages   = {1433--1456}
 }
 
-@Article{zhou.yazici:discretization,
+@Article{2011:zhou.yazici:discretization,
   author  = {L. Zhou and B. Yazici},
   title   = {Discretization Error Analysis and Adaptive Meshing Algorithms for Fluorescence Diffuse Optical Tomography in the Presence of Measurement Noise},
   journal = {IEEE Trans. Image Processing},
@@ -493,7 +493,7 @@
   pages   = {1094--1111}
 }
 
-@Article{zhu.schotzau:robust,
+@Article{2011:zhu.schotzau:robust,
   author  = {L. Zhu and D. Sch\"{o}tzau},
   title   = {A robust a posteriori error estimate for hp-adaptive DG methods for convection-diffusion equations},
   journal = {IMA J. Numer. Math.},

--- a/publications-2012.bib
+++ b/publications-2012.bib
@@ -1,13 +1,13 @@
 % Encoding: US-ASCII
 
-@PhDThesis{adeniran:biophysically,
+@PhDThesis{2012:adeniran:biophysically,
   author  = {I. Adeniran},
   title   = {Biophysically detailed modelling of the functional impact of gene mutations associated with the ``short QT syndrome''},
   year    = 2012,
   school  = {University of Manchester}
 }
 
-@MastersThesis{albring:optimal,
+@MastersThesis{2012:albring:optimal,
   author  = {T. A. Albring},
   title   = {Optimal Control of PDEs solved by Fixed Point Iterations using Algorithmic Differentiation},
   school  = {RWTH Aachen University},
@@ -16,14 +16,14 @@
   url     = {http://www.mathcces.rwth-aachen.de/_media/5people/albring/thesis_bsc.pdf}
 }
 
-@PhDThesis{alcalde:parallel,
+@PhDThesis{2012:alcalde:parallel,
   author  = {E. Romero Alcalde},
   title   = {Parallel implementation of Davidson-type methods for large-scale eigenvalue problems},
   year    = 2012,
   school  = {Universitat Politecnica de Valencia}
 }
 
-@Article{alexe.sandu:fully,
+@Article{2012:alexe.sandu:fully,
   author  = {M. Alexe and A. Sandu},
   title   = {A fully discrete framework for the adaptive solution of inverse problems },
   journal = {Technical report, Computer Science Department, Virginia Tech.},
@@ -31,7 +31,7 @@
   url     = {https://vtechworks.lib.vt.edu/handle/10919/19441}
 }
 
-@Article{bause.kocher:numerical,
+@Article{2012:bause.kocher:numerical,
   author  = {M. Bause and U. K\"{o}cher},
   title   = {Numerical simulation of elastic wave propagation in composite material},
   journal = {Proceedings of the European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS 2012) J. Eberhardsteiner et.al. (eds.) Vienna, Austria, September 10-14},
@@ -39,7 +39,7 @@
   url     = {http://link.springer.com/article/10.1007/s10915-014-9831-3}
 }
 
-@Article{besier.wollner:on,
+@Article{2012:besier.wollner:on,
   author  = {M. Besier and W. Wollner},
   title   = {On the pressure approximation in nonstationary incompressible flow simulations on dynamically varying spatial meshes},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -48,7 +48,7 @@
   pages   = {1045--1064}
 }
 
-@Article{blank.sarbu.ea:preconditioning,
+@Article{2012:blank.sarbu.ea:preconditioning,
   author  = {L. Blank and L. Sarbu and M. Stoll},
   title   = {Preconditioning for Allen-Cahn variational inequalities with non-local constraints},
   journal = {Journal of Computational Physics},
@@ -57,7 +57,7 @@
   pages   = {5406--5402}
 }
 
-@Article{boehm.ulbrich:newton-cg,
+@Article{2012:boehm.ulbrich:newton-cg,
   author  = {C. Boehm and M. Ulbrich},
   title   = {A Newton-CG method for full-waveform inversion in a coupled solid-fluid system},
   note    = {Submitted},
@@ -65,14 +65,14 @@
   url     = {http://www-m1.ma.tum.de/bin/view/Lehrstuhl/PublikationenUlbrich}
 }
 
-@PhDThesis{boyanova:on,
+@PhDThesis{2012:boyanova:on,
   author  = {P. Boyanova},
   title   = {On Numerical Solution Methods for Block-Structured Discrete Systems},
   year    = 2012,
   school  = {University of Uppsala}
 }
 
-@Article{braack.lube.ea:divergence,
+@Article{2012:braack.lube.ea:divergence,
   author  = {M. Braack and G. Lube and L. R\"{o}he},
   title   = {Divergence preserving interpolation on anisotropic quadrilateral meshes},
   journal = {Comput. Methods Appl. Math., Vol. 12},
@@ -80,14 +80,14 @@
   pages   = {123--138}
 }
 
-@PhDThesis{burg:fully,
+@PhDThesis{2012:burg:fully,
   author  = {M. B\"{u}rg},
   title   = {A Fully Automatic $hp$-Adaptive Refinement Strategy},
   year    = 2012,
   school  = {Karlsruhe Institute of Technology (KIT)}
 }
 
-@Article{burg:residual-based,
+@Article{2012:burg:residual-based,
   author  = {M. B\"{u}rg},
   title   = {A Residual-Based A Posteriori Error Estimator for the $hp$-Finite Element Method for Maxwell's Equations},
   journal = {Appl. Numer. Math.},
@@ -96,7 +96,7 @@
   pages   = {922--940}
 }
 
-@Article{cangiani.georgoulis.ea:discontinuous,
+@Article{2012:cangiani.georgoulis.ea:discontinuous,
   author  = {A. Cangiani and E. Georgoulis and M. Jensen},
   title   = {Discontinuous Galerkin methods for mass transfer through semi-permeable membranes},
   note    = {Submitted},
@@ -104,14 +104,14 @@
   url     = {http://www2.le.ac.uk/departments/mathematics/extranet/staff-material/staff-profiles/eg64/publications}
 }
 
-@Article{cangiani.georgoulis.ea:posteriori,
+@Article{2012:cangiani.georgoulis.ea:posteriori,
   author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
   title   = {An a posteriori error estimator for discontinuous Galerkin methods for non-stationary convection-diffusion problems},
   note    = {Submitted},
   year    = 2012
 }
 
-@Article{carraro.joos.ea:3d,
+@Article{2012:carraro.joos.ea:3d,
   author  = {T. Carraro and J. Joos and B. R\"{u}ger and A. Weber and E. Ivers-Tiff\'{e}e},
   title   = {3D finite element model for reconstructed mixed-conducting cathodes: I. Performance quantification},
   journal = {Electrochimica Acta},
@@ -121,7 +121,7 @@
   doi     = {10.1016/j.electacta.2012.04.109}
 }
 
-@Article{carraro.joos.ea:3d*1,
+@Article{2012:carraro.joos.ea:3d*1,
   author  = {T. Carraro and J. Joos and B. R\"{u}ger and A. Weber and E. Ivers-Tiff\'{e}e},
   title   = {3D finite element model for reconstructed mixed-conducting cathodes: II. Parameter sensitivity analysis},
   journal = {Electrochimica Acta},
@@ -131,7 +131,7 @@
   doi     = {10.1016/j.electacta.2012.04.163}
 }
 
-@PhDThesis{chapman:on,
+@PhDThesis{2012:chapman:on,
   author  = {J. Chapman},
   title   = {On Discontinuous Galerkin Methods for Singularly Perturbed and Incompressible Miscible Displacement Problems },
   year    = 2012,
@@ -139,7 +139,7 @@
   url     = {http://etheses.dur.ac.uk/5886/1/JRChapman_thesis_final.pdf?DDD21}
 }
 
-@Article{demlow.georgoulis:pointwise,
+@Article{2012:demlow.georgoulis:pointwise,
   author  = {A. Demlow and A. H. Georgoulis},
   title   = {Pointwise a posteriori error control for discontinuous Galerkin methods for elliptic problems},
   journal = {SIAM Journal on Numerical Analysis},
@@ -148,14 +148,14 @@
   pages   = {2159--2181}
 }
 
-@Article{dobson.lei.ea:characterization,
+@Article{2012:dobson.lei.ea:characterization,
   author  = {P. Dobson and C. Lei and T. Navessin and M. Secanell},
   title   = {Characterization of the PEM Fuel Cell Catalyst Layer Microstructure by Nonlinear Least-Squares Parameter Estimation},
   journal = {Journal of the Electrochemical Society, 159(5), B1-B10},
   year    = 2012
 }
 
-@Article{efendiev.galvis.ea:robust,
+@Article{2012:efendiev.galvis.ea:robust,
   author  = {Y. Efendiev and J. Galvis and R. Lazarov and J. Willems},
   title   = {Robust domain decomposition preconditioners for abstract symmetric positive definite bilinear forms},
   journal = {ESAIM: Mathematical Modelling and Numerical Analysis},
@@ -165,7 +165,7 @@
   doi     = {10.1051/m2an/2011073}
 }
 
-@InProceedings{efendiev.galvis.ea:robust*1,
+@InProceedings{2012:efendiev.galvis.ea:robust*1,
   doi     = {10.1007/978-3-642-29843-1_4},
   year    = 2012,
   publisher = {Springer Berlin Heidelberg},
@@ -176,7 +176,7 @@
   editors = {I. Lirkov and S. Margenov and J. Wasniewski}
 }
 
-@Article{fang.gao.ea:kohn-sham,
+@Article{2012:fang.gao.ea:kohn-sham,
   author  = {J. Fang and X. Gao and A. Zhou},
   title   = {A Kohn-Sham equation solver based on hexahedral finite elements},
   journal = {Journal of Computational Physics, pp. 3166--3180},
@@ -184,28 +184,28 @@
   volume  = 231
 }
 
-@Article{fankhauser.wihler.ea:hp-adaptive,
+@Article{2012:fankhauser.wihler.ea:hp-adaptive,
   author  = {T. Fankhauser and T. P. Wihler and M. Wirz},
   title   = {hp-adaptive FEM based on continuous Sobolev embeddings: isotropic refinements},
   journal = {Research report 2012-10, University of Bern, Switzerland},
   year    = 2012
 }
 
-@MastersThesis{fankhauser:hp-adaptive,
+@MastersThesis{2012:fankhauser:hp-adaptive,
   author  = {T. Fankhauser},
   title   = {An hp-adaptive strategy based on smoothness estimation in 2d},
   year    = 2012,
   school  = {University of Bern, Switzerland}
 }
 
-@PhDThesis{ferguson:brittle,
+@PhDThesis{2012:ferguson:brittle,
   author  = {L. Ferguson},
   title   = {Brittle fracture modeling with a surface tension excess property},
   year    = 2012,
   school  = {Texas A\&M University}
 }
 
-@Article{frisani.hassan:on,
+@Article{2012:frisani.hassan:on,
   author  = {A. Frisani and Y. A. Hassan},
   title   = {On the Immersed Boundary Method: Finite Element Versus Finite Volume Approach},
   journal = {2012 20th International Conference on Nuclear Engineering and the ASME 2012 Power Conference},
@@ -214,14 +214,14 @@
   url     = {http://proceedings.asmedigitalcollection.asme.org/proceeding.aspx?articleid=1764417}
 }
 
-@Article{gaitero.dolado.ea:computational,
+@Article{2012:gaitero.dolado.ea:computational,
   author  = {J. J. Gaitero and J. S. Dolado and C. Neuen and F. Heber and E. Koenders},
   title   = {Computational 3d simulation of Calcium leaching in cement matrices},
   journal = {Institut f\"{u}r numerische Simulation, Rheinische Friedrich-Wilhelms-Universit\"{a}t Bonn, INS Preprint 1203},
   year    = 2012
 }
 
-@MastersThesis{hai:numerical,
+@MastersThesis{2012:hai:numerical,
   author  = {B. S. M. Ebna Hai},
   title   = {Numerical approximation of fluid structure interaction (FSI) problem and simplified model for the vertical vibrations of the aircraft wing},
   year    = 2012,
@@ -230,7 +230,7 @@
   url     = {https://www.lap-publishing.com/catalog/details/store/gb/book/978-3-659-30284-8/numerical-approximation-of-fluid-structure-interaction-fsi-problem}
 }
 
-@InProceedings{hartmann:higher-order,
+@InProceedings{2012:hartmann:higher-order,
   doi     = {10.2514/6.2012-459},
   year    = 2012,
   month   = nov,
@@ -240,7 +240,7 @@
   booktitle = {50th {AIAA} Aerospace Sciences Meeting including the New Horizons Forum and Aerospace Exposition}
 }
 
-@Article{heltai.costanzo:variational,
+@Article{2012:heltai.costanzo:variational,
   author  = {L. Heltai and F. Costanzo},
   title   = {Variational implementation of immersed finite element methods},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -250,21 +250,21 @@
   doi     = {10.1016/j.cma.2012.04.001}
 }
 
-@Article{heltai.roy.ea:fully,
+@Article{2012:heltai.roy.ea:fully,
   author  = {L. Heltai and S. Roy and F. Costanzo},
   title   = {A Fully Coupled Immersed Finite Element Method for Fluid Structure Interaction via the Deal.II Library},
   journal = {arXiv:1209.2811 [math.NA]},
   year    = 2012
 }
 
-@Article{hintermuller.schiela.ea:length,
+@Article{2012:hintermuller.schiela.ea:length,
   author  = {M. Hinterm\"{u}ller and A. Schiela and W. Wollner},
   title   = {The length of the primal-dual path in Moreau-Yosida-based path-following for state constrained optimal control},
   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik, 2012-03},
   year    = 2012
 }
 
-@Article{hinze.kunkel.ea:model,
+@Article{2012:hinze.kunkel.ea:model,
   author  = {M. Hinze and M. Kunkel and A. Steinbrecher and T. Stykel},
   title   = {Model order reduction of coupled circuit-device systems},
   journal = {International Journal of Numerical Modelling: Electronic Networks, Devices and Fields},
@@ -275,7 +275,7 @@
   doi     = {10.1002/jnm.840}
 }
 
-@Article{hinze.kunkel.ea:pod,
+@Article{2012:hinze.kunkel.ea:pod,
   author  = {M. Hinze and M. Kunkel and U. Matthes},
   title   = {POD Model Order Reduction of electrical networks with semiconductors modeled by the transient Drift--Diffusion equations},
   journal = {Progress in Industrial Mathematics at ECMI 2010 Mathematics in Industry, pp 161-168},
@@ -284,7 +284,7 @@
   url     = {http://link.springer.com/chapter/10.1007/978-3-642-25100-9_19}
 }
 
-@Article{hinze.kunkel:discrete,
+@Article{2012:hinze.kunkel:discrete,
   author  = {M. Hinze and M. Kunkel},
   title   = {Discrete empirical interpolation in POD Model Order Reduction of Drift-Diffusion Equations in Electrical Networks},
   journal = {Scientific Computing in Electrical Engineering, SCEE 2010 Mathematics in Industry, part 5},
@@ -294,7 +294,7 @@
   url     = {http://link.springer.com/chapter/10.1007%2F978-3-642-22453-9_45}
 }
 
-@Article{jirousek.zlamal:large-scale,
+@Article{2012:jirousek.zlamal:large-scale,
   author  = {O. Jirousek and P. Zlamal},
   title   = {Large-scale micro-finite element simulation of compressive behavior of trabecular bone microstructure},
   journal = {Proceedings of the 18th Conference on Engineering Mechanics, Svratka, Czech Republic, May 14-17, 2012; paper \#206},
@@ -302,7 +302,7 @@
   pages   = {543--549}
 }
 
-@Article{joos.ender.ea:representative,
+@Article{2012:joos.ender.ea:representative,
   author  = {J. Joos and M. Ender and T. Carraro and A. Weber and E. Ivers-Tiff\'{e}e},
   title   = {Representative Volume Element Size for Accurate Solid Oxide Fuel Cell Cathode Reconstructions from Focused Ion Beam Tomography Data},
   journal = {Electrochimica Acta},
@@ -311,14 +311,14 @@
   note    = {In press}
 }
 
-@PhDThesis{joshi:model,
+@PhDThesis{2012:joshi:model,
   author  = {S. Joshi},
   title   = {A model for the estimation of residual stresses in soft tissues},
   year    = 2012,
   school  = {Texas A\&M University}
 }
 
-@PhDThesis{kormann:efficient,
+@PhDThesis{2012:kormann:efficient,
   author  = {K. Kormann},
   title   = {Efficient and Reliable Simulation of Quantum Molecular Dynamics},
   year    = 2012,
@@ -326,14 +326,14 @@
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A549981&dswid=6393}
 }
 
-@PhDThesis{kormann:on,
+@PhDThesis{2012:kormann:on,
   author  = {K. Kormann},
   title   = {On Numerical Solution Methods for Block-Structured Discrete Systems},
   year    = 2012,
   school  = {University of Uppsala}
 }
 
-@Article{kormann:time-space,
+@Article{2012:kormann:time-space,
   author  = {K. Kormann},
   title   = {A time-space adaptive method for the Schr\"{o}dinger equation},
   journal = {University of Uppsala, research report},
@@ -341,14 +341,14 @@
   url     = {https://www.cambridge.org/core/journals/communications-in-computational-physics/article/timespace-adaptive-method-for-the-schrodinger-equation/92B29B2C22440E091DD4DB7149E9140D}
 }
 
-@PhDThesis{kramer:cuda-based,
+@PhDThesis{2012:kramer:cuda-based,
   author  = {S. Kramer},
   title   = {CUDA-based scientific computing tools and selected applications},
   year    = 2012,
   school  = {G\"{o}ttingen University, Germany}
 }
 
-@Article{kronbichler.heister.ea:high,
+@Article{2012:kronbichler.heister.ea:high,
   author  = {M. Kronbichler and T. Heister and W. Bangerth},
   title   = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods},
   journal = {Geophysical Journal International},
@@ -357,7 +357,7 @@
   pages   = {12--29}
 }
 
-@Article{kronbichler.kormann:generic,
+@Article{2012:kronbichler.kormann:generic,
   doi     = {10.1016/j.compfluid.2012.04.012},
   url     = {https://doi.org/10.1016/j.compfluid.2012.04.012},
   year    = 2012,
@@ -370,14 +370,14 @@
   journal = {Computers {\&} Fluids}
 }
 
-@PhDThesis{kunkel:nonsmooth,
+@PhDThesis{2012:kunkel:nonsmooth,
   author  = {M. Kunkel},
   title   = {Nonsmooth Newton Methods and Convergence of Discretized Optimal Control Problems subject to DAEs},
   year    = 2012,
   school  = {Universit\"{a}t der Bundeswehr M\"{u}nchen}
 }
 
-@Article{lowe.lube:projection-based,
+@Article{2012:lowe.lube:projection-based,
   author  = {J. L\"{o}we and G. Lube},
   title   = {A projection-based variational multiscale method for large-eddy simulation with application to non-isothermal free convection problems},
   journal = {Math. Models Methods Appl. Sci., article 1150011},
@@ -385,7 +385,7 @@
   volume  = 22
 }
 
-@Article{mcbride.mergheim.ea:micro-to-macro,
+@Article{2012:mcbride.mergheim.ea:micro-to-macro,
   author  = {A. T. McBride and J. Mergheim and A. Javili and P. Steinmann and S. Bargmann},
   title   = {Micro-to-macro transitions for heterogeneous material layers accounting for in-plane stretch},
   journal = {Journal of the Mechanics and Physics of Solids},
@@ -394,7 +394,7 @@
   pages   = {1221--1239}
 }
 
-@MastersThesis{moore:investigation,
+@MastersThesis{2012:moore:investigation,
   author  = {M. Moore},
   title   = {Investigation of the Double-Trap Intrinsic Kinetic Equation for the Oxygen Reduction Reaction and its implementation into a Membrane Electrode Assembly model},
   year    = 2012,
@@ -402,14 +402,14 @@
   url     = {https://era.library.ualberta.ca/public/view/item/uuid:79f8832e-b550-49fd-8160-9b055147ee6d/}
 }
 
-@Article{neuen.griebel.ea:multiscale,
+@Article{2012:neuen.griebel.ea:multiscale,
   author  = {C. Neuen and M. Griebel and J. Hamaekers},
   title   = {Multiscale simulation of ion migration for battery system},
   journal = {Institut f\"{u}r numerische Simulation, Rheinische Friedrich-Wilhelms-Universit\"{a}t Bonn, INS Preprint 1208},
   year    = 2012
 }
 
-@Article{pearson.stoll.ea:regularization-robust,
+@Article{2012:pearson.stoll.ea:regularization-robust,
   author  = {J. Pearson and M. Stoll and A. Wathen},
   title   = {Regularization-robust preconditioners for time-dependent PDE constrained optimization problems},
   journal = {SIAM J. Matrix Analysis and Applications},
@@ -418,7 +418,7 @@
   pages   = {1126--1152}
 }
 
-@Article{pelteret.reddy:computational,
+@Article{2012:pelteret.reddy:computational,
   author  = {J-P. V. Pelteret and B. D. Reddy},
   title   = {Computational model of soft tissues in the human upper airway},
   journal = {International Journal for Numerical Methods in Biomedical Engineering},
@@ -431,7 +431,7 @@
   publisher = {Wiley}
 }
 
-@Article{rapson.tapson.ea:unification,
+@Article{2012:rapson.tapson.ea:unification,
   doi     = {10.1121/1.3699238},
   url     = {https://doi.org/10.1121/1.3699238},
   year    = 2012,
@@ -445,7 +445,7 @@
   journal = {The Journal of the Acoustical Society of America}
 }
 
-@PhDThesis{rapson:extensible,
+@PhDThesis{2012:rapson:extensible,
   author  = {Michael J. Rapson},
   title   = {An extensible computational cochlear modelling framework},
   year    = 2012,
@@ -453,21 +453,21 @@
   url     = {http://hdl.handle.net/11427/5117}
 }
 
-@Article{reis.wollner:finite-rank,
+@Article{2012:reis.wollner:finite-rank,
   author  = {T. Reis and W. Wollner},
   title   = {Finite-Rank ADI Iteration for Operator Lyapunov Equations},
   journal = {Hamburger Beitr\"{a}ge zur Angewandten Mathematik, 2012-09},
   year    = 2012
 }
 
-@MastersThesis{richardson:investigation,
+@MastersThesis{2012:richardson:investigation,
   author  = {N. Richardson},
   title   = {An Investigation into Aspects of Rate-Independent Single Crystal Plasticity},
   year    = 2012,
   school  = {University of Cape Town, South Africa}
 }
 
-@Article{riedlbauer.mergheim.ea:macroscopic,
+@Article{2012:riedlbauer.mergheim.ea:macroscopic,
   author  = {D. Riedlbauer and J. Mergheim and A. McBride and P. Steinmann},
   title   = {Macroscopic modelling of the selective beam melting process},
   journal = {PAMM, p. 381-382},
@@ -475,14 +475,14 @@
   volume  = 12
 }
 
-@PhDThesis{roy:numerical,
+@PhDThesis{2012:roy:numerical,
   author  = {S. Roy},
   title   = {Numerical simulation using the generalized immersed boundary method: An application to Hydrocephalus},
   year    = 2012,
   school  = {The Pennsylvania State University}
 }
 
-@Article{sauter:multiscale,
+@Article{2012:sauter:multiscale,
   author  = {J. Sauter},
   title   = {A Multiscale Method for Interacting Particle Systems},
   journal = {Diplomarbeit, Westfalische Wilhelms-Universitat Munster},
@@ -490,21 +490,21 @@
   url     = {http://wwwmath.uni-muenster.de/num/Arbeitsgruppen/ag_burger/organization/burger/pictures/DA%20Sauter.pdf}
 }
 
-@Article{schotzau.schwab.ea:exponential,
+@Article{2012:schotzau.schwab.ea:exponential,
   author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
   title   = {Exponential convergence of the hp-DGFEM for elliptic problems in polyhedral domains},
   journal = {Research Report 2012-40, Seminar f\"{u}r Angewandte Mathematik, ETH Zurich},
   year    = 2012
 }
 
-@MastersThesis{sheldon:comparison,
+@MastersThesis{2012:sheldon:comparison,
   author  = {J. Sheldon},
   title   = {A comparison of fluid-structure interaction coupling algorithms using the finite element method},
   year    = 2012,
   school  = {The Pennsylvania State University}
 }
 
-@Article{stoll.wathen:all-at-once,
+@Article{2012:stoll.wathen:all-at-once,
   author  = {M. Stoll and A. Wathen},
   title   = {All-at-once solution of time-dependent Stokes control},
   journal = {Journal of Computational Physics},
@@ -513,7 +513,7 @@
   pages   = {498--515}
 }
 
-@Article{stoll.wathen:preconditioning,
+@Article{2012:stoll.wathen:preconditioning,
   author  = {M. Stoll and A. Wathen},
   title   = {Preconditioning for partial differential equation constrained optimization with control constraints},
   journal = {Numerical Linear Algebra with Applications},
@@ -522,7 +522,7 @@
   pages   = {53--71}
 }
 
-@Article{symes.wang:harmonic,
+@Article{2012:symes.wang:harmonic,
   author  = {W. Symes and X. Wang},
   title   = {Harmonic coordinate finite element method for acoustic waves},
   journal = {SEG Technical Program Expanded Abstracts 2012},
@@ -530,14 +530,14 @@
   pages   = {1--5}
 }
 
-@Article{taylor.dontsova.ea:dissolution,
+@Article{2012:taylor.dontsova.ea:dissolution,
   author  = {S. Taylor and K. Dontsova and S. Bigl and C. Richardson and J. Lever and J. Pitt and J. P. Bradley and M. Walsh. J. Simunek},
   title   = {Dissolution Rate of Propellant Energetics from Nitrocellulose Matrices},
   journal = {Engineer Research and Development Center, Cold Regions Research and Engineering Laboratory, US Army Corps of Engineers, Technical Report ER-1691},
   year    = 2012
 }
 
-@Article{thalhammer.abhau:numerical,
+@Article{2012:thalhammer.abhau:numerical,
   author  = {M. Thalhammer and J. Abhau},
   title   = {A numerical study of adaptive space and time discretisations for Gross--Pitaevskii equations},
   journal = {Journal of Computational Physics},
@@ -546,14 +546,14 @@
   pages   = {6665--6681}
 }
 
-@Article{trangenstein:numerical,
+@Article{2012:trangenstein:numerical,
   author  = {J. Trangenstein},
   title   = {Numerical Solution of Elliptic and Parabolic Partial Differential Equations},
   journal = {Cambridge University Press},
   year    = 2012
 }
 
-@Article{vavalis.mu.ea:finite,
+@Article{2012:vavalis.mu.ea:finite,
   author  = {M. Vavalis and M. Mu and G. Sarailidis},
   title   = {Finite element simulations of window Josephson junctions},
   journal = {Journal of Computational and Applied Mathematics},
@@ -562,14 +562,14 @@
   pages   = {3186--3197}
 }
 
-@Article{wallraff.leicht.ea:numerical,
+@Article{2012:wallraff.leicht.ea:numerical,
   author  = {M. Wallraff and T. Leicht and M. Lange-Hegermann},
   title   = {Numerical flux functions for RANS-k$\omega$ computations with a line-implicit p-multigrid DG solver},
   journal = {50$^{\textnormal{th}}$ AIAA Aerospace Sciences Meeting, AIAA 2012-458},
   year    = 2012
 }
 
-@Article{wang:transfer-of-approximation,
+@Article{2012:wang:transfer-of-approximation,
   author  = {X. Wang},
   title   = {Transfer-of-approximation Approaches for Subgrid Modeling},
   journal = {PhD dissertation, Rice University},
@@ -577,7 +577,7 @@
   url     = {http://www.trip.caam.rice.edu/reports/2012/ThesisFinal_XWang.pdf}
 }
 
-@Article{wick:goal-oriented,
+@Article{2012:wick:goal-oriented,
   author  = {T. Wick},
   title   = {Goal-oriented mesh adaptivity for fluid-structure interaction with application to heart-valve settings},
   journal = {Arch. Mech. Engrg.},
@@ -586,14 +586,14 @@
   pages   = {73--99}
 }
 
-@Article{willems:robust,
+@Article{2012:willems:robust,
   author  = {J. Willems},
   title   = {Robust multilevel methods for general symmetric positive definite operators},
   journal = {RICAM Report 2012-06},
   year    = 2012
 }
 
-@PhDThesis{worthen:inverse,
+@PhDThesis{2012:worthen:inverse,
   author  = {J. A. Worthen},
   title   = {Inverse problems in mantle convection : models, algorithms, and applications },
   year    = 2012,
@@ -601,7 +601,7 @@
   url     = {http://repositories.lib.utexas.edu/handle/2152/19458}
 }
 
-@Article{yoon.walkley.ea:two,
+@Article{2012:yoon.walkley.ea:two,
   author  = {S. Yoon and M. A. Walkley and O. G. Harlen},
   title   = {Two particle interactions in a confined viscoelastic fluid under shear},
   journal = {Journal of Non-Newtonian Fluid Mechanics, /186},
@@ -610,7 +610,7 @@
   pages   = {39--48}
 }
 
-@Article{zhang.lin.ea:new,
+@Article{2012:zhang.lin.ea:new,
   author  = {S. Zhang and X. Lin and H. Zhang and D. A. Yuen and Y. Shi},
   title   = {A new method for calculating displacements from elastic dislocation over arbitrary 3-D fault surface with extended FEM and Adaptive Mesh Refinement (AMR)},
   journal = {Proceedings of the International Workshop on Deep Geothermal Systems, Wuhan, China, June 29-30},

--- a/publications-2013.bib
+++ b/publications-2013.bib
@@ -1,13 +1,13 @@
 % Encoding: US-ASCII
 
-@MastersThesis{alam:fast,
+@MastersThesis{2013:alam:fast,
   author  = {G. Alam},
   title   = {Fast iterative solution of large scale statistical inverse problems},
   year    = 2013,
   school  = {Stockholm University}
 }
 
-@Article{alouges.desimone.ea:optimally,
+@Article{2013:alouges.desimone.ea:optimally,
   author  = {F. Alouges and A. DeSimone and L. Heltai and A. Lefebvre-Lepot and B. Merlet},
   title   = {Optimally swimming Stokesian robots},
   journal = {Discrete Contin. Dyn. Syst. Ser. B, pp. 1189--1215},
@@ -15,35 +15,35 @@
   volume  = 18
 }
 
-@MastersThesis{araujo-cabarcas:numerical,
+@MastersThesis{2013:araujo-cabarcas:numerical,
   author  = {J. C. Araujo-Cabarcas},
   title   = {Numerical methods for glacial isostatic adjustment models},
   year    = 2013,
   school  = {Uppsala University, Uppsala, Sweden}
 }
 
-@Article{argoul.ruocci.ea:improved,
+@Article{2013:argoul.ruocci.ea:improved,
   author  = {P. Argoul and G. Ruocci and F. Freddi and K. Benzarti},
   title   = {An improved damage modelling to deal with the variability of fracture mechanisms in FRP reinforced concrete structures},
   journal = {International Journal of Adhesion and Adhesives 45 , 7-20},
   year    = 2013
 }
 
-@MastersThesis{arndt:augmented,
+@MastersThesis{2013:arndt:augmented,
   author  = {D. Arndt},
   title   = {Augmented Taylor-Hood Elements for Incompressible Flow},
   year    = 2013,
   school  = {University of G\"{o}ttingen, Germany}
 }
 
-@Article{axelsson.boyanova.ea:numerical,
+@Article{2013:axelsson.boyanova.ea:numerical,
   author  = {O. Axelsson and P. Boyanova and M. Kronbichler and M. Neytcheva and X. Wu},
   title   = {Numerical and computational efficiency of solvers for two-phase problems},
   journal = {Comput. Math. Appl., 65, 301-314},
   year    = 2013
 }
 
-@Article{bangerth.heister.ea:deal-ii,
+@Article{2013:bangerth.heister.ea:deal-ii,
   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
   title   = {The \texttt{deal.II} Library, Version 8.1},
   journal = {arXiv.org preprint 1312.2266v4},
@@ -51,7 +51,7 @@
   url     = {http://arxiv.org/abs/1312.2266v4}
 }
 
-@Article{bangerth.heister.ea:deal-ii*1,
+@Article{2013:bangerth.heister.ea:deal-ii*1,
   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
   title   = {The \texttt{deal.II} Library, Version 8.0},
   journal = {arXiv.org preprint 1312.2266v3},
@@ -59,7 +59,7 @@
   url     = {http://arxiv.org/abs/1312.2266v3}
 }
 
-@Article{bangerth.heister:what,
+@Article{2013:bangerth.heister:what,
   author  = {W. Bangerth and T. Heister},
   title   = {What makes computational open source software libraries successful?},
   journal = {Computational Science \& Discovery, article 015010},
@@ -67,14 +67,14 @@
   volume  = 6
 }
 
-@Article{benner.stoll:optimal,
+@Article{2013:benner.stoll:optimal,
   author  = {P. Benner and M. Stoll},
   title   = {Optimal control for Allen-Cahn equations enhanced by model predictive control},
   journal = {Preprint, MPI Magdeburg},
   year    = 2013
 }
 
-@Article{bonito.devore.ea:adaptive,
+@Article{2013:bonito.devore.ea:adaptive,
   author  = {A. Bonito and R. DeVore and R. H. Nochetto},
   title   = {Adaptive Finite Element Methods for Elliptic Problems with Discontinuous Coefficients},
   journal = {SIAM Journal on Numerical Analysis},
@@ -83,14 +83,14 @@
   pages   = {3106--3134}
 }
 
-@Article{bonito.kyza.ea:dg,
+@Article{2013:bonito.kyza.ea:dg,
   author  = {A. Bonito and I. Kyza and R. H. Nochetto},
   title   = {A dG Approach to Higher Order ALE Formulations in Time},
   journal = {2012 Barrett Lectures, The IMA Volume in Mathematics and its Applications, Vol. 157, 36 pages, Springer},
   year    = 2013
 }
 
-@Article{bonito.kyza.ea:time-discrete,
+@Article{2013:bonito.kyza.ea:time-discrete,
   author  = {A. Bonito and I. Kyza and R. H. Nochetto},
   title   = {Time-discrete higher order ALE formulations: A priori error analysis},
   journal = {Numer. Math.},
@@ -100,7 +100,7 @@
   doi     = {10.1007/s00211-013-0539-3}
 }
 
-@Article{bonito.kyza.ea:time-discrete*1,
+@Article{2013:bonito.kyza.ea:time-discrete*1,
   author  = {A. Bonito and I. Kyza and R. H. Nochetto},
   title   = {Time-discrete higher order ALE formulations: Stability},
   journal = {SIAM J. Numer. Anal.},
@@ -111,14 +111,14 @@
   doi     = {10.1137/120862715}
 }
 
-@PhDThesis{bramwell:discontinuous,
+@PhDThesis{2013:bramwell:discontinuous,
   author  = {J. A. Bramwell},
   title   = {A discontinuous Petrov-Galerkin method for seismic tomography problems},
   year    = 2013,
   school  = {University of Texas at Austin}
 }
 
-@Article{burg:convergence,
+@Article{2013:burg:convergence,
   author  = {M. B\"{u}rg},
   title   = {Convergence of an automatic $hp$-adaptive finite element strategy for Maxwell's equations},
   journal = {Applied Numerical Mathematics},
@@ -127,7 +127,7 @@
   pages   = {188--204}
 }
 
-@Article{cangiani.chapman.ea:implementation,
+@Article{2013:cangiani.chapman.ea:implementation,
   author  = {A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen},
   title   = {Implementation of the Continuous-Discontinuous Galerkin Finite Element Method},
   journal = {Numerical Mathematics and Advanced Applications 2011},
@@ -135,7 +135,7 @@
   pages   = {315--322}
 }
 
-@Article{carraro.goll.ea:pressure,
+@Article{2013:carraro.goll.ea:pressure,
   author  = {T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikelic},
   title   = {Pressure jump interface law for the Stokes-Darcy coupling: Confirmation by direct numerical simulation},
   journal = {Journal of Fluid Mechanics},
@@ -144,7 +144,7 @@
   pages   = {510--536}
 }
 
-@Article{carraro.joos:parameter,
+@Article{2013:carraro.joos:parameter,
   author  = {T. Carraro and J. Joos},
   title   = {Parameter estimation for a reconstructed SOFC mixed-conducting LSCF-cathode},
   journal = {Model Based Parameter Estimation, H. G. Bock et al., eds., Springer},
@@ -152,7 +152,7 @@
   pages   = {267--285}
 }
 
-@Article{chueh.djilali.ea:h-adaptive,
+@Article{2013:chueh.djilali.ea:h-adaptive,
   author  = {C. C. Chueh and N. Djilali and W. Bangerth},
   title   = {An h-adaptive Operator Splitting Method for Two-phase Flow in 3D Heterogeneous Porous Media},
   journal = {SIAM Journal on Scientific Computing, pp. B149-175},
@@ -160,14 +160,14 @@
   volume  = 35
 }
 
-@MastersThesis{devaud:adaptive,
+@MastersThesis{2013:devaud:adaptive,
   author  = {D. Devaud},
   title   = {Adaptive Methods for the Stokes System with Discontinuous Viscosities},
   year    = 2013,
   school  = {EPFL}
 }
 
-@Article{dohnal.dorfler:coupled,
+@Article{2013:dohnal.dorfler:coupled,
   author  = {T. Dohnal and W. D\"{o}rfler},
   title   = {Coupled Mode Equation Modeling for Out-of-Plane Gap Solitons in 2D Photonic Crystals},
   journal = {Multiscale Modeling and Simulation},
@@ -176,21 +176,21 @@
   pages   = {162--191}
 }
 
-@MastersThesis{donev:time,
+@MastersThesis{2013:donev:time,
   author  = {I. Donev},
   title   = {Time Dependent Finite Element Simulations of a Generalized Oldroyd-B Fluid},
   year    = 2013,
   school  = {University of Cape Town}
 }
 
-@MastersThesis{dugan:dynamic,
+@MastersThesis{2013:dugan:dynamic,
   author  = {K. Dugan},
   title   = {Dynamic adaptive multimesh refinement for coupled physics applicable to nuclear engineering},
   year    = 2013,
   school  = {Texas A\&M University}
 }
 
-@Article{efendiev.galvis.ea:multiscale,
+@Article{2013:efendiev.galvis.ea:multiscale,
   author  = {Y. Efendiev and J. Galvis and S. Pauletti},
   title   = {Multiscale finite element methods for flows on rough surfaces},
   journal = {Communications in Computational Physics},
@@ -199,7 +199,7 @@
   pages   = {979--1000}
 }
 
-@Article{emmrich.wroblewska-kaminska:convergence,
+@Article{2013:emmrich.wroblewska-kaminska:convergence,
   author  = {E. Emmrich and A. Wr\'{o}blewska-Kami\'{n}ska},
   title   = {Convergence of a Full Discretization of Quasi-linear Parabolic Equations in Isotropic and Anisotropic Orlicz Spaces},
   journal = {SIAM Journal on Numerical Analysis},
@@ -208,7 +208,7 @@
   pages   = {1163--1184}
 }
 
-@Article{fang.gao.ea:finite,
+@Article{2013:fang.gao.ea:finite,
   author  = {J. Fang and X. Gao and A. Zhou},
   title   = {A finite element recovery approach to eigenvalue approximations with applications to electronic structure calculations},
   journal = {Journal of Scientific Computing},
@@ -217,7 +217,7 @@
   pages   = {432--454}
 }
 
-@Article{flath:hessian-based,
+@Article{2013:flath:hessian-based,
   author  = {H. P. Flath},
   title   = {Hessian-based response surface approximations for uncertainty quantification in large-scale statistical inverse problems, with applications to groundwater flow},
   journal = {PhD dissertation, University of Texas at Austin},
@@ -225,7 +225,7 @@
   url     = {http://repositories.lib.utexas.edu/handle/2152/21157}
 }
 
-@Article{geringer.lenhof.ea:macroscopic,
+@Article{2013:geringer.lenhof.ea:macroscopic,
   author  = {A. Geringer and B. Lenhof and S. Diebels},
   title   = {Macroscopic modeling of foams: an order-parameter approach vs. a micropolar model},
   journal = {Technische Mechanik},
@@ -235,14 +235,14 @@
   url     = {http://www.uni-magdeburg.de/ifme/zeitschrift_tm/2013_Heft2/01_Geringer_Lenhof_Diebels.pdf}
 }
 
-@PhDThesis{gimbel:modelling,
+@PhDThesis{2013:gimbel:modelling,
   author  = {F. Gimbel},
   title   = {Modelling and numerical simulation of contact and lubrication},
   year    = 2013,
   school  = {University of Siegen, Germany}
 }
 
-@MastersThesis{giuliani:hybrid,
+@MastersThesis{2013:giuliani:hybrid,
   author  = {N. Giuliani},
   title   = {An hybrid boundary element method for free surface flows},
   year    = 2013,
@@ -250,7 +250,7 @@
   url     = {https://www.politesi.polimi.it/handle/10589/81430}
 }
 
-@Article{grieshaber:locking-free,
+@Article{2013:grieshaber:locking-free,
   author  = {B. J. Grieshaber},
   title   = {Locking-free discontinuous Galerkin methods for problems in elasticity, using linear and multilinear approximations},
   journal = {PhD disseration, University of Cape Town},
@@ -258,7 +258,7 @@
   url     = {http://link.springer.com/article/10.1007/s00419-014-0943-x}
 }
 
-@Article{gupta.nataraj:posteriori,
+@Article{2013:gupta.nataraj:posteriori,
   author  = {N. Gupta and N. Nataraj},
   title   = {A posteriori error estimates for an optimal control problem of laser surface hardening of steel},
   journal = {Adv. Comp. Math.},
@@ -268,28 +268,28 @@
   url     = {http://link.springer.com/article/10.1007%2Fs10444-011-9270-8}
 }
 
-@Article{hai.bause:adaptive,
+@Article{2013:hai.bause:adaptive,
   author  = {B. S. M. Ebna Hai and M. Bause},
   title   = {Adaptive Multigrid Methods for Fluid-Structure Interaction (FSI) Optimization in an Aircraft and Design of Integrated Structural Health Monitoring (SHM) Systems},
   journal = {Proceedings of The 2nd ECCOMAS Young Investigators Conference (YIC2013), At Bordeaux, France},
   year    = 2013
 }
 
-@Article{hai.bause:finite,
+@Article{2013:hai.bause:finite,
   author  = {B. S. M. Ebna Hai and M. Bause},
   title   = {Finite Element Approximation of Fluid Structure Interaction (FSI) Optimization in Arbitrary Lagrangian-Eulerian Coordinates},
   journal = {In proceedings of: the ASME International Mechanical Engineering Congress \& Exposition, Vol. 7B, No. IMECE2013-62291, pp. V07BT08A034/1--8, Nov 13--21, San Diego, California, USA},
   year    = 2013
 }
 
-@Article{hai.bause:numerical,
+@Article{2013:hai.bause:numerical,
   author  = {B. S. M. Ebna Hai and M. Bause},
   title   = {Numerical Approximation of Fluid Structure Interaction (FSI) Problem},
   journal = {In proceedings of: the ASME Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2013-16013, pp. V01AT02A001/1-10, July 7--11, Incline Village, Nevada, USA},
   year    = 2013
 }
 
-@Article{hartmann:higher-order,
+@Article{2013:hartmann:higher-order,
   author  = {R. Hartmann},
   title   = {Higher-order and adaptive discontinuous Galerkin methods with shock-capturing applied to transonic turbulent delta wing flow},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -300,7 +300,7 @@
   doi     = {10.1002/fld.3762}
 }
 
-@Article{hartmann:higher-order*1,
+@Article{2013:hartmann:higher-order*1,
   author  = {R. Hartmann},
   title   = {Higher-order and adaptive Discontinuous Galerkin methods applied to turbulent delta wing flow},
   journal = {New Results in Numerical and Experimental Fluid Mechanics VIII, Notes on Numerical Fluid Mechanics and Multidisciplinary Design},
@@ -311,7 +311,7 @@
   doi     = {10.1007/978-3-642-35680-3_59}
 }
 
-@Article{heister.rapin:efficient,
+@Article{2013:heister.rapin:efficient,
   author  = {T. Heister and G. Rapin},
   title   = {Efficient augmented Lagrangian-type preconditioning for the Oseen problem using Grad-Div stabilization},
   journal = {Int. J. Num. Meth. Fluids, 71, 118--134},
@@ -319,14 +319,14 @@
   doi     = {10.1002/fld.3654}
 }
 
-@Article{hinze.mathes:model,
+@Article{2013:hinze.mathes:model,
   author  = {M. Hinze and U. Mathes},
   title   = {Model order reduction for networks of ODE and PDE systems},
   journal = {System Modeling and Optimization, IFIP Advances in Information and Communication Technology Vol. 391, pp 92-101},
   year    = 2013
 }
 
-@Article{joshi.j.ea:reconstruction,
+@Article{2013:joshi.j.ea:reconstruction,
   author  = {S. Joshi and J and Walton},
   title   = {Reconstruction of the residual stresses in a hyperelastic body using ultrasound techniques},
   journal = {International Journal on Engineering Science},
@@ -335,7 +335,7 @@
   pages   = {46--72}
 }
 
-@Article{kallen-brown:computational,
+@Article{2013:kallen-brown:computational,
   author  = {J. A. Kallen-Brown},
   title   = {Computational methods for ice flow simulation},
   journal = {PhD dissertation, ETH Z\"{u}rich},
@@ -343,14 +343,14 @@
   url     = {http://e-collection.library.ethz.ch/eserv/eth:5692/eth-5692-02.pdf?pid=eth:5692&dsID=eth-5692-02.pdf}
 }
 
-@PhDThesis{klein:consistent,
+@PhDThesis{2013:klein:consistent,
   author  = {N. Klein},
   title   = {Consistent FE-Analysis of elliptic Variational Inequalities},
   year    = 2013,
   school  = {University of Siegen, Germany}
 }
 
-@Article{kramer:cuda-based,
+@Article{2013:kramer:cuda-based,
   author  = {S. Kramer},
   title   = {CUDA-based parallel preconditioning for RANS simulation of indoor airflow},
   journal = {Numerical Mathematics and Advanced Applications (Proceedings of the ENUMATH 2011 conference), Springer},
@@ -358,7 +358,7 @@
   pages   = {663--671}
 }
 
-@Article{kramer:finite-element,
+@Article{2013:kramer:finite-element,
   author  = {S. Kramer},
   title   = {Finite-element methods for spatially resolved mesoscopic electron transport},
   journal = {Physical Review B 88, 125308},
@@ -367,14 +367,14 @@
   doi     = {10.1103/PhysRevB.88.125308}
 }
 
-@PhDThesis{kruger:regularization-based,
+@PhDThesis{2013:kruger:regularization-based,
   author  = {T. Kr\"{u}ger},
   title   = {Regularization-based fictitious domain methods},
   year    = 2013,
   school  = {University of Siegen, Germany}
 }
 
-@Article{kumar.noorden.ea:ale-based,
+@Article{2013:kumar.noorden.ea:ale-based,
   author  = {K. Kumar and T. van Noorden and M. F. Wheeler and T. Wick},
   title   = {An ALE-based method for reaction-induced boundary movement towards clogging},
   journal = {ENUMATH Proc.},
@@ -382,14 +382,14 @@
   note    = {Submitted}
 }
 
-@Article{kumar.wheeler.ea:reactive,
+@Article{2013:kumar.wheeler.ea:reactive,
   author  = {K. Kumar and M. F. Wheeler and T. Wick},
   title   = {Reactive flow reaction-induced boundary movement in a thin channel},
   journal = {SIAM J. Sci. Comput. 35(6), pp. B1235-B1266},
   year    = 2013
 }
 
-@Article{lenhof.geringer.ea:macroscopic,
+@Article{2013:lenhof.geringer.ea:macroscopic,
   author  = {B. Lenhof and A. Geringer and S. Diebels},
   title   = {Macroscopic modeling of size effects in foams using an order parameter},
   journal = {Generalized Continua as Models for Materials, Advanced Structured Materials},
@@ -398,7 +398,7 @@
   pages   = {237--254}
 }
 
-@MastersThesis{lim:numerical,
+@MastersThesis{2013:lim:numerical,
   author  = {S. H. Lim},
   title   = {Numerical Simulation of Two-phase Heat Flow and Transient Partial Melting in the Lower Crust with Adaptive Mesh Refinement},
   year    = 2013,
@@ -406,7 +406,7 @@
   note    = {Undergraduate honors thesis}
 }
 
-@Article{mikelic.wheeler.ea:phase,
+@Article{2013:mikelic.wheeler.ea:phase,
   author  = {A. Mikelic and M. F. Wheeler and T. Wick},
   title   = {A phase field approach to the fluid filled fracture surrounded by a poroelastic medium},
   journal = {ICES preprint 13-15},
@@ -414,7 +414,7 @@
   url     = {http://www.ices.utexas.edu/research/reports/}
 }
 
-@Article{mola.heltai.ea:stable,
+@Article{2013:mola.heltai.ea:stable,
   author  = {A. Mola and L. Heltai and A. DeSimone},
   title   = {A stable and adaptive semi-Lagrangian potential model for unsteady and nonlinear ship-wave interactions},
   journal = {Engineering Analysis with Boundary Elements},
@@ -423,7 +423,7 @@
   pages   = {128--143}
 }
 
-@Article{neytcheva.lund:efficient,
+@Article{2013:neytcheva.lund:efficient,
   author  = {M. Neytcheva and B. Lund},
   title   = {Efficient numerical solution methods for isostatic adjustment of visco- poroelastic Earth models},
   journal = {Joint project with Dept. of Info. Tech. and Earth Sci., Uppsala University},
@@ -431,7 +431,7 @@
   url     = {http://www.math.uu.se/digitalAssets/157/157344_3gia_project_cim_2013_bl.pdf}
 }
 
-@Article{opmeer.reis.ea:finite-rank,
+@Article{2013:opmeer.reis.ea:finite-rank,
   author  = {M. R. Opmeer and T. Reis and W. Wollner},
   title   = {Finite-Rank ADI Iteration for Operator Lyapunov Equations},
   journal = {SIAM Journal on Control and Optimization, no. 5},
@@ -441,7 +441,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/120885310}
 }
 
-@Article{pearson.stoll:fast,
+@Article{2013:pearson.stoll:fast,
   author  = {J. Pearson and M. Stoll},
   title   = {Fast Iterative Solution of Reaction-Diffusion Control Problems Arising from Chemical Processes},
   journal = {SIAM Journal on Scientific Computing, pp. B987-B1009},
@@ -449,7 +449,7 @@
   volume  = 35
 }
 
-@PhDThesis{pelteret:computational,
+@PhDThesis{2013:pelteret:computational,
   author  = {J. P. V. Pelteret},
   title   = {A computational neuromuscular model of the human upper airway with application to the study of obstructive sleep apnoea},
   school  = {University of Cape Town},
@@ -458,21 +458,21 @@
   url     = {https://open.uct.ac.za/handle/11427/9519}
 }
 
-@MastersThesis{povall:single,
+@MastersThesis{2013:povall:single,
   author  = {T. Povall},
   title   = {Single Crystal Plasticity at Finite Strains: A Computational Investigation of Hardening Relations},
   year    = 2013,
   school  = {University of Cape Town}
 }
 
-@Article{redlund.cheng:implementation,
+@Article{2013:redlund.cheng:implementation,
   author  = {A. Redlund and G. Cheng},
   title   = {Implementation and performance studies of a three-phase model solver},
   journal = {Technical report, University of Uppsala},
   year    = 2013
 }
 
-@Article{reinhardt.weysser.ea:density,
+@Article{2013:reinhardt.weysser.ea:density,
   author  = {J. Reinhardt and F. Weysser and J. M. Brader},
   title   = {Density functional approach to nonlinear rheology},
   journal = {Europhysics Letters, article 28011},
@@ -480,7 +480,7 @@
   volume  = 102
 }
 
-@Article{reis.wollner:iterative,
+@Article{2013:reis.wollner:iterative,
   author  = {T. Reis and W. Wollner},
   title   = {Iterative solution of operator Lyapunov equations arising in heat transfer},
   journal = {2013 European Control Conference, Zurich Switzerland},
@@ -488,14 +488,14 @@
   pages   = {41--46}
 }
 
-@Article{richter.wick:on,
+@Article{2013:richter.wick:on,
   author  = {T. Richter and T. Wick},
   title   = {On time discretizations of fluid-structure interactions},
   note    = {Submitted},
   year    = 2013
 }
 
-@Article{richter.wick:optimal,
+@Article{2013:richter.wick:optimal,
   author  = {T. Richter and T. Wick},
   title   = {Optimal Control and Parameter Estimation for Stationary Fluid-Structure Interaction Problems},
   journal = {SIAM J. Sci. Comput., pp. B1085-B1104},
@@ -503,14 +503,14 @@
   volume  = 35
 }
 
-@Article{richter.wick:solid,
+@Article{2013:richter.wick:solid,
   author  = {T. Richter and T. Wick},
   title   = {Solid growth and clogging in fluid-structure interaction computed in ALE and fully Eulerian coordinates},
   note    = {Submitted},
   year    = 2013
 }
 
-@PhDThesis{roberts:discontinuous,
+@PhDThesis{2013:roberts:discontinuous,
   author  = {N. V. Roberts},
   title   = {A discontinuous Petrov-Galerkin methodology for incompressible flow problems},
   year    = 2013,
@@ -518,7 +518,7 @@
   url     = {http://repositories.lib.utexas.edu/handle/2152/21174}
 }
 
-@Article{roy.heltai.ea:immersed,
+@Article{2013:roy.heltai.ea:immersed,
   author  = {S. Roy and L. Heltai and D. Drapaca and F. Costanzo},
   title   = {An immersed finite element method approach for brain biomechanics},
   journal = {Mechanics of Biological Systems and Materials, Vol. 5, Conference Proceedings of the Society for Experimental Mechanics Series},
@@ -526,7 +526,7 @@
   pages   = {79--86}
 }
 
-@Article{rudraraju.mills.ea:multiphysics,
+@Article{2013:rudraraju.mills.ea:multiphysics,
   author  = {S. Rudraraju and K. L. Mills and R. Kemkemer and K. Garikipati},
   title   = {Multiphysics Modeling of Reactions, Mass Transport and Mechanics of Tumor Growth},
   journal = {Computer Models in Biomechanics, G. Holzapfel and E. Kuhl (eds.), Spinger Verlag},
@@ -534,7 +534,7 @@
   pages   = {293--303}
 }
 
-@Article{sabouni.venkateswaran.ea:automated,
+@Article{2013:sabouni.venkateswaran.ea:automated,
   author  = {A. Sabouni and A. Venkateswaran and A. Shmuel and P. Pouliot and F. Lesage},
   title   = {An automated technique to determine the induced current in transcranial magnetic stimulation},
   journal = {Proceedings, Antennas and Propagation Society International Symposium (APSURSI), 2013 IEEE},
@@ -542,7 +542,7 @@
   pages   = {2050--2051}
 }
 
-@Article{sagebaum.gauger.ea:algorithmic,
+@Article{2013:sagebaum.gauger.ea:algorithmic,
   author  = {M. Sagebaum and N. R. Gauger and U. Naumann and J. Lotz and K. Leppkes},
   title   = {Algorithmic differentiation of a complex C++ code with underlying libraries},
   journal = {Procedia Computer Science},
@@ -551,7 +551,7 @@
   pages   = {208--217}
 }
 
-@Article{salgado:diffuse,
+@Article{2013:salgado:diffuse,
   author  = {A. J. Salgado},
   title   = {A diffuse interface fractional time-stepping technique for incompressible two-phase flows with moving contact lines},
   journal = {ESAIM Math. Model. Numer. Anal., pp. 743--769},
@@ -559,7 +559,7 @@
   volume  = 47
 }
 
-@Article{salgado:framework,
+@Article{2013:salgado:framework,
   author  = {A. J. Salgado},
   title   = {A framework for the implementation of coupled multiphase flow problems using the deal.II library and its application to electrowetting},
   journal = {Archive of Numerical Software, article 2},
@@ -568,7 +568,7 @@
   pages   = {1--19}
 }
 
-@Article{schillinger.evans.ea:isogeometric,
+@Article{2013:schillinger.evans.ea:isogeometric,
   author  = {D. Schillinger and J. A. Evans and A. Reali and M. A. Scott and T. J.R. Hughes},
   title   = {Isogeometric Collocation: Cost Comparison with Galerkin Methods and Extension to Adaptive Hierarchical NURBS Discretizations},
   journal = {ICES Report, Austin, TX},
@@ -576,7 +576,7 @@
   url     = {https://www.ticam.utexas.edu/media/reports/2013/1303.pdf}
 }
 
-@MastersThesis{siehr:stabilisierungsmethoden,
+@MastersThesis{2013:siehr:stabilisierungsmethoden,
   author  = {P. Siehr},
   title   = {Stabilisierungsmethoden f\"{u}r die Stokes-Gleichungen},
   year    = 2013,
@@ -584,14 +584,14 @@
   note    = {Bachelor thesis}
 }
 
-@Article{stapf.garbe:partikelbasierte,
+@Article{2013:stapf.garbe:partikelbasierte,
   author  = {J. Stapf and C. Garbe},
   title   = {Partikelbasierte Str\"{o}mungsmessung unter Ausnutzung typischer Bewegungsmuster},
   journal = {Proceedings, Fachtagung ``Lasermethoden in der Str\"{o}mungsmesstechnik, Munich, September 3-5, 2013, C. J. K\"{a}hler, R. Hain, C. Cierpka, B. Ruck, A. Leder, D. Dopheide (eds.), article 1},
   year    = 2013
 }
 
-@Article{steigemann.schramm:precise,
+@Article{2013:steigemann.schramm:precise,
   author  = {M. Steigemann and B. Schramm},
   title   = {Precise computation and error control of stress intensity factors and certain integral characteristics in anisotropic inhomogeneous materials},
   journal = {International Journal of Fracture},
@@ -600,7 +600,7 @@
   pages   = {67--91}
 }
 
-@Article{stoll.wathen:all-at-once,
+@Article{2013:stoll.wathen:all-at-once,
   author  = {M. Stoll and A. Wathen},
   title   = {All-at-once solution of time-dependent PDE-constrained optimization problems},
   journal = {Journal of Computational Physics},
@@ -609,21 +609,21 @@
   pages   = {498--515}
 }
 
-@MastersThesis{sutton:numerical,
+@MastersThesis{2013:sutton:numerical,
   author  = {O. Sutton},
   title   = {Numerical methods for reaction diffusion systems arising in Mathematical Biology},
   year    = 2013,
   school  = {University of Leicester}
 }
 
-@MastersThesis{tong:exactly,
+@MastersThesis{2013:tong:exactly,
   author  = {Q. Tong},
   title   = {An exactly divergence-free finite element method for non-isothermal flow problems},
   year    = 2013,
   school  = {University of British Columbia}
 }
 
-@Article{tran:partitioned,
+@Article{2013:tran:partitioned,
   author  = {H. A. Tran},
   title   = {Partitioned Methods for Coupled Fluid Flow Problems},
   journal = {PhD dissertation, University of Pittsburgh},
@@ -631,7 +631,7 @@
   url     = {http://d-scholarship.pitt.edu/18509/}
 }
 
-@MastersThesis{vakulin.shaw.ea:elec,
+@MastersThesis{2013:vakulin.shaw.ea:elec,
   author  = {N. Vakulin and R. Shaw and T. Livingston},
   title   = {ELEC 490, final report: High performance computing with GPUs},
   school  = {Queen's University},
@@ -639,7 +639,7 @@
   year    = 2013
 }
 
-@Article{wallraff.leicht.ea:numerical,
+@Article{2013:wallraff.leicht.ea:numerical,
   author  = {M. Wallraff and T. Leicht and M. Lange-Hegermann},
   title   = {Numerical flux functions for Reynolds-averaged Navier-Stokes and k$\omega$ turbulence model computations with a line-preconditioned p-multigrid discontinuous Galerkin solver},
   journal = {Int. J. Numer. Meth. Fluids},
@@ -648,28 +648,28 @@
   pages   = {1055--1072}
 }
 
-@Article{wick.elsheikh.ea:parameter,
+@Article{2013:wick.elsheikh.ea:parameter,
   author  = {T. Wick and A. H. Elsheikh and M. F. Wheeler},
   title   = {Parameter Estimation for the Coupled Biot-Lame-Navier Problem in Subsurface Modeling},
   journal = {ARMA Conference in San Francisco, Jun 23-26},
   year    = 2013
 }
 
-@Article{wick:coupling,
+@Article{2013:wick:coupling,
   author  = {T. Wick},
   title   = {Coupling of fully Eulerian and arbitrary Lagrangian-Eulerian methods for fluid-structure interaction computations},
   journal = {Computational Mechanics, DOI: 10.1007/s00466-013-0866-3},
   year    = 2013
 }
 
-@Article{wick:flapping,
+@Article{2013:wick:flapping,
   author  = {T. Wick},
   title   = {Flapping and Contact FSI Computations with the Fluid-Solid Interface-Tracking/Interface-Capturing Technique and Mesh Adaptivity},
   journal = {Computational Mechanics, DOI: 10.1007/s00466-013-0890-3},
   year    = 2013
 }
 
-@Article{wick:fully,
+@Article{2013:wick:fully,
   author  = {T. Wick},
   title   = {Fully Eulerian fluid-structure interaction for time-dependent problems},
   journal = {Comp. Methods Appl. Mech. Engrg.},
@@ -678,7 +678,7 @@
   pages   = {14--26}
 }
 
-@Article{wick:solving,
+@Article{2013:wick:solving,
   author  = {T. Wick},
   title   = {Solving Monolithic Fluid-Structure Interaction Problems in Arbitrary Lagrangian Eulerian Coordinates with the deal.II Library},
   journal = {Archive of Numerical Software, article 1},
@@ -687,7 +687,7 @@
   pages   = {1--19}
 }
 
-@Article{willems:robust,
+@Article{2013:willems:robust,
   author  = {J. Willems},
   title   = {Robust Multilevel Solvers for High-Contrast Anisotropic Multiscale Problems},
   journal = {Journal of Computational and Applied Mathematics, 251:47-60},
@@ -695,14 +695,14 @@
   doi     = {10.1016/j.cam.2013.03.030}
 }
 
-@Article{willems:spectral,
+@Article{2013:willems:spectral,
   author  = {J. Willems},
   title   = {Spectral Coarse Spaces in Robust Two-Level Schwartz Methods},
   journal = {O. Iliev, S. Margenov, P. Minev, P. Vassilevski, L. Zikatanov, editors, Numerical Solution of Partial Differential Equations: Theory, Algorithms and their Applications, 303-326, Springer Proceedings in Mathematics \& Statistics, Springer},
   year    = 2013
 }
 
-@Article{yoon.kang:mass,
+@Article{2013:yoon.kang:mass,
   author  = {S. Yoon and Y. T. Kang},
   title   = {Mass transfer enhancement in non-Brownian particle suspension under a confined shear},
   journal = {International Journal of Heat and Mass Transfer},
@@ -711,7 +711,7 @@
   pages   = {114--124}
 }
 
-@Article{young.romero.ea:parallel,
+@Article{2013:young.romero.ea:parallel,
   author  = {T. D. Young and E. Romero and J. E. Roman},
   title   = {Parallel finite element density functional theory exploiting grid refinement and subspace recycling},
   journal = {Comput. Phys. Commun., 1},
@@ -720,7 +720,7 @@
   pages   = {66--72}
 }
 
-@Article{young:finite,
+@Article{2013:young:finite,
   author  = {T. D. Young},
   title   = {A finite basis grid analysis of the Hartree-Fock wavefunction method for one- and two-electron atoms},
   journal = {AIP Conf. Proc., pp. 1524},
@@ -728,7 +728,7 @@
   volume  = 1558
 }
 
-@Article{zingan.guermond.ea:implementation,
+@Article{2013:zingan.guermond.ea:implementation,
   author  = {V. Zingan and J.-L. Guermond and J. Morel and B. Popov},
   title   = {Implementation of the entropy viscosity method with the Discontinuous Galerkin Method},
   journal = {Computer Methods in Applied Mechanics and Engineering},

--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{abaimov.cusumano:nucleation,
+@Article{2014:abaimov.cusumano:nucleation,
   title   = {Nucleation phenomena in an annealed damage model: Statistics of times to failure},
   author  = {Abaimov, S. G. and Cusumano, J. P.},
   journal = {Phys. Rev. E},
@@ -15,7 +15,7 @@
   url     = {https://link.aps.org/doi/10.1103/PhysRevE.90.062401}
 }
 
-@Book{adeniran:modelling,
+@Book{2014:adeniran:modelling,
   doi     = {10.1007/978-3-319-07200-5},
   url     = {https://doi.org/10.1007/978-3-319-07200-5},
   year    = 2014,
@@ -24,14 +24,14 @@
   title   = {Modelling the Short {QT} Syndrome Gene Mutations}
 }
 
-@Article{adler.atherton.ea:energy,
+@Article{2014:adler.atherton.ea:energy,
   author  = {J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan},
   title   = {Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects},
   journal = {arXiv:1407.3197},
   year    = 2014
 }
 
-@Article{adler.dorfmann.ea:mathematical,
+@Article{2014:adler.dorfmann.ea:mathematical,
   author  = {J. H. Adler and L. Dorfmann and D. Han and S. P. MacLachlan and C. Paetsch},
   title   = {Mathematical and computational models of incompressible materials subject to shear},
   journal = {IMA Journal of Applied Mathematics},
@@ -40,7 +40,7 @@
   pages   = {889--914}
 }
 
-@Article{adler.emerson.ea:constrained,
+@Article{2014:adler.emerson.ea:constrained,
   author  = {J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel},
   title   = {Constrained Optimization for Liquid Crystal Equilibria: Extended Results},
   journal = {arXiv:1412.8056},
@@ -48,7 +48,7 @@
   url     = {http://arxiv.org/abs/1412.8056}
 }
 
-@Article{albert.schwarz:dynamics,
+@Article{2014:albert.schwarz:dynamics,
   doi     = {10.1016/j.bpj.2014.04.036},
   url     = {https://doi.org/10.1016/j.bpj.2014.04.036},
   year    = 2014,
@@ -62,7 +62,7 @@
   journal = {Biophysical Journal}
 }
 
-@Article{alexe.sandu:space-time,
+@Article{2014:alexe.sandu:space-time,
   author  = {M. Alexe and A. Sandu},
   title   = {Space--time adaptive solution of inverse problems with the discrete adjoint method},
   journal = {Journal of Computational Physics, pp. 21--39},
@@ -71,7 +71,7 @@
   url     = {http://link.springer.com/article/10.1007/s10208-014-9208-x}
 }
 
-@Article{avila.meister.ea:on,
+@Article{2014:avila.meister.ea:on,
   author  = {A. I. Avila and A. Meister and M. Steigemann},
   title   = {On numerical methods for nonlinear singularly perturbed Schr\"{o}dinger problems},
   journal = {Applied Numerical Mathematics},
@@ -80,14 +80,14 @@
   pages   = {22--42}
 }
 
-@Article{bangerth.heister:quo,
+@Article{2014:bangerth.heister:quo,
   author  = {W. Bangerth and T. Heister},
   title   = {Quo Vadis, Scientific Software?},
   journal = {SIAM News, January 2014},
   year    = 2014
 }
 
-@Article{bartels.nochetto.ea:discrete,
+@Article{2014:bartels.nochetto.ea:discrete,
   author  = {S. Bartels and R. H. Nochetto and A. J. Salgado},
   title   = {Discrete total variation flows without regularization},
   journal = {SIAM Journal on Numerical Analysis},
@@ -96,7 +96,7 @@
   pages   = {363--385}
 }
 
-@Article{bertei.chueh.ea:modified,
+@Article{2014:bertei.chueh.ea:modified,
   author  = {A. Bertei and C.-C. Chueh and J. Pharoah and C. Nicolella},
   title   = {Modified collective rearrangement sphere-assembly algorithm for random packings of nonspherical particles: Towards engineering applications},
   journal = {Powder Technology},
@@ -105,7 +105,7 @@
   pages   = {311--324}
 }
 
-@Article{bhaiya.putz.ea:analysis,
+@Article{2014:bhaiya.putz.ea:analysis,
   author  = {M. Bhaiya and A. Putz and M. Secanell},
   title   = {Analysis of non-isothermal effects on polymer electrolyte fuel cell electrode assemblies},
   journal = {Electrochimica Acta},
@@ -114,14 +114,14 @@
   pages   = {294--309}
 }
 
-@PhDThesis{bhaiya:open-source,
+@PhDThesis{2014:bhaiya:open-source,
   author  = {M. Bhaiya},
   title   = {An open-source two-phase non-isothermal mathematical model of a polymer electrolyte membrane fuel cell},
   year    = 2014,
   school  = {University of Alberta, Edmonton}
 }
 
-@Article{bonito.glowinski:on,
+@Article{2014:bonito.glowinski:on,
   author  = {A. Bonito and R. Glowinski},
   title   = {On the Nodal Set of the Eigenfunctions of the Laplace-Beltrami Operator for Bounded Surfaces in R$^{3}$: A Computational Approach},
   journal = {Communications on Pure and Applied Mathematics},
@@ -130,7 +130,7 @@
   pages   = {2115--2126}
 }
 
-@Article{bosch.kay.ea:fast,
+@Article{2014:bosch.kay.ea:fast,
   author  = {J. Bosch and D. Kay and M. Stoll and A. J. Wathen},
   title   = {Fast solvers for Cahn-Hilliard inpainting},
   journal = {SIAM Journal on Imaging Science},
@@ -139,7 +139,7 @@
   pages   = {67--97}
 }
 
-@Article{bosch.stoll.ea:fast,
+@Article{2014:bosch.stoll.ea:fast,
   author  = {J. Bosch and M. Stoll and P. Benner},
   title   = {Fast solution of Cahn-Hilliard variational inequalities using implicit time discretizations and finite elements},
   journal = {Journal of Computational Physics},
@@ -148,14 +148,14 @@
   pages   = {38--57}
 }
 
-@PhDThesis{brauss:implementation,
+@PhDThesis{2014:brauss:implementation,
   author  = {K. D. Brauss},
   title   = {An implementation of the finite element method for the velocity-current magnetohydrodynamics equations},
   year    = 2014,
   school  = {University of Texas at Austin}
 }
 
-@Article{cangiani.chapman.ea:on,
+@Article{2014:cangiani.chapman.ea:on,
   author  = {A. Cangiani and J. Chapman and E. Georgoulis and M. Jensen},
   title   = {On local super-penalization of interior penalty discontinuous Galerkin methods},
   journal = {International Journal of Numerical Analysis \& Modeling},
@@ -164,7 +164,7 @@
   pages   = {478--495}
 }
 
-@Article{cangiani.georgoulis.ea:adaptive,
+@Article{2014:cangiani.georgoulis.ea:adaptive,
   author  = {A. Cangiani and E. Georgoulis and S. Metcalfe},
   title   = {Adaptive discontinuous Galerkin methods for nonstationary convection--diffusion problems},
   journal = {IMA Journal of Numerical Analysis, Vol. 34, Issue 4},
@@ -173,21 +173,21 @@
   url     = {http://imajna.oxfordjournals.org/content/34/4/1578.short}
 }
 
-@Article{castelletto.white.ea:unified,
+@Article{2014:castelletto.white.ea:unified,
   author  = {N. Castelletto and J. A. White and H. A. Tchelepi},
   title   = {A unified framework for fully-implicit and sequential-implicit schemes for coupled poroelasticity},
   journal = {Proceedings, ECMOR XIV - 14th European conference on the mathematics of oil recovery},
   year    = 2014
 }
 
-@PhDThesis{cattoglio:multigrid,
+@PhDThesis{2014:cattoglio:multigrid,
   author  = {F. Cattoglio},
   title   = {Multigrid preconditioning techniques for saddle point problems with highly variable coefficients},
   year    = 2014,
   school  = {Politecnico di Milano}
 }
 
-@Article{chueh.bertei.ea:effective,
+@Article{2014:chueh.bertei.ea:effective,
   author  = {C. C. Chueh and A. Bertei and J. Pharoah and C. Nicolella},
   title   = {Effective Conductivity in Random Porous Media with Convex and Non-Convex Porosity},
   journal = {International Journal of Heat and Mass Transfer},
@@ -196,7 +196,7 @@
   pages   = {183--188}
 }
 
-@Article{dahmen.gerber.ea:numerical,
+@Article{2014:dahmen.gerber.ea:numerical,
   author  = {W. Dahmen and V. Gerber and T. Gotzen and S. Muller and M. Rom and C. Windisch},
   title   = {Numerical Simulation of Transpiration Cooling with a Mixture of Thermally Perfect Gases},
   journal = {11th World Congress on Computational Mechanics (WCCM XI), Spain},
@@ -204,7 +204,7 @@
   url     = {http://wccm-eccm-ecfd2014.org/admin/files/filePaper/p1331.pdf}
 }
 
-@Article{dahmen.gotzen.ea:numerical,
+@Article{2014:dahmen.gotzen.ea:numerical,
   author  = {W. Dahmen and T. Gotzen and S. M\"{u}ller and M. Rom},
   title   = {Numerical simulation of transpiration cooling through porous material},
   journal = {Int. J. Numer. Meth. Fluids. Vol. 76, pp:331--365},
@@ -212,7 +212,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.3935/full}
 }
 
-@Article{davydov.pelteret.ea:comparison,
+@Article{2014:davydov.pelteret.ea:comparison,
   author  = {D. Davydov and J-P. Pelteret and P. Steinmann},
   title   = {Comparison of several staggered atomistic-to-continuum concurrent coupling strategies},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -224,7 +224,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{davydov.voyiatzis.ea:size,
+@Article{2014:davydov.voyiatzis.ea:size,
   author  = {D. Davydov and E. Voyiatzis and G. Chatzigeorgiou and S. Liu and P. Steinmann and M. C. B\"{o}hm and F. M\"{u}ller-Plathe},
   title   = {Size Effects in a Silica-Polystyrene Nanocomposite: Molecular Dynamics and Surface-enhanced Continuum Approaches},
   journal = {Soft Materials, pp. S142-S151},
@@ -232,7 +232,7 @@
   volume  = 12
 }
 
-@Article{donev.reddy:time-dependent,
+@Article{2014:donev.reddy:time-dependent,
   author  = {I. G. Donev and B. D. Reddy},
   title   = {Time-dependent finite element simulations of a shear-thinning viscoelastic fluid with application to blood flow},
   journal = {International Journal for Numerical Methods in Fluids, pp. 668--686},
@@ -240,7 +240,7 @@
   volume  = 75
 }
 
-@Article{dorostkar.lukarski.ea:cpu,
+@Article{2014:dorostkar.lukarski.ea:cpu,
   author  = {A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt},
   title   = {CPU and GPU Performance of Large Scale Numerical Simulations in Geophysics},
   journal = {Lecture Notes in Computer Science, Vol. 8805, pp: 12-23},
@@ -248,14 +248,14 @@
   url     = {http://link.springer.com/chapter/10.1007/978-3-319-14325-5_2#page-1}
 }
 
-@Article{dorostkar.lukarski.ea:parallel,
+@Article{2014:dorostkar.lukarski.ea:parallel,
   author  = {A. Dorostkar and D. Lukarski and B. Lund and M. Neytcheva and Y. Notay and P. Schmidt},
   title   = {Parallel performance study of block-preconditioned iterative methods on multicore computer systems},
   journal = {Technical Report 2014-007, Department of Information Technology, Uppsala University},
   year    = 2014
 }
 
-@InProceedings{ebna-hai.bause:finite-element-model-based-structural-health-monitoring-shm-systems-for-composite-material-under-fluid-structure-interaction-fsi-effect,
+@InProceedings{2014:ebna-hai.bause:finite-element-model-based-structural-health-monitoring-shm-systems-for-composite-material-under-fluid-structure-interaction-fsi-effect,
   title   = {{Finite Element Model-Based Structural Health Monitoring (SHM) Systems for Composite Material under Fluid-Structure Interaction (FSI) Effect}},
   author  = {Ebna Hai, Bhuiyan Shameem Mahmood and Bause, Markus},
   url     = {https://hal.inria.fr/hal-01021185},
@@ -270,7 +270,7 @@
   hal_version = {v1}
 }
 
-@Article{ebrahimi.monavari.ea:numerical,
+@Article{2014:ebrahimi.monavari.ea:numerical,
   author  = {A. Ebrahimi and M. Monavari and T. Hochrainer},
   title   = {Numerical implementation of continuum dislocation dynamics with discontinuous-Galerkin method},
   journal = {MRS Proceedings},
@@ -278,7 +278,7 @@
   volume  = 1651
 }
 
-@Article{el-kurdi.gross.ea:parallel,
+@Article{2014:el-kurdi.gross.ea:parallel,
   author  = {Y. El-Kurdi and W. J. Gross and D. Giannacopoulos},
   title   = {Parallel Multigrid Acceleration for the Finite-Element Gaussian Belief Propagation Algorithm},
   journal = {IEEE Transactions on Magnetics, article 7014304},
@@ -286,7 +286,7 @@
   volume  = 50
 }
 
-@Article{evgrafov:state,
+@Article{2014:evgrafov:state,
   author  = {A. Evgrafov},
   title   = {State space Newton's method for topology optimization},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -295,7 +295,7 @@
   pages   = {272--290}
 }
 
-@Article{faigle.helmig.ea:efficient,
+@Article{2014:faigle.helmig.ea:efficient,
   author  = {B. Faigle and R. Helmig and I. Aavatsmark and B. Flemisch},
   title   = {Efficient multiphysics modelling with adaptive grid refinement using a MPFA method},
   journal = {Comput. Geosci. Vol. 18, pp. 625--636},
@@ -303,7 +303,7 @@
   url     = {http://link.springer.com/article/10.1007/s10596-014-9407-1#page}
 }
 
-@Article{fankhauser.wihler.ea:hp-adaptive,
+@Article{2014:fankhauser.wihler.ea:hp-adaptive,
   author  = {T. Fankhauser and T. Wihler and M. Wirz},
   title   = {The hp-adaptive FEM based on continuous Sobolev embeddings: Isotropic refinements},
   journal = {Computers \& Mathematics with Applications},
@@ -312,7 +312,7 @@
   pages   = {854--868}
 }
 
-@Article{fayez.vidal-ferrandiz.ea:h-p,
+@Article{2014:fayez.vidal-ferrandiz.ea:h-p,
   author  = {R. Fayez and A. Vidal-Ferrandiz and D. Ginestar and G. Verdu},
   title   = {h-p finite element method for the Lambda modes problem in hexagonal geometries},
   journal = {40 Annual Meeting of Spanish Nuclear Society, Volume 46, Issue 13},
@@ -320,21 +320,21 @@
   url     = {https://inis.iaea.org/search/searchsinglerecord.aspx?recordsFor=SingleRecord&RN=46032323}
 }
 
-@Article{ferguson.breitzman:implementation,
+@Article{2014:ferguson.breitzman:implementation,
   author  = {L. Ferguson and T. D. Breitzman},
   title   = {Implementation and experimental validation of the Sendova-Walton theory for mode-I fracture},
   journal = {Proceedings of the 11th World Congress on Computationa Mechnics (WCCM XI)},
   year    = 2014
 }
 
-@MastersThesis{fraters:thermo-mechanically,
+@MastersThesis{2014:fraters:thermo-mechanically,
   author  = {M. Fraters},
   title   = {Thermo-mechanically coupled subduction modelling with ASPECT},
   year    = 2014,
   school  = {Utrecht University}
 }
 
-@MastersThesis{fraters:thermo-mechanically-coupled-subduction-modelling-with-aspect,
+@MastersThesis{2014:fraters:thermo-mechanically-coupled-subduction-modelling-with-aspect,
   author  = {Fraters, Menno},
   number  = {August},
   school  = {Utrecht University},
@@ -343,7 +343,7 @@
   year    = 2014
 }
 
-@Article{freddi.royer-carfagni:plastic,
+@Article{2014:freddi.royer-carfagni:plastic,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {Plastic flow as an energy minimization problem. Numerical Experiments},
   journal = {Journal of Elasticity},
@@ -352,7 +352,7 @@
   pages   = {53--74}
 }
 
-@Article{freddi.sacco:interface,
+@Article{2014:freddi.sacco:interface,
   author  = {F. Freddi and E. Sacco},
   title   = {An interface damage model accounting for in-plane effects},
   journal = {International Journal of Solids and Structures},
@@ -361,7 +361,7 @@
   pages   = {4230--4244}
 }
 
-@InCollection{frei.richter.ea:eulerian,
+@InCollection{2014:frei.richter.ea:eulerian,
   doi     = {10.1007/978-3-319-10705-9_74},
   year    = 2014,
   month   = oct,
@@ -372,7 +372,7 @@
   booktitle = {Numerical Mathematics and Advanced Applications - ENUMATH 2013}
 }
 
-@InCollection{frei.richter.ea:eulerian*1,
+@InCollection{2014:frei.richter.ea:eulerian*1,
   doi     = {10.1007/978-3-319-10705-9_75},
   year    = 2014,
   month   = oct,
@@ -383,7 +383,7 @@
   booktitle = {Numerical Mathematics and Advanced Applications - ENUMATH 2013}
 }
 
-@Article{frei.richter.ea:solid,
+@Article{2014:frei.richter.ea:solid,
   author  = {S. Frei and T. Richter and T. Wick},
   title   = {Solid growth and clogging in fluid-structure interaction using ALE and fully Eulerian coordinates},
   journal = {RICAM, research report},
@@ -391,7 +391,7 @@
   url     = {https://www.ricam.oeaw.ac.at/people/member/?firstname=Thomas&lastname=Wick&show=publications}
 }
 
-@Article{fu.hager.ea:efficient,
+@Article{2014:fu.hager.ea:efficient,
   author  = {R. R. Fu and B. H. Hager and A. I. Ermakov and M. T. Zuber},
   title   = {Efficient early global relaxation of asteroid Vesta},
   journal = {Icarus},
@@ -400,28 +400,28 @@
   pages   = {133--145}
 }
 
-@Article{gaitero.dolado.ea:3d,
+@Article{2014:gaitero.dolado.ea:3d,
   author  = {J. J. Gaitero and J. S. Dolado and C. Neuen and F. Heber and E. Koenders},
   title   = {3D Computational Simulation of Calcium Leaching in Cement Matrices},
   journal = {Materiales de Construcci\'{o}n, Vol 64, article e035},
   year    = 2014
 }
 
-@Article{george.thomas:simulation,
+@Article{2014:george.thomas:simulation,
   author  = {K. George and H. Thomas},
   title   = {Simulation of groundwater flow based on adaptive mesh refinement},
   journal = {Proceedings of the 7th International Congress on Environmental Modelling and Software, San Diego, International Environmental Modelling and Software Society (iEMSs)},
   year    = 2014
 }
 
-@Article{ghorashi.amani.ea:goal-oriented,
+@Article{2014:ghorashi.amani.ea:goal-oriented,
   author  = {S. Sh. Ghorashi and J. Amani and A. S. Bagherzadeh and T. Rabczuk},
   title   = {Goal-oriented error estimation and mesh adaptivity in three-dimensional elasticity problems},
   journal = {Proceedings of the 11th World Congress on Computational Mechnics (WCCM XI)},
   year    = 2014
 }
 
-@Article{giestas.milhazes.ea:numerical,
+@Article{2014:giestas.milhazes.ea:numerical,
   author  = {M. C. Giestas and J. P. Milhazes and H. L. Pina},
   title   = {Numerical Modeling of Solar Ponds},
   journal = {Energy Procedia, pp. 2416--2425},
@@ -430,7 +430,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S1876610214016178}
 }
 
-@Article{girault.kanschat.ea:error,
+@Article{2014:girault.kanschat.ea:error,
   author  = {V. Girault and G. Kanschat and B. Rivi\`{e}re},
   title   = {Error analysis for a monolithic discretization of coupled Darcy and Stokes problems},
   journal = {Journal of Numerical Mathematics, no. 2},
@@ -440,7 +440,7 @@
   doi     = {10.1515/jnma-2014-0005}
 }
 
-@Article{grayver.burg:robust,
+@Article{2014:grayver.burg:robust,
   author  = {A. Grayver and M. B\"{u}rg},
   title   = {Robust and scalable 3-D geo-electromagnetic modelling approach using the finite element method},
   journal = {Geophysical Journal International 2014, published online (DOI 10.1093/gji/ggu119)},
@@ -448,7 +448,7 @@
   url     = {http://gji.oxfordjournals.org/content/early/2014/04/29/gji.ggu119.abstract?keytype=ref&ijkey=gkyDCSgpUEOjqWw}
 }
 
-@Article{gupta.nataraj:dual,
+@Article{2014:gupta.nataraj:dual,
   author  = {N. Gupta and N. Nataraj},
   title   = {A dual weighted residual method for an optimal control problem of laser surface hardening of steel},
   journal = {Mathematics and Computers in Simulation, pp. 12--32},
@@ -457,7 +457,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0378475414000494}
 }
 
-@Article{ha.caldwell.ea:solid-solid,
+@Article{2014:ha.caldwell.ea:solid-solid,
   author  = {D.H. Ha and A. H. Caldwell and M. J. Ward and S.s Honrao and K. Mathew and R. Hovden and M. K. A. Koker and D. A. Muller and R. G. Hennig and R. D. Robinson},
   title   = {Solid--Solid Phase Transformations Induced through Cation Exchange and Strain in 2D Heterostructured Copper Sulfide Nanocrystals},
   journal = {NANO Letters, 14(12)},
@@ -466,7 +466,7 @@
   url     = {http://pubs.acs.org/doi/abs/10.1021/nl5035607}
 }
 
-@InProceedings{hai.bause:adaptive,
+@InProceedings{2014:hai.bause:adaptive,
   doi     = {10.1115/fedsm2014-21379},
   url     = {https://doi.org/10.1115/fedsm2014-21379},
   year    = 2014,
@@ -477,7 +477,7 @@
   booktitle = {Volume 1B, Symposia: Fluid Machinery; Fluid-Structure Interaction and Flow-Induced Noise in Industrial Applications; Flow Applications in Aerospace; Flow Manipulation and Active Control: Theory, Experiments and Implementation; Multiscale Methods for Multiphase Flow; Noninvasive Measurements in Single and Multiphase Flows}
 }
 
-@InProceedings{hai.bause:finite,
+@InProceedings{2014:hai.bause:finite,
   doi     = {10.1115/gt2014-26314},
   url     = {https://doi.org/10.1115/gt2014-26314},
   year    = 2014,
@@ -488,7 +488,7 @@
   booktitle = {Volume 7A: Structures and Dynamics}
 }
 
-@Article{hale.kerfriden.ea:parallel,
+@Article{2014:hale.kerfriden.ea:parallel,
   author  = {J. S. Hale and P. Kerfriden and J. J. R. Garcia and S. P. A. Bordas},
   title   = {Parallel Simulations of Soft-Tissue using an Adaptive Quadtree/Octree Implicit Bounadry Finite Element Method},
   journal = {11th World Congress on Computational Mechanics (WCCM XI), Spain},
@@ -496,7 +496,7 @@
   url     = {http://journals.aps.org/pre/abstract/10.1103/PhysRevE.90.062401}
 }
 
-@Article{harting.marciniak-czochra:spike,
+@Article{2014:harting.marciniak-czochra:spike,
   author  = {S. H\"{a}rting and A. Marciniak-Czochra},
   title   = {Spike patterns in a reaction-diffusion-ode model with Turing instability},
   journal = {Mathematical Methods in the Applied Sciences, Issue 9},
@@ -505,7 +505,7 @@
   pages   = {1377--1391}
 }
 
-@Article{hartmann.leicht:higher,
+@Article{2014:hartmann.leicht:higher,
   author  = {R. Hartmann and T. Leicht},
   title   = {Higher order and adaptive DG methods for compressible flows},
   journal = {In H. Deconinck and R. Abgrall, editors, VKI LS 2014-03: 37th Advanced VKI CFD Lecture Series: Recent developments in higher order methods and industrial application in aeronautics, Dec. 9-12, 2013. Von Karman Institute for Fluid Dynamics, Rhode Saint Genese, Belgium},
@@ -513,7 +513,7 @@
   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/}
 }
 
-@Article{heltai.roy.ea:fully,
+@Article{2014:heltai.roy.ea:fully,
   author  = {L. Heltai and S. Roy and F. Costanzo},
   title   = {A Fully Coupled Immersed Finite Element Method for Fluid Structure Interaction via the Deal.II Library},
   journal = {Archive of Numerical Software, article 1},
@@ -522,7 +522,7 @@
   pages   = {1--27}
 }
 
-@Article{hintermuller.schiela.ea:length,
+@Article{2014:hintermuller.schiela.ea:length,
   author  = {M. Hinterm\"{u}ller and A. Schiela and W. Wollner},
   title   = {The length of the primal-dual path in Moreau-Yosida-based path-following for state constrained optimal control},
   journal = {SIAM J. Optim.},
@@ -531,14 +531,14 @@
   pages   = {108--126}
 }
 
-@Article{janssen.wihler:existence,
+@Article{2014:janssen.wihler:existence,
   author  = {B. Janssen and T. Wihler},
   title   = {Existence Results for the Continuous and Discontinuous Galerkin Time Stepping Methods for Nonlinear Initial Value Problems},
   journal = {arXiv:1407.5520},
   year    = 2014
 }
 
-@Article{javili.mcbride.ea:unified,
+@Article{2014:javili.mcbride.ea:unified,
   author  = {A. Javili and A. T. McBride and P. Steinmann and B. D. Reddy},
   title   = {A unified computational framework for bulk and surface elasticity theory: a curvilinear-coordinate-based finite element methodology},
   journal = {Computational Mechanics},
@@ -547,7 +547,7 @@
   pages   = {745--762}
 }
 
-@Article{kanschat.ragusa:robust,
+@Article{2014:kanschat.ragusa:robust,
   author  = {G. Kanschat and J. V. Ragusa},
   title   = {A Robust Multigrid Preconditioner for S$S_{\textnormal{N}}$DG Approximation of Monochromatic, Isotropic Radiation Transport Problems},
   journal = {SIAM J. Sci. Comput. no. 5},
@@ -557,7 +557,7 @@
   doi     = {10.1137/13091600X}
 }
 
-@Article{kanschat.sharma:divergence-conforming,
+@Article{2014:kanschat.sharma:divergence-conforming,
   author  = {G. Kanschat and N. Sharma},
   title   = {Divergence-conforming Discontinuous Galerkin Methods and C$^{0}$ Interior Penalty Methods},
   journal = {SIAM J. Numer. Anal., no. 4},
@@ -567,7 +567,7 @@
   doi     = {10.1137/120902975}
 }
 
-@Article{kim:analysis,
+@Article{2014:kim:analysis,
   author  = {S. Kim},
   title   = {Analysis of the convected Helmholtz equation with a uniform mean flow in a waveguide with complete radiation boundary conditions},
   journal = {Journal of Mathematical Analysis and Applications},
@@ -577,7 +577,7 @@
   doi     = {10.1016/j.jmaa.2013.08.018}
 }
 
-@Article{kim:cartesian,
+@Article{2014:kim:cartesian,
   author  = {S. Kim},
   title   = {Cartesian PML approximation to resonances in open systems in R$^{2}$},
   journal = {Applied Numerical Mathematics},
@@ -586,7 +586,7 @@
   pages   = {50--75}
 }
 
-@Article{kocher.bause:variational,
+@Article{2014:kocher.bause:variational,
   author  = {U. K\"{o}cher and M. Bause},
   title   = {Variational Space-Time Methods for the Wave Equation},
   journal = {Journal of Scientific Computing, Vol 61, issue 2},
@@ -595,21 +595,21 @@
   url     = {http://link.springer.com/article/10.1007/s10915-014-9831-3}
 }
 
-@Article{kourakos.harter:simulation,
+@Article{2014:kourakos.harter:simulation,
   author  = {G. Kourakos and T. Harter},
   title   = {Simulation of Groundwater Flow based on Adaptive Mesh Refinement},
   journal = {In: Ames, D.P., Quinn, N.W.T., Rizzoli, A.E. (Eds.), Proceedings of the 7th International Congress on Environmental Modelling and Software, June 15-19, San Diego, California, USA; },
   year    = 2014
 }
 
-@Article{kramer.lube:finite,
+@Article{2014:kramer.lube:finite,
   author  = {S. Kramer and G. Lube},
   title   = {Finite Element-Boundary Element Methods for Accurate Modeling of Excluded Volume Effects in Dielectric Relaxation Spectroscopy},
   journal = {Preprint},
   year    = 2014
 }
 
-@Article{krehel.muntean.ea:multiscale,
+@Article{2014:krehel.muntean.ea:multiscale,
   author  = {O. Krehel and A. Muntean and P. Knabner},
   title   = {Multiscale modeling of colloidal dynamics in porous media: Capturing aggregation and deposition effects},
   journal = {arXiv.org preprint 1404.4207},
@@ -617,7 +617,7 @@
   url     = {http://arxiv.org/abs/1404.4207}
 }
 
-@PhDThesis{krehel:aggregation,
+@PhDThesis{2014:krehel:aggregation,
   author  = {O. Krehel},
   title   = {Aggregation and fragmentation in reaction-diffusion systems posed in heterogeneous domains},
   year    = 2014,
@@ -625,21 +625,21 @@
   url     = {http://alexandria.tue.nl/extra2/780944.pdf}
 }
 
-@Article{kumar.noorden.ea:ale-based,
+@Article{2014:kumar.noorden.ea:ale-based,
   author  = {K. Kumar and T. van Noorden and M. F. Wheeler and T. Wick},
   title   = {An ALE-based method for reaction-induced boundary movement towards clogging},
   journal = {ENUMATH Proceedings},
   year    = 2014
 }
 
-@PhDThesis{leonard:mathematical,
+@PhDThesis{2014:leonard:mathematical,
   author  = {K. Leonard},
   title   = {Mathematical and Computational Modelling of Tissue Engineered Bone in a Hydrostatic Bioreactor},
   year    = 2014,
   school  = {University of Oxford}
 }
 
-@Article{liebenstein.sandfeld.ea:higher,
+@Article{2014:liebenstein.sandfeld.ea:higher,
   author  = {S. Liebenstein and S. Sandfeld and M. Zaiser},
   title   = {Higher Order Continuum Modelling for Predicting the Mechanical Behaviour of Solid Foams},
   journal = {PAMM: Proc. Appl. Math. Mech., pp. 315--316},
@@ -648,7 +648,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410145/abstract}
 }
 
-@Article{lube.arndt.ea:understanding,
+@Article{2014:lube.arndt.ea:understanding,
   author  = {G. Lube and D. Arndt and H. Dallmann},
   title   = {Understanding the limits of inf-sup stable Galerkin-FEM for incompressible flows},
   journal = {BAIL 2014 - Boundary and Interior Layers},
@@ -657,7 +657,7 @@
   doi     = {10.1007/978-3-319-25727-3}
 }
 
-@Article{madzvamuse.chung:fully,
+@Article{2014:madzvamuse.chung:fully,
   author  = {A. Madzvamuse and A. H. W. Chung},
   title   = {Fully implicit time-stepping schemes and non-linear solvers for systems of reaction--diffusion equations},
   journal = {Applied Mathematics and Computation},
@@ -666,7 +666,7 @@
   pages   = {361--374}
 }
 
-@Article{malhotra.gholami.ea:volume,
+@Article{2014:malhotra.gholami.ea:volume,
   author  = {D. Malhotra and A. Gholami and G. Biros},
   title   = {A volume integral equation Stokes solver for problems with variable coefficients},
   journal = {SC14: International Conference for High Performance Computing, Network, Storage and Analysis},
@@ -674,21 +674,21 @@
   url     = {http://dl.acm.org/citation.cfm?id=2683604}
 }
 
-@Article{mallikarjunaiah.walton:on,
+@Article{2014:mallikarjunaiah.walton:on,
   author  = {M. S. Mallikarjunaiah and J. Walton},
   title   = {On the direct numerical simulation (DNS) of an anti-plane shear crack in a new class of strain-limiting elastic bodies},
   journal = {Proceedings of the US National Congress on Theoretical and Applied Mechanics (USNTAM-14) to be held in Michigan State University-East Lansing, June 15-20},
   year    = 2014
 }
 
-@MastersThesis{merten:entwicklung,
+@MastersThesis{2014:merten:entwicklung,
   author  = {J. Y. Merten},
   title   = {Entwicklung eines adaptiven Finite-Elemente-Verfahrens f\"{u}r ein Lithium-Ionen-Akkumulator Modell},
   year    = 2014,
   school  = {University of Heidelberg}
 }
 
-@PhDThesis{metcalfe:adaptive,
+@PhDThesis{2014:metcalfe:adaptive,
   author  = {S. A. Metcalfe},
   title   = {Adaptive discontinuous Galerkin methods for nonlinear parabolic problems},
   year    = 2014,
@@ -696,7 +696,7 @@
   url     = {http://arXiv.org/abs/1504.02646}
 }
 
-@Article{michoski.evans.ea:discontinuous,
+@Article{2014:michoski.evans.ea:discontinuous,
   author  = {C. E. Michoski and J. A. Evans and P. G. Schmitz},
   title   = {Discontinuous Galerkin hp-adaptive methods for multiscale chemical reactors: Quiescent reactors},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -705,7 +705,7 @@
   pages   = {163--197}
 }
 
-@Article{mills.rudraraju.ea:elastic,
+@Article{2014:mills.rudraraju.ea:elastic,
   author  = {K. L. Mills and S. Rudraraju and R. Kemkemer and K. Garikipati},
   title   = {Elastic free energy drives the shape of prevascular tumors},
   journal = {PLoS ONE},
@@ -713,7 +713,7 @@
   url     = {http://arxiv.org/abs/1405.3293}
 }
 
-@Article{mola.heltai.ea:fully,
+@Article{2014:mola.heltai.ea:fully,
   author  = {A. Mola and L. Heltai and A. DeSimone},
   title   = {A fully nonlinear potential model for ship hydrodynamics directly interfaced with CAD data structures},
   journal = {The Twenty-fourth International Ocean and Polar Engineering Conference, Busan, Korea},
@@ -721,14 +721,14 @@
   url     = {https://www.onepetro.org/conference-paper/ISOPE-I-14-475}
 }
 
-@MastersThesis{muller:explicit,
+@MastersThesis{2014:muller:explicit,
   author  = {C. M\"{u}ller},
   title   = {An explicit formulation of the hybridizable discontinuous Galerkin method for the acoustic wave equation},
   year    = 2014,
   school  = {Technische Universit\"{a}t M\"{u}nchen}
 }
 
-@Article{nama.huang.ea:investigation,
+@Article{2014:nama.huang.ea:investigation,
   author  = {N. Nama and P.-H. Huang and T. J. Huang and F. Costanzo},
   title   = {Investigation of acoustic streaming patterns around oscillating sharp edges},
   journal = {Lab Chip},
@@ -737,7 +737,7 @@
   pages   = {2824--2836}
 }
 
-@Article{neytcheva.lund:numerical,
+@Article{2014:neytcheva.lund:numerical,
   author  = {M. Neytcheva and B. Lund},
   title   = {Numerical solution methods for algebraic systems arising in discrete coupled visco-/poroelastic models},
   journal = {Joint project with Dept. of Info. Tech. and Earth Sci., Uppsala University},
@@ -745,7 +745,7 @@
   url     = {http://user.it.uu.se/~maya/Projects/GIA/GIA_project_TDB_2014.pdf}
 }
 
-@Article{nochetto.salgado.ea:diffuse,
+@Article{2014:nochetto.salgado.ea:diffuse,
   author  = {R. H. Nochetto and A. J. Salgado and S. W. Walker},
   title   = {A diffuse interface model for electrowetting with moving contact lines},
   journal = {Mathematical Models and Methods in Applied Sciences, article 67},
@@ -754,7 +754,7 @@
   url     = {http://www.worldscientific.com/doi/abs/10.1142/S0218202513500474?journalCode=m3as}
 }
 
-@Article{nochetto.salgado.ea:micropolar,
+@Article{2014:nochetto.salgado.ea:micropolar,
   author  = {R. H. Nochetto and A. J. Salgado and I. Tomas},
   title   = {The micropolar Navier-Stokes equations: A priori error analysis},
   journal = {Mathematical Models and Methods in Applied Sciences},
@@ -763,7 +763,7 @@
   pages   = {1237--1264}
 }
 
-@PhDThesis{otarola:pde,
+@PhDThesis{2014:otarola:pde,
   author  = {Enrique Otarola},
   title   = {A {PDE} approach to numerical fractional diffusion},
   year    = 2014,
@@ -771,7 +771,7 @@
   url     = {http://hdl.handle.net/1903/15317}
 }
 
-@Article{pearson.stoll.ea:preconditioners,
+@Article{2014:pearson.stoll.ea:preconditioners,
   author  = {J. Pearson and M. Stoll and A. Wathen},
   title   = {Preconditioners for state-constrained optimal control problems with Moreau--Yosida penalty function},
   journal = {Numerical Linear Algebra},
@@ -780,7 +780,7 @@
   pages   = {81--97}
 }
 
-@Article{pelteret.reddy:development,
+@Article{2014:pelteret.reddy:development,
   author  = {Jean-Paul V. Pelteret and Batmanathan D. Reddy},
   title   = {Development of a computational biomechanical model of the human upper-airway soft-tissues toward simulating obstructive sleep apnea},
   journal = {Clinical Anatomy},
@@ -793,7 +793,7 @@
   publisher = {Wiley}
 }
 
-@Article{pernach.bzowski.ea:numerical,
+@Article{2014:pernach.bzowski.ea:numerical,
   author  = {M. Pernach and K. Bzowski and M. Pietrzyk},
   title   = {Numerical modelling of phase transformation in DP steel after hot rolling and laminar cooling},
   journal = {International Journal for Multiscale Computational Engineering},
@@ -802,14 +802,14 @@
   pages   = {397--410}
 }
 
-@PhDThesis{phillips:fast,
+@PhDThesis{2014:phillips:fast,
   author  = {E. G. Phillips},
   title   = {Fast Solvers and Uncertainty Quantification for Models of Magnetohydrodynamics},
   year    = 2014,
   school  = {University of Maryland}
 }
 
-@Article{povall.mcbride.ea:finite,
+@Article{2014:povall.mcbride.ea:finite,
   author  = {T. Povall and A. T. McBride and B. D. Reddy},
   title   = {Finite element simulation of large-strain single-crystal viscoplasticity: An investigation of various hardening relations},
   journal = {Computational Materials Science},
@@ -818,7 +818,7 @@
   pages   = {386--396}
 }
 
-@PhDThesis{quinquis:a-numerical-study-of-subduction-zone-dynamics-using-linear-viscous-to-thermo-mechanical-model-setups-including-dehydration-processes,
+@PhDThesis{2014:quinquis:a-numerical-study-of-subduction-zone-dynamics-using-linear-viscous-to-thermo-mechanical-model-setups-including-dehydration-processes,
   author  = {Quinquis, M.},
   school  = {Charles University},
   title   = {{A numerical study of subduction zone dynamics using linear viscous to thermo-mechanical model setups including (de)hydration processes}},
@@ -826,7 +826,7 @@
   url     = {http://hdl.handle.net/20.500.11956/66505}
 }
 
-@Article{rahemi.nigam.ea:regionalizing,
+@Article{2014:rahemi.nigam.ea:regionalizing,
   author  = {H. Rahemi and N. Nigam and J. M. Wakeling},
   title   = {Regionalizing muscle activity causes changes to the magnitude and direction of the force from whole muscles -- A modelling study},
   journal = {Frontiers in Physiology (Integrative Physiology), article 298},
@@ -834,7 +834,7 @@
   volume  = 5
 }
 
-@Article{rapson.hamilton.ea:on,
+@Article{2014:rapson.hamilton.ea:on,
   doi     = {10.1121/1.4883382},
   url     = {https://doi.org/10.1121/1.4883382},
   year    = 2014,
@@ -848,7 +848,7 @@
   journal = {The Journal of the Acoustical Society of America}
 }
 
-@Article{reinhardt.scacchi.ea:microrheology,
+@Article{2014:reinhardt.scacchi.ea:microrheology,
   author  = {J. Reinhardt and A. Scacchi and J. M. Brader},
   title   = {Microrheology close to an equilibrium phase transition},
   journal = {J. Chem. Phys., article 144901},
@@ -856,21 +856,21 @@
   volume  = 140
 }
 
-@Article{reinwald.leonard.ea:evaluation,
+@Article{2014:reinwald.leonard.ea:evaluation,
   author  = {Y. Reinwald and K. Leonard and J. R. Henstock and J. P. Whiteley and J. M. Osborne and S. L. Waters and P. Levesque and A. J. El Haj},
   title   = {Evaluation of the growth environment of a hydrostatic force bioreactor for preconditioning of tissue-engineered constructs},
   journal = {Tissue engineering. Part C, Methods, article 24967717},
   year    = 2014
 }
 
-@Article{richter.wick:on,
+@Article{2014:richter.wick:on,
   author  = {T. Richter and T. Wick},
   title   = {On time discretizations of fluid-structure interactions},
   journal = {In: T. Carraro, M. Geiger, S. K\"{o}rkel, and R. Rannacher (eds), ``Multiple Shooting and Time Domain Decomposition Methods'', Contributions in Mathematical and Computational Science, Springer},
   year    = 2014
 }
 
-@Article{riedlbauer.drexler.ea:modelling,
+@Article{2014:riedlbauer.drexler.ea:modelling,
   author  = {D. Riedlbauer and M. Drexler and D. Drummer and P. Steinmann and J. Mergheim},
   title   = {Modelling, simulation and experimental validation of heat transfer in selective laser melting of the polymeric material PA12},
   journal = {Computational Materials Science},
@@ -879,7 +879,7 @@
   pages   = {239--248}
 }
 
-@Article{riedlbauer.mergheim.ea:simulation,
+@Article{2014:riedlbauer.mergheim.ea:simulation,
   author  = {D. Riedlbauer and J. Mergheim and P. Steinmann},
   title   = {Simulation of the temperature distribution in the selective beam melting process for polymer material},
   journal = {AIP Conf. Proc. 1593, 708},
@@ -887,7 +887,7 @@
   url     = {http://scitation.aip.org/content/aip/proceeding/aipcp/1593?ver=pdfcov&page=2}
 }
 
-@Article{riedlbauer.mergheim.ea:thermomechanical,
+@Article{2014:riedlbauer.mergheim.ea:thermomechanical,
   author  = {D. Riedlbauer and J. Mergheim and P. Steinmann},
   title   = {Thermomechanical Simulation of the Electron Beam Melting Process for TiAl6V4},
   journal = {PAMM: Proc. Appl. Math. Mech., pp. 463 -- 464},
@@ -896,7 +896,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410219/abstract}
 }
 
-@Article{riedlbauer.steinmann.ea:thermomechanical,
+@Article{2014:riedlbauer.steinmann.ea:thermomechanical,
   author  = {D. Riedlbauer and P. Steinmann and J. Mergheim},
   title   = {Thermomechanical finite element simulations of selective electron beam melting processes: performance considerations},
   journal = {Computational Mechanics},
@@ -905,7 +905,7 @@
   pages   = {109--122}
 }
 
-@Article{riehl.steinmann:integrated,
+@Article{2014:riehl.steinmann:integrated,
   author  = {S. Riehl and P. Steinmann},
   title   = {An integrated approach to shape optimization and mesh adaptivity based on material residual forces},
   journal = {Computer Methods in Applied Mechanics and Engineering, pp. 640--663},
@@ -913,7 +913,7 @@
   volume  = 278
 }
 
-@Article{rudraraju.ven.ea:three-dimensional,
+@Article{2014:rudraraju.ven.ea:three-dimensional,
   author  = {S. Rudraraju and A. van der Ven and K. Garikipati},
   title   = {Three-dimensional isogeometric solutions to general boundary value problems of Toupin's gradient elasticity theory at finite strains},
   journal = {Comp. Meth. App. Mech. Engr.},
@@ -922,7 +922,7 @@
   pages   = {705--728}
 }
 
-@Article{sabouni.pouliot.ea:brain,
+@Article{2014:sabouni.pouliot.ea:brain,
   author  = {A. Sabouni and P. Pouliot and A. Shmuel},
   title   = {BRAIN initiative: Fast and parallel solver for real-time monitoring of the eddy current in the brain for TMS applications},
   journal = {Proceedings of the Engineering in Medicine and Biology Society (EMBC), 2014 36th Annual International Conference of the IEEE},
@@ -930,7 +930,7 @@
   pages   = {6250--6253}
 }
 
-@PhDThesis{schmidt:direct,
+@PhDThesis{2014:schmidt:direct,
   author  = {A. Schmidt},
   title   = {Direct Metods for PDE-Constrained Optimization Using Derivative-Extended POD Reduced-Order Models },
   year    = 2014,
@@ -938,7 +938,7 @@
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/17780/}
 }
 
-@Article{schoenawa.hartmann:discontinuous,
+@Article{2014:schoenawa.hartmann:discontinuous,
   author  = {S. Schoenawa and R. Hartmann},
   title   = {Discontinuous Galerkin discretization of the Reynolds-averaged Navier-Stokes equations with the shear-stress transport model},
   journal = {Journal of Computational Physics},
@@ -947,14 +947,14 @@
   pages   = {194--216}
 }
 
-@Article{schotzau.schwab.ea:exponential,
+@Article{2014:schotzau.schwab.ea:exponential,
   author  = {D. Sch\"{o}tzau and C. Schwab and T. Wihler and M. Wirz},
   title   = {Exponential Convergence of hp-DGFEM for Elliptic Problems in Polyhedral Domains},
   journal = {Spectral and High Order Methods for Partial Differential Equations - ICOSAHOM 2012. Lecture Notes in Computational Science and Engineering Vol. 95, pp 57-73 },
   year    = 2014
 }
 
-@Article{sheldon.miller.ea:methodology,
+@Article{2014:sheldon.miller.ea:methodology,
   author  = {J. Sheldon and S. Miller and J. Pitt},
   title   = {Methodology for Comparing Coupling Algorithms for Fluid-Structure Interaction Problems},
   journal = {World Journal of Mathematics},
@@ -963,14 +963,14 @@
   pages   = {54--70}
 }
 
-@PhDThesis{soine:reconstruction,
+@PhDThesis{2014:soine:reconstruction,
   author  = {J. R. D. Soin\'{e}},
   title   = {Reconstruction and Simulation of Cellular Traction Forces},
   year    = 2014,
   school  = {University of Heidelberg}
 }
 
-@Article{stapf.garbe:learning-based,
+@Article{2014:stapf.garbe:learning-based,
   author  = {J. Stapf and C. Garbe},
   title   = {A learning-based approach for highly accurate measurements of turbulent fluid flows},
   journal = {Experiments in Fluids, article 1799},
@@ -978,14 +978,14 @@
   volume  = 55
 }
 
-@Article{stapf.garbe:variational,
+@Article{2014:stapf.garbe:variational,
   author  = {J. Stapf and C. Garbe},
   title   = {A variational optical flow approach using learned motion models for the determination of fluid flows},
   journal = {Proceedings, 17th International Symposium on Applications of Laser Techniques to Fluid Mechanics, Lisbon, Portugual},
   year    = 2014
 }
 
-@Article{stoll:one-shot,
+@Article{2014:stoll:one-shot,
   author  = {M. Stoll},
   title   = {One-shot solution of a time-dependent time-periodic PDE-constrained optimization problem},
   journal = {IMA Journal of Numerical Analysis, Volume 34, Issue 4},
@@ -994,21 +994,21 @@
   url     = {http://imajna.oxfordjournals.org/content/34/4/1554}
 }
 
-@Article{tirupathi.hesthaven.ea:multilevel,
+@Article{2014:tirupathi.hesthaven.ea:multilevel,
   author  = {S. Tirupathi and J. S. Hesthaven and Y. Liang and M. Parmentier},
   title   = {Multilevel and Local Timestepping Discontinuous Galerkin Methods for Magma Dynamics},
   journal = {Infoscience, article 197347},
   year    = 2014
 }
 
-@Article{vavalis.sarailidis:implementing,
+@Article{2014:vavalis.sarailidis:implementing,
   author  = {M. Vavalis and G. Sarailidis},
   title   = {Implementing hybrid PDE solvers},
   journal = {Preprint},
   year    = 2014
 }
 
-@Article{vidal-ferrandiz.fayez.ea:solution,
+@Article{2014:vidal-ferrandiz.fayez.ea:solution,
   author  = {A. Vidal-Ferrandiz and R. Fayez and D. Ginestar and G. Verd\'{u}},
   title   = {Solution of the Lambda modes problem of a nuclear power reactor using an h--p finite element method},
   journal = {Annals of Nuclear Energy, pp. 338--349},
@@ -1017,7 +1017,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0306454914002473}
 }
 
-@Article{vogel.pelteret.ea:magnetic,
+@Article{2014:vogel.pelteret.ea:magnetic,
   author  = {F. Vogel and J.-P. Pelteret and S. Kaessmair and P. Steinmann},
   title   = {Magnetic force and torque on particles subject to a magnetic field},
   journal = {European Journal of Mechanics A/Solids},
@@ -1029,7 +1029,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{vuong.simeon:on,
+@Article{2014:vuong.simeon:on,
   author  = {J. Vuong and B. Simeon},
   title   = {On finite element method--flux corrected transport stabilization for advection--diffusion problems in a partial differential--algebraic framework},
   journal = {Journal of Computational and Applied Mathematics},
@@ -1038,7 +1038,7 @@
   pages   = {115--126}
 }
 
-@InProceedings{walter.saxena.ea:on,
+@InProceedings{2014:walter.saxena.ea:on,
   author  = {B. Walter and P. Saxena and J.-P. V. Pelteret and J. Kaschta and D. Schubert and P. Steinmann},
   title   = {On The Preparation, Characterisation, Modelling And Simulation Of Magneto-Sensitive Elastomers},
   booktitle = {Proceedings of the Second Seminar on the Mechanics of Multifunctional Materials},
@@ -1049,28 +1049,28 @@
   address = {Bad Honnef, Germany}
 }
 
-@PhDThesis{wang:parallel,
+@PhDThesis{2014:wang:parallel,
   author  = {K. Wang},
   title   = {Parallel Markov Chain Monte Carlo Methods for Large Scale Inverse Problems},
   year    = 2014,
   school  = {Texas A\&M University}
 }
 
-@PhDThesis{wang:regularizing,
+@PhDThesis{2014:wang:regularizing,
   author  = {F. Wang},
   title   = {Regularizing Inverse Problems},
   year    = 2014,
   school  = {Texas A\&M University}
 }
 
-@PhDThesis{weiler:optimum,
+@PhDThesis{2014:weiler:optimum,
   author  = {C. Weiler},
   title   = {Optimum Experimental Design for the Identification of Gaussian Disorder Mobility Parameters in Charge Transport Models of Organic Semiconductors},
   year    = 2014,
   school  = {University of Heidelberg, Germany}
 }
 
-@Article{weinbub.rupp.ea:highly,
+@Article{2014:weinbub.rupp.ea:highly,
   author  = {J. Weinbub and K. Rupp and S. Selberherr},
   title   = {Highly flexible and reusable finite element simulations with ViennaX},
   journal = {Journal of Computational and Applied Mathematics},
@@ -1079,7 +1079,7 @@
   pages   = {484--495}
 }
 
-@Article{weinbub.rupp.ea:viennax,
+@Article{2014:weinbub.rupp.ea:viennax,
   author  = {J. Weinbub and K. Rupp and S. Selberherr},
   title   = {ViennaX: a parallel plugin execution framework for scientific computing},
   journal = {Engineering with Computers, Vol 30 (4), pp 651-668},
@@ -1087,7 +1087,7 @@
   url     = {http://link.springer.com/article/10.1007/s00366-013-0314-1}
 }
 
-@Article{wheeler.wick.ea:augmented-lagrangian,
+@Article{2014:wheeler.wick.ea:augmented-lagrangian,
   author  = {M. F. Wheeler and T. Wick and W. Wollner},
   title   = {An Augmented-Lagrangian Method for the Phase-Field Approach for Pressurized Fractures},
   journal = {Comput. Methods Appl. Mech. Engrg.},
@@ -1096,28 +1096,28 @@
   pages   = {69--85}
 }
 
-@Article{wick.singh.ea:pressurized-fracture,
+@Article{2014:wick.singh.ea:pressurized-fracture,
   author  = {T. Wick and G. Singh and M. F. Wheeler},
   title   = {Pressurized-Fracture propagation using a phase-field approach coupled to a reservoir simulator},
   journal = {SPE 168597-MS, SPE HFTC Proc.},
   year    = 2014
 }
 
-@Article{wick.wollner:on,
+@Article{2014:wick.wollner:on,
   author  = {T. Wick and W. Wollner},
   title   = {On the differentiability of fluid-structure interaction problems with respect to the problem data},
   journal = {RICAM report 2014-16},
   year    = 2014
 }
 
-@Article{wick:modeling,
+@Article{2014:wick:modeling,
   author  = {T. Wick},
   title   = {Modeling, Discretization, Optimization, and Simulation of Fluid-Structure Interaction},
   journal = {Lecture notes (177 pages), IWR Heidelberg},
   year    = 2014
 }
 
-@Article{willems:robust,
+@Article{2014:willems:robust,
   author  = {J. Willems},
   title   = {Robust Multilevel Methods for General Symmetric Positive Definite Operators},
   journal = {SIAM J. Numer. Anal., no. 1, 103-124},
@@ -1125,7 +1125,7 @@
   volume  = 52
 }
 
-@Article{wilmers.lenhof:comparison,
+@Article{2014:wilmers.lenhof:comparison,
   author  = {J. Wilmers and B. Lenhof},
   title   = {Comparison of Different FE-approaches for Modelling of Short Fibre Composites},
   journal = {Technische Mechanik},
@@ -1134,7 +1134,7 @@
   pages   = {90--103}
 }
 
-@Article{worthen.stadler.ea:towards,
+@Article{2014:worthen.stadler.ea:towards,
   author  = {J. Worthen and G. Stadler and N. Petra and M. Gurnis and O. Ghattas},
   title   = {Towards adjoint-based inversion for rheological parameters in nonlinear viscous mantle flow},
   journal = {Physics of the Earth and Planetary Interiors},
@@ -1143,7 +1143,7 @@
   pages   = {23--34}
 }
 
-@Article{yoon.chung.ea:particle,
+@Article{2014:yoon.chung.ea:particle,
   author  = {S. Yoon and J. T. Chung and Y. T. Kang},
   title   = {The particle hydrodynamic effect on the mass transfer in a buoyant CO$_{2}$-bubble through the experimental and computational studies},
   journal = {International Journal of Heat and Mass Transfer},
@@ -1152,7 +1152,7 @@
   pages   = {399--409}
 }
 
-@Article{zarestky.bangerth:teaching,
+@Article{2014:zarestky.bangerth:teaching,
   author  = {J. Zarestky and W. Bangerth},
   title   = {Teaching HPC: Lessons from a flipped classroom, project-based course on finite element methods},
   journal = {EduHPC '14, Proceedings of the Workshop on Education for High-Performance Computing},
@@ -1161,7 +1161,7 @@
   url     = {http://dl.acm.org/citation.cfm?id=2690860&dl=ACM&coll=DL&CFID=594739437&CFTOKEN=14279369}
 }
 
-@PhDThesis{zhang:spn,
+@PhDThesis{2014:zhang:spn,
   author  = {Y. Zhang},
   title   = {SP$_{\textnormal{N}}$ Model Error and Iterative Solution Techniques},
   year    = 2014,

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -567,6 +567,17 @@
   pages   = {2255--2278}
 }
 
+@InProceedings{2015:hai.bause:adaptive,
+  doi     = {10.1115/imece2015-53265},
+  url     = {https://doi.org/10.1115/imece2015-53265},
+  year    = 2015,
+  month   = nov,
+  publisher = {American Society of Mechanical Engineers},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Adaptive Multigrid Methods for Extended Fluid-Structure Interaction ({eXFSI}) Problem: Part I --- Mathematical Modelling},
+  booktitle = {Volume 7B: Fluids Engineering Systems and Technologies}
+}
+
 @Article{2015:harting.marciniak-czochra.ea:stable,
   author  = {S. H\"{a}rting and A. Marciniak-Czochra and I. Takagi},
   title   = {Stable patterns with jump discontinuity in systems with Turing instability and hysteresis},
@@ -1317,17 +1328,6 @@
   number  = 1,
   pages   = {692--695},
   url     = {https://www.researchgate.net/publication/285973862_Non-oscillatory_Reweighted_Least_Square_Finite_Element_for_Solving_Pn_Transport}
-}
-
-@InProceedings{2016:hai.bause:adaptive,
-  doi     = {10.1115/imece2015-53265},
-  url     = {https://doi.org/10.1115/imece2015-53265},
-  year    = 2016,
-  month   = mar,
-  publisher = {American Society of Mechanical Engineers},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Adaptive Multigrid Methods for Extended Fluid-Structure Interaction ({eXFSI}) Problem: Part I --- Mathematical Modelling},
-  booktitle = {Volume 7B: Fluids Engineering Systems and Technologies}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -1,13 +1,13 @@
 % Encoding: US-ASCII
 
-@Article{adler.atherton.ea:energy,
+@Article{2015:adler.atherton.ea:energy,
   author  = {J. H. Adler and T. J. Atherton and T. R. Benson and D. B. Emerson and S. P. MacLachlan},
   title   = {Energy minimization for liquid crystal equilibrium with electric and flexoelectric effects},
   journal = {SIAM Journal on Scientific Computing, 37(5), pp. S157-S176},
   year    = 2015
 }
 
-@Article{adler.atherton.ea:energy-minimization,
+@Article{2015:adler.atherton.ea:energy-minimization,
   author  = {J. H. Adler and T. J. Atherton and D. B. Emerson and S. P. MacLachlan},
   title   = {An energy-minimization finite-element approach for the Frank-Oseen Model of nematic liquid crystals},
   journal = {SIAM J. Numer. Anal., Vol. 53},
@@ -16,7 +16,7 @@
   url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf}
 }
 
-@PhDThesis{alrashed:parallel,
+@PhDThesis{2015:alrashed:parallel,
   author  = {F. S. Alrashed},
   title   = {Parallel multiphase Navier-Stokes solver},
   year    = 2015,
@@ -24,7 +24,7 @@
   url     = {http://webhosting.math.tufts.edu/dbemerson/LiquidCrystalMinimization.pdf}
 }
 
-@Article{alvarez.flores:existence,
+@Article{2015:alvarez.flores:existence,
   author  = {F. Alvarez and S. Flores},
   title   = {Existence And Approximation Results For Variational Problems Under Uniform Constraints On The Gradient By Power Penalty},
   journal = {SIAM J. Math. Anal.},
@@ -35,14 +35,14 @@
   doi     = {10.1137/140988619}
 }
 
-@Article{alvarez.flores:solving,
+@Article{2015:alvarez.flores:solving,
   author  = {F. Alvarez and S. Flores},
   title   = {Solving variational problems with uniform gradient bounds by p-Laplacian approximation},
   journal = {CMM Technical Report No, 2015001, Departemento de Ingenieria, Universidad de Chile},
   year    = 2015
 }
 
-@Article{antil.nochetto.ea:optimal,
+@Article{2015:antil.nochetto.ea:optimal,
   author  = {H. Antil and R. H. Nochetto and P. Sodr\'{e}},
   title   = {Optimal control of a free boundary problem with surface tension effects: A priori error analysis},
   journal = {SIAM Journal on Numerical Analysis, 53(5)},
@@ -50,7 +50,7 @@
   pages   = {2279--2306}
 }
 
-@Article{arndt.dallmann.ea:local,
+@Article{2015:arndt.dallmann.ea:local,
   author  = {D. Arndt and H. Dallmann and G. Lube},
   title   = {Local projection FEM stabilization for the time-dependent incompressible Navier-Stokes problems},
   journal = {Numerical Methods for Partial Differential Equations, Vol. 31, Issue 4},
@@ -59,7 +59,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/num.21944/full}
 }
 
-@Article{austermann.pollard.ea:impact,
+@Article{2015:austermann.pollard.ea:impact,
   author  = {J. Austermann and D. Pollard and J.X. Mitrovica and R. Moucha and A. M. Forte and R. M. DeConto and D. B. Rowley and M. E. Raymo},
   title   = {The impact of dynamic topography change on Antarctic Ice Sheet stability in the Pliocene},
   journal = {Geology},
@@ -69,7 +69,7 @@
   doi     = {10.1130/G36988.1}
 }
 
-@Article{baltzell.parmentier.ea:high-order,
+@Article{2015:baltzell.parmentier.ea:high-order,
   author  = {C. Baltzell and E. M. Parmentier and Y. Liang and S. Tirupathi},
   title   = {A high-order numerical study of reactive dissolution in an upwelling heterogeneous mantle: 2. Effect of shear deformation},
   journal = {Geochemistry, Geophysics, Geosystems, Vol. 16(11)},
@@ -78,7 +78,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2015GC006038/full}
 }
 
-@Article{bangerth.heister.ea:deal-ii,
+@Article{2015:bangerth.heister.ea:deal-ii,
   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and T. D. Young},
   title   = {The \texttt{deal.II} Library, Version 8.2},
   journal = {Archive of Numerical Software},
@@ -87,7 +87,7 @@
   doi     = {10.11588/ans.2015.100.18031}
 }
 
-@Article{bangerth:finite,
+@Article{2015:bangerth:finite,
   author  = {W. Bangerth},
   title   = {Finite Element Methods at Realistic Complexities},
   journal = {Pan American Congress on Computational Mechanics--PANACM },
@@ -95,7 +95,7 @@
   url     = {http://congress.cimne.com/PANACM2015/admin/files/fileabstract/a429.pdf}
 }
 
-@Article{bangerth:simulating,
+@Article{2015:bangerth:simulating,
   author  = {W. Bangerth},
   title   = {Simulating Complex Flows in the Earth Mantle},
   journal = {The 18th International Conference on Finite Elements in Flow Problems, Taiwan},
@@ -103,7 +103,7 @@
   url     = {http://www.fef2015.tw/Files/E%20Abstracts/J-007.pdf}
 }
 
-@MastersThesis{bardelloni:high,
+@MastersThesis{2015:bardelloni:high,
   author  = {M. Bardelloni},
   title   = {High performance programming paradigms applied to computational fluid dynamic simulations},
   year    = 2015,
@@ -111,7 +111,7 @@
   url     = {http://urania.sissa.it/xmlui/handle/1963/35161}
 }
 
-@Article{bartels.bonito.ea:bilayer,
+@Article{2015:bartels.bonito.ea:bilayer,
   doi     = {10.1002/cpa.21626},
   url     = {https://doi.org/10.1002/cpa.21626},
   year    = 2015,
@@ -125,7 +125,7 @@
   journal = {Communications on Pure and Applied Mathematics}
 }
 
-@Article{bartels.nochetto.ea:total,
+@Article{2015:bartels.nochetto.ea:total,
   author  = {S. Bartels and R. H. Nochetto and A. J. Salgado},
   title   = {A total variation diminishing interpolation operator and applications},
   journal = {Math. Comp., Vol 84, 2569-2587},
@@ -133,7 +133,7 @@
   url     = {http://www.ams.org/journals/mcom/2015-84-296/S0025-5718-2015-02942-1/home.html}
 }
 
-@Article{bause.kocher:variational,
+@Article{2015:bause.kocher:variational,
   author  = {M. Bause and U. K\"{o}cher},
   title   = {Variational time discretization for mixed finite element approximations of nonstationary diffusion problems},
   journal = {J. Comput. Appl. Math., pp. 208--224},
@@ -142,7 +142,7 @@
   url     = {https://dx.doi.org/10.1016/j.cam.2015.02.015}
 }
 
-@MastersThesis{bercovici:experimental,
+@MastersThesis{2015:bercovici:experimental,
   author  = {B. Bercovici},
   title   = {Experimental and numerical validation of ion extractor grids},
   year    = 2015,
@@ -150,7 +150,7 @@
   url     = {http://hdl.handle.net/2142/72822}
 }
 
-@Article{biermann.blum.ea:simulation,
+@Article{2015:biermann.blum.ea:simulation,
   author  = {D. Biermann and H. Blum and J. Frohne and I. Iovkov and A. Rademacher and K. Rosin},
   title   = {Simulation of MQL Deep Hole Drilling for Predicting Thermally Induced Workpiece Deformations},
   journal = {Procedia CIRP},
@@ -159,7 +159,7 @@
   pages   = {148--153}
 }
 
-@Article{binder.schopfer.ea:defect,
+@Article{2015:binder.schopfer.ea:defect,
   author  = {F. Binder and F. Sch\"{o}pfer and T. Schuster},
   title   = {Defect localization in fibre-reinforced composites by computing external volume forces from surface sensor measurements},
   journal = {Inverse Problems },
@@ -168,7 +168,7 @@
   url     = {http://iopscience.iop.org/0266-5611/31/2/025006/pdf/0266-5611_31_2_025006.pdf}
 }
 
-@Article{bonito.devaud:adaptive,
+@Article{2015:bonito.devaud:adaptive,
   author  = {A. Bonito and D. Devaud},
   title   = {Adaptive Finite Element Methods for the Stokes Problems with Discontinuous Viscosity},
   journal = {Math. Comp.},
@@ -178,7 +178,7 @@
   url     = {http://www.ams.org/journals/mcom/2015-84-295/S0025-5718-2015-02935-4/home.html}
 }
 
-@Article{bonito.guermond.ea:modified,
+@Article{2015:bonito.guermond.ea:modified,
   author  = {A. Bonito and J.-L. Guermond and S. Lee},
   title   = {Modified Pressure-Correction Projection Methods: Open Boundary and Variable Time Stepping, Numerical Mathematics and Advanced Applications},
   journal = {Proceedings of the ENUMATH 2013 Conference, Lecture Notes in Computational Science and Engineering},
@@ -187,7 +187,7 @@
   pages   = {623--631}
 }
 
-@Article{bonito.pasciak:numerical,
+@Article{2015:bonito.pasciak:numerical,
   author  = {A. Bonito and J. E. Pasciak},
   title   = {Numerical Approximation of Fractional Powers of Elliptic Operators},
   journal = {Math. Comp., Vol. 84},
@@ -196,7 +196,7 @@
   url     = {http://www.ams.org/journals/mcom/2015-84-295/S0025-5718-2015-02937-8/home.html}
 }
 
-@Article{bosch.stoll:preconditioning,
+@Article{2015:bosch.stoll:preconditioning,
   author  = {J. Bosch and M. Stoll},
   title   = {Preconditioning for vector-valued Cahn-Hilliard equations},
   journal = {SIAM J. Sci. COMPUT., Vol. 37, No. 5. pp. S216-S243},
@@ -204,7 +204,7 @@
   url     = {http://pubman.mpdl.mpg.de/pubman/item/escidoc:2125565/component/escidoc:2225345/2125565_bosch.pdf}
 }
 
-@Article{burg.nazarov:goal-oriented,
+@Article{2015:burg.nazarov:goal-oriented,
   author  = {M. B\"{u}rg and M. Nazarov},
   title   = {Goal-Oriented adaptive finite element methods for elliptic problems revisited},
   journal = {Journal of Computational and Applied Mathematics},
@@ -214,7 +214,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042715001843}
 }
 
-@Article{burg.schroder:posteriori,
+@Article{2015:burg.schroder:posteriori,
   author  = {M. B\"{u}rg and A. Schr\"{o}der},
   title   = {A posteriori error control of hp-finite elements for variational inequalities of the first and second kind},
   journal = {Computers \& Maathematics with Applications, Vol. 70(12)},
@@ -223,7 +223,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0898122115004101}
 }
 
-@Article{carraro.goll.ea:effective,
+@Article{2015:carraro.goll.ea:effective,
   author  = {T. Carraro and C. Goll and A. Marciniak-Czochra and A. Mikeli\'{c}},
   title   = {Effective interface conditions for the forced infiltration of a viscous fluid into a porous medium using homogenization},
   journal = {Comput. Methods Appl. Mech. Engrg., Volume 292},
@@ -232,7 +232,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782514004204}
 }
 
-@Article{carraro.wetterauer:on,
+@Article{2015:carraro.wetterauer:on,
   author  = {T. Carraro and S. Wetterauer},
   title   = {On the implementation of the eXtended Finite Element Method (XFEM) for interface problems},
   journal = {arXiv:1507.04238},
@@ -240,7 +240,7 @@
   url     = {http://arxiv.org.ezproxy.library.tamu.edu/pdf/1507.04238v1.pdf}
 }
 
-@Article{cavallini.weeger.ea:effective,
+@Article{2015:cavallini.weeger.ea:effective,
   author  = {N. Cavallini and O. Weeger and M.S. Pauletti and M. Martinelli and P. Antonio},
   title   = {Effective Integration of Sophisticated Operators in Isogeometric Analysis with igatools},
   journal = {Isogeometric Analysis and Applications, Vol. 107},
@@ -249,7 +249,7 @@
   url     = {http://link.springer.com/chapter/10.1007/978-3-319-23315-4_9}
 }
 
-@Article{chadwick.bindel:efficient,
+@Article{2015:chadwick.bindel:efficient,
   author  = {J. N. Chadwick and D. S. Bindel},
   title   = {An Efficient Solver for Sparse Linear Systems Based on Rank-Structured Cholesky Factorization},
   journal = {arXiv:1507.05593},
@@ -257,7 +257,7 @@
   url     = {http://arxiv.org/abs/1507.05593}
 }
 
-@Article{chandrashekar.zenk:well-balanced,
+@Article{2015:chandrashekar.zenk:well-balanced,
   author  = {P. Chandrashekar and M. Zenk},
   title   = {Well-balanced nodal discontinuous Galerkin method for Euler equations with gravity},
   journal = {arXiv:1511.08739},
@@ -265,7 +265,7 @@
   url     = {http://arxiv.org/abs/1511.08739}
 }
 
-@Article{choo.borja:stabilized,
+@Article{2015:choo.borja:stabilized,
   author  = {J. Choo and R. I. Borja},
   title   = {Stabilized mixed finite elements for deformable porous media with double porosity},
   journal = {Computer Methods in Applied Mechanics and Engineering, Vol. 293},
@@ -274,7 +274,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782515001334}
 }
 
-@Article{crestel.russell.ea:moving,
+@Article{2015:crestel.russell.ea:moving,
   author  = {B. Crestel and R. D. Russell and S. J. Ruuth},
   title   = {Moving mesh methods on parametric surfaces},
   journal = {Procedia Engineering, Vol. 124},
@@ -283,7 +283,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S1877705815032300}
 }
 
-@Article{dahlem.schmidt.ea:cortical,
+@Article{2015:dahlem.schmidt.ea:cortical,
   author  = {M. A. Dahlem and B. Schmidt and I. Bojak and S. Boie and F. Kneer and N. Hadjikhani and J. Kurths},
   title   = {Cortical hot spots and labyrinths: Why cortical neuromodulation for episodic migraine with aura should be personalized},
   journal = {Front Comput Neurosci.},
@@ -291,7 +291,7 @@
   url     = {http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4350394/}
 }
 
-@Article{dahmen.muller.ea:numerical,
+@Article{2015:dahmen.muller.ea:numerical,
   author  = {W. Dahmen and S. M\"{u}ller and M. Rom and S. Schweikert and M. Selzer and J. von Wolfersdorf},
   title   = {Numerical boundary layer investigations of transpiration-cooled turbulent channel flow},
   journal = {International Journal of Heat and Mass Transfer, pp. 90--100},
@@ -300,7 +300,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0017931015002483}
 }
 
-@Article{dahmen.roland.ea:automated,
+@Article{2015:dahmen.roland.ea:automated,
   author  = {T. Dahmen and M. Roland and T. Tjardes and B. Bouillon and P. Slusallek and S. Diebels},
   title   = {An automated workflow for the biomechanical simulation of a tibia with implant using computed tomography and the finite element method},
   journal = {Computers \& Mathematics with Applications, Vol. 70, Issue 5},
@@ -309,14 +309,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0898122115002953}
 }
 
-@PhDThesis{dallmann:finite,
+@PhDThesis{2015:dallmann:finite,
   author  = {H. Dallmann},
   title   = {Finite element methods with local projection stabilization for thermally coupled incompressible flow},
   year    = 2015,
   school  = {University of G\"{o}ttingen, Germany}
 }
 
-@PhDThesis{dannberg:dynamics,
+@PhDThesis{2015:dannberg:dynamics,
   author  = {J. Dannberg},
   title   = {Dynamics of mantle plumes: Linking scales and coupling physics},
   year    = 2015,
@@ -324,7 +324,7 @@
   url     = {https://publishup.uni-potsdam.de/opus4-ubp/frontdoor/index/index/docId/9102}
 }
 
-@MastersThesis{davidsson:orbital-free,
+@MastersThesis{2015:davidsson:orbital-free,
   author  = {J. Davidsson},
   title   = {Orbital-free Density-Functional Theory in a Finite Element Basis},
   year    = 2015,
@@ -332,7 +332,7 @@
   url     = {http://www.diva-portal.org/smash/get/diva2:864857/FULLTEXT01.pdf}
 }
 
-@Article{deolmi.dahmen.ea:effective,
+@Article{2015:deolmi.dahmen.ea:effective,
   author  = {G. Deolmi and W. Dahmen and S. M\"{u}ller},
   title   = {Effective boundary conditions for compressible flows over rough boundaries},
   journal = {Math. Models Methods Appl. Sci. 25, 1257},
@@ -340,7 +340,7 @@
   url     = {http://www.worldscientific.com/doi/abs/10.1142/S0218202515500323}
 }
 
-@Article{dorfler.findeisen:numerical,
+@Article{2015:dorfler.findeisen:numerical,
   author  = {W. D\"{o}rfler and S. Findeisen},
   title   = {Numerical optimization of a waveguide transition using finite element beam propagation},
   journal = {International Journal of Numerical Modelling: Electronic Networks, Devices and Fields, Vol. 28, Issue 2},
@@ -349,7 +349,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/jnm.1997/abstract?userIsAuthenticated=false&deniedAccessCustomisedMessage=}
 }
 
-@Article{dorostkar.neytcheva.ea:numerical,
+@Article{2015:dorostkar.neytcheva.ea:numerical,
   author  = {A. Dorostkar and M. Neytcheva and B. Lund},
   title   = {Numerical and computational aspects of some block-preconditioners for saddle point systems},
   journal = {Parallel Computing, Vol. 49},
@@ -358,7 +358,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0167819115000897}
 }
 
-@Article{drzycimski.arnold:smoke,
+@Article{2015:drzycimski.arnold:smoke,
   author  = {K. Drzycimski and L. Arnold},
   title   = {Smoke and fire simulations with adaptive FEM},
   journal = {Proceedings of the 27th International Conference on Parallel Computational Fluid Dynamics (Parallel CFD2015)},
@@ -366,7 +366,7 @@
   url     = {https://www.researchgate.net/publication/282611203_Smoke_and_Fire_Simulations_with_Adaptive_FEM}
 }
 
-@Article{el-kurdi.gross.ea:parallel,
+@Article{2015:el-kurdi.gross.ea:parallel,
   author  = {Y. El-Kurdi and W. J. Gross and M. M. Dehnavi and D. Giannacopoulos},
   title   = {Parallel finite element technique using Gaussian belief propagation},
   journal = {Computer Physics Communications, April },
@@ -374,7 +374,7 @@
   volume  = 193
 }
 
-@PhDThesis{emerson:advanced,
+@PhDThesis{2015:emerson:advanced,
   author  = {D. B. Emerson},
   title   = {Advanced discretizations and multigrid methods for liquid crystal configurations},
   year    = 2015,
@@ -382,7 +382,7 @@
   url     = {http://webhosting.math.tufts.edu/dbemerson/PHD_thesis.pdf}
 }
 
-@Article{evgrafov:on,
+@Article{2015:evgrafov:on,
   author  = {A. Evgrafov},
   title   = {On Chebyshev's method for topology optimization of Stokes flows},
   journal = {Structural and Multidisciplinary Optimization, Vol. 51(4)},
@@ -391,7 +391,7 @@
   url     = {http://link.springer.com/article/10.1007/s00158-014-1176-x}
 }
 
-@Article{fan.monk:time,
+@Article{2015:fan.monk:time,
   author  = {L. Fan and P. Monk},
   title   = {Time dependent scattering from a grating},
   journal = {Journal of Comput. Phys., Vol. 302, pp 97-113},
@@ -399,7 +399,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999115005677}
 }
 
-@MastersThesis{farouq:performance,
+@MastersThesis{2015:farouq:performance,
   author  = {S. Farouq},
   title   = {Performance comparisons of preconditioned iterative methods for problems arising in PDE-constrained optimization},
   year    = 2015,
@@ -407,14 +407,14 @@
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A815563&dswid=5325}
 }
 
-@MastersThesis{fehn:discontinuous,
+@MastersThesis{2015:fehn:discontinuous,
   author  = {N. Fehn},
   title   = {A Discontinuous Galerkin Approach for the Unsteady Incompressible Navier--Stokes Equations},
   year    = 2015,
   school  = {Technische Universit\"{a}t M\"{u}nchen}
 }
 
-@Article{ferguson.muddamallappa.ea:numerical,
+@Article{2015:ferguson.muddamallappa.ea:numerical,
   author  = {L. A. Ferguson and M. Muddamallappa and J. R. Walton},
   title   = {Numerical simulation of mode-III fracture incorporating interfacial mechanics},
   journal = {International Journal of Fracture, issue 1},
@@ -424,7 +424,7 @@
   url     = {http://link.springer.com/article/10.1007/s10704-014-9984-y}
 }
 
-@Article{fischer:posteriori,
+@Article{2015:fischer:posteriori,
   author  = {J. Fischer},
   title   = {A Posteriori Modeling Error Estimates for the Assumption of Perfect Incompressibility in the Navier--Stokes Equation.},
   journal = {SIAM Journal on Numerical Analysis, 53(5)},
@@ -432,7 +432,7 @@
   pages   = {2178--2205}
 }
 
-@Article{friedmann:pdeode,
+@Article{2015:friedmann:pdeode,
   author  = {E. Friedmann},
   title   = {PDE/ODE modeling and simulation to determine the role of diffusion in long-term and -range cellular signaling},
   journal = {BMC Biophysics, 8:10},
@@ -440,7 +440,7 @@
   doi     = {10.1186/s13628-015-0024-8}
 }
 
-@Article{frisani.hassan:on,
+@Article{2015:frisani.hassan:on,
   author  = {A. Frisani and Y. A. Hassan},
   title   = {On the Immersed Boundary Method: Finite Element Versus Finite Volume Approach},
   journal = {Computers \& Fluids},
@@ -450,7 +450,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045793015002765}
 }
 
-@PhDThesis{fu:magnetic,
+@PhDThesis{2015:fu:magnetic,
   author  = {R. R. Fu},
   title   = {Magnetic fields in the early solar system},
   year    = 2015,
@@ -458,7 +458,7 @@
   url     = {http://hdl.handle.net/1721.1/101348}
 }
 
-@MastersThesis{furst:parallel,
+@MastersThesis{2015:furst:parallel,
   author  = {E. Furst},
   title   = {Parallel Preconditioners for Finite Element Computations},
   year    = 2015,
@@ -467,14 +467,14 @@
   url     = {http://digitalcommons.csbsju.edu/cgi/viewcontent.cgi?article=1065&context=honors_theses}
 }
 
-@PhDThesis{gerecht:adaptive,
+@PhDThesis{2015:gerecht:adaptive,
   author  = {D. Gerecht},
   title   = {Adaptive Finite Element Simulation of Coupled PDE/ODE Systems Modeling Intercellular Signaling},
   year    = 2015,
   school  = {University of Heidelberg, Germany}
 }
 
-@Article{giavaras.boateng:transient,
+@Article{2015:giavaras.boateng:transient,
   author  = {A. Giavaras and E. Boateng},
   title   = {Transient filling modelling at meso-level for RTM process using a single phase LSM},
   journal = {International Journal of Material Forming, Vol. 8(2)},
@@ -483,7 +483,7 @@
   url     = {http://link.springer.com/article/10.1007/s12289-013-1160-9}
 }
 
-@Article{giuliani.mola.ea:fem,
+@Article{2015:giuliani.mola.ea:fem,
   author  = {N. Giuliani and A. Mola and L. Heltai and L. Fomaggia},
   title   = {FEM SUPG stabilisation of mixed isoparametric BEMs: application to linearised free surface flows},
   journal = {Engineering Analysis with Boundary Elements, Vol. 59},
@@ -492,7 +492,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0955799715001058}
 }
 
-@Article{goldschmidt.diebels:modeling,
+@Article{2015:goldschmidt.diebels:modeling,
   author  = {F. Goldschmidt and S. Diebels},
   title   = {Modeling the moisture and temperature dependent material behavior of adhesive bonds },
   journal = {Proc. Appl. Math. Mech. Vol. 15, issue 1, pp: 295-296},
@@ -500,7 +500,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201410157/abstract}
 }
 
-@Article{goldschmidt.diebels:modelling,
+@Article{2015:goldschmidt.diebels:modelling,
   author  = {F. Goldschmidt and S. Diebels},
   title   = {Modelling and numerical investigations of the mechanical behavior of polyurethane under the influence of moisture},
   journal = {Archive of Applied Mechanics, Vol. 85, Issue 8},
@@ -509,7 +509,7 @@
   url     = {http://link.springer.com/article/10.1007/s00419-014-0943-x}
 }
 
-@Article{goldschmidt:modeling,
+@Article{2015:goldschmidt:modeling,
   author  = {F. Goldschmidt},
   title   = {Modeling and simulation of adhesive bounded joints with a gradient in the mechanical properties},
   journal = {PhD dissertation, University of des Saarlandes},
@@ -517,7 +517,7 @@
   url     = {http://scidok.sulb.uni-saarland.de/volltexte/2015/6197/}
 }
 
-@Article{goll.rannacher.ea:damped,
+@Article{2015:goll.rannacher.ea:damped,
   doi     = {10.21314/jcf.2015.301},
   url     = {https://doi.org/10.21314/jcf.2015.301},
   year    = 2015,
@@ -531,14 +531,14 @@
   journal = {The Journal of Computational Finance}
 }
 
-@PhDThesis{gong:formation,
+@PhDThesis{2015:gong:formation,
   author  = {J. Gong},
   title   = {Formation of Physical Sedimentary Structure in the Presence of Microbial Communities},
   year    = 2015,
   school  = {Texas A\&M University}
 }
 
-@Article{grayver.kolev:large-scale,
+@Article{2015:grayver.kolev:large-scale,
   author  = {A. V. Grayver and T. V. Kolev},
   title   = {Large-scale 3D geoelectromagnetic modeling using parallel adaptive high-order finite element method},
   journal = {Geophysics, No. 6},
@@ -548,7 +548,7 @@
   url     = {http://library.seg.org/doi/abs/10.1190/geo2015-0013.1}
 }
 
-@Article{grayver:parallel,
+@Article{2015:grayver:parallel,
   author  = {A. V. Grayver},
   title   = {Parallel 3D magnetotelluric inversion using adaptive finite-element method. Part I: theory and synthetic study},
   journal = {Geophysical Journal International},
@@ -558,7 +558,7 @@
   doi     = {10.1093/gji/ggv165}
 }
 
-@Article{grieshaber.mcbride.ea:uniformly,
+@Article{2015:grieshaber.mcbride.ea:uniformly,
   author  = {B. J. Grieshaber and A. T. McBride and B. D. Reddy and B D},
   title   = {Uniformly convergent interior penalty methods using multilinear approximations for problems in elasticity},
   journal = {SIAM Journal on Numerical Analysis},
@@ -567,18 +567,7 @@
   pages   = {2255--2278}
 }
 
-@InProceedings{hai.bause:adaptive,
-  doi     = {10.1115/imece2015-53265},
-  url     = {https://doi.org/10.1115/imece2015-53265},
-  year    = 2016,
-  month   = mar,
-  publisher = {American Society of Mechanical Engineers},
-  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
-  title   = {Adaptive Multigrid Methods for Extended Fluid-Structure Interaction ({eXFSI}) Problem: Part I --- Mathematical Modelling},
-  booktitle = {Volume 7B: Fluids Engineering Systems and Technologies}
-}
-
-@Article{harting.marciniak-czochra.ea:stable,
+@Article{2015:harting.marciniak-czochra.ea:stable,
   author  = {S. H\"{a}rting and A. Marciniak-Czochra and I. Takagi},
   title   = {Stable patterns with jump discontinuity in systems with Turing instability and hysteresis},
   journal = {arXiv:1506.00881},
@@ -586,7 +575,7 @@
   url     = {http://arxiv.org/abs/1506.00881}
 }
 
-@Article{hartmann.leicht:generalized,
+@Article{2015:hartmann.leicht:generalized,
   author  = {R. Hartmann and T. Leicht},
   title   = {Generalized adjoint consistent treatment of wall boundary conditions for compressible flows},
   journal = {Journal of Computational Physics},
@@ -596,7 +585,7 @@
   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/}
 }
 
-@Article{hartmann.leicht:high-order,
+@Article{2015:hartmann.leicht:high-order,
   author  = {R. Hartmann and T. Leicht},
   title   = {High-order unstructured grid generation and Discontinuous Galerkin discretization applied to a 3D high-lift configuration},
   journal = {Proceedings of the 53rd AIAA Aerospace Sciences Meeting (SciTech 2015), AIAA 2015-0819, Kissimmee, Florida},
@@ -604,7 +593,7 @@
   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/}
 }
 
-@MastersThesis{heilmann:magneto-statics,
+@MastersThesis{2015:heilmann:magneto-statics,
   author  = {D. Heilmann},
   title   = {Magneto-statics in multi-material media},
   year    = 2015,
@@ -612,7 +601,7 @@
   note    = {Bachelor thesis}
 }
 
-@Article{heister.wheeler.ea:primal-dual,
+@Article{2015:heister.wheeler.ea:primal-dual,
   author  = {T. Heister and M. F. Wheeler and T. Wick},
   title   = {A primal-dual active set method and predictor-corrector mesh adaptivity for computing fracture propagation using a phase-field approach},
   journal = {CMAME, Vol. 290, 15 June 2015, Pages 466-495, ISSN 0045-7825},
@@ -620,7 +609,7 @@
   url     = {http://dx.doi.org/10.1016/j.cma.2015.03.009}
 }
 
-@Article{holmgren.kreiss:towards,
+@Article{2015:holmgren.kreiss:towards,
   author  = {H. Holmgren and G. Kreiss},
   title   = {Towards Accurate Modeling of Moving Contact Lines},
   journal = {arXiv:1510.06639},
@@ -628,7 +617,7 @@
   url     = {http://arxiv.org.ezproxy.library.tamu.edu/abs/1510.06639}
 }
 
-@Article{homyk:scalable,
+@Article{2015:homyk:scalable,
   author  = {A. P. Homyk},
   title   = {Scalable Methods for Deterministic Integration of Quantum Emitters in Photonic Crystal Cavities},
   journal = {PhD dissertation, California Institute of Technology, Pasadena},
@@ -636,14 +625,14 @@
   url     = {http://thesis.library.caltech.edu/8970/}
 }
 
-@PhDThesis{janka:sequential,
+@PhDThesis{2015:janka:sequential,
   author  = {D. Janka},
   title   = {Sequential quadratic programming with indefinite Hessian approximations for nonlinear optimum experimental design for parameter estimation in differential--algebraic equations},
   year    = 2015,
   school  = {University of Heidelberg, Germany}
 }
 
-@Article{jean-baptiste.lofstead.ea:delta,
+@Article{2015:jean-baptiste.lofstead.ea:delta,
   author  = {G. Jean-Baptiste and G. Lofstead and R. A. Oldfield},
   title   = {Delta: Data reduction for integrated application workflows},
   journal = {Sandia Technical Report SAND2015-5029},
@@ -651,7 +640,7 @@
   url     = {http://prod.sandia.gov/techlib/access-control.cgi/2015/155029.pdf}
 }
 
-@Article{kanschat.mao:multigrid,
+@Article{2015:kanschat.mao:multigrid,
   author  = {G. Kanschat and Y. Mao},
   title   = {Multigrid methods for Hdiv-conforming discontinuous Galerkin methods for the Stokes equations},
   journal = {J. Numer. Math no. 1},
@@ -661,7 +650,7 @@
   url     = {http://arxiv.org/abs/1501.06021}
 }
 
-@Article{karrech.schrank.ea:parallel,
+@Article{2015:karrech.schrank.ea:parallel,
   author  = {A. Karrech and C. Schrank and K. Regenauer-Lieb},
   title   = {A parallel computing tool for large-scale simulation of massive fluid injection in thermo-poro-mechanical systems},
   journal = {Philosophical Magazine, Vol. 95, Issue 28-30},
@@ -670,7 +659,7 @@
   url     = {http://www.tandfonline.com/doi/abs/10.1080/14786435.2015.1067373}
 }
 
-@Article{kim.zhang:optimized,
+@Article{2015:kim.zhang:optimized,
   author  = {S. Kim and H. Zhang},
   title   = {Optimized Schwarz Method with Complete Radiation Transmission Conditions for the Helmholtz Equation in Waveguides},
   journal = {SIAM J. Numer. Anal.},
@@ -681,7 +670,7 @@
   doi     = {10.1137/140980491}
 }
 
-@PhDThesis{kircheis:structure,
+@PhDThesis{2015:kircheis:structure,
   author  = {Robert Kircheis},
   title   = {Structure Exploiting Parameter Estimation and Optimum Experimental Design Methods and Applications in Microbial Enhanced Oil Recovery},
   school  = {Heidelberg University},
@@ -690,7 +679,7 @@
   url     = {http://www.ub.uni-heidelberg.de/archiv/22098}
 }
 
-@Article{klinsmann.rosato.ea:assessment,
+@Article{2015:klinsmann.rosato.ea:assessment,
   author  = {M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking},
   title   = {An assessment of the phase field formulation for crack growth},
   journal = {Computer Methods in Applied Mechanics and Engineering, Vol. 294},
@@ -699,7 +688,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782515002017}
 }
 
-@PhDThesis{kocher:variational,
+@PhDThesis{2015:kocher:variational,
   author  = {U. K\"{o}cher},
   title   = {Variational Space-Time Methods for the Elastic Wave Equation and the Diffusion Equation},
   year    = 2015,
@@ -707,7 +696,7 @@
   url     = {http://nbn-resolving.de/urn:nbn:de:gbv:705-opus-31129}
 }
 
-@Article{kramer.hagemann:scipal,
+@Article{2015:kramer.hagemann:scipal,
   author  = {S. C. Kramer and J. Hagemann},
   title   = {SciPAL: Expression templates and composition closure objects for high performance computational physics with CUDA and OpenMP},
   journal = {ACM Transactions on Parallel Computing, 1(2), p. 15},
@@ -715,7 +704,7 @@
   url     = {http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short}
 }
 
-@Article{kriemann.borne:h-fainv,
+@Article{2015:kriemann.borne:h-fainv,
   author  = {R. Kriemann and S. Le Borne},
   title   = {{H-FAINV}: hierarchically factored approximate inverse preconditioners},
   journal = {Computing and Visualization in Science, 17(3)},
@@ -725,7 +714,7 @@
   doi     = {10.1007/s00791-015-0254-y}
 }
 
-@Article{kuberry:optimization-based,
+@Article{2015:kuberry:optimization-based,
   author  = {P. A. Kuberry},
   title   = {An Optimization-Based Approach to Decoupling Fluid-Structure Interaction},
   journal = {PhD dissertation, Clemson University},
@@ -733,7 +722,7 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/1487/}
 }
 
-@Article{kunisch.rund:time,
+@Article{2015:kunisch.rund:time,
   author  = {K. Kunisch and A. Rund},
   title   = {Time optimal control of the monodomain model in cardiac electrophysiology},
   journal = {IMA Journal of Applied Mathematics},
@@ -741,7 +730,7 @@
   url     = {http://imamat.oxfordjournals.org/content/early/2015/05/23/imamat.hxv010.short}
 }
 
-@Article{kus:convergence,
+@Article{2015:kus:convergence,
   author  = {P. Kus},
   title   = {Convergence and stability of higher-order finite element solution of reaction-diffusion equation with Turing instability},
   journal = {Conference Applications of Mathematics 2015, Institute of Mathematics CAS, Prague},
@@ -749,21 +738,21 @@
   url     = {http://am2015.math.cas.cz/proceedings/contributions/kus.pdf}
 }
 
-@Article{lee.wheeler.ea:3d,
+@Article{2015:lee.wheeler.ea:3d,
   author  = {S. Lee and M. F. Wheeler and T. Wick},
   title   = {3D Fluid Filled Fracture Propagation in Porous Media using Phase Field and Adaptive Finite Elements},
   note    = {Submitted},
   year    = 2015
 }
 
-@MastersThesis{lemenager:numerical,
+@MastersThesis{2015:lemenager:numerical,
   author  = {A. Lemenager},
   title   = {Numerical modelling of the Sydney Basin using temperature dependent thermal conductivity measurements},
   year    = 2015,
   school  = {Macquarie University}
 }
 
-@Article{li.hartmann:adjoint-based,
+@Article{2015:li.hartmann:adjoint-based,
   author  = {D. Li and R. Hartmann},
   title   = {Adjoint-based airfoil optimization with discretization error control},
   journal = {International Journal on Numerical Methods Fluids},
@@ -772,7 +761,7 @@
   pages   = {1--17}
 }
 
-@Article{liu.do-quang.ea:thermohydrodynamics,
+@Article{2015:liu.do-quang.ea:thermohydrodynamics,
   author  = {J. Liu and M. Do-Quang and G. Amberg},
   title   = {Thermohydrodynamics of boiling in binary compressible fluids},
   journal = {Physical Review E 92, 043017},
@@ -780,7 +769,7 @@
   url     = {http://journals.aps.org/pre/abstract/10.1103/PhysRevE.92.043017}
 }
 
-@MastersThesis{ljungkvist:techniques,
+@MastersThesis{2015:ljungkvist:techniques,
   author  = {K. Ljungkvist},
   title   = {Techniques for finite element methods on modern processors},
   year    = 2015,
@@ -788,7 +777,7 @@
   note    = {IT licentiate thesis}
 }
 
-@PhDThesis{londero:cut-cell,
+@PhDThesis{2015:londero:cut-cell,
   author  = {A. A. Londero},
   title   = {A Cut-Cell Implementation of the Finite Element Method in deal.ii},
   year    = 2015,
@@ -796,21 +785,21 @@
   url     = {http://www.diva-portal.org/smash/get/diva2:858026/FULLTEXT01.pdf}
 }
 
-@Article{madzvamuse.chung.ea:stability,
+@Article{2015:madzvamuse.chung.ea:stability,
   author  = {A. Madzvamuse and A. H. Chung and C. Venkataraman},
   title   = {Stability analysis and simulations of coupled bulk-surface reaction--diffusion systems},
   journal = {Proc. R. Soc. A. Vol. 471. No. 2175. The Royal Society},
   year    = 2015
 }
 
-@PhDThesis{maier:duality-based,
+@PhDThesis{2015:maier:duality-based,
   author  = {M. Maier},
   title   = {Duality-based adaptivity of model and discretization in multiscale finite-element methods},
   year    = 2015,
   school  = {Heidelberg University, Germany}
 }
 
-@Article{mallikarjunaiah.walton:on,
+@Article{2015:mallikarjunaiah.walton:on,
   author  = {S. M. Mallikarjunaiah and J. R. Walton},
   title   = {On the direct numerical simulation of plane-strain fracture in a class of strain-limiting anisotropic elastic bodies},
   journal = {International Journal of Fracture, Vol. 192(2)},
@@ -819,7 +808,7 @@
   url     = {http://link.springer.com/article/10.1007/s10704-015-0006-5}
 }
 
-@Article{mcbride.javili.ea:finite,
+@Article{2015:mcbride.javili.ea:finite,
   author  = {A. McBride and A. Javili and P. Steinmann and B. D. Reddy},
   title   = {A finite element implementation of surface elasticity at finite strains in deal.II},
   journal = {arXiv 1506.01361},
@@ -827,7 +816,7 @@
   url     = {http://arxiv.org/abs/1506.01361}
 }
 
-@Article{michoski.meyerson.ea:discontinuous,
+@Article{2015:michoski.meyerson.ea:discontinuous,
   author  = {C. E. Michoski and D. Meyerson and T. Isaac and F. Waelbroeck},
   title   = {Discontinuous Galerkin methods for plasma physics in the scrape-off layer of tokamaks},
   journal = {Journal of Computational Physics, Vol. 274},
@@ -836,7 +825,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999114004768}
 }
 
-@Article{mikelic.wheeler.ea:phase-field,
+@Article{2015:mikelic.wheeler.ea:phase-field,
   doi     = {10.1137/140967118},
   url     = {http://epubs.siam.org/doi/abs/10.1137/140967118},
   year    = 2015,
@@ -849,7 +838,7 @@
   journal = {Multiscale Modeling \& Simulation}
 }
 
-@Article{mikelic.wheeler.ea:phase-field*1,
+@Article{2015:mikelic.wheeler.ea:phase-field*1,
   doi     = {10.1007/s10596-015-9532-5},
   url     = {http://link.springer.com/article/10.1007%2Fs10596-015-9532-5},
   year    = 2015,
@@ -863,7 +852,7 @@
   journal = {Computational Geosciences}
 }
 
-@Article{mikelic.wheeler.ea:quasi-static,
+@Article{2015:mikelic.wheeler.ea:quasi-static,
   doi     = {10.1088/0951-7715/28/5/1371},
   url     = {https://doi.org/10.1088/0951-7715/28/5/1371},
   year    = 2015,
@@ -877,7 +866,7 @@
   journal = {Nonlinearity}
 }
 
-@MastersThesis{mital:enriched,
+@MastersThesis{2015:mital:enriched,
   author  = {P. Mital},
   title   = {The Enriched Galerkin Method for Linear Elasticity and Phase Field Fracture Propagation},
   year    = 2015,
@@ -885,7 +874,7 @@
   url     = {http://hdl.handle.net/2152/34222}
 }
 
-@Article{muddamallappa:on,
+@Article{2015:muddamallappa:on,
   author  = {M. S. Muddamallappa},
   title   = {On Two Theories for Brittle Fracture: Modeling and Direct Numerical Simulations},
   journal = {PhD dissertation, Texas A\&M University.},
@@ -893,7 +882,7 @@
   url     = {http://oaktrust.library.tamu.edu/handle/1969.1/156484}
 }
 
-@Article{neitzel.wick.ea:optimal,
+@Article{2015:neitzel.wick.ea:optimal,
   author  = {I. Neitzel and T. Wick and W. Wollner},
   title   = {An optimal control problem governed by a regularized phase field fraction propagation model},
   journal = {IGDK 1754 Preprint No. IGDK-2015-12},
@@ -901,7 +890,7 @@
   url     = {http://preprint.math.uni-hamburg.de/public/papers/hbam/hbam2015-18.pdf}
 }
 
-@Article{nochetto.otarola.ea:pde,
+@Article{2015:nochetto.otarola.ea:pde,
   author  = {R. H. Nochetto and E. Ot\'{a}rola and A. J. Salgado},
   title   = {A PDE Approach to Numerical Fractional Diffusion},
   journal = {arXiv:1508.04382},
@@ -910,7 +899,7 @@
   note    = {Final version appeared in the Proceedings of the ICIAM, 2015}
 }
 
-@Article{nochetto.otarola.ea:pde*1,
+@Article{2015:nochetto.otarola.ea:pde*1,
   author  = {R. H. Nochetto and E. Ot\'{a}rola and A. J. Salgado},
   title   = {A PDE Approach to Fractional Diffusion in General Domains: A Priori Error Analysis},
   journal = {Foundations of Computational Mathematics},
@@ -923,7 +912,7 @@
   doi     = {10.1007/s10208-014-9208-x}
 }
 
-@Article{odsaeter.kvamsdal.ea:postprocessing,
+@Article{2015:odsaeter.kvamsdal.ea:postprocessing,
   author  = {L. H. Odsaeter and T. Kvamsdal and M. F. Wheeler},
   title   = {A postprocessing technique to produce locally conservative flux},
   journal = {28th Nordic Seminar on Computational Mechanics. CENS, Institute of Cybernetics at Tallinn University of Technology},
@@ -931,7 +920,7 @@
   url     = {http://folk.ntnu.no/odsater/nscm_abstract.pdf}
 }
 
-@Article{olshanskii.heister.ea:natural,
+@Article{2015:olshanskii.heister.ea:natural,
   author  = {M. A. Olshanskii and T. Heister and L. G. Rebholz and K. J. Galvin},
   title   = {Natural vorticity boundary conditions on solid walls},
   journal = {CMAME, Vol. 297},
@@ -940,7 +929,7 @@
   url     = {http://dx.doi.org/10.1016/j.cma.2015.08.011}
 }
 
-@Article{papanicolaou.aristotelous:high-order,
+@Article{2015:papanicolaou.aristotelous:high-order,
   author  = {N. C. Papanicolaou and A. C. Aristotelous},
   title   = {High-order discontinuous Galerkin methods for coupled thermoconvective flows under gravity modulation },
   journal = {AIP Conference Proceedings 1684, 090010},
@@ -949,7 +938,7 @@
   doi     = {10.1063/1.4934335}
 }
 
-@Article{pauletti.martinelli.ea:igatools,
+@Article{2015:pauletti.martinelli.ea:igatools,
   author  = {M. S. Pauletti and M. Martinelli and N. Cavallini and P. Antolin},
   title   = {Igatools: An Isogeometric Analysis Library },
   journal = {SIAM J. Sci. Comput., issue 4, pp. 465--496},
@@ -959,7 +948,7 @@
   doi     = {10.1137/140955252}
 }
 
-@PhDThesis{peyre:methode,
+@PhDThesis{2015:peyre:methode,
   author  = {G. Peyre},
   title   = {Methode EF et hyperreduction de modele: vers des calculs massifs a l'echelle micro},
   year    = 2015,
@@ -967,7 +956,7 @@
   url     = {https://hal.archives-ouvertes.fr/tel-01247931/}
 }
 
-@Article{phillips.elman:stochastic,
+@Article{2015:phillips.elman:stochastic,
   author  = {E. G. Phillips and H. C. Elman},
   title   = {A stochastic approach to uncertainty in the equations of MHD kinematics},
   journal = {J. of Comput. Phys., Vol. 284, pp. 334--350},
@@ -975,7 +964,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999114008092}
 }
 
-@Article{rahemi.nigam.ea:effect,
+@Article{2015:rahemi.nigam.ea:effect,
   author  = {H. Rahemi and N. Nigam and J. M. Wakeling},
   title   = {The effect of intramuscular fat on skeletal muscle mechanics: implications for the elderly and obese},
   journal = {DOI: 10.1098/rsif.2015.0365., Interface, Jul},
@@ -983,7 +972,7 @@
   url     = {http://rsif.royalsocietypublishing.org/content/12/109/20150365?cpetoc}
 }
 
-@Article{renda.hartmann.ea:high-order,
+@Article{2015:renda.hartmann.ea:high-order,
   author  = {S. M. Renda and R. Hartmann and C. De Bartolo and M. Wallraff},
   title   = {A high-order discontinuous Galerkin method for all-speed flows},
   journal = {International Journal for Numerical Methods in Fluids, issue 4, pp. 224--247},
@@ -992,7 +981,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.3987/abstract}
 }
 
-@Article{richter.wick:variational,
+@Article{2015:richter.wick:variational,
   author  = {T. Richter and T. Wick},
   title   = {Variational localization of the dual weighted residual estimator},
   journal = {Journal for Computational and Applied Mathematics, Volume 279, Issue C},
@@ -1001,7 +990,7 @@
   url     = {http://dl.acm.org/citation.cfm?id=2802959}
 }
 
-@Article{riedlbauer.steinmann.ea:thermomechanical,
+@Article{2015:riedlbauer.steinmann.ea:thermomechanical,
   author  = {D. Riedlbauer and P. Steinmann and J. Mergheim},
   title   = {Thermomechanical simulation of the selective laser melting process for PA12 including volumetric shrinkage},
   journal = {ROCEEDINGS OF PPS-30: The 30th International Conference of the Polymer Processing Society--Conference Papers, Vol. 1664, No. 1},
@@ -1009,7 +998,7 @@
   url     = {http://scitation.aip.org/content/aip/proceeding/aipcp/10.1063/1.4918512}
 }
 
-@Article{riehl.steinmann:staggered,
+@Article{2015:riehl.steinmann:staggered,
   author  = {S. Riehl and P. Steinmann},
   title   = {A staggered approach to shape and topology optimization using the traction method and an evolutionary-type advancing front algorithm},
   journal = {Computer Methods in Applied Mechanics and Engineering, pp. 1--30},
@@ -1018,7 +1007,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042715001934}
 }
 
-@Article{roland.tjardes.ea:algorithmic,
+@Article{2015:roland.tjardes.ea:algorithmic,
   author  = {M. Roland and T. Tjardes and T. Dahmen and R. Otchwemah and P. Slusallek and B. Bouillon and S. Diebels},
   title   = {An algorithmic strategy for the simulation of bone healing directly on computed tomography data},
   journal = {Proceedings in Applied Mathematics and Mechanics, Vol. 15(1)},
@@ -1027,7 +1016,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/pamm.201510043/abstract}
 }
 
-@Article{roy.heltai.ea:benchmarking,
+@Article{2015:roy.heltai.ea:benchmarking,
   author  = {Saswati Roy and Luca Heltai and Francesco Costanzo},
   title   = {Benchmarking the immersed finite element method for fluid-structure interaction problems},
   doi     = {10.1016/j.camwa.2015.03.012},
@@ -1039,7 +1028,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{salgado:convergence,
+@Article{2015:salgado:convergence,
   author  = {A. J. Salgado},
   title   = {Convergence Analysis of Fractional Time-Stepping Techniques for Incompressible Fluids with Microstructure},
   journal = {Journal of Scientific Computing, Volume 64, Issue 1},
@@ -1048,7 +1037,7 @@
   url     = {http://link.springer.com/article/10.1007%2Fs10915-014-9926-x}
 }
 
-@Article{saxena.pelteret.ea:modelling,
+@Article{2015:saxena.pelteret.ea:modelling,
   author  = {Prashant Saxena and Jean-Paul Pelteret and Paul Steinmann},
   title   = {Modelling of iron-filled magneto-active polymers with a dispersed chain-like microstructure},
   journal = {European Journal of Mechanics - A/Solids},
@@ -1060,7 +1049,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{scheffer.goldschmidt.ea:implementation,
+@Article{2015:scheffer.goldschmidt.ea:implementation,
   author  = {T. Scheffer and F. Goldschmidt and S. Diebels},
   title   = {Implementation of the strongly pronounced non-linear viscoelasticity of an incompressible filled rubber},
   journal = {Technische Mechanik, Vol. 35(2)},
@@ -1069,7 +1058,7 @@
   url     = {http://www.uni-magdeburg.de/ifme/zeitschrift_tm/2015_Heft2/04_Scheffer.pdf}
 }
 
-@Article{schmitt.gumbsch.ea:internal,
+@Article{2015:schmitt.gumbsch.ea:internal,
   author  = {S. Schmitt and P. Gumbsch and K. Schulz},
   title   = {Internal stresses in a homogenized representation of dislocation microstructures},
   journal = {Journal of the Mechanics and Physics of Solids, Vol. 84},
@@ -1078,14 +1067,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0022509615300946}
 }
 
-@PhDThesis{schoenawa:higher-order,
+@PhDThesis{2015:schoenawa:higher-order,
   author  = {S. Schoenawa},
   title   = {Higher-order discontinuous Galerkin discretizations of two-equation models of turbulence},
   year    = 2015,
   school  = {TU Braunschweig, Germany}
 }
 
-@Article{shyer.huycke.ea:bending,
+@Article{2015:shyer.huycke.ea:bending,
   author  = {A. E. Shyer and T. R. Huycke and C. Lee and L. Mahadevan and C. J. Tabin},
   title   = {Bending Gradients: How the Intestinal Stem Cell Gets Its Home},
   journal = {Cell, issue 3},
@@ -1095,7 +1084,7 @@
   url     = {http://dx.doi.org/10.1016/j.cell.2015.03.041}
 }
 
-@Article{stapf:novel,
+@Article{2015:stapf:novel,
   author  = {J. Stapf},
   title   = {Novel learning-based techniques for dense fluid motion measurements},
   journal = {PhD dissertation, Ruperto-Carola University of Heidelberg, Germany},
@@ -1103,7 +1092,7 @@
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/18116/}
 }
 
-@Article{stevens.downs.ea:predicting,
+@Article{2015:stevens.downs.ea:predicting,
   author  = {M. Stevens and C. Downs and D. Emerson and J. Adler and S. MacIachlan and T. E. Vandervelde},
   title   = {Predicting V$_{\textnormal{OC}}$ at ultra-high solar concentration using computational numerical analysis},
   journal = {Proceedings of the 31st European Photovoltaic Solar Energy Conference (EUPVSC). Hamburg, Germany, Sept. 14--18},
@@ -1111,7 +1100,7 @@
   url     = {https://www.semanticscholar.org/paper/Predicting-V-Oc-at-Ultra-high-Solar-Concentration-Stevens-Downs/b1fa511a5ec06f75f6223c57cbc9c53823d9c4fc/pdf}
 }
 
-@Article{stevens.downs.ea:studying,
+@Article{2015:stevens.downs.ea:studying,
   author  = {M. A. Stevens and C. Downs and D. Emerson and J. Adler and S. Maclachlan and T. E. Vandervelde},
   title   = {Studying anomalous open-circuit voltage drop-out in concentrated photovoltaics using computational numerical analysis},
   journal = {Proceedings of the 42nd Photovoltaic Specialist Conference (PVSC), 2015, . IEEE},
@@ -1119,7 +1108,7 @@
   pages   = {1--5}
 }
 
-@Article{stoll.breiten:low-rank,
+@Article{2015:stoll.breiten:low-rank,
   author  = {M. Stoll and T. Breiten},
   title   = {A low-rank in time approach to PDE-constrained optimization},
   journal = {SIAM J. Sci Comput., Vol 37, No.1, pp. B1-B29},
@@ -1127,14 +1116,14 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/130926365}
 }
 
-@MastersThesis{tezzele:isogeometric,
+@MastersThesis{2015:tezzele:isogeometric,
   author  = {M. Tezzele},
   title   = {Isogeometric analysis in HPC: object oriented design and open source massively parallel implementation},
   year    = 2015,
   school  = {University of Milan}
 }
 
-@Article{thurley.gerecht.ea:three-dimensional,
+@Article{2015:thurley.gerecht.ea:three-dimensional,
   author  = {K. Thurley and D. Gerecht and E. Friedmann and T. H\"{o}fer},
   title   = {Three-Dimensional Gradients of Cytokine Signaling between T Cells},
   journal = {PLOS Computational Biology, article e1004206},
@@ -1144,7 +1133,7 @@
   doi     = {10.1371/journal.pcbi.1004206}
 }
 
-@Article{tirupathi.hesthaven.ea:modeling,
+@Article{2015:tirupathi.hesthaven.ea:modeling,
   author  = {S. Tirupathi and J. S. Hesthaven and Y. Liang},
   title   = {Modeling 3D Magma Dynamics Using a Discontinuous Galerkin Method},
   journal = {Communications in Computational Physics, num. 01, pp 230-246},
@@ -1153,7 +1142,7 @@
   url     = {http://infoscience.epfl.ch/record/197481}
 }
 
-@Article{tirupathi.hesthaven.ea:multilevel,
+@Article{2015:tirupathi.hesthaven.ea:multilevel,
   author  = {S. Tirupathi and J. S. Hesthaven and Y. Liang and M. Parmentier},
   title   = {Multilevel and local time-stepping discontinuous Galerkin methods for magma dynamics},
   journal = {Computational Geosciences, Vol. 19, Issue 4},
@@ -1162,7 +1151,7 @@
   url     = {http://link.springer.com/article/10.1007/s10596-015-9514-7}
 }
 
-@Article{tosi.stein.ea:community,
+@Article{2015:tosi.stein.ea:community,
   author  = {N. Tosi and C. Stein and L. Noack and C. Huttig and P. Maierova and H. Samuel and D. R. Davies and C. R. Wilson and S. C. Kramer and C. Thieulot and A. Glerum and M. Fraters and W. Spakman and A. Rozel and P. J. Tackley},
   title   = {A community benchmark for viscoplastic thermal convection in a 2-D square box},
   journal = {Geochemistry, Geophysics, Geosystems, Vol. 16, Issue 7},
@@ -1173,7 +1162,7 @@
   doi     = {1002/2015GC005807}
 }
 
-@Article{turcksin.heister.ea:clone,
+@Article{2015:turcksin.heister.ea:clone,
   author  = {B. Turcksin and T. Heister and W. Bangerth},
   title   = {Clone and graft: Testing scientific applications as they are built},
   journal = {arXiv: 1508.07231},
@@ -1181,7 +1170,7 @@
   url     = {http://arxiv.org/abs/1508.07231}
 }
 
-@Article{vanegas.galvis.ea:some,
+@Article{2015:vanegas.galvis.ea:some,
   author  = {F. P. Vanegas and J. Galvis and J. M. Mantilla},
   title   = {Some numerical studies of oscillating chemical reactions using discontinuous finite elements},
   journal = {Revista de la Facultad de Ciencias, Universidad Nacional de Colombia, issue 2},
@@ -1191,7 +1180,7 @@
   url     = {http://www.revistas.unal.edu.co/index.php/rfc/article/viewFile/50864/51158}
 }
 
-@Article{vidal-ferrandiz.fayez.ea:moving,
+@Article{2015:vidal-ferrandiz.fayez.ea:moving,
   author  = {A. Vidal-Ferrandiz and R. Fayez and D. Ginestar and G. Verdu},
   title   = {Moving meshes to solve the time-dependent neutron diffusion equation in hexagonal geometry},
   journal = {Journal of Computational and Applied Mathematics},
@@ -1201,7 +1190,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042715001934}
 }
 
-@Article{vienne.chen.ea:novel,
+@Article{2015:vienne.chen.ea:novel,
   author  = {G. Vienne and X. Chen and Y. S. Teh and Y. J. Ng and N. O. Chia and C. P. Ooi},
   title   = {Novel layout of a bi-metallic nanoring for magnetic field pulse generation from light},
   journal = {New J. Phys., article 013049},
@@ -1210,7 +1199,7 @@
   url     = {http://iopscience.iop.org/1367-2630/17/1/013049}
 }
 
-@Article{wacker:stabilisierte,
+@Article{2015:wacker:stabilisierte,
   author  = {B. Wacker},
   title   = {Stabilisierte Lagrange Finite-Elemente im Elektromagnetismus und in der inkompressiblen Magnetohydrodynamik},
   journal = {PhD dissertation, University of Goettingen},
@@ -1218,28 +1207,28 @@
   url     = {https://ediss.uni-goettingen.de/bitstream/handle/11858/00-1735-0000-0023-9675-E/Dissertation_Wacker_2015_10_26_Final.pdf?sequence=1}
 }
 
-@Article{wallraff.hartmann.ea:multigrid,
+@Article{2015:wallraff.hartmann.ea:multigrid,
   author  = {M. Wallraff and R. Hartmann and T. Leicht},
   title   = {Multigrid solver algorithms for DG methods and applications to aerodynamic flows},
   journal = {In N. Kroll and C. Hirsch and F. Bassi and C. Johnston and K. Hillewaert, editors, IDIHOM - Industrialization of High-Order Methods - A Top Down Approach, Vol. 128 of Notes on Numerical Fluid Mechanics and Multidisciplinary Design, pages 153-178, Springer},
   year    = 2015
 }
 
-@PhDThesis{wallraff:investigation,
+@PhDThesis{2015:wallraff:investigation,
   author  = {M. Wallraff},
   title   = {An investigation of multigrid algorithms for a higher order Discontinuous Galerkin RANS solver},
   year    = 2015,
   school  = {TU Braunschweig, Germany}
 }
 
-@Article{wells.wang.ea:regularized,
+@Article{2015:wells.wang.ea:regularized,
   author  = {D. Wells and Z. Wang and X. Xie and T. Iliescu},
   title   = {Regularized Reduced Order Models},
   journal = {arXiv:1506.07555},
   year    = 2015
 }
 
-@Article{wells:stabilization,
+@Article{2015:wells:stabilization,
   author  = {D. Wells},
   title   = {Stabilization of POD-ROMs},
   journal = {PhD dissertation, Virginia Tech},
@@ -1247,7 +1236,7 @@
   url     = {https://vtechworks.lib.vt.edu/handle/10919/52960}
 }
 
-@Article{wernsing.buskens:parameter,
+@Article{2015:wernsing.buskens:parameter,
   author  = {H. Wernsing and C. B\"{u}skens.},
   title   = {Parameter identification for finite element based models in dry machining applications},
   journal = {Procedia CIRP, 31},
@@ -1255,7 +1244,7 @@
   pages   = {328--333}
 }
 
-@Article{wick.lee.ea:3d,
+@Article{2015:wick.lee.ea:3d,
   author  = {T. Wick and S. Lee and M. F. Wheeler},
   title   = {3D Phase-Field for Pressurized Fracture Propagation in Heterogeneous Media},
   journal = {VI International Conference on Computational Methods for Coupled Problems in Science and Engineering 2015 Proceedings},
@@ -1263,7 +1252,7 @@
   pages   = {605--613}
 }
 
-@Article{wick.singh.ea:fluid-filled,
+@Article{2015:wick.singh.ea:fluid-filled,
   author  = {T. Wick and G. Singh and M. F. Wheeler},
   title   = {Fluid-Filled Fracture Propagation using a Phase-Field Approach and Coupling to a Reservoir Simulator},
   journal = {Reservoir Simulator, SPE Journal},
@@ -1272,7 +1261,7 @@
   doi     = {10.2118/168597-PA}
 }
 
-@Article{wick.wick.ea:numerical,
+@Article{2015:wick.wick.ea:numerical,
   author  = {D. Wick and T. Wick and H. R. Hellmig and H.-J. Christ},
   title   = {Numerical simulations of crack propagation in screws with phase-field modeling},
   journal = {Computational Materials Science},
@@ -1281,7 +1270,7 @@
   pages   = {367--379}
 }
 
-@Article{wilmers.bargmann:continuum,
+@Article{2015:wilmers.bargmann:continuum,
   author  = {J. Wilmers and S. Bargmann},
   title   = {A continuum mechanical model for the description of solvent induced swelling in polymeric glasses: Thermomechanics coupled with diffusion},
   journal = {European Journal of Mechanics - A/Solids, Vol. 53},
@@ -1290,7 +1279,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0997753815000224}
 }
 
-@Article{zareei.alam:cloaking,
+@Article{2015:zareei.alam:cloaking,
   author  = {A. Zareei and M.-R. Alam},
   title   = {Cloaking in shallow-water waves via nonlinear medium transformation},
   journal = {Journal of Fluid Mechanics},
@@ -1300,7 +1289,7 @@
   url     = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=9886676&fileId=S002211201500350X}
 }
 
-@MastersThesis{zelst:mantle,
+@MastersThesis{2015:zelst:mantle,
   author  = {I. van Zelst},
   title   = {Mantle dynamics on Venus: insights from numerical modelling},
   year    = 2015,
@@ -1308,7 +1297,7 @@
   url     = {http://dspace.library.uu.nl/bitstream/handle/1874/316227/Iris_van_Zelst_final_master_thesis.pdf}
 }
 
-@Article{zheng.mcclarren:non-oscillatory,
+@Article{2015:zheng.mcclarren:non-oscillatory,
   author  = {W. Zheng and R. G. McClarren},
   title   = {Non-oscillatory Reweighted Least Square Finite Element Method for SN Transport},
   journal = {Transactions of American Nuclear Society},
@@ -1319,7 +1308,7 @@
   url     = {https://www.researchgate.net/publication/280558859_Non-oscillatory_Reweighted_Least_Square_Finite_Element_Method_for_SN_Transport}
 }
 
-@Article{zheng.mcclarren:non-oscillatory*1,
+@Article{2015:zheng.mcclarren:non-oscillatory*1,
   author  = {W. Zheng and R. G. McClarren},
   title   = {Non-oscillatory Reweighted Least Square Finite Element for Solving PN Transport},
   journal = {Transactions of American Nuclear Society},
@@ -1328,6 +1317,17 @@
   number  = 1,
   pages   = {692--695},
   url     = {https://www.researchgate.net/publication/285973862_Non-oscillatory_Reweighted_Least_Square_Finite_Element_for_Solving_Pn_Transport}
+}
+
+@InProceedings{2016:hai.bause:adaptive,
+  doi     = {10.1115/imece2015-53265},
+  url     = {https://doi.org/10.1115/imece2015-53265},
+  year    = 2016,
+  month   = mar,
+  publisher = {American Society of Mechanical Engineers},
+  author  = {Bhuiyan Shameem Mahmood Ebna Hai and Markus Bause},
+  title   = {Adaptive Multigrid Methods for Extended Fluid-Structure Interaction ({eXFSI}) Problem: Part I --- Mathematical Modelling},
+  booktitle = {Volume 7B: Fluids Engineering Systems and Technologies}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -145,10 +145,11 @@
 }
 
 @MastersThesis{2016:blom:state,
-  author  = {C. A. H. Blom},
-  title   = {State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls},
-  year    = 2016,
-  school  = {Utrecht University, The Netherlands}
+  author  = {Blom, C. A. H.},
+  school  = {Utrecht University, Netherlands},
+  title   = {State of the art numerical subduction modelling with {ASPECT}; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls},
+  url     = {https://studenttheses.uu.nl/handle/20.500.12932/25682},
+  year    = 2016
 }
 
 @Article{2016:bonito.demlow:convergence,
@@ -664,13 +665,16 @@
 }
 
 @Article{2016:harmon.gamba.ea:numerical,
-  author  = {M. Harmon and I. M. Gamba and K. Ren},
-  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
-  journal = {Journal of Computational Physics},
+  doi     = {10.1016/j.jcp.2016.08.026},
+  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303825},
   year    = 2016,
+  month   = dec,
+  publisher = {Elsevier {BV}},
   volume  = 327,
   pages   = {140--167},
-  url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303825}
+  author  = {Michael Harmon and Irene M. Gamba and Kui Ren},
+  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical ({PEC}) solar cells},
+  journal = {Journal of Computational Physics}
 }
 
 @PhDThesis{2016:harmon:numerical,

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{adler.emerson.ea:constrained,
+@Article{2016:adler.emerson.ea:constrained,
   author  = {J. H. Adler and D. B. Emerson and S. P. MacLachlan and T. A. Manteuffel},
   title   = {Constrained Optimization for Liquid Crystal Equilibria},
   journal = {SIAM J. Sci. Comput., (1), B50-B76},
@@ -9,7 +9,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/141001846}
 }
 
-@Article{adler.emerson.ea:deflation,
+@Article{2016:adler.emerson.ea:deflation,
   author  = {J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan},
   title   = {A Deflation Technique for Detecting Multiple Liquid Crystal Equilibrium States},
   journal = {arXiv:1601.07383},
@@ -17,7 +17,7 @@
   url     = {http://arxiv.org/abs/1601.07383}
 }
 
-@Article{arbogast.taicher:linear,
+@Article{2016:arbogast.taicher:linear,
   author  = {T. Arbogast and A. L. Taicher},
   title   = {A Linear Degenerate Elliptic Equation Arising from Two-Phase Mixtures},
   journal = {SIAM J. Numer. Anal., issue 5},
@@ -27,7 +27,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1067846}
 }
 
-@Misc{arndt.lucero.ea:a-parallel-multigrid-matrix-free-solver-using-schwarz-smoothers,
+@Misc{2016:arndt.lucero.ea:a-parallel-multigrid-matrix-free-solver-using-schwarz-smoothers,
   author  = {Arndt, D and Lucero, P and Witte, J and Kanschat, PEG},
   title   = {{A Parallel Multigrid Matrix-Free Solver using Schwarz Smoothers}},
   howpublished = {PDE Software Frameworks 2016},
@@ -35,14 +35,14 @@
   url     = {http://www.mathsim.eu/~darndt/files/PDESoft2016Arndt.pdf}
 }
 
-@PhDThesis{arndt:stabilized,
+@PhDThesis{2016:arndt:stabilized,
   author  = {D. Arndt},
   title   = {Stabilized Finite Element Methods for Coupled Incompressible Flow},
   year    = 2016,
   school  = {Georg-August-Universit\"{a}t G\"{o}ttingen, Germany}
 }
 
-@Article{assier.poon.ea:spectral-study-of-the-laplace-beltrami-operator-arising-in-the-problem-of-acoustic-wave-scattering-by-a-quarter-plane,
+@Article{2016:assier.poon.ea:spectral-study-of-the-laplace-beltrami-operator-arising-in-the-problem-of-acoustic-wave-scattering-by-a-quarter-plane,
   author  = {Assier, RC and Poon, C and Peake, N},
   title   = {{Spectral study of the Laplace--Beltrami operator arising in the problem of acoustic wave scattering by a quarter-plane}},
   journal = {The Quarterly Journal of Mechanics and Applied Mathematics},
@@ -55,7 +55,7 @@
   publisher = {Oxford University Press ({OUP})}
 }
 
-@Article{axelsson.farouq.ea:comparison,
+@Article{2016:axelsson.farouq.ea:comparison,
   author  = {O. Axelsson and S. Farouq and M. Neytcheva},
   title   = {Comparison of preconditioned Krylov subspace iteration methods for PDE-constrained optimization problems. Poisson and convection-diffusion control},
   journal = {Numerical Algorithm, issue 3},
@@ -65,7 +65,7 @@
   url     = {https://link.springer.com/article/10.1007/s11075-016-0111-1}
 }
 
-@MastersThesis{balen:multi-component,
+@MastersThesis{2016:balen:multi-component,
   author  = {C. A. Balen},
   title   = {A Multi-Component Mass Transport Model for Polymer Electrolyte Fuel Cells},
   year    = 2016,
@@ -73,7 +73,7 @@
   url     = {http://www.esdlab.mece.ualberta.ca/pdfs/Balen_Chad_A_201607_MSc.pdf}
 }
 
-@Article{ballani.kressner:reduced,
+@Article{2016:ballani.kressner:reduced,
   author  = {J. Ballani and D. Kressner},
   title   = {Reduced basis methods: from low-rank matrices to low-rank tensors},
   journal = {SIAM Journal on Scientific Computing Vol. 38, No. 4, pp. A2045-A2067},
@@ -81,7 +81,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1042784}
 }
 
-@Article{bangerth.davydov.ea:deal-ii,
+@Article{2016:bangerth.davydov.ea:deal-ii,
   author  = {W. Bangerth and D. Davydov and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and B. Turcksin and D. Wells},
   title   = {The \texttt{deal.II} Library, Version 8.4},
   journal = {Journal of Numerical Mathematics},
@@ -91,7 +91,7 @@
   doi     = {10.1515/jnma-2016-1045}
 }
 
-@Article{bangerth.heister.ea:deal-ii,
+@Article{2016:bangerth.heister.ea:deal-ii,
   author  = {W. Bangerth and T. Heister and L. Heltai and G. Kanschat and M. Kronbichler and M. Maier and B. Turcksin},
   title   = {The \texttt{deal.II} Library, Version 8.3},
   journal = {Archive of Numerical Software},
@@ -101,7 +101,7 @@
   doi     = {10.11588/ans.2016.100.23122}
 }
 
-@Article{barker.rees.ea:fast,
+@Article{2016:barker.rees.ea:fast,
   author  = {A. Barker and T. Rees and M. Stoll},
   title   = {A fast solver for an H$^{1}$ regularized PDE-constrained optimization problem},
   journal = {Communications in Computational Physics, issue 1},
@@ -111,7 +111,7 @@
   url     = {https://www.cambridge.org/core/journals/communications-in-computational-physics/article/fast-solver-for-an-h1-regularized-pdeconstrained-optimization-problem/8109B45FF4F96F568D3383EA8835A7E7}
 }
 
-@Article{bauman.stogner:grins--a-multiphysics-framework-based-on-the-libmesh-finite-element-library,
+@Article{2016:bauman.stogner:grins--a-multiphysics-framework-based-on-the-libmesh-finite-element-library,
   author  = {Bauman, Paul T. and Stogner, Roy H.},
   title   = {{GRINS: A Multiphysics Framework Based on the libMesh Finite Element Library}},
   journal = {{SIAM} Journal on Scientific Computing},
@@ -126,7 +126,7 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@Article{bause.kocher:iterative,
+@Article{2016:bause.kocher:iterative,
   author  = {M. Bause and U. K\"{o}cher},
   title   = {Iterative coupling of variational space-time methods for Biot's system of poroelasticity},
   journal = {Numer. Math. Adv. Appl. ENUMATH},
@@ -136,7 +136,7 @@
   url     = {https://link.springer.com/chapter/10.1007%2F978-3-319-39929-4_15}
 }
 
-@MastersThesis{beez:funktionsinterpolation,
+@MastersThesis{2016:beez:funktionsinterpolation,
   author  = {C. Beez},
   title   = {Funktionsinterpolation: Alternativen zu EIM/DEIM},
   year    = 2016,
@@ -144,14 +144,14 @@
   note    = {Project thesis}
 }
 
-@MastersThesis{blom:state,
+@MastersThesis{2016:blom:state,
   author  = {C. A. H. Blom},
   title   = {State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls},
   year    = 2016,
   school  = {Utrecht University, The Netherlands}
 }
 
-@Article{bonito.demlow:convergence,
+@Article{2016:bonito.demlow:convergence,
   author  = {A. Bonito and A. Demlow},
   title   = {Convergence and optimality of higher-order adaptive finite element methods for eigenvalue clusters},
   journal = {SIAM J. Numer. Anal., issue 4, pp. 2379--2388},
@@ -160,7 +160,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1036877.}
 }
 
-@Article{bonito.guermond.ea:numerical,
+@Article{2016:bonito.guermond.ea:numerical,
   author  = {A. Bonito and J.-L. Guermond and S. Lee},
   title   = {Numerical Simulations of Bouncing Jets},
   journal = {Internat. J. Numer. Methods Fluids, Vol. 80, No. 1},
@@ -169,7 +169,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/fld.4071/full}
 }
 
-@Article{bonito.pasciak:numerical-approximation-of-fractional-powers-of-regularly-accretive-operators,
+@Article{2016:bonito.pasciak:numerical-approximation-of-fractional-powers-of-regularly-accretive-operators,
   author  = {Andrea Bonito and Joseph E. Pasciak},
   title   = {{Numerical approximation of fractional powers of regularly accretive operators}},
   journal = {{IMA} Journal of Numerical Analysis},
@@ -182,7 +182,7 @@
   publisher = {Oxford University Press ({OUP})}
 }
 
-@Article{bosch:fast,
+@Article{2016:bosch:fast,
   author  = {J. Bosch},
   title   = {Fast Iterative Solvers for Cahn--Hilliard Problems},
   journal = {PhD dissertation, Otto von Guericke University Magdeburg, Germany},
@@ -190,7 +190,7 @@
   url     = {http://pubman.mpdl.mpg.de/pubman/item/escidoc:2306051/component/escidoc:2400003/Dissertation_Bosch.pdf}
 }
 
-@Article{brand:forces,
+@Article{2016:brand:forces,
   author  = {C. A. Brand},
   title   = {Forces and Flow of Contractile Networks},
   journal = {PhD dissertation, University of Heidelberg, Germany},
@@ -198,7 +198,7 @@
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20233/}
 }
 
-@Article{brands.mergheim.ea:reduced-order,
+@Article{2016:brands.mergheim.ea:reduced-order,
   author  = {B. Brands and J. Mergheim and P. Steinmann},
   title   = {Reduced-order modelling for linear heat conduction with parametrised moving heat sources},
   journal = {GAMM-Mitteilungen},
@@ -209,7 +209,7 @@
   doi     = {10.1002/gamm.201610011}
 }
 
-@Article{brenner.oh.ea:c0,
+@Article{2016:brenner.oh.ea:c0,
   author  = {S.C. Brenner and M. Oh and S. Pollock and K. Porwal and M. Schedensack and N. S. Sharma},
   title   = {A C$^{0}$ Interior Penalty Method for Elliptic Distributed Optimal Control Problems in Three Dimensions with Pointwise State Constraints},
   journal = {Topics in Numerical Partial Differential Equations and Scientific Computing},
@@ -219,7 +219,7 @@
   url     = {https://link.springer.com/chapter/10.1007/978-1-4939-6399-7_1}
 }
 
-@Article{bucci.chiang.ea:formulation,
+@Article{2016:bucci.chiang.ea:formulation,
   author  = {G. Bucci and Y. M. Chiang and W. C. Carter},
   title   = {Formulation of the coupled electrochemical-mechanical boundary value problem, with applications to transport of multiple charged species},
   journal = {Acta Materialia Vol. 104},
@@ -228,7 +228,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S1359645415300811}
 }
 
-@Article{burstedde.holke:a-tetrahedral-space-filling-curve-for-nonconforming-adaptive-meshes,
+@Article{2016:burstedde.holke:a-tetrahedral-space-filling-curve-for-nonconforming-adaptive-meshes,
   author  = {Burstedde, Carsten and Holke, Johannes},
   title   = {{A Tetrahedral Space-Filling Curve for Nonconforming Adaptive Meshes}},
   journal = {{SIAM} Journal on Scientific Computing},
@@ -243,7 +243,7 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@MastersThesis{bystricky:using,
+@MastersThesis{2016:bystricky:using,
   author  = {L. Bystricky},
   title   = {Using deal.ii to solve problems in computational fluid dynamics},
   year    = 2016,
@@ -251,7 +251,7 @@
   url     = {http://search.proquest.com/docview/1806862661/previewPDF/E6506DE2A6364AD3PQ/1?accountid=7082}
 }
 
-@Article{bzowski.bachniak.ea:sensitivity,
+@Article{2016:bzowski.bachniak.ea:sensitivity,
   author  = {K. Bzowski and D. Bachniak and M. Pernach and M. Pietrzyk},
   title   = {Sensitivity analysis of phase transformation model based on solution of diffusion equation},
   journal = {Archives of Civil and Mechanical Engineering, Vol. 16},
@@ -260,7 +260,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S164496651500093X}
 }
 
-@Article{cangiani.georgoulis.ea:adaptivity,
+@Article{2016:cangiani.georgoulis.ea:adaptivity,
   author  = {A. Cangiani and E. H. Georgoulis and I. Kyza and S. Metcalfe},
   title   = {Adaptivity and blow-up detection for nonlinear evolution problems},
   journal = {SIAM J. Sci. Comput., issue 6, pp. A3833--A3856},
@@ -269,7 +269,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/16M106073X?journalCode=sjoce3}
 }
 
-@Article{carraro.friedmann.ea:coupling,
+@Article{2016:carraro.friedmann.ea:coupling,
   author  = {T. Carraro and E. Friedmann and D. Gerecht},
   title   = {Coupling vs decoupling approaches for PDE/ODE systems modeling intercellular signaling},
   journal = {Journal of Computational Physics},
@@ -279,7 +279,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116001728}
 }
 
-@Article{castelletto.white.ea:scalable,
+@Article{2016:castelletto.white.ea:scalable,
   author  = {N. Castelletto and J. A. White and M. Ferronato},
   title   = {Scalable algorithms for three-field mixed finite element coupled poromechanics},
   journal = {Journal of Computational Physics},
@@ -289,21 +289,21 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116304843}
 }
 
-@MastersThesis{castelli:numerische,
+@MastersThesis{2016:castelli:numerische,
   author  = {Castelli, G. F.},
   title   = {Die Numerische Simulation eines Mikroskalenmodells f{\"u}r Li-Ionen-Batterien},
   school  = {Karlsruhe Institute of Technology (KIT)},
   year    = 2016
 }
 
-@Manual{chen.ladenheim.ea:the-manchester-thermal-analyzer,
+@Manual{2016:chen.ladenheim.ea:the-manchester-thermal-analyzer,
   title   = {{The Manchester Thermal Analyzer}},
   author  = {Chen, Yi-Chung and Ladenheim, Scott and Mihajlovi{\'{c}}, Milan and Pavlidis, Vasilis},
   year    = 2016,
   url     = {https://pdfs.semanticscholar.org/853e/b3362f9d2670680f21dc7ed280e745fa6a9f.pdf}
 }
 
-@Article{chidyagwai.ladenheim.ea:constraint-preconditioning-for-the-coupled-stokes-darcy-system,
+@Article{2016:chidyagwai.ladenheim.ea:constraint-preconditioning-for-the-coupled-stokes-darcy-system,
   author  = {Chidyagwai, Prince and Ladenheim, Scott and Szyld, Daniel B.},
   title   = {{Constraint Preconditioning for the Coupled Stokes--Darcy System}},
   journal = {{SIAM} Journal on Scientific Computing},
@@ -317,7 +317,7 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@Article{choo.white.ea:hydromechanical-modeling-of-unsaturated-flow-in-double-porosity-media,
+@Article{2016:choo.white.ea:hydromechanical-modeling-of-unsaturated-flow-in-double-porosity-media,
   author  = {Choo, Jinhyun and White, Joshua A. and Borja, Ronaldo I.},
   title   = {{Hydromechanical Modeling of Unsaturated Flow in Double Porosity Media}},
   journal = {International Journal of Geomechanics},
@@ -331,7 +331,7 @@
   publisher = {American Society of Civil Engineers ({ASCE})}
 }
 
-@Article{chugunova.jadamba.ea:study,
+@Article{2016:chugunova.jadamba.ea:study,
   author  = {M. Chugunova and B. Jadamba and C.-Y. Kao and C. Klymko and E. Thomas and B. Zhao},
   title   = {Study of a Mixed Dispersal Population Dynamics Model},
   journal = {Topics in Numerical Partial Differential Equations and Scientific Computing},
@@ -341,7 +341,7 @@
   url     = {https://link.springer.com/chapter/10.1007/978-1-4939-6399-7_3}
 }
 
-@Article{cockburn.demlow:hybridizable-discontinuous-galerkin-and-mixed-finite-element-methods-for-elliptic-problems-on-surfaces,
+@Article{2016:cockburn.demlow:hybridizable-discontinuous-galerkin-and-mixed-finite-element-methods-for-elliptic-problems-on-surfaces,
   author  = {Bernardo Cockburn and Alan Demlow},
   title   = {{Hybridizable discontinuous Galerkin and mixed finite element methods for elliptic problems on surfaces}},
   journal = {Mathematics of Computation},
@@ -354,14 +354,14 @@
   publisher = {American Mathematical Society ({AMS})}
 }
 
-@PhDThesis{cox:adaptive,
+@PhDThesis{2016:cox:adaptive,
   author  = {S. Cox},
   title   = {Adaptive large-scale mantle convection simulations},
   year    = 2016,
   school  = {University of Leicester}
 }
 
-@Article{cruz.ramos:general,
+@Article{2016:cruz.ramos:general,
   author  = {Luis M. De La Cruz and Eduardo Ramos},
   title   = {General Template Units for the Finite Volume Method in Box-Shaped Domains},
   journal = {{ACM} Transactions on Mathematical Software},
@@ -374,7 +374,7 @@
   publisher = {Association for Computing Machinery ({ACM})}
 }
 
-@Article{dalcin.collier.ea:petiga--a-framework-for-high-performance-isogeometric-analysis,
+@Article{2016:dalcin.collier.ea:petiga--a-framework-for-high-performance-isogeometric-analysis,
   author  = {L. Dalcin and N. Collier and P. Vignal and A.M.A. C{\^{o}}rtes and V.M. Calo},
   title   = {{PetIGA: A framework for high-performance isogeometric analysis}},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -387,7 +387,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{dallmann.arndt.ea:local,
+@Article{2016:dallmann.arndt.ea:local,
   author  = {H. Dallmann and D. Arndt and G. Lube},
   title   = {Local projection stabilization for the Oseen problem},
   journal = {IMA Journal of Numerical Analysis, issue 2},
@@ -396,7 +396,7 @@
   pages   = {796--823}
 }
 
-@Article{dannberg.heister:compressible,
+@Article{2016:dannberg.heister:compressible,
   author  = {J. Dannberg and T. Heister},
   title   = {Compressible Magma/Mantle Dynamics: 3d, Adaptive Simulations in ASPECT},
   journal = {Geophysics Journal International},
@@ -407,7 +407,7 @@
   doi     = {10.1093/gji/ggw329}
 }
 
-@PhDThesis{dannberg:dynamics-of-mantle-plumes--linking-scales-and-coupling-physics,
+@PhDThesis{2016:dannberg:dynamics-of-mantle-plumes--linking-scales-and-coupling-physics,
   author  = {Dannberg, J.},
   school  = {Potsdam University},
   title   = {{Dynamics of Mantle Plumes: Linking Scales and Coupling Physics}},
@@ -415,7 +415,7 @@
   year    = 2016
 }
 
-@Article{davydov.young.ea:on,
+@Article{2016:davydov.young.ea:on,
   author  = {D. Davydov and T. D. Young and P. Steinmann},
   title   = {On the adaptive finite element analysis of the Kohn-Sham equations: Methods, algorithms, and implementation},
   journal = {International Journal for Numerical Methods in Engineering, Vol. 106},
@@ -424,7 +424,7 @@
   url     = {http://dx.doi.org/10.1002/nme.5140}
 }
 
-@InProceedings{droba:tangle-free-finite-element-mesh-motion-for-ablation-problems,
+@InProceedings{2016:droba:tangle-free-finite-element-mesh-motion-for-ablation-problems,
   author  = {Droba, Justin},
   title   = {{Tangle-Free Finite Element Mesh Motion for Ablation Problems}},
   booktitle = {46th {AIAA} Thermophysics Conference},
@@ -436,7 +436,7 @@
   note    = {Unconfirmed citation}
 }
 
-@Article{ellam.zabaras.ea:bayesian,
+@Article{2016:ellam.zabaras.ea:bayesian,
   author  = {L. Ellam and N. Zabaras and M. Girolami},
   title   = {A Bayesian approach to multiscale inverse problems with on-the-fly scale determination},
   journal = {Journal of Computational Physics},
@@ -446,7 +446,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303886}
 }
 
-@Article{ervin.lee.ea:generalized-newtonian-fluid-flow-through-a-porous-medium,
+@Article{2016:ervin.lee.ea:generalized-newtonian-fluid-flow-through-a-porous-medium,
   author  = {V.J. Ervin and Hyesuk Lee and A.J. Salgado},
   title   = {{Generalized Newtonian fluid flow through a porous medium}},
   journal = {Journal of Mathematical Analysis and Applications},
@@ -461,7 +461,7 @@
   url     = {https://www.sciencedirect.com/science/article/pii/S0022247X15007003}
 }
 
-@Article{exner.brezina:partition,
+@Article{2016:exner.brezina:partition,
   author  = {P. Exner and J. Brezina},
   title   = {Partition of unity methods for approximation of point water sources in porous media},
   journal = {Applied Mathematics and Computation},
@@ -471,7 +471,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0096300315012862}
 }
 
-@Article{feng.hui:force-sensing-using-3d-displacement-measurements-in-linear-elastic-bodies,
+@Article{2016:feng.hui:force-sensing-using-3d-displacement-measurements-in-linear-elastic-bodies,
   author  = {Feng, Xinzeng and Hui, Chung-Yuen},
   title   = {{Force sensing using 3D displacement measurements in linear elastic bodies}},
   journal = {Computational Mechanics},
@@ -485,7 +485,7 @@
   publisher = {Springer Nature}
 }
 
-@Article{freddi.royer-carfagni:phase-field,
+@Article{2016:freddi.royer-carfagni:phase-field,
   author  = {F. Freddi and G. Royer-Carfagni},
   title   = {Phase-field slip-line theory of plasticity},
   journal = {Journal of the Mechanics and Physics of Solids},
@@ -495,7 +495,7 @@
   doi     = {10.1016/j.jmps.2016.04.024}
 }
 
-@Article{freddi.sacco:damage,
+@Article{2016:freddi.sacco:damage,
   author  = {F. Freddi and E. Sacco},
   title   = {A damage model for a finite thickness composite interface accounting for in-plane deformation},
   journal = {Engineering Fraction Mechanics},
@@ -505,7 +505,7 @@
   url     = {http://dx.doi.org/10.1016/j.engfracmech.2016.06.001}
 }
 
-@Article{freddi.sacco:interphase,
+@Article{2016:freddi.sacco:interphase,
   author  = {F. Freddi and E. Sacco},
   title   = {An interphase model for the analysis of the masonry-FRP bond},
   journal = {Composite Structures, Volume 138},
@@ -514,7 +514,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0263822315010442}
 }
 
-@Article{frei.richter.ea:long-term,
+@Article{2016:frei.richter.ea:long-term,
   doi     = {10.1016/j.jcp.2016.06.015},
   url     = {https://doi.org/10.1016/j.jcp.2016.06.015},
   year    = 2016,
@@ -527,7 +527,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{frei:eulerian,
+@Article{2016:frei:eulerian,
   author  = {S. Frei},
   title   = {Eulerian finite element methods for interface problems and fluid-structure interactions},
   journal = {PhD dissertation, University of Heidelberg, Heidelberg, Germany},
@@ -535,7 +535,7 @@
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/21590}
 }
 
-@Article{frohne.heister.ea:efficient,
+@Article{2016:frohne.heister.ea:efficient,
   author  = {J. Frohne and T. Heister and W. Bangerth},
   title   = {Efficient numerical methods for the large-scale, parallel solution of elastoplastic contact problems},
   journal = {International Journal for Numerical Methods in Engineering},
@@ -544,7 +544,7 @@
   pages   = {416--439}
 }
 
-@Article{fu.jin.ea:parameter-free,
+@Article{2016:fu.jin.ea:parameter-free,
   author  = {G. Fu and Y. Jin and W. Qiu},
   title   = {Parameter-free superconvergent H(div)-conforming HDG methods for the Brinkman equations},
   journal = {ArXiv:1607.07662},
@@ -552,7 +552,7 @@
   url     = {https://arxiv.org/abs/1607.07662}
 }
 
-@Article{gallego-valencia.klingenberg.ea:on,
+@Article{2016:gallego-valencia.klingenberg.ea:on,
   author  = {J. P. Gallego-Valencia and C. Klingenberg and P. Chandrashekar},
   title   = {On limiting for higher order discontinuous Galerkin method for 2D Euler equations},
   journal = {Bulletin of the Brazilian Mathematical Society, New Series, issue 1},
@@ -562,7 +562,7 @@
   doi     = {10.1007/s00574-016-0142-1}
 }
 
-@Misc{gassmoeller.heien.ea:flexible,
+@Misc{2016:gassmoeller.heien.ea:flexible,
   title   = {Flexible and scalable particle-in-cell methods for massively parallel computations},
   author  = {R. Gassmoeller and E. Heien and E. G. Puckett and W. Bangerth},
   year    = 2016,
@@ -571,7 +571,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{gassmoller.dannberg.ea:major,
+@Article{2016:gassmoller.dannberg.ea:major,
   author  = {R. Gassm\"{o}ller and J. Dannberg and E. Bredow and B. Steinberger and T. H. Torsvik},
   title   = {Major influence of plume-ridge interaction, lithosphere thickness variations, and global mantle flow on hotspot volcanism - The example of Tristan},
   journal = {Geochem. Geophys. Geosyst., 1454-1479},
@@ -580,7 +580,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2015GC006177/full}
 }
 
-@Misc{gersbacher:implementation,
+@Misc{2016:gersbacher:implementation,
   title   = {Implementation of $hp$-adaptive discontinuous finite element methods in Dune-Fem},
   author  = {Christoph Gersbacher},
   year    = 2016,
@@ -589,7 +589,7 @@
   primaryclass = {cs.MS}
 }
 
-@Article{gholami.malhotra.ea:fft,
+@Article{2016:gholami.malhotra.ea:fft,
   author  = {Gholami, Amir and Malhotra, Dhairya and Sundar, Hari and Biros, George},
   title   = {{FFT}, {FMM}, or Multigrid? A comparative Study of State-Of-the-Art Poisson Solvers for Uniform and Nonuniform Grids in the Unit Cube},
   journal = {SIAM Journal on Scientific Computing},
@@ -604,21 +604,21 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@PhDThesis{ghorashi:goal-oriented,
+@PhDThesis{2016:ghorashi:goal-oriented,
   author  = {S. S. Ghorashi},
   title   = {Goal-Oriented Adaptive Modeling of 3d Elastoplasticity Problems},
   school  = {Bauhaus-Universitat Weimar, Weimar, Germany},
   year    = 2016
 }
 
-@Article{giestas.milhazes.ea:cfd,
+@Article{2016:giestas.milhazes.ea:cfd,
   author  = {M. C. Giestas and J. P. Milhazes and A. M. Joyce and H. L. Pina},
   title   = {CFD modeling of a small case solar pond},
   journal = {Proceedings of the EuroSun 2016 conference, Palma de Mallorca, Spain, 11-14 October 2016; International Solar Energy Society},
   year    = 2016
 }
 
-@Article{giuliani.krivodonova:edge,
+@Article{2016:giuliani.krivodonova:edge,
   author  = {Giuliani, Andrew and Krivodonova, Lilia},
   title   = {Edge coloring in unstructured CFD codes},
   journal = {arxiv.org},
@@ -632,7 +632,7 @@
   url     = {http://arxiv.org/abs/1601.07613}
 }
 
-@PhDThesis{guittet:simulation-of-incompressible-viscous-flows-on-distributed-octree-grids,
+@PhDThesis{2016:guittet:simulation-of-incompressible-viscous-flows-on-distributed-octree-grids,
   author  = {Guittet, A},
   title   = {{Simulation of incompressible viscous flows on distributed Octree grids}},
   school  = {University of California},
@@ -641,7 +641,7 @@
   url     = {https://search.proquest.com/openview/a7b27aaca7f352c4cd8446610eeb79f0/1?pq-origsite=gscholar&cbl=18750&diss=y}
 }
 
-@Article{gupta.langelaar.ea:combined,
+@Article{2016:gupta.langelaar.ea:combined,
   author  = {D. K. Gupta and M. Langelaar and F. van Keulen},
   title   = {Combined mesh and penalization adaptivity based topology optimization},
   journal = {Proceedings of the 57th AIAA/ASCE/AHS/ASC Structures, Structural Dynamics, and Materials Conference, AIAA SciTech},
@@ -649,21 +649,21 @@
   url     = {http://dx.doi.org/10.2514/6.2016-0943}
 }
 
-@Article{hai.bause.ea:finite,
+@Article{2016:hai.bause.ea:finite,
   author  = {B. S. M. Ebna Hai and M. Bause and P. A. Kuberry},
   title   = {Finite Element Approximation of the eXtended Fluid-Structure Interaction (eXFSI) Problem},
   journal = {In proceedings of: the ASME 2016 Fluids Engineering Division Summer Meeting, Vol. 1A, No. FEDSM2016-7506, pp. V01AT11A001/1--12, July 10--14, Washington, DC, USA},
   year    = 2016
 }
 
-@MastersThesis{hamann:linear,
+@MastersThesis{2016:hamann:linear,
   author  = {T. Hamann},
   title   = {A linear finite element model of the biceps brachii skeletal muscle},
   year    = 2016,
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
 }
 
-@Article{harmon.gamba.ea:numerical,
+@Article{2016:harmon.gamba.ea:numerical,
   author  = {M. Harmon and I. M. Gamba and K. Ren},
   title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
   journal = {Journal of Computational Physics},
@@ -673,14 +673,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303825}
 }
 
-@PhDThesis{harmon:numerical,
+@PhDThesis{2016:harmon:numerical,
   author  = {M. Harmon},
   title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical (PEC) solar cells},
   year    = 2016,
   school  = {University of Texas at Austin}
 }
 
-@Article{harting:reaction-diffusion-ode,
+@Article{2016:harting:reaction-diffusion-ode,
   author  = {S. H\"{a}rting},
   title   = {Reaction-diffusion-ODE systems: de-novo formation of irregular patterns and model reduction},
   journal = {PhD Dissertation, University of Heidelberg, Germany},
@@ -688,7 +688,7 @@
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/20550/}
 }
 
-@Article{hartmann.leicht:generation,
+@Article{2016:hartmann.leicht:generation,
   author  = {R. Hartmann and T. Leicht},
   title   = {Generation of unstructured curvilinear grids and high-order Discontinuous Galerkin discretization applied to a 3D high-lift configuration},
   journal = {International Journal on Numerical Methods Fluids},
@@ -698,7 +698,7 @@
   url     = {http://ganymed.iwr.uni-heidelberg.de/~hartmann/}
 }
 
-@Article{herz.knabner:including,
+@Article{2016:herz.knabner:including,
   author  = {M. Herz and P. Knabner},
   title   = {Including van der Waals Forces in Diffusion-Convection Equations - Modeling, Analysis, and Numerical Simulations},
   journal = {ArXiv:1608.08431},
@@ -706,7 +706,7 @@
   url     = {https://arxiv.org/abs/1608.08431}
 }
 
-@Article{homolya.ham:parallel,
+@Article{2016:homolya.ham:parallel,
   author  = {M. Homolya and D. A. Ham},
   title   = {A parallel edge orientation algorithm for quadrilateral meshes},
   journal = {SIAM Journal on Scientific Computing, pp. S48-S61},
@@ -714,7 +714,7 @@
   volume  = 38
 }
 
-@MastersThesis{huang:computational,
+@MastersThesis{2016:huang:computational,
   author  = {Tzu-Hsuan Huang},
   title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
   school  = {National Taiwan University},
@@ -723,7 +723,7 @@
   url     = {https://hdl.handle.net/11296/2hzk7d}
 }
 
-@Article{jiang.rudraraju.ea:multiphysics,
+@Article{2016:jiang.rudraraju.ea:multiphysics,
   doi     = {10.1021/acs.jpcc.6b09775},
   url     = {https://doi.org/10.1021/acs.jpcc.6b09775},
   year    = 2016,
@@ -737,14 +737,14 @@
   journal = {The Journal of Physical Chemistry C}
 }
 
-@MastersThesis{jodlbauer:robust,
+@MastersThesis{2016:jodlbauer:robust,
   author  = {D. Jodlbauer},
   title   = {Robust Preconditioners for Fluid-Structure-Interaction Problems},
   year    = 2016,
   school  = {Johannes Kepler University Linz, Austria}
 }
 
-@Book{john:finite,
+@Book{2016:john:finite,
   title   = {Finite Element Methods for Incompressible Flow Problems},
   publisher = {Springer International Publishing},
   year    = 2016,
@@ -753,7 +753,7 @@
   url     = {https://link.springer.com/content/pdf/10.1007/978-3-319-45750-5.pdf}
 }
 
-@InCollection{john:the-time-dependent-navier-stokes-equations--laminar-flows,
+@InCollection{2016:john:the-time-dependent-navier-stokes-equations--laminar-flows,
   author  = {John, Volker},
   title   = {{The Time-Dependent Navier--Stokes Equations: Laminar Flows}},
   booktitle = {Finite Element Methods for Incompressible Flow Problems},
@@ -766,7 +766,7 @@
   journal = {Springer}
 }
 
-@MastersThesis{kahler:on,
+@MastersThesis{2016:kahler:on,
   author  = {R. Kahler},
   title   = {On Identification of Nonlinear Parameters in PDEs},
   year    = 2016,
@@ -774,14 +774,14 @@
   url     = {http://scholarworks.rit.edu/theses/9018/}
 }
 
-@Article{kalichmanow:vergleich,
+@Article{2016:kalichmanow:vergleich,
   author  = {A. Kalichmanow},
   title   = {Vergleich der k-space Methode und der Hybridisierbaren Diskontinuierlichen Galerkin Methode f\"{u}r die akustische Wellengleichung},
   journal = {Term Paper, Technical University of Munich},
   year    = 2016
 }
 
-@Article{kanschat.lorca:weakly,
+@Article{2016:kanschat.lorca:weakly,
   doi     = {10.1515/cmam-2016-0023},
   url     = {https://doi.org/10.1515/cmam-2016-0023},
   year    = 2016,
@@ -795,14 +795,14 @@
   journal = {Computational Methods in Applied Mathematics}
 }
 
-@Article{kanschat.mao:multiplicative,
+@Article{2016:kanschat.mao:multiplicative,
   author  = {G. Kanschat and Y. Mao},
   title   = {Multiplicative overlapping Schwarz smoothers for H$^{\textnormal{div}}$-conforming discontinuous Galerkin methods for the Stokes problem},
   journal = {Domain Decomposition Methods in Science and Engineering XXII; Dickopf, Th., Gander, M.J., Halpern, L., Krause, R., Pavarino, L.F. (Eds.)},
   year    = 2016
 }
 
-@Article{karangelis:analysis,
+@Article{2016:karangelis:analysis,
   author  = {A. Karangelis},
   title   = {Analysis and Massively Parallel Implementation of the 2-Lagrange Multiplier Methods and Optimized Schwarz Methods},
   journal = {PhD dissertation, Heriot-Watt University, Edinburgh, UK},
@@ -810,7 +810,7 @@
   url     = {http://www.macs.hw.ac.uk/~sl398/thesis-karangelis.pdf}
 }
 
-@Article{karban.dolezel:modeling,
+@Article{2016:karban.dolezel:modeling,
   author  = {P. Karban and I. Dolezel},
   title   = {Modeling of fast transients on transmission line using higher-order adaptive methods},
   journal = {2016 ELEKTRO},
@@ -818,7 +818,7 @@
   url     = {http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=7512133}
 }
 
-@Article{kim.zhang:optimized,
+@Article{2016:kim.zhang:optimized,
   author  = {S. Kim and H. Zhang},
   title   = {Optimized double sweep Schwarz method by complete radiation boundary conditions},
   journal = {Computers \& Mathematics with Applications, issue 6},
@@ -828,7 +828,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0898122116304266}
 }
 
-@Article{klinsmann.rosato.ea:modeling,
+@Article{2016:klinsmann.rosato.ea:modeling,
   author  = {M. Klinsmann and D. Rosato and M. Kamlah and R. M. McMeeking},
   title   = {Modeling Crack Growth during Li Extraction in Storage Particles Using a Fracture Phase Field Approach},
   journal = {Journal of The Electrochemical Society, Vol. 63(2), 102-118},
@@ -836,7 +836,7 @@
   url     = {http://jes.ecsdl.org/content/163/2/A102.short}
 }
 
-@Article{klinsmann.rosato.ea:modeling-crack-growth-during-li-insertion-in-storage-particles-using-a-fracture-phase-field-approach,
+@Article{2016:klinsmann.rosato.ea:modeling-crack-growth-during-li-insertion-in-storage-particles-using-a-fracture-phase-field-approach,
   author  = {Markus Klinsmann and Daniele Rosato and Marc Kamlah and Robert M. McMeeking},
   title   = {{Modeling crack growth during Li insertion in storage particles using a fracture phase field approach}},
   journal = {Journal of the Mechanics and Physics of Solids},
@@ -849,7 +849,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Book{klinsmann:effects,
+@Book{2016:klinsmann:effects,
   title   = {The Effects of Internal Stress and Lithium Transport on Fracture in Storage Materials in Lithium-Ion Batteries},
   publisher = {KIT Scientific Publishing},
   year    = 2016,
@@ -862,7 +862,7 @@
   url     = {https://books.google.com/books?hl=en&lr=&id=DaPBCwAAQBAJ&oi=fnd&pg=PA1&ots=OQG-TEOrRd&sig=Rpv8vp1yic72js-9bWMDR3l2lPY}
 }
 
-@Article{konzen.sauter.ea:green,
+@Article{2016:konzen.sauter.ea:green,
   author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo},
   title   = {Green Function Formulation and Finite Element Discretization for Solving the Heat Radiative Transfer in a Slab},
   journal = {Journal of Computational and Theoretical Transport, no. 5},
@@ -872,7 +872,7 @@
   url     = {http://www.tandfonline.com/doi/pdf/10.1080/23324309.2016.1179647?needAccess=true}
 }
 
-@Article{konzen.sauter.ea:numerical,
+@Article{2016:konzen.sauter.ea:numerical,
   author  = {P.H.A. Konzen and E. Sauter and F.S. Azevedo and P. Zingano},
   title   = {Numerical simulations with the finite element method for the Burgers' equation on the real line},
   journal = {arXiv:1605.01109},
@@ -880,7 +880,7 @@
   url     = {https://arxiv.org/abs/1605.01109}
 }
 
-@Article{kormann:time-space,
+@Article{2016:kormann:time-space,
   doi     = {10.4208/cicp.101214.021015a},
   url     = {https://doi.org/10.4208/cicp.101214.021015a},
   year    = 2016,
@@ -894,7 +894,7 @@
   journal = {Communications in Computational Physics}
 }
 
-@MastersThesis{kottapalli:numerical-prediction-of-flow-induced-vibrations-in-nuclear-reactors-through-pressure-fluctuation-modeling,
+@MastersThesis{2016:kottapalli:numerical-prediction-of-flow-induced-vibrations-in-nuclear-reactors-through-pressure-fluctuation-modeling,
   author  = {Shravan Kottapalli},
   title   = {{Numerical Prediction of Flow Induced Vibrations in Nuclear Reactors through Pressure Fluctuation Modeling}},
   school  = {Delft University of Technology},
@@ -902,7 +902,7 @@
   url     = {https://repository.tudelft.nl/islandora/object/uuid:f2c3e758-6c90-4877-8c89-cea243be882c/datastream/OBJ/www.cfd-online.com/Wiki/Reynolds_stress _model_(RSM).pdf}
 }
 
-@Article{kramer.hagemann.ea:parallel,
+@Article{2016:kramer.hagemann.ea:parallel,
   author  = {S. C. Kramer and J. Hagemann and L. Kunneke and J. Lebert},
   title   = {Parallel Statistical Multiresolution Estimation for Image Reconstruction},
   journal = {SIAM J. Sci. Comput.},
@@ -913,7 +913,7 @@
   doi     = {10.1137/15M1020332}
 }
 
-@Article{kronbichler.diagne.ea:fast,
+@Article{2016:kronbichler.diagne.ea:fast,
   author  = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
   title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
   journal = {The International Journal of High Performance Computing Applications},
@@ -927,7 +927,7 @@
   url     = {https://mediatum.ub.tum.de/1272587}
 }
 
-@Article{kronbichler.schoeder.ea:comparison,
+@Article{2016:kronbichler.schoeder.ea:comparison,
   author  = {M. Kronbichler and S. Schoeder and C. M\"{u}ller and W. A. Wall},
   title   = {Comparison of implicit and explicit hybridizable discontinuous Galerkin methods for the acoustic wave equation},
   journal = {International Journal for Numerical Methods in Engineering, Vol 106},
@@ -937,7 +937,7 @@
   doi     = {10.1002/nme.5137}
 }
 
-@Article{kuberry.lee:convergence-of-a-fluid-structure-interaction-problem-decoupled-by-a-neumann-control-over-a-single-time-step,
+@Article{2016:kuberry.lee:convergence-of-a-fluid-structure-interaction-problem-decoupled-by-a-neumann-control-over-a-single-time-step,
   author  = {Paul Kuberry and Hyesuk Lee},
   title   = {{Convergence of a fluid--structure interaction problem decoupled by a Neumann control over a single time step}},
   journal = {Journal of Mathematical Analysis and Applications},
@@ -952,14 +952,14 @@
   url     = {https://www.sciencedirect.com/science/article/pii/S0022247X16000470}
 }
 
-@MastersThesis{kufner:entwurf,
+@MastersThesis{2016:kufner:entwurf,
   author  = {M. Kufner},
   title   = {Entwurf und Implementierung eines Perfectly Matched Layer f\"{u}r die lineare Akustik},
   year    = 2016,
   school  = {Technical University of Munich}
 }
 
-@MastersThesis{kumar:investigation,
+@MastersThesis{2016:kumar:investigation,
   author  = {Kumar, Pankaj},
   title   = {{I}nvestigation of density in {B}uoyancy {F}lows using {CFD} code {J}u{F}ire},
   school  = {Bergische Universit{\"a}t Wuppertal},
@@ -969,7 +969,7 @@
   url     = {https://juser.fz-juelich.de/record/819869}
 }
 
-@Article{kunisch.pieper.ea:time,
+@Article{2016:kunisch.pieper.ea:time,
   author  = {K. Kunisch and K. Pieper and A. Rund},
   title   = {Time optimal control for a reaction diffusion system arising in cardiac electrophysiology - a monolithic approach},
   journal = {ESAIM:M2AN, Vol. 50},
@@ -978,7 +978,7 @@
   url     = {http://www.esaim-m2an.org/articles/m2an/abs/2016/02/m2an141121/m2an141121.html}
 }
 
-@InProceedings{lahnert.burstedde.ea:towards,
+@InProceedings{2016:lahnert.burstedde.ea:towards,
   author  = {Michael Lahnert and Carsten Burstedde and Christian Holm and Miriam Mehl and Georg Rempfer and Florian Weik},
   title   = {Towards Lattice--Boltzmann On Dynamically Adaptive Grids -- Minimally-invasive Grid Exchange In Espresso},
   booktitle = {Proceedings of the {VII} European Congress on Computational Methods in Applied Sciences and Engineering},
@@ -987,7 +987,7 @@
   url     = {https://pdfs.semanticscholar.org/8fc8/2d82beb2997c127248b85ceec8c21bdecfca.pdf}
 }
 
-@InCollection{le-borne:hierarchical,
+@InCollection{2016:le-borne:hierarchical,
   author  = {{Le Borne}, Sabine},
   title   = {Hierarchical Preconditioners for High-Order {FEM}},
   booktitle = {Lecture Notes in Computational Science and Engineering},
@@ -998,7 +998,7 @@
   url     = {http://link.springer.com/10.1007/978-3-319-18827-0_57}
 }
 
-@Article{lee.lee.ea:locally,
+@Article{2016:lee.lee.ea:locally,
   author  = {S. Lee and Y.-J. Lee and M. F. Wheeler},
   title   = {A Locally Conservative Enriched Galerkin Approximation and Efficient Solver for the Parabolic Problems},
   journal = {SIAM Journal on Scientific Computing, Issue 3, pp. A1404-A1429},
@@ -1007,7 +1007,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1041109}
 }
 
-@Article{lee.mikelic.ea:phase-field,
+@Article{2016:lee.mikelic.ea:phase-field,
   doi     = {10.1016/j.cma.2016.02.008},
   url     = {https://doi.org/10.1016/j.cma.2016.02.008},
   year    = 2016,
@@ -1020,7 +1020,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{lee.reber.ea:investigation,
+@Article{2016:lee.reber.ea:investigation,
   doi     = {10.1002/2016gl069979},
   url     = {https://doi.org/10.1002/2016gl069979},
   year    = 2016,
@@ -1034,7 +1034,7 @@
   journal = {Geophysical Research Letters}
 }
 
-@Article{lee.salgado:stability,
+@Article{2016:lee.salgado:stability,
   author  = {S. Lee and A. Salgado},
   title   = {Stability analysis of pressure correction schemes for the Navier-Stokes equations with traction boundary conditions},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1044,7 +1044,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516304923}
 }
 
-@Article{lee.wheeler.ea:pressure,
+@Article{2016:lee.wheeler.ea:pressure,
   author  = {S. Lee and M. F. Wheeler and T. Wick},
   title   = {Pressure and fluid-driven fracture propagation in porous media using an adaptive finite element phase field model},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
@@ -1055,14 +1055,14 @@
   doi     = {10.1016/j.cma.2016.02.037}
 }
 
-@MastersThesis{legat:advancement,
+@MastersThesis{2016:legat:advancement,
   author  = {S. Legat},
   title   = {Advancement of a semi-explicit discontinuous Galerkin approach for simulation of turbulent incompressible flow},
   year    = 2016,
   school  = {Technical University of Munich}
 }
 
-@Article{leibner.milk.ea:extending-dune--the-dune-xt-modules,
+@Article{2016:leibner.milk.ea:extending-dune--the-dune-xt-modules,
   author  = {Leibner, Tobias and Milk, Ren{\'{e}} and Schindler, Felix},
   title   = {{Extending DUNE: The dune-xt modules}},
   journal = {arxiv.org},
@@ -1074,7 +1074,7 @@
   url     = {http://arxiv.org/abs/1602.08991}
 }
 
-@Article{lemenager.oneill.ea:numerical-modelling-of-the-sydney-basin-using-temperature-dependent-thermal-conductivity-measurements,
+@Article{2016:lemenager.oneill.ea:numerical-modelling-of-the-sydney-basin-using-temperature-dependent-thermal-conductivity-measurements,
   author  = {Alexandre Lemenager and Craig O'Neill and Siqi Zhang},
   title   = {{Numerical Modelling of the Sydney Basin Using Temperature Dependent Thermal Conductivity Measurements}},
   journal = {{ASEG} Extended Abstracts},
@@ -1086,7 +1086,7 @@
   url     = {http://www.publish.csiro.au/EX/ASEG2016ab238}
 }
 
-@Article{li.hartmann:adjoint-based,
+@Article{2016:li.hartmann:adjoint-based,
   author  = {D. Li and R. Hartmann},
   title   = {Adjoint-based error estimation and mesh refinement in an adjoint-based airfoil shape optimization of a transonic benchmark problem},
   journal = {New Results in Numerical and Experimental Fluid Mechanics X: Contributions to the 19th STAB/DGLR Symposium Munich, Germany, 2014, Notes on Numerical Fluid Mechanics and Multidisciplinary Design, Springer. },
@@ -1094,7 +1094,7 @@
   pages   = {537--546}
 }
 
-@Article{liu.amberg.ea:diffuse,
+@Article{2016:liu.amberg.ea:diffuse,
   author  = {J. Liu and G. Amberg and M. Do-Quang},
   title   = {Diffuse interface method for a compressible binary fluid},
   journal = {Physical Rev. E},
@@ -1105,7 +1105,7 @@
   doi     = {10.1103/PhysRevE.93.013121}
 }
 
-@InProceedings{lofstead.jean-baptiste.ea:delta,
+@InProceedings{2016:lofstead.jean-baptiste.ea:delta,
   author  = {Lofstead, Jay and Jean-Baptiste, Gregory and Oldfield, Ron},
   title   = {Delta: Data Reduction for Integrated Application Workflows and Data Storage},
   booktitle = {ISC High Performance 2016: High Performance Computing},
@@ -1120,7 +1120,7 @@
   journal = {Springer}
 }
 
-@Article{madzvamuse.chung:analysis-and-simulations-of-coupled-bulk-surface-reaction-diffusion-systems-on-exponentially-evolving-volumes,
+@Article{2016:madzvamuse.chung:analysis-and-simulations-of-coupled-bulk-surface-reaction-diffusion-systems-on-exponentially-evolving-volumes,
   author  = {A. Madzvamuse and A. H. Chung},
   title   = {{Analysis and Simulations of Coupled Bulk-surface Reaction-Diffusion Systems on Exponentially Evolving Volumes}},
   journal = {Mathematical Modelling of Natural Phenomena},
@@ -1134,7 +1134,7 @@
   publisher = {{EDP} Sciences}
 }
 
-@Article{madzvamuse.chung:bulk-surface,
+@Article{2016:madzvamuse.chung:bulk-surface,
   author  = {A. Madzvamuse and A. H. W. Chung},
   title   = {The bulk-surface finite element method for reaction--diffusion systems on stationary volumes},
   journal = {Finite Elements in Analysis and Design},
@@ -1144,7 +1144,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0168874X15001377}
 }
 
-@Article{maier.bardelloni.ea:linearoperator-a,
+@Article{2016:maier.bardelloni.ea:linearoperator-a,
   doi     = {10.1016/j.camwa.2016.04.024},
   url     = {https://doi.org/10.1016/j.camwa.2016.04.024},
   year    = 2016,
@@ -1158,7 +1158,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{maier.rannacher:duality-based,
+@Article{2016:maier.rannacher:duality-based,
   author  = {M. Maier and R. Rannacher},
   title   = {Duality-based adaptivity in finite element discretization of heterogeneous multiscale problems},
   journal = {Journal of Numerical Mathematics, Issue 3},
@@ -1168,7 +1168,7 @@
   url     = {https://www.degruyter.com/view/j/jnma.2016.24.issue-3/jnma-2014-0074/jnma-2014-0074.xml}
 }
 
-@Article{mandal.dean-ben.ea:visual,
+@Article{2016:mandal.dean-ben.ea:visual,
   author  = {Subhamoy Mandal and Xose Luis Dean-Ben and Daniel Razansky},
   title   = {Visual Quality Enhancement in Optoacoustic Tomography Using Active Contour Segmentation Priors},
   journal = {{IEEE} Transactions on Medical Imaging},
@@ -1181,7 +1181,7 @@
   publisher = {Institute of Electrical and Electronics Engineers ({IEEE})}
 }
 
-@Article{marojevic.goklu.ea:atus-pro,
+@Article{2016:marojevic.goklu.ea:atus-pro,
   author  = {\v{Z}. Marojevi\'{c}' and E. G\"{o}kl\"{u} and C. L\"{a}mmerzahl},
   title   = {ATUS-PRO: A FEM-based solver for the time-dependent and stationary Gross-Pitaevskii equation},
   journal = {Computer Physics Communications},
@@ -1190,7 +1190,7 @@
   pages   = {216--232}
 }
 
-@MastersThesis{maroudas:support-of-pdes-for-multidomain-problems-in-a-solving-environment,
+@MastersThesis{2016:maroudas:support-of-pdes-for-multidomain-problems-in-a-solving-environment,
   author  = {Maroudas, Emmanouil},
   title   = {{Support of PDEs for multidomain problems in a solving environment}},
   school  = {University of Thessaly},
@@ -1198,7 +1198,7 @@
   url     = {http://ir.lib.uth.gr/bitstream/handle/11615/46361/14595.pdf?sequence=1}
 }
 
-@Article{maurer.wieners:scalable,
+@Article{2016:maurer.wieners:scalable,
   author  = {Maurer, Daniel and Wieners, Christian},
   title   = {A scalable parallel factorization of finite element matrices with distributed Schur complements},
   journal = {Numerical Linear Algebra with Applications},
@@ -1212,7 +1212,7 @@
   publisher = {Wiley}
 }
 
-@Article{mcrae.bercea.ea:automated,
+@Article{2016:mcrae.bercea.ea:automated,
   author  = {McRae, A. T. T. and Bercea, G.-T. and Mitchell, L. and Ham, D. A. and Cotter, C. J.},
   title   = {Automated Generation and Symbolic Manipulation of Tensor Product Finite Elements},
   journal = {{SIAM} Journal on Scientific Computing},
@@ -1225,7 +1225,7 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@InProceedings{mihankhah.wang:environment,
+@InProceedings{2016:mihankhah.wang:environment,
   author  = {Ehsan Mihankhah and Danwei Wang},
   title   = {Environment characterization using Laplace eigenvalues},
   booktitle = {2016 14th International Conference on Control, Automation, Robotics and Vision (ICARCV)},
@@ -1236,7 +1236,7 @@
   doi     = {10.1109/icarcv.2016.7838769}
 }
 
-@Article{milk.rave.ea:pymor,
+@Article{2016:milk.rave.ea:pymor,
   author  = {R. Milk and S. Rave and F. Schindler},
   title   = {pyMOR - Generic Algorithms and Interfaces for Model Order Reduction},
   journal = {SIAM J. Sci. Comput., issue 5, pp. S194-S216},
@@ -1245,7 +1245,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/15M1026614}
 }
 
-@Article{mirzadeh.guittet.ea:parallel-level-set-methods-on-adaptive-tree-based-grids,
+@Article{2016:mirzadeh.guittet.ea:parallel-level-set-methods-on-adaptive-tree-based-grids,
   author  = {Mohammad Mirzadeh and Arthur Guittet and Carsten Burstedde and Frederic Gibou},
   title   = {{Parallel level-set methods on adaptive tree-based grids}},
   journal = {Journal of Computational Physics},
@@ -1258,14 +1258,14 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{mital.wick.ea:discontinuous,
+@Article{2016:mital.wick.ea:discontinuous,
   author  = {P. Mital and T. Wick and M. F. Wheeler and G. Pencheva},
   title   = {Discontinuous and enriched Galerkin methods for phase-field fracture propagation in elasticity},
   journal = {In: Numerical Mathematics and Advanced Applications, Proceedings of the ENUMATH 2015 conference, Springer},
   year    = 2016
 }
 
-@Article{mitchell.muller:high-level-implementation-of-geometric-multigrid-solvers-for-finite-element-problems--applications-in-atmospheric-modelling,
+@Article{2016:mitchell.muller:high-level-implementation-of-geometric-multigrid-solvers-for-finite-element-problems--applications-in-atmospheric-modelling,
   author  = {Lawrence Mitchell and Eike Hermann M\"{u}ller},
   title   = {{High level implementation of geometric multigrid solvers for finite element problems: Applications in atmospheric modelling}},
   journal = {Journal of Computational Physics},
@@ -1278,7 +1278,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{moawad:approximation,
+@Article{2016:moawad:approximation,
   author  = {R. F. M. Moawad},
   title   = {Approximation of The Neutron Diffusion Equation on Hexagonal Geometries Using a h-p Finite Element Method},
   journal = {PhD dissertation, La Universitat Polit\`{e}cnica de Val\`{e}ncia, Spain},
@@ -1286,14 +1286,14 @@
   url     = {https://riunet.upv.es/handle/10251/65353}
 }
 
-@Misc{mohebujjaman:solution,
+@Misc{2016:mohebujjaman:solution,
   author  = {Muhammad Mohebujjaman},
   title   = {Solution of incompressible viscous time-dependent Navier-Stokes equations using projection method},
   year    = 2016,
   url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/project/Solution-of-incompressible-viscous-time-dependent-Navier-Stokes-equations-using-projection-method/attachment/57ad503e08aef1b475aef153/AS:394116325232643@1470976062899/download/project+_write.pdf?context=ProjectUpdatesLog}
 }
 
-@Article{moinger.forster-zugel.ea:simulation,
+@Article{2016:moinger.forster-zugel.ea:simulation,
   author  = {H. M\"{o}{\ss}inger and F. F\"{o}rster-Z\"{u}gel and H. F. Schlaak},
   title   = {Simulation of the Transient Electromechanical Behaviour of Dielectric Elastomer Transducers},
   journal = {Proc. SPIE 9798, Electroactive Polymer Actuators and Devices (EAPAD), April 15},
@@ -1302,7 +1302,7 @@
   doi     = {10.1117/12.2219133}
 }
 
-@Article{mola.heltai.ea:ship,
+@Article{2016:mola.heltai.ea:ship,
   author  = {A. Mola and L. Heltai and A. D. Simone},
   title   = {Ship Sinkage and Trim Predictions Based on a CAD Interfaced Fully Nonlinear Potential Model},
   journal = {Proceedings of the Twenty-sixth International Ocean and Polar Engineering Conference Rhodes, Greece, June 26-July 1},
@@ -1310,7 +1310,7 @@
   url     = {https://www.onepetro.org/conference-paper/ISOPE-I-16-438}
 }
 
-@Article{monavari.sandfeld.ea:continuum,
+@Article{2016:monavari.sandfeld.ea:continuum,
   author  = {M. Monavari and S. Sandfeld and M. Zaiser},
   title   = {Continuum Representation of Systems of Dislocation Lines: A General Method for Deriving Closed-Form Evolution Equations},
   journal = {Journal of the Mechanics and Physics of Solids},
@@ -1320,7 +1320,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0022509615301903}
 }
 
-@Article{munoz-criollo.cleall.ea:factors,
+@Article{2016:munoz-criollo.cleall.ea:factors,
   author  = {J. J. Munoz-Criollo and P. J. Cleall and S. W. Rees},
   title   = {Factors influencing collection performance of near surface interseasonal ground energy collection and storage systems},
   journal = {Geomechanics for Energy and the Environment},
@@ -1330,7 +1330,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S235238081630020X}
 }
 
-@Article{murphy.venkataraman.ea:computational,
+@Article{2016:murphy.venkataraman.ea:computational,
   author  = {L. Murphy and C. Venkataraman and A. Madzvamuse},
   title   = {A computational approach for mode isolation for reaction-diffusion systems on arbitrary geometries},
   journal = {arXiv:1604.05653},
@@ -1338,7 +1338,7 @@
   url     = {https://arxiv.org/abs/1604.05653}
 }
 
-@MastersThesis{narayanan:parallel,
+@MastersThesis{2016:narayanan:parallel,
   author  = {R. K. Narayanan},
   title   = {Parallel particle-in-cell performance optimization: a case study of electrospray simulation},
   year    = 2016,
@@ -1346,7 +1346,7 @@
   url     = {https://etda.libraries.psu.edu/files/final_submissions/11560}
 }
 
-@Article{nochetto.salgado.ea:diffuse,
+@Article{2016:nochetto.salgado.ea:diffuse,
   author  = {R. H. Nochetto and A. J. Salgado and I. Thomas},
   title   = {A diffuse interface model for two-phase ferrofluid flows},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1356,7 +1356,7 @@
   doi     = {10.1016/j.cma.2016.06.011}
 }
 
-@Article{nochetto.salgado.ea:equations,
+@Article{2016:nochetto.salgado.ea:equations,
   author  = {R. H. Nochetto and A. J. Salgado and I. Tomas},
   title   = {The equations of ferrohydrodynamics: modeling and numerical methods},
   journal = {Mathematical Models and Methods in Applied Sciences, No. 13},
@@ -1366,7 +1366,7 @@
   url     = {http://www.worldscientific.com/doi/abs/10.1142/S0218202516500573?journalCode=m3as}
 }
 
-@Article{oswald.poy.ea:lehmann,
+@Article{2016:oswald.poy.ea:lehmann,
   doi     = {10.1080/02678292.2016.1255363},
   url     = {https://doi.org/10.1080/02678292.2016.1255363},
   year    = 2016,
@@ -1380,7 +1380,7 @@
   journal = {Liquid Crystals}
 }
 
-@Article{owen.barnes:ground-state,
+@Article{2016:owen.barnes:ground-state,
   author  = {E. W. Owen and C. H. W. Barnes},
   title   = {Ground-State Electronic Structure of Quasi-One-Dimensional Wires in Semiconductor Heterostructures},
   journal = {Phys. Rev. Applied, pp. 054007/1-12},
@@ -1390,7 +1390,7 @@
   doi     = {10.1103/PhysRevApplied.6.054007}
 }
 
-@Article{pelteret.davydov.ea:computational,
+@Article{2016:pelteret.davydov.ea:computational,
   author  = {Jean-Paul Pelteret and Denis Davydov and Andrew McBride and Duc Khoi Vu and Paul Steinmann},
   title   = {Computational electro-elasticity and magneto-elasticity for quasi-incompressible media immersed in free space},
   journal = {International Journal for Numerical Methods in Engineering},
@@ -1403,7 +1403,7 @@
   publisher = {Wiley}
 }
 
-@Article{peterson.stogner:a-c1-continuous-finite-element-formulation-for-solving-the-jeffery-hamel-boundary-value-problem,
+@Article{2016:peterson.stogner:a-c1-continuous-finite-element-formulation-for-solving-the-jeffery-hamel-boundary-value-problem,
   author  = {John W. Peterson and Roy H. Stogner},
   title   = {{A C$^{1}$-continuous finite element formulation for solving the Jeffery-Hamel boundary value problem}},
   journal = {arxiv.org},
@@ -1417,14 +1417,14 @@
   url     = {https://arxiv.org/abs/1612.06312}
 }
 
-@PhDThesis{quezada-de-luna:high-order,
+@PhDThesis{2016:quezada-de-luna:high-order,
   author  = {M. {Quezada de Luna}},
   title   = {High-order and maximum principle preserving (MPP) techniques for solving conservation laws with applications on multiphase flow},
   year    = 2016,
   school  = {Texas A\&M University}
 }
 
-@MastersThesis{rahman:posteriori,
+@MastersThesis{2016:rahman:posteriori,
   author  = {Rahman, Mohammad Arifur},
   title   = {An a posteriori error estimator for the C$^{0}$ Interior Penalty Approximations of Fourth Order Elliptic Boundary Value Problem on Quadrilateral Meshes},
   school  = {The University of Texas at El Paso},
@@ -1433,7 +1433,7 @@
   url     = {http://search.proquest.com/openview/a1ba7b7eb39434a7aa45eb9e604a8e22/1?pq-origsite=gscholar&cbl=18750&diss=y}
 }
 
-@Article{rathgeber.ham.ea:firedrake--automating-the-finite-element-method-by-composing-abstractions,
+@Article{2016:rathgeber.ham.ea:firedrake--automating-the-finite-element-method-by-composing-abstractions,
   author  = {Florian Rathgeber and David A. Ham and Lawrence Mitchell and Michael Lange and Fabio Luporini and Andrew T. T. Mcrae and Gheorghe-Teodor Bercea and Graham R. Markall and Paul H. J. Kelly},
   title   = {{Firedrake: automating the finite element method by composing abstractions}},
   journal = {{ACM} Transactions on Mathematical Software},
@@ -1447,7 +1447,7 @@
   url     = {http://www.doc.ic.ac.uk/~lmitche1/08-06-PASC-firedrake.pdf}
 }
 
-@InProceedings{riedlbauer.steinmann.ea:simulation-of-temperature-distribution-and-mechanical-material-behaviour-in-selective-beam-melting-processes,
+@InProceedings{2016:riedlbauer.steinmann.ea:simulation-of-temperature-distribution-and-mechanical-material-behaviour-in-selective-beam-melting-processes,
   author  = {Riedlbauer, D and Steinmann, P and Mergheim, J},
   title   = {{Simulation of temperature distribution and mechanical material behaviour in selective beam melting processes}},
   booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
@@ -1455,7 +1455,7 @@
   url     = {https://www.eccomas2016.org/proceedings/pdf/4477.pdf}
 }
 
-@MastersThesis{roberge:computational,
+@MastersThesis{2016:roberge:computational,
   author  = {J. R. Roberge},
   title   = {Computational Design of Ceramic Bone Scaffolds Fabricated Via Direct Ink Writing},
   year    = 2016,
@@ -1463,7 +1463,7 @@
   url     = {http://digitalcommons.uconn.edu/gs_theses/989/}
 }
 
-@InProceedings{rodriguez-gonzalez.montesi:new,
+@InProceedings{2016:rodriguez-gonzalez.montesi:new,
   author  = {Rodr\'{i}guez-Gonz\'{a}lez, Juan and Montesi, Laurent},
   title   = {A new finite element code for the study of strain-localization under strike-slip faults},
   booktitle = {American Geophysical Union Fall Meeting Abstracts},
@@ -1471,7 +1471,7 @@
   url     = {https://agu.confex.com/agu/fm16/meetingapp.cgi/Paper/183591}
 }
 
-@Article{rose:true,
+@Article{2016:rose:true,
   author  = {I. R. Rose},
   title   = {True polar wander on convecting planets},
   journal = {PhD dissertation, University of Califonia, Berkeley},
@@ -1479,7 +1479,7 @@
   url     = {http://search.proquest.com/docview/1873864258?pq-origsite=gscholar}
 }
 
-@PhDThesis{roszmann:simulation,
+@PhDThesis{2016:roszmann:simulation,
   author  = {Roszmann, Jordan Douglas},
   title   = {Simulation and growth of cadmium zinc telluride from small seeds by the travelling heater method},
   school  = {University of Victoria},
@@ -1487,7 +1487,7 @@
   url     = {http://dspace.library.uvic.ca/handle/1828/7347}
 }
 
-@Article{rudraraju.ven.ea:mechano-chemical,
+@Article{2016:rudraraju.ven.ea:mechano-chemical,
   author  = {Shiva Rudraraju and Anton Van der Ven and Krishna Garikipati},
   title   = {Mechano-chemical spinodal decomposition: a phenomenological theory of phase transformations in multi-component, crystalline solids},
   journal = {Computational Materials},
@@ -1497,7 +1497,7 @@
   url     = {10.1038/npjcompumats.2016.12}
 }
 
-@Article{salinger.bartlett.ea:albany--using-component-based-design-to-develop-a-flexible--generic-multiphysics-analysis-code,
+@Article{2016:salinger.bartlett.ea:albany--using-component-based-design-to-develop-a-flexible--generic-multiphysics-analysis-code,
   author  = {Andrew G. Salinger and Roscoe A. Bartlett and Andrew M. Bradley and Qiushi Chen and Irina P. Demeshko and Xujiao Gao and Glen A. Hansen and Alejandro Mota and Richard P. Muller and Erik Nielsen and Jakob T. Ostien and Roger P. Pawlowski and Mauro Perego and Eric T. Phipps and WaiChing Sun and Irina K. Tezaur},
   title   = {{Albany: Using component-based design to develop a flexible, generic multiphysics analysis code}},
   journal = {International Journal for Multiscale Computational Engineering},
@@ -1510,7 +1510,7 @@
   publisher = {Begell House}
 }
 
-@InProceedings{salmoiraghi.ballarin.ea:advances,
+@InProceedings{2016:salmoiraghi.ballarin.ea:advances,
   author  = {Salmoiraghi, F and Ballarin, F and Corsi, G and Mola, A and Tezzele, M},
   title   = {Advances in geometrical parametrization and reduced order models and methods for computational fluid dynamics problems in applied sciences and engineering},
   booktitle = {Proceedings of the ECCOMAS Congress 2016, VII European Conference on Computational Methods in Applied Sciences and Engineering},
@@ -1522,7 +1522,7 @@
   doi     = {10.7712/100016.1867.8680}
 }
 
-@Article{samii.michoski.ea:parallel,
+@Article{2016:samii.michoski.ea:parallel,
   author  = {A. Samii and C. Michoski and C. Dawson},
   title   = {A parallel and adaptive hybridized discontinuous Galerkin method for anisotropic nonhomogeneous diffusion},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1532,7 +1532,7 @@
   doi     = {10.1016/j.cma.2016.02.009}
 }
 
-@TechReport{sasidharan.snir:miniamr,
+@TechReport{2016:sasidharan.snir:miniamr,
   author  = {Sasidharan, Aparna and Snir, Marc},
   title   = {MiniAMR -- A miniapp for Adaptive Mesh Refinement},
   institution = {University of Illinois at Urbana-Champaign},
@@ -1540,7 +1540,7 @@
   url     = {https://www.ideals.illinois.edu/handle/2142/91046}
 }
 
-@PhDThesis{scheffer:charakterisierung,
+@PhDThesis{2016:scheffer:charakterisierung,
   author  = {Scheffer, Tobias},
   title   = {Charakterisierung des nichtlinear-viskoelastischen Materialverhaltens gef{\"{u}}llter Elastomere},
   school  = {Universit\"{a}t des Saarlandes},
@@ -1549,7 +1549,7 @@
   url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/23186}
 }
 
-@Article{schlogl.leyendecker:dynamic,
+@Article{2016:schlogl.leyendecker:dynamic,
   author  = {T. Schl\"{o}gl and S. Leyendecker},
   title   = {Dynamic Simulation of Dielectric Elastomer Actuated Multibody Systems},
   journal = {Proceedings of the ASME 2016 Conference on Smart Materials, Adaptive Structures and Intelligent Systems SMASIS2016, September 28-30},
@@ -1557,7 +1557,7 @@
   url     = {http://proceedings.asmedigitalcollection.asme.org/proceeding.aspx?articleid=2589204}
 }
 
-@Article{schlogl.leyendecker:electrostatic-viscoelastic,
+@Article{2016:schlogl.leyendecker:electrostatic-viscoelastic,
   author  = {T. Schl\"{o}gl and S. Leyendecker},
   title   = {Electrostatic--viscoelastic finite element model of dielectric actuators},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1567,7 +1567,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782515003461}
 }
 
-@Article{sheldon.miller.ea:hybridizable,
+@Article{2016:sheldon.miller.ea:hybridizable,
   author  = {J. P. Sheldon and S. T. Miller and J. S. Pitt},
   title   = {A hybridizable discontinuous Galerkin method for modeling fluid--structure interaction},
   journal = {Journal of Computational Physics, pp. 91--114},
@@ -1576,21 +1576,21 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116303941}
 }
 
-@PhDThesis{sheldon:hybridizable,
+@PhDThesis{2016:sheldon:hybridizable,
   author  = {J. Sheldon},
   title   = {A hybridizable discontinuous Galerkin method for modeling fluid-structure interaction.},
   year    = 2016,
   school  = {The Pennsylvania State University}
 }
 
-@MastersThesis{siehr:das-newton-verfahren-zur-berechnung-variationeller-eigenwertprobleme,
+@MastersThesis{2016:siehr:das-newton-verfahren-zur-berechnung-variationeller-eigenwertprobleme,
   author  = {Siehr, Philipp},
   title   = {{Das Newton-Verfahren zur Berechnung variationeller Eigenwertprobleme}},
   school  = {Universit\"{a}t Heidelberg},
   year    = 2016
 }
 
-@Article{soine.hersch.ea:measuring,
+@Article{2016:soine.hersch.ea:measuring,
   doi     = {10.1098/rsfs.2016.0024},
   url     = {https://doi.org/10.1098/rsfs.2016.0024},
   year    = 2016,
@@ -1604,7 +1604,7 @@
   journal = {Interface Focus}
 }
 
-@InProceedings{stegmann.yang:development-of-a-discontinuous-galerkin-time-domain-solver-on-a-staggered-grid-for-pan-spectral-single-scattering-analysis,
+@InProceedings{2016:stegmann.yang:development-of-a-discontinuous-galerkin-time-domain-solver-on-a-staggered-grid-for-pan-spectral-single-scattering-analysis,
   author  = {P. G. Stegmann and P. Yang},
   title   = {{Development of a Discontinuous Galerkin Time Domain Solver on a staggered grid for pan-spectral single scattering analysis}},
   booktitle = {Light, Energy and the Environment},
@@ -1615,7 +1615,7 @@
   note    = {Unconfirmed citation}
 }
 
-@PhDThesis{stegmann:light,
+@PhDThesis{2016:stegmann:light,
   author  = {Stegmann, Patrick G\"{u}nther},
   title   = {Light Scattering by Non-Spherical Particles},
   school  = {Technische Universit\"{a}t Darmstadt},
@@ -1623,7 +1623,7 @@
   url     = {http://tuprints.ulb.tu-darmstadt.de/5257/}
 }
 
-@Article{stoll.pearson.ea:fast,
+@Article{2016:stoll.pearson.ea:fast,
   author  = {M. Stoll and J. Pearson and P. K. Maini},
   title   = {Fast solvers for optimal control problems from pattern formation},
   journal = {Journal of Computational Physics, Volume 304},
@@ -1632,7 +1632,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999115006683}
 }
 
-@PhDThesis{tsoeu:electrical,
+@PhDThesis{2016:tsoeu:electrical,
   author  = {T{\v{s}}oeu, Mohohlo Samuel},
   title   = {Electrical Impedance Tomography/Spectroscopy (EITS): a Code Division Multiplexed (CDM) approaches},
   school  = {University of Cape Town},
@@ -1640,7 +1640,7 @@
   url     = {https://open.uct.ac.za/handle/11427/22866}
 }
 
-@Article{turcksin.kronbichler.ea:workstream,
+@Article{2016:turcksin.kronbichler.ea:workstream,
   author  = {B. Turcksin and M. Kronbichler and W. Bangerth},
   title   = {WorkStream -- a design pattern for multicore-enabled finite element computations},
   journal = {ACM Transactions on Mathematical Software, pp. 2/1-29},
@@ -1648,7 +1648,7 @@
   volume  = 43
 }
 
-@Article{turner.clarno.ea:the-virtual-environment-for-reactor-applications-vera--design-and-architecture,
+@Article{2016:turner.clarno.ea:the-virtual-environment-for-reactor-applications-vera--design-and-architecture,
   author  = {John A. Turner and Kevin Clarno and Matt Sieger and Roscoe Bartlett and Benjamin Collins and Roger Pawlowski and Rodney Schmidt and Randall Summers},
   title   = {{The Virtual Environment for Reactor Applications (VERA): Design and architecture}},
   journal = {Journal of Computational Physics},
@@ -1661,7 +1661,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{veske.kyritsakis.ea:atomistic,
+@Article{2016:veske.kyritsakis.ea:atomistic,
   author  = {M. Veske and A. Kyritsakis and F. Djurabekova and R. Aare and K. Eimre and V. Zadin},
   title   = {Atomistic modeling of metal surfaces under high electric fields: Direct coupling of electric fields to the atomistic simulations},
   journal = {29th International Vacuum Nanoelectronics Conference (IVNC), Vancouver, Canada},
@@ -1669,7 +1669,7 @@
   url     = {http://ieeexplore.ieee.org/document/7551501/}
 }
 
-@Article{vidal-ferrandiz.fayez.ea:moving,
+@Article{2016:vidal-ferrandiz.fayez.ea:moving,
   doi     = {10.1016/j.cam.2015.03.040},
   url     = {https://doi.org/10.1016/j.cam.2015.03.040},
   year    = 2016,
@@ -1682,7 +1682,7 @@
   journal = {Journal of Computational and Applied Mathematics}
 }
 
-@Article{vidal-ferrandiz.gonzalez-pintor.ea:use,
+@Article{2016:vidal-ferrandiz.gonzalez-pintor.ea:use,
   author  = {A. Vidal-Ferrandiz and S. Gonzalez-Pintor and D. Ginestart and G. Verdu and M. Asadzadeh and C. Demaziere},
   title   = {Use of discontinuity factors in high-order finite element methods},
   journal = {Annals of Nuclear Energy, Part 2},
@@ -1692,7 +1692,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0306454915003357}
 }
 
-@InProceedings{voll.stollenwerk.ea:computing,
+@InProceedings{2016:voll.stollenwerk.ea:computing,
   doi     = {10.1117/12.2220292},
   url     = {http://proceedings.spiedigitallibrary.org/proceeding.aspx?articleid=2505859},
   year    = 2016,
@@ -1704,7 +1704,7 @@
   booktitle = {High-Power Laser Materials Processing: Lasers, Beam Delivery, Diagnostics, and Applications V}
 }
 
-@Article{wacker.arndt.ea:nodal-based,
+@Article{2016:wacker.arndt.ea:nodal-based,
   author  = {B. Wacker and D. Arndt and G. Lube},
   title   = {Nodal-based Finite Element Methods with Local Projection Stabilization for Linearized Incompressible Magnetohydrodynamics},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1714,7 +1714,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516000062}
 }
 
-@Article{wang.rudraraju.ea:three,
+@Article{2016:wang.rudraraju.ea:three,
   title   = {A three dimensional field formulation, and isogeometric solutions to point and line defects using Toupin's theory of gradient elasticity at finite strains},
   journal = {Journal of the Mechanics and Physics of Solids},
   volume  = 94,
@@ -1724,7 +1724,7 @@
   author  = {Z. Wang and S. Rudraraju and K. Garikipati}
 }
 
-@Article{white.castelletto.ea:block-partitioned,
+@Article{2016:white.castelletto.ea:block-partitioned,
   author  = {J. A. White and N. Castelletto and H. A. Tchelepi},
   title   = {Block-partitioned solvers for coupled poromechanics: A unified framework},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1734,7 +1734,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516000104}
 }
 
-@PhDThesis{white:parallel-block-preconditioning-of-the-incompressible-navier-stokes-equations-with-weakly-imposed-boundary-conditions,
+@PhDThesis{2016:white:parallel-block-preconditioning-of-the-incompressible-navier-stokes-equations-with-weakly-imposed-boundary-conditions,
   author  = {White, Raymon},
   title   = {{Parallel block preconditioning of the incompressible Navier-Stokes equations with weakly imposed boundary conditions}},
   school  = {University of Manchester},
@@ -1743,7 +1743,7 @@
   url     = {http://search.proquest.com/openview/283931f019e73788c05df3ebafe35abc/1?pq-origsite=gscholar&cbl=2026366&diss=y}
 }
 
-@InProceedings{wick:coupling,
+@InProceedings{2016:wick:coupling,
   doi     = {10.1007/978-3-319-39929-4_38},
   year    = 2016,
   publisher = {Springer International Publishing},
@@ -1754,7 +1754,7 @@
   series  = {Lecture Notes in Computational Science and Engineering}
 }
 
-@Article{wick:coupling*1,
+@Article{2016:wick:coupling*1,
   doi     = {10.1016/j.jcp.2016.09.024},
   year    = 2016,
   month   = dec,
@@ -1766,7 +1766,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{wick:goal,
+@Article{2016:wick:goal,
   author  = {T. Wick},
   title   = {Goal functional evaluations for phase-field fracture using PU-based DWR mesh adaptivity},
   journal = {Computational Mechanics},
@@ -1776,7 +1776,7 @@
   url     = {http://dx.doi.org/10.1007/s00466-016-1275-1}
 }
 
-@TechReport{wilbrandt.bartsch.ea:parmoon,
+@TechReport{2016:wilbrandt.bartsch.ea:parmoon,
   author  = {Wilbrandt, U and Bartsch, C and Ahmed, N and Alia, N and Anker, F},
   title   = {ParMooN -- a modernized program package based on mapped finite elements},
   institution = {Weierstra{\ss}-Institut f\"{u}r Angewandte Analysis und Stochastik},
@@ -1784,7 +1784,7 @@
   url     = {http://www.wias-berlin.de/preprint/2316/wias_preprints_2316_20161220.pdf}
 }
 
-@InProceedings{xu.ye.ea:high,
+@InProceedings{2016:xu.ye.ea:high,
   author  = {Li-Yang Xu and Shuai Ye and Yong-Quan Feng and Hao Li and Xin-Hai Xu and Xiao-Guang Ren},
   title   = {High Order Accurate Curved-element Implementation in {OpenFOAM} for Discontinuous Galerkin Method},
   booktitle = {Advanced Science and Technology Letters},
@@ -1796,7 +1796,7 @@
   url     = {https://www.researchgate.net/profile/Hao_Li192/publication/312344754_High_Order_Accurate_Curved-element_Implementation_in_OpenFOAM_for_Discontinuous_Galerkin_Method/links/590d26134585159781831faa/High-Order-Accurate-Curved-element-Implementation-in-OpenFOAM-for-Discontinuous-Galerkin-Method.pdf}
 }
 
-@PhDThesis{yang:continuous,
+@PhDThesis{2016:yang:continuous,
   author  = {Y. Yang},
   title   = {Continuous finite element approximation of hyperbolic systems},
   year    = 2016,
@@ -1804,7 +1804,7 @@
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/157976}
 }
 
-@Article{yoon.kang:mass-transfer-enhancement-by-a-single-emulsion-droplet,
+@Article{2016:yoon.kang:mass-transfer-enhancement-by-a-single-emulsion-droplet,
   author  = {Yoon, Sungho and Kang, Yong Tae},
   title   = {{Mass Transfer Enhancement by a Single Emulsion Droplet}},
   journal = {International Journal of Air-Conditioning and Refrigeration},
@@ -1817,7 +1817,7 @@
   url     = {http://www.worldscientific.com/doi/abs/10.1142/S2010132516500036}
 }
 
-@Article{young.vargas.ea:hartree-fock,
+@Article{2016:young.vargas.ea:hartree-fock,
   author  = {T. D. Young and R. Vargas and J.Garza},
   title   = {A Hartree--Fock study of the confined helium atom: Local and global basis set approaches},
   journal = {Physics Letters A, Vol. 380},
@@ -1826,7 +1826,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0375960115009998}
 }
 
-@Article{zander.bog.ea:the-multi-level-hp-method-for-three-dimensional-problems--dynamically-changing-high-order-mesh-refinement-with-arbitrary-hanging-nodes,
+@Article{2016:zander.bog.ea:the-multi-level-hp-method-for-three-dimensional-problems--dynamically-changing-high-order-mesh-refinement-with-arbitrary-hanging-nodes,
   author  = {Nils Zander and Tino Bog and Mohamed Elhaddad and Felix Frischmann and Stefan Kollmannsberger and Ernst Rank},
   title   = {{The multi-level hp-method for three-dimensional problems: Dynamically changing high-order mesh refinement with arbitrary hanging nodes}},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1839,7 +1839,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{zhang.norato.ea:geometry,
+@Article{2016:zhang.norato.ea:geometry,
   author  = {S. Zhang and J. A. Norato and A. L. Gain and N. Lyu},
   title   = {A geometry projection method for the topology optimization of plate structures},
   journal = {Structural and Multidisciplinary Optimization, issue 5, pp. 1173--1190},
@@ -1848,7 +1848,7 @@
   url     = {https://link.springer.com/article/10.1007/s00158-016-1466-6}
 }
 
-@Article{zhang.oneill:early,
+@Article{2016:zhang.oneill:early,
   author  = {S. Zhang and C. O'Neill},
   title   = {The early geodynamic evolution of Mars-type planets},
   journal = {Icarus, Vol. 265, pp. 187--208},
@@ -1856,14 +1856,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0019103515004856}
 }
 
-@Article{zheng.mcclarren:asymptotic,
+@Article{2016:zheng.mcclarren:asymptotic,
   author  = {W. Zheng and R. G. McClarren},
   title   = {Asymptotic preserving least square PN methods of transport equation},
   journal = {Proceedings of PHYSOR 2016, Sun Valley, Idaho, May 1-5},
   year    = 2016
 }
 
-@Article{zheng.mcclarren:effective-non-oscillatory-regularized-l1-finite-elements-for-particle-transport-simulations,
+@Article{2016:zheng.mcclarren:effective-non-oscillatory-regularized-l1-finite-elements-for-particle-transport-simulations,
   author  = {Zheng, Weixiong and McClarren, Ryan G.},
   title   = {{Effective Non-oscillatory Regularized L1 Finite Elements for Particle Transport Simulations}},
   journal = {arxiv.org},
@@ -1877,7 +1877,7 @@
   url     = {https://arxiv.org/abs/1612.05581}
 }
 
-@Article{zheng.mcclarren:moment,
+@Article{2016:zheng.mcclarren:moment,
   author  = {W. Zheng and R. G. McClarren},
   title   = {Moment closures based on minimizing the residual of the PN angular expansion in radiation transport},
   journal = {J. Comput. Phys.},
@@ -1887,7 +1887,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116001820}
 }
 
-@PhDThesis{zheng:least-squares,
+@PhDThesis{2016:zheng:least-squares,
   author  = {Zheng, Weixiong},
   title   = {Least-Squares and Other Residual Based Techniques for Radiation Transport Calculations},
   school  = {Texas A\&M University},
@@ -1895,7 +1895,7 @@
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/159075}
 }
 
-@MastersThesis{zixuan:computational,
+@MastersThesis{2016:zixuan:computational,
   title   = {Computational Phase-Field Modeling for Microstructural Evolution in Bioinspired Material from Freeze-Casting Process},
   author  = {Huang Zixuan},
   year    = 2016,

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1,6 +1,19 @@
 % Encoding: US-ASCII
 
-@Article{adler.emerson.ea:combining,
+@Article{2016:harmon.gamba.ea:numerical,
+  doi     = {10.1016/j.jcp.2016.08.026},
+  url     = {https://doi.org/10.1016/j.jcp.2016.08.026},
+  year    = 2016,
+  month   = dec,
+  publisher = {Elsevier {BV}},
+  volume  = 327,
+  pages   = {140--167},
+  author  = {Michael Harmon and Irene M. Gamba and Kui Ren},
+  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical ({PEC}) solar cells},
+  journal = {Journal of Computational Physics}
+}
+
+@Article{2017:adler.emerson.ea:combining,
   author  = {J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan},
   title   = {Combining Deflation and Nested Iteration for Computing Multiple Solutions of Nonlinear Variational Problems},
   journal = {SIAM J. Sci. Comput., issue 1, B29-B52},
@@ -9,7 +22,7 @@
   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1058728}
 }
 
-@Article{agelek.anderson.ea:on,
+@Article{2017:agelek.anderson.ea:on,
   author  = {R. Agelek and M. Anderson and W. Bangerth and W. L. Barth},
   title   = {On orienting edges of unstructured two- and three-dimensional meshes},
   journal = {ACM Transactions on Mathematical Software, article 5},
@@ -17,7 +30,7 @@
   volume  = 44
 }
 
-@Article{aizinger.kosik.ea:anisotropic,
+@Article{2017:aizinger.kosik.ea:anisotropic,
   doi     = {10.1002/fld.4360},
   url     = {https://doi.org/10.1002/fld.4360},
   year    = 2017,
@@ -31,14 +44,14 @@
   journal = {International Journal for Numerical Methods in Fluids}
 }
 
-@Article{almani.lee.ea:multirate,
+@Article{2017:almani.lee.ea:multirate,
   author  = {T. Almani and S. Lee and M. F. Wheeler and T. Wick},
   title   = {Multirate coupling for flow and geomechanics applied to hydraulic fracturing using an adaptive phase-field technique},
   journal = {SPE RSC 182610-MS, Feb. 2017, Montgomery, Texas, USA},
   year    = 2017
 }
 
-@Article{almeida-konzen.azevedo.ea:numerical,
+@Article{2017:almeida-konzen.azevedo.ea:numerical,
   doi     = {10.5540/tema.2017.018.02.0287},
   url     = {https://doi.org/10.5540/tema.2017.018.02.0287},
   year    = 2017,
@@ -52,7 +65,7 @@
   journal = {{TEMA} (S{\~{a}}o Carlos)}
 }
 
-@MastersThesis{alzetta:core,
+@MastersThesis{2017:alzetta:core,
   author  = {G. Alzetta},
   title   = {Core building blocks for massively parallel multi-physics applications},
   school  = {SISSA},
@@ -60,7 +73,7 @@
   url     = {https://iris.sissa.it/retrieve/handle/20.500.11767/68032/61711/Giovanni%20Alzetta.pdf}
 }
 
-@Article{araujo.engstrom:on,
+@Article{2017:araujo.engstrom:on,
   doi     = {10.1016/j.camwa.2017.07.020},
   url     = {https://doi.org/10.1016/j.camwa.2017.07.020},
   year    = 2017,
@@ -74,7 +87,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{arbogast.hesse.ea:mixed,
+@Article{2017:arbogast.hesse.ea:mixed,
   doi     = {10.1137/16m1091095},
   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1091095},
   year    = 2017,
@@ -88,7 +101,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@InProceedings{aristotelous.papanicolaou:numerical,
+@InProceedings{2017:aristotelous.papanicolaou:numerical,
   doi     = {10.1063/1.5007418},
   url     = {https://doi.org/10.1063/1.5007418},
   year    = 2017,
@@ -97,7 +110,7 @@
   title   = {A numerical study of biofilm growth in a microgravity environment}
 }
 
-@Article{arndt.bangerth.ea:deal-ii,
+@Article{2017:arndt.bangerth.ea:deal-ii,
   author  = {D. Arndt and W. Bangerth and D. Davydov and T. Heister and L. Heltai and M. Kronbichler and M. Maier and B. Turcksin and D. Wells},
   title   = {The \texttt{deal.II} Library, Version 8.5},
   journal = {Journal of Numerical Mathematics},
@@ -107,7 +120,7 @@
   doi     = {10.1515/jnma-2017-0058}
 }
 
-@Article{austermann.mitrovica.ea:detection,
+@Article{2017:austermann.mitrovica.ea:detection,
   author  = {J. Austermann and J. X. Mitrovica and P. Huybers and A. Rovere},
   title   = {Detection of a dynamic topography signal in last interglacial sea-level records},
   journal = {Science Advances},
@@ -118,7 +131,7 @@
   doi     = {10.1126/sciadv.1700457}
 }
 
-@Article{avila.meister.ea:adaptive,
+@Article{2017:avila.meister.ea:adaptive,
   doi     = {10.1016/j.apnum.2017.06.013},
   url     = {https://doi.org/10.1016/j.apnum.2017.06.013},
   year    = 2017,
@@ -131,7 +144,7 @@
   journal = {Applied Numerical Mathematics}
 }
 
-@Article{axelsson.farouq.ea:preconditioner,
+@Article{2017:axelsson.farouq.ea:preconditioner,
   author  = {O. Axelsson and S. Farouq and M. Neytcheva},
   title   = {A preconditioner for optimal control problems, constrained by Stokes equation with a time-harmonic control},
   journal = {Journal of Computational and Applied Mathematics},
@@ -141,7 +154,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302631}
 }
 
-@Article{badnava.etemadi.ea:phase,
+@Article{2017:badnava.etemadi.ea:phase,
   author  = {H. Badnava and E. Etemadi and M. A. Msekh},
   title   = {A Phase Field Model for Rate-Dependent Ductile Fracture},
   journal = {Metals, article 180},
@@ -150,7 +163,7 @@
   url     = {http://www.mdpi.com/2075-4701/7/5/180/htm}
 }
 
-@Article{ballani.kressner.ea:multilevel,
+@Article{2017:ballani.kressner.ea:multilevel,
   doi     = {10.1007/s40072-017-0092-7},
   url     = {https://doi.org/10.1007/s40072-017-0092-7},
   year    = 2017,
@@ -164,7 +177,7 @@
   journal = {Stochastics and Partial Differential Equations: Analysis and Computations}
 }
 
-@Article{basak.levitas:interfacial,
+@Article{2017:basak.levitas:interfacial,
   author  = {A. Basak and V. I. Levitas},
   title   = {Interfacial stresses within boundary between martensitic variants: Analytical and numerical finite strain solutions for three phase field models},
   journal = {Acta Materialia},
@@ -173,7 +186,7 @@
   pages   = {174--187}
 }
 
-@Article{bause.radu.ea:error,
+@Article{2017:bause.radu.ea:error,
   author  = {M. Bause and F. Radu and U. K\"{o}cher},
   title   = {Error analysis for discretizations of parabolic problems using continuous finite elements in time and mixed finite elements in space},
   journal = {Numerische Mathematik},
@@ -184,7 +197,7 @@
   doi     = {10.1007/s00211-017-0894-6}
 }
 
-@Article{bause.radu.ea:space-time,
+@Article{2017:bause.radu.ea:space-time,
   author  = {M. Bause and F. A. Radu and U. K\"{o}cher},
   title   = {Space-time finite element approximation of the Biot poroelasticity system with iterative coupling},
   journal = {Comput. Meth. Appl. Mech. Engrg.},
@@ -194,7 +207,7 @@
   url     = {https://www.sciencedirect.com/science/article/pii/S0045782516316164?via%3Dihub}
 }
 
-@PhDThesis{beams:high-order-hybrid-methods-using-greens-functions-and-finite-elements,
+@PhDThesis{2017:beams:high-order-hybrid-methods-using-greens-functions-and-finite-elements,
   title   = {{High-order hybrid methods using Green's functions and finite elements}},
   author  = {Beams, Natalie N},
   school  = {University of Illinois at Urbana-Champaign},
@@ -202,14 +215,14 @@
   url     = {https://www.ideals.illinois.edu/bitstream/handle/2142/98387/BEAMS-DISSERTATION-2017.pdf?sequence=1}
 }
 
-@Article{becerra.akbarzadeh-sharbaf.ea:solving,
+@Article{2017:becerra.akbarzadeh-sharbaf.ea:solving,
   author  = {D. M. Fernandez Becerra and A. Akbarzadeh-Sharbaf and D. Giannacopoulos},
   title   = {Solving Finite-Element Time-Domain Problems with GaBP},
   journal = {IEEE Transactions on Magnetics PP(99):1-1},
   year    = 2017
 }
 
-@Misc{berselli.wells.ea:spatial,
+@Misc{2017:berselli.wells.ea:spatial,
   title   = {Spatial Filtering for Reduced Order Modeling},
   author  = {L. C. Berselli and D. Wells and X. Xie and T. Iliescu},
   year    = 2017,
@@ -218,7 +231,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{biermann.blum.ea:modelling,
+@Article{2017:biermann.blum.ea:modelling,
   author  = {D. Biermann and H. Blum and I. Iovkov and A. Rademacher and K. Rosin and F.-T. Suttmeier},
   title   = {Modelling, Simulation and Compensation of Thermomechanically Induced Deviations in Deep-Hole Drilling with Minimum Quantity Lubrication},
   journal = {In: Biermann D., Hollmann F. (eds): Thermal Effects in Complex Machining Processes. Lecture Notes in Production Engineering. Springer},
@@ -228,7 +241,7 @@
   doi     = {10.1007/978-3-319-57120-1_10}
 }
 
-@MastersThesis{boltersdorf:ausarbeitung,
+@MastersThesis{2017:boltersdorf:ausarbeitung,
   author  = {Boltersdorf, Jana},
   title   = {{A}usarbeitung und {V}ergleich verschiedener {G}itterverfeinerungsstrategien hinsichtlich der parallelen {P}erformance eines {B}randsimulationsprogramms mit adaptiver {G}itterverfeinerung},
   school  = {Fachhochschule Aachen},
@@ -238,14 +251,14 @@
   url     = {https://juser.fz-juelich.de/record/842585}
 }
 
-@Article{bonetti.cavaterra.ea:nonlinear,
+@Article{2017:bonetti.cavaterra.ea:nonlinear,
   author  = {E. Bonetti and C. Cavaterra and F. Freddi and M. Grasselli and R. Natalini},
   title   = {A nonlinear model for marble sulphation including surface rugosity: theoretical and numerical results},
   journal = {arXiv:1710.01225},
   year    = 2017
 }
 
-@Article{bonetti.freddi.ea:existence,
+@Article{2017:bonetti.freddi.ea:existence,
   author  = {E. Bonetti and F. Freddi and A. Segatti},
   title   = {An existence result for a model of complete damage in elastic materials with reversible evolution},
   journal = {Continuum Mechanics and Thermodynamics, issue 1},
@@ -255,7 +268,7 @@
   url     = {https://link.springer.com/article/10.1007/s00161-016-0520-3}
 }
 
-@Misc{bonito.demlow.ea:priori,
+@Misc{2017:bonito.demlow.ea:priori,
   title   = {A Priori Error Estimates for Finite Element Approximations to Eigenvalues and Eigenfunctions of the Laplace-Beltrami Operator},
   author  = {Andrea Bonito and Alan Demlow and Justin Owen},
   year    = 2017,
@@ -264,7 +277,7 @@
   primaryclass = {math.NA}
 }
 
-@PhDThesis{brand:forces-and-flow-of-contractile-networks,
+@PhDThesis{2017:brand:forces-and-flow-of-contractile-networks,
   title   = {{Forces and Flow of Contractile Networks}},
   author  = {Brand, Christoph Alexander},
   year    = 2017,
@@ -273,14 +286,14 @@
   doi     = {10.11588/heidok.00020233}
 }
 
-@MastersThesis{brauer:reduced-order,
+@MastersThesis{2017:brauer:reduced-order,
   author  = {P. Br\"{a}uer},
   title   = {Reduced-Order modeling for transient thermoelasticity with moving sources using global-local bases},
   year    = 2017,
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
 }
 
-@Article{bredow.steinberger.ea:how,
+@Article{2017:bredow.steinberger.ea:how,
   author  = {E. Bredow and B. Steinberger and R. Gassm\"{o}ller and J. Dannberg},
   title   = {How plume-ridge interaction shapes the crustal thickness pattern of the R\'{e}union hotspot track},
   journal = {Geochem. Geophys. Geosyst.},
@@ -289,7 +302,7 @@
   doi     = {10.1002/2017GC006875}
 }
 
-@Article{brisard:reconstructing,
+@Article{2017:brisard:reconstructing,
   doi     = {10.1002/nme.5263},
   year    = 2017,
   month   = jan,
@@ -302,7 +315,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Article{bucci.swamy.ea:modeling,
+@Article{2017:bucci.swamy.ea:modeling,
   author  = {G. Bucci and T. Swamy and Y.-M. Chiang and W. C. Carter},
   title   = {Modeling of internal mechanical failure of all-solid-state batteries during electrochemical cycling, and implications for battery design},
   journal = {Journals of Materials Chemistry A},
@@ -310,7 +323,7 @@
   volume  = 5
 }
 
-@Article{burger.kenettinkara.ea:approximate,
+@Article{2017:burger.kenettinkara.ea:approximate,
   doi     = {10.1016/j.camwa.2017.06.019},
   url     = {https://doi.org/10.1016/j.camwa.2017.06.019},
   year    = 2017,
@@ -324,7 +337,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{cajuhi.sanavia.ea:phase-field,
+@Article{2017:cajuhi.sanavia.ea:phase-field,
   doi     = {10.1007/s00466-017-1459-3},
   url     = {https://doi.org/10.1007/s00466-017-1459-3},
   year    = 2017,
@@ -338,7 +351,7 @@
   journal = {Computational Mechanics}
 }
 
-@Article{carraro.goll:goal-oriented,
+@Article{2017:carraro.goll:goal-oriented,
   author  = {T. Carraro and C. Goll},
   title   = {A Goal-Oriented Error Estimator for a Class of Homogenization Problems},
   journal = {Journal of Scientific Computing, issue 3},
@@ -348,7 +361,7 @@
   url     = {https://link.springer.com/article/10.1007/s10915-016-0338-y}
 }
 
-@Article{carreno.vidal-ferrandiz.ea:multilevel,
+@Article{2017:carreno.vidal-ferrandiz.ea:multilevel,
   author  = {A. Carre{\~{n}}o and A. Vidal-Ferrandiz and D. Ginestar and G. Verd\'{u}},
   title   = {Multilevel method to compute the lambda modes of the neutron diffusion equation},
   journal = {Applied Mathematics and Nonlinear Sciences},
@@ -357,7 +370,7 @@
   pages   = {225--236}
 }
 
-@Article{chandrashekar.zenk:well-balanced,
+@Article{2017:chandrashekar.zenk:well-balanced,
   author  = {Praveen Chandrashekar and Markus Zenk},
   title   = {Well-Balanced Nodal Discontinuous Galerkin Method for Euler Equations with Gravity},
   journal = {Journal of Scientific Computing},
@@ -370,7 +383,7 @@
   publisher = {Springer Nature}
 }
 
-@Misc{charnyi.heister.ea:efficient,
+@Misc{2017:charnyi.heister.ea:efficient,
   title   = {Efficient discretizations for the EMAC formulation of the incompressible Navier-Stokes equations},
   author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
   year    = 2017,
@@ -379,7 +392,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{charnyi.heister.ea:on,
+@Article{2017:charnyi.heister.ea:on,
   author  = {S. Charnyi and T. Heister and M. A. Olshanskii and L. G. Rebholz},
   title   = {On conservation laws of Navier-Stokes Galerkin discretizations},
   journal = {Journal of Computational Physics},
@@ -389,14 +402,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S002199911730133X}
 }
 
-@PhDThesis{chu:application,
+@PhDThesis{2017:chu:application,
   author  = {H.-C. Chu},
   title   = {Application of the fictitious domain method to flow problems with complex geometries},
   year    = 2017,
   school  = {Texas A\&M University}
 }
 
-@PhDThesis{cox:adaptive-large-scale-mantle-convection-simulations,
+@PhDThesis{2017:cox:adaptive-large-scale-mantle-convection-simulations,
   title   = {{Adaptive large-scale mantle convection simulations}},
   author  = {Cox, S. P.},
   year    = 2017,
@@ -404,7 +417,7 @@
   url     = {https://lra.le.ac.uk/handle/2381/39571}
 }
 
-@Article{dannberg.eilon.ea:importance,
+@Article{2017:dannberg.eilon.ea:importance,
   doi     = {10.1002/2017gc006944},
   url     = {https://doi.org/10.1002/2017gc006944},
   year    = 2017,
@@ -418,7 +431,7 @@
   journal = {Geochemistry, Geophysics, Geosystems}
 }
 
-@MastersThesis{david:multi-patch,
+@MastersThesis{2017:david:multi-patch,
   author  = {K. David},
   title   = {Multi-patch Discontinuous Galerkin Isogeometric Analysis for Porous Media Flow},
   year    = 2017,
@@ -426,7 +439,7 @@
   url     = {http://repository.tudelft.nl/islandora/object/uuid:85dfa311-2926-4390-a91b-876141e607e0/datastream/OBJ/view}
 }
 
-@Article{davydov.gerasimov.ea:convergence,
+@Article{2017:davydov.gerasimov.ea:convergence,
   author  = {Denis Davydov and Tymofiy Gerasimov and Jean-Paul Pelteret and Paul Steinmann},
   title   = {Convergence study of the h-adaptive {PUM} and the hp-adaptive {FEM} applied to eigenvalue problems in quantum mechanics},
   journal = {Advanced Modeling and Simulation in Engineering Sciences},
@@ -439,7 +452,7 @@
   publisher = {Springer Nature}
 }
 
-@Article{deolmi.dahmen.ea:effective,
+@Article{2017:deolmi.dahmen.ea:effective,
   doi     = {10.4208/cicp.oa-2016-0015},
   url     = {https://doi.org/10.4208/cicp.oa-2016-0015},
   year    = 2017,
@@ -453,7 +466,7 @@
   journal = {Communications in Computational Physics}
 }
 
-@Article{dewitt.solomon.ea:misfit-driven,
+@Article{2017:dewitt.solomon.ea:misfit-driven,
   author  = {S. DeWitt and E. L. S. Solomon and A. R. Natarajan and V. Araulio-Peters and S. Rudrajaru and L. K. Aegesen and B. Puchala and E. A. Marquis and A. van der Ven and K. Thornton and J. E. Allison},
   title   = {Misfit-driven {\ss}''' precipitate composition and morphology in Mg-Nd alloys},
   journal = {Acta Materialia},
@@ -463,7 +476,7 @@
   doi     = {10.1016/j.actamat.2017.06.053}
 }
 
-@Article{dhillon.milinkovitch.ea:bifurcation,
+@Article{2017:dhillon.milinkovitch.ea:bifurcation,
   doi     = {10.1007/s11538-017-0255-8},
   url     = {https://doi.org/10.1007/s11538-017-0255-8},
   year    = 2017,
@@ -477,7 +490,7 @@
   journal = {Bulletin of Mathematical Biology}
 }
 
-@Article{diehl:review,
+@Article{2017:diehl:review,
   author  = {M. Diehl},
   title   = {Review and outlook: Mechanical, thermodynamic, and kinetic continuum modeling of metallic materials at the grain scale},
   journal = {MRS Communications},
@@ -487,7 +500,7 @@
   doi     = {10.1557/mrc.2017.98}
 }
 
-@MastersThesis{dockhorn:turbulence,
+@MastersThesis{2017:dockhorn:turbulence,
   author  = {T. Dockhorn},
   title   = {Turbulence modeling for large eddy simulation of incompressible flows using high-order discontinuous Galerkin methods},
   year    = 2017,
@@ -495,7 +508,7 @@
   note    = {Bachelor's thesis}
 }
 
-@Misc{emerson:posteriori,
+@Misc{2017:emerson:posteriori,
   title   = {A Posteriori Error Estimators for the Frank-Oseen Model of Liquid Crystals},
   author  = {D. B. Emerson},
   year    = 2017,
@@ -504,7 +517,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{endtmayer.wick:partition-of-unity,
+@Article{2017:endtmayer.wick:partition-of-unity,
   doi     = {10.1515/cmam-2017-0001},
   url     = {https://doi.org/10.1515/cmam-2017-0001},
   year    = 2017,
@@ -517,7 +530,7 @@
   journal = {Computational Methods in Applied Mathematics}
 }
 
-@Article{ervin.lee.ea:nonlinear,
+@Article{2017:ervin.lee.ea:nonlinear,
   author  = {V. J. Ervin and H. Lee and J. Ruiz-Ramirez},
   title   = {Nonlinear Darcy fluid flow with deposition},
   journal = {Journal of Computational and Applied Mathematics},
@@ -527,7 +540,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302977}
 }
 
-@Article{fehn.wall.ea:on,
+@Article{2017:fehn.wall.ea:on,
   author  = {N. Fehn and W. A. Wall and M. Kronbichler},
   title   = {On the stability of projection methods for the incompressible Navier-Stokes equations based on high-order discontinuous Galerkin discretizations},
   journal = {Journal of Computational Physics},
@@ -536,7 +549,7 @@
   pages   = {392--421}
 }
 
-@Article{freddi.iurlano:numerical,
+@Article{2017:freddi.iurlano:numerical,
   author  = {F. Freddi and F. Iurlano},
   title   = {Numerical insight of a variational smeared approach to cohesive fracture},
   journal = {Journal of the Mechanics and Physics of Solids},
@@ -546,7 +559,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0022509616304860}
 }
 
-@Article{fu.ermakov.ea:interior,
+@Article{2017:fu.ermakov.ea:interior,
   doi     = {10.1016/j.epsl.2017.07.053},
   url     = {https://doi.org/10.1016/j.epsl.2017.07.053},
   year    = 2017,
@@ -559,7 +572,7 @@
   journal = {Earth and Planetary Science Letters}
 }
 
-@MastersThesis{fuchs:hermite-artige,
+@MastersThesis{2017:fuchs:hermite-artige,
   author  = {A. Fuchs},
   title   = {Hermite-artige Basisfunktionen f\"{u}r diskontinuierliche Galerkin-Verfahren hoher Ordnung},
   year    = 2017,
@@ -567,7 +580,7 @@
   note    = {Bachelor's thesis}
 }
 
-@Misc{galiano.velasco:on,
+@Misc{2017:galiano.velasco:on,
   title   = {On a cross-diffusion system arising in image denosing},
   author  = {Gonzalo Galiano and Juli{\'a}n Velasco},
   year    = 2017,
@@ -576,7 +589,7 @@
   primaryclass = {math.AP}
 }
 
-@PhDThesis{gallego-valencia:on,
+@PhDThesis{2017:gallego-valencia:on,
   author  = {J. P. Gallego-Valencia},
   title   = {On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamic model},
   school  = {University of W\"{u}rzburg, Germany},
@@ -584,7 +597,7 @@
   url     = {https://www.researchgate.net/profile/Juan_Gallego-Valencia/publication/317093976_On_Runge-Kutta_discontinuous_Galerkin_methods_for_compressible_Euler_equations_and_the_ideal_magneto-hydrodynamical_model/links/592978060f7e9b9979a686c2/On-Runge-Kutta-discontinuous-Galerkin-methods-for-compressible-Euler-equations-and-the-ideal-magneto-hydrodynamical-model.pdf}
 }
 
-@PhDThesis{gallego-valencia:on-runge-kutta-discontinuous-galerkin-methods-for-compressible-euler-equations-and-the-ideal-magneto-hydrodynamical-model,
+@PhDThesis{2017:gallego-valencia:on-runge-kutta-discontinuous-galerkin-methods-for-compressible-euler-equations-and-the-ideal-magneto-hydrodynamical-model,
   title   = {{On Runge-Kutta discontinuous Galerkin methods for compressible Euler equations and the ideal magneto-hydrodynamical model}},
   author  = {J. P. {Gallego Valencia}},
   year    = 2017,
@@ -592,7 +605,7 @@
   url     = {https://www.researchgate.net/profile/Juan_Gallego-Valencia/publication/317093976_On_Runge-Kutta_discontinuous_Galerkin_methods_for_compressible_Euler_equations_and_the_ideal_magneto-hydrodynamical_model/links/592978060f7e9b9979a686c2/On-Runge-Kutta-discontinuous-Galerkin-methods-for-compressible-Euler-equations-and-the-ideal-magneto-hydrodynamical-model.pdf}
 }
 
-@Article{ganesan:microstructural-response-of-magnesium-alloys--3d-crystal-plasticity-and-experimental-validation,
+@Article{2017:ganesan:microstructural-response-of-magnesium-alloys--3d-crystal-plasticity-and-experimental-validation,
   title   = {{Microstructural Response of Magnesium Alloys: 3D Crystal Plasticity and Experimental Validation}},
   author  = {Ganesan, S},
   year    = 2017,
@@ -600,7 +613,7 @@
   url     = {http://www-personal.umich.edu/~veeras/papers/sriramthesis.pdf}
 }
 
-@Article{garikipati:perspectives,
+@Article{2017:garikipati:perspectives,
   doi     = {10.1016/j.jmps.2016.11.013},
   url     = {https://doi.org/10.1016/j.jmps.2016.11.013},
   year    = 2017,
@@ -613,14 +626,14 @@
   journal = {Journal of the Mechanics and Physics of Solids}
 }
 
-@PhDThesis{ghesmati:residual,
+@PhDThesis{2017:ghesmati:residual,
   author  = {A. Ghesmati},
   title   = {Residual and goal-oriented h- and hp-adaptive finite element; application for elliptic and saddle point problems},
   year    = 2017,
   school  = {Texas A\&M University}
 }
 
-@Article{ghorashi.lahmer.ea:stochastic,
+@Article{2017:ghorashi.lahmer.ea:stochastic,
   doi     = {10.1016/j.enggeo.2016.07.012},
   url     = {https://doi.org/10.1016/j.enggeo.2016.07.012},
   year    = 2017,
@@ -633,7 +646,7 @@
   journal = {Engineering Geology}
 }
 
-@Article{ghorashi.rabczuk:goal-oriented,
+@Article{2017:ghorashi.rabczuk:goal-oriented,
   author  = {S. S. Ghorashi and T. Rabczuk},
   title   = {Goal-oriented error estimation and mesh adaptivity in 3d elastoplasticity problems},
   journal = {International Journal of Fracture, issue 1},
@@ -643,7 +656,7 @@
   url     = {https://link.springer.com/article/10.1007/s10704-016-0113-y}
 }
 
-@PhDThesis{giuliani:modelling-fluid-structure-interaction-problems-using-boundary-element-method,
+@PhDThesis{2017:giuliani:modelling-fluid-structure-interaction-problems-using-boundary-element-method,
   title   = {{Modelling Fluid Structure Interaction problems using Boundary Element Method}},
   author  = {Giuliani, N},
   school  = {Scuola Internazionale Superiore di Studi Avanzati - Trieste},
@@ -651,7 +664,7 @@
   url     = {https://iris.sissa.it/handle/20.500.11767/57293}
 }
 
-@Article{glerum.thieulot.ea:implementing,
+@Article{2017:glerum.thieulot.ea:implementing,
   author  = {A. Glerum and C. Thieulot and M. Fraters and C. Blom and W. Spakman},
   title   = {Implementing nonlinear viscoplasticity in ASPECT: benchmarking and applications to 3D subduction modeling},
   note    = {Submitted},
@@ -659,21 +672,21 @@
   url     = {https://www.solid-earth-discuss.net/se-2017-9/}
 }
 
-@MastersThesis{goering:implicit-explicit,
+@MastersThesis{2017:goering:implicit-explicit,
   author  = {C. Goering},
   title   = {Implicit-explicit Runge-Kutta methods for acoustics with the hybridizable discontinuous Galerkin method},
   year    = 2017,
   school  = {Technical University of Munich}
 }
 
-@Article{goering:slope,
+@Article{2017:goering:slope,
   author  = {C. Goering},
   title   = {Slope limiters and shock capturing for acoustics with HDG discretization},
   journal = {Term Paper, Technical University of Munich},
   year    = 2017
 }
 
-@Article{goll.wick.ea:dopelib,
+@Article{2017:goll.wick.ea:dopelib,
   doi     = {10.11588/ANS.2017.2.11815},
   url     = {http://journals.ub.uni-heidelberg.de/index.php/ans/article/view/11815},
   author  = {Goll, Christian and Wick, Thomas and Wollner, Winnifried},
@@ -686,7 +699,7 @@
   year    = 2017
 }
 
-@Article{grohs.hiptmair.ea:tensor-product,
+@Article{2017:grohs.hiptmair.ea:tensor-product,
   doi     = {10.5802/smai-jcm.26},
   url     = {https://doi.org/10.5802/smai-jcm.26},
   year    = 2017,
@@ -698,7 +711,7 @@
   journal = {{SMAI} Journal of Computational Mathematics}
 }
 
-@PhDThesis{grove:discretizations,
+@PhDThesis{2017:grove:discretizations,
   title   = {Discretizations \& Efficient Linear Solvers for Problems Related to Fluid Flow},
   author  = {Ryan R. Grove},
   school  = {Clemson University},
@@ -706,7 +719,7 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/1985/}
 }
 
-@Article{guermond.luna.ea:conservative,
+@Article{2017:guermond.luna.ea:conservative,
   author  = {J.-L. Guermond and M. Quesada de Luna and T. Thompson},
   title   = {An conservative anti-diffusion technique for the level set method},
   journal = {Journal of Computational and Applied Mathematics},
@@ -716,7 +729,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S037704271730081X}
 }
 
-@Article{guermond.popov.ea:invariant,
+@Article{2017:guermond.popov.ea:invariant,
   doi     = {10.1137/16m1063034},
   url     = {https://doi.org/10.1137/16m1063034},
   year    = 2017,
@@ -730,7 +743,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{gupta.veen.ea:bounds,
+@Article{2017:gupta.veen.ea:bounds,
   author  = {D. K. Gupta and G. J. van der Veen and A. M. Aragon and M. Langelaar and F. van Keulen},
   title   = {Bounds for decoupled design and analysis discretizations in topology optimization},
   journal = {International Journal for Numerical Methods in Engineering},
@@ -739,35 +752,35 @@
   note    = {In press}
 }
 
-@Article{hai.bause:finite,
+@Article{2017:hai.bause:finite,
   author  = {B. S. M. Ebna Hai and M. Bause},
   title   = {Finite Element Approximation of Fluid-Structure Interaction (FSI) Problem with Coupled Wave Propagation},
   journal = {In proceedings of: the 88 th GAMM Annual Meeting of the International Association of Applied Mathematics and Mechanics, March 6--10, Weimar, Germany. In: PAMM - Proceedings in Applied Mathematics and Mechanics},
   year    = 2017
 }
 
-@Article{hai.bause:mathematical,
+@Article{2017:hai.bause:mathematical,
   author  = {B. S. M. Ebna Hai and M. Bause},
   title   = {Mathematical Modelling and Numerical Simulation of the On-line Structural Health Monitoring System},
   journal = {In proceedings of: the 11 th International Workshop on Structural Health Monitoring, Structural Health Monitoring 2017, Sept 12--14, Stanford University, CA, USA. In: F-K. Chang and F. Kopsaftopoulos (Ed.), ``Structural Health Monitoring 2017: Real-Time Material State Awareness and Data-Driven Safety Assurance.''},
   year    = 2017
 }
 
-@PhDThesis{hai:finite,
+@PhDThesis{2017:hai:finite,
   author  = {B. S. M. Ebna Hai},
   title   = {Finite Element Approximation of Ultrasonic Wave Propagation under Fluid-Structure Interaction for Structural Health Monitoring Systems},
   year    = 2017,
   school  = {Helmut Schmidt University-University of the Federal Armed Forces Hambur, Germany}
 }
 
-@MastersThesis{haider:numerical,
+@MastersThesis{2017:haider:numerical,
   author  = {S. Haider},
   title   = {Numerical analysis and comparison of high performance incompressible Navier Stokes equations solvers based on the discontinuous Galerkin Method},
   year    = 2017,
   school  = {Technical University of Munich}
 }
 
-@MastersThesis{hanowski:numerical,
+@MastersThesis{2017:hanowski:numerical,
   author  = {C. Hanowski},
   title   = {Numerical Homogenisation of Magneto-Active Materials},
   year    = 2017,
@@ -775,20 +788,7 @@
   note    = {Project thesis}
 }
 
-@Article{harmon.gamba.ea:numerical,
-  doi     = {10.1016/j.jcp.2016.08.026},
-  url     = {https://doi.org/10.1016/j.jcp.2016.08.026},
-  year    = 2016,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 327,
-  pages   = {140--167},
-  author  = {Michael Harmon and Irene M. Gamba and Kui Ren},
-  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical ({PEC}) solar cells},
-  journal = {Journal of Computational Physics}
-}
-
-@Article{he.puckett.ea:discontinuous,
+@Article{2017:he.puckett.ea:discontinuous,
   author  = {Y. He and E. G. Puckett and M. I. Billen},
   title   = {A Discontinuous Galerkin Method with a Bound Preserving Limiter for the Advection of non-Diffusive Fields in Solid Earth Geodynamics},
   journal = {Physics of the Earth and Planetary Interiors},
@@ -798,7 +798,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0031920116300747}
 }
 
-@Article{heister.dannberg.ea:high,
+@Article{2017:heister.dannberg.ea:high,
   author  = {T. Heister and J. Dannberg and R. Gassm\"{o}ller and W. Bangerth},
   title   = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods. II: Realistic Models and Problems},
   journal = {Geophysical Journal International},
@@ -809,7 +809,7 @@
   doi     = {10.1093/gji/ggx195}
 }
 
-@InCollection{hinze.kunkel.ea:model,
+@InCollection{2017:hinze.kunkel.ea:model,
   doi     = {10.1007/978-3-319-07236-4_1},
   url     = {https://doi.org/10.1007/978-3-319-07236-4_1},
   year    = 2017,
@@ -820,7 +820,7 @@
   booktitle = {Mathematics in Industry}
 }
 
-@PhDThesis{holmgren:modelling-of-moving-contact-lines-in-two-phase-flows,
+@PhDThesis{2017:holmgren:modelling-of-moving-contact-lines-in-two-phase-flows,
   title   = {{Modelling of Moving Contact Lines in Two-Phase Flows}},
   author  = {Holmgren, H},
   year    = 2017,
@@ -828,7 +828,7 @@
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2:1139929}
 }
 
-@InProceedings{horak.straub.ea:epicyclic,
+@InProceedings{2017:horak.straub.ea:epicyclic,
   title   = {Epicyclic oscillations of thick relativistic disks},
   author  = {J. Hor{\'a}k and O. Straub and E. {\v{S}}r{\'a}mkov{\'a} and K. Goluchov{\'{a}} and G. T{\"{o}}r{\"{o}}k},
   booktitle = {Proceedings of RAGtime 2015/2016/2017, Opava, Czech Republic},
@@ -838,7 +838,7 @@
   url     = {http://proceedings.physics.cz/images/proc17/hor2.pdf}
 }
 
-@Article{hwang.fish.ea:software,
+@Article{2017:hwang.fish.ea:software,
   doi     = {10.1002/2016ea000225},
   url     = {https://doi.org/10.1002/2016ea000225},
   year    = 2017,
@@ -852,7 +852,7 @@
   journal = {Earth and Space Science}
 }
 
-@Article{jansen.sohrabi.ea:hulk,
+@Article{2017:jansen.sohrabi.ea:hulk,
   author  = {G. Jansen and R. Sohrabi and S. A. Miller},
   title   = {HULK -- Simple and fast generation of structured hexahedral meshes for improved subsurface simulations},
   journal = {Computers \& Geoscience},
@@ -862,14 +862,14 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0098300416307063}
 }
 
-@Article{jodlbauer.wick:monolithic,
+@Article{2017:jodlbauer.wick:monolithic,
   author  = {D. Jodlbauer and T. Wick},
   title   = {A monolithic FSI solver applied to the FSI 1,2,3 benchmarks},
   journal = {In: Fluid-Structure Interaction: Modeling, Adaptive Discretization and Solvers, S. Frei and B. Holm and T. Richter and T. Wick and H. Yang (eds.), Walter de Gruyter},
   year    = 2017
 }
 
-@PhDThesis{joos:microstructural-characterisation--modelling-and-simulation-of-solid-oxide-fuel-cell-cathodes,
+@PhDThesis{2017:joos:microstructural-characterisation--modelling-and-simulation-of-solid-oxide-fuel-cell-cathodes,
   title   = {{Microstructural Characterisation, Modelling and Simulation of Solid Oxide Fuel Cell Cathodes}},
   author  = {Joos, J},
   year    = 2017,
@@ -877,7 +877,7 @@
   url     = {https://publikationen.bibliothek.kit.edu/1000064791/4189242}
 }
 
-@Misc{joshi.chatterjee:a-posteriori,
+@Misc{2017:joshi.chatterjee:a-posteriori,
   title   = {A-posteriori diffusion analysis of higher-order numerical schemes for application to propagating linear waves},
   author  = {S. M. Joshi and A. Chatterjee},
   year    = 2017,
@@ -886,7 +886,7 @@
   primaryclass = {physics.comp-ph}
 }
 
-@MastersThesis{kan:finite,
+@MastersThesis{2017:kan:finite,
   author  = {Kan, Duygu},
   title   = {Finite element solution for 2-D and 3-D acoustic scattering problem},
   school  = {\.{I}stanbul Teknik \"{U}niversitesi},
@@ -894,7 +894,7 @@
   url     = {https://acikbilim.yok.gov.tr/handle/20.500.12812/128565}
 }
 
-@Article{kanschat.lazarov.ea:geometric,
+@Article{2017:kanschat.lazarov.ea:geometric,
   author  = {G. Kanschat and R. Lazarov and Y. Mao},
   title   = {Geometric Multigrid for Darcy and Brinkman models of flows in highly heterogeneous porous media: A numerical study},
   journal = {Journal of Computational and Applied Mathematics},
@@ -904,7 +904,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302333}
 }
 
-@Article{karban.dolezel:fully,
+@Article{2017:karban.dolezel:fully,
   doi     = {10.1007/s00202-017-0629-9},
   url     = {https://doi.org/10.1007/s00202-017-0629-9},
   year    = 2017,
@@ -918,7 +918,7 @@
   journal = {Electrical Engineering}
 }
 
-@Article{karrecha.abbassi.ea:self-consistent,
+@Article{2017:karrecha.abbassi.ea:self-consistent,
   author  = {A. Karrecha and F. Abbassi and H. Basarir and M. Attar},
   title   = {Self-consistent fractal damage of natural geo-materials in finite strain},
   journal = {Mechanics of Materials, pp. 107--120},
@@ -927,7 +927,7 @@
   url     = {https://www.degruyter.com/view/j/cmam.2016.16.issue-4/cmam-2016-0023/cmam-2016-0023.xml}
 }
 
-@Article{kauffman.sheldon.ea:overset,
+@Article{2017:kauffman.sheldon.ea:overset,
   doi     = {10.1002/nme.5512},
   url     = {https://doi.org/10.1002/nme.5512},
   year    = 2017,
@@ -941,7 +941,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@InProceedings{kodanganallur-narayanan:parallel-particle-in-cell-performance-optimization--a-case-study-of-electrospray-simulation,
+@InProceedings{2017:kodanganallur-narayanan:parallel-particle-in-cell-performance-optimization--a-case-study-of-electrospray-simulation,
   author  = {{Kodanganallur Narayanan}, Ramachandran},
   title   = {{Parallel Particle-in-Cell Performance Optimization: A Case Study of Electrospray Simulation}},
   booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})},
@@ -951,7 +951,7 @@
   doi     = {10.1109/ipdpsw.2017.160}
 }
 
-@InProceedings{korous.karban.ea:distributed,
+@InProceedings{2017:korous.karban.ea:distributed,
   title   = {Distributed Implicit Discontinuous Galerkin {MHD} Solver},
   author  = {Korous, L and Karban, P and Skala, J},
   booktitle = {Proceedings of the 2017 CompuMag conference},
@@ -959,7 +959,7 @@
   url     = {http://www.compumag.org/CMAG2017/[PD-A7-13]_492.pdf}
 }
 
-@Article{kramer.kullmer.ea:semi-lagrangian,
+@Article{2017:kramer.kullmer.ea:semi-lagrangian,
   doi     = {10.1103/physreve.95.023305},
   url     = {https://doi.org/10.1103/physreve.95.023305},
   year    = 2017,
@@ -972,7 +972,7 @@
   journal = {Physical Review E}
 }
 
-@PhDThesis{kramer:lattice-boltzmann-methoden,
+@PhDThesis{2017:kramer:lattice-boltzmann-methoden,
   author  = {Andreas Kr{\"a}mer},
   title   = {Lattice-{B}oltzmann-{M}ethoden zur {S}imulation inkompressibler {W}irbelstr{\"o}mungen},
   year    = 2017,
@@ -980,7 +980,7 @@
   url     = {https://dspace.ub.uni-siegen.de/handle/ubsi/1237}
 }
 
-@Article{krank.fehn.ea:high-order,
+@Article{2017:krank.fehn.ea:high-order,
   author  = {B. Krank and N. Fehn and W. A. Wall and M. Kronbichler},
   title   = {A high-order semi-explicit discontinuous Galerkin solver for 3D incompressible flow with application to DNS and LES of turbulent channel flow},
   journal = {Journal of Computational Physics},
@@ -989,7 +989,7 @@
   pages   = {634--659}
 }
 
-@Article{kronbichler.kormann.ea:fast,
+@Article{2017:kronbichler.kormann.ea:fast,
   author  = {M. Kronbichler and K. Kormann and I. Pasichnyk and M. Allalen},
   title   = {Fast matrix-free discontinuous Galerkin kernels on modern computer architectures},
   journal = {ISC High Performance 2017, LNCS 10266},
@@ -998,7 +998,7 @@
   url     = {https://dx.doi.org/10.1007/978-3-319-58667-0_13}
 }
 
-@Article{kronbichler.kreiss:phase-field,
+@Article{2017:kronbichler.kreiss:phase-field,
   author  = {M. Kronbichler and G. Kreiss},
   title   = {A phase-field microscale enhancement for macro models of capillary-driven contact point dynamics},
   journal = {The Journal for Computational Multiphase Flows},
@@ -1006,7 +1006,7 @@
   url     = {http://dx.doi.org/10.1177/1757482X17700148}
 }
 
-@Article{kynch.ledger:resolving,
+@Article{2017:kynch.ledger:resolving,
   doi     = {10.1016/j.compstruc.2016.05.021},
   url     = {https://doi.org/10.1016/j.compstruc.2016.05.021},
   year    = 2017,
@@ -1019,7 +1019,7 @@
   journal = {Computers {\&} Structures}
 }
 
-@Article{lee.wheeler.ea:initialization,
+@Article{2017:lee.wheeler.ea:initialization,
   author  = {S. Lee and M. F. Wheeler and T. Wick and S. Srinivasan},
   title   = {Initialization of phase-field fracture propagation in porous media using probability maps of fracture networks},
   journal = {Mechanics Research Communications, pp. 16--23},
@@ -1029,7 +1029,7 @@
   doi     = {10.1016/j.mechrescom.2016.04.002}
 }
 
-@Article{lee.wheeler.ea:iterative,
+@Article{2017:lee.wheeler.ea:iterative,
   author  = {S. Lee and M. F. Wheeler and T. Wick},
   title   = {Iterative coupling of flow, geomechanics and adaptive phase-field fracture including level-set crack width approaches},
   journal = {Journal of Computational and Applied Mathematics},
@@ -1042,7 +1042,7 @@
   url     = {https://pdfs.semanticscholar.org/02aa/832e109562d3201aaab220f0b6e3a4ddddbb.pdf}
 }
 
-@Article{lee.wheeler:adaptive,
+@Article{2017:lee.wheeler:adaptive,
   author  = {S. Lee and M. F. Wheeler},
   title   = {Adaptive enriched Galerkin methods for miscible displacement problems with entropy residual stabilization},
   journal = {Journal of Computational Physics},
@@ -1052,7 +1052,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999116305952}
 }
 
-@Article{li.gurnis.ea:towards,
+@Article{2017:li.gurnis.ea:towards,
   author  = {D. Li and M. Gurnis and G. Stadler},
   title   = {Towards adjoint-based inversion of time-dependent mantle convection with nonlinear viscosity},
   journal = {Geophysics Journal International},
@@ -1061,7 +1061,7 @@
   pages   = {86--105}
 }
 
-@InProceedings{li.ren.ea:practical,
+@InProceedings{2017:li.ren.ea:practical,
   doi     = {10.1109/cit.2017.22},
   url     = {https://doi.org/10.1109/cit.2017.22},
   year    = 2017,
@@ -1072,7 +1072,7 @@
   booktitle = {2017 {IEEE} International Conference on Computer and Information Technology ({CIT})}
 }
 
-@Misc{licht.maier:flux,
+@Misc{2017:licht.maier:flux,
   title   = {Flux Reconstruction for Goal-Oriented A Posteriori Error Estimation},
   author  = {Martin Licht and Matthias Maier},
   year    = 2017,
@@ -1081,7 +1081,7 @@
   primaryclass = {math.NA}
 }
 
-@MastersThesis{lin:high,
+@MastersThesis{2017:lin:high,
   author  = {S. Lin},
   title   = {High Performance Techniques Applied in Partial Differential Equations Library},
   year    = 2017,
@@ -1089,7 +1089,7 @@
   note    = {Honors thesis}
 }
 
-@Article{liu.foo.ea:3d,
+@Article{2017:liu.foo.ea:3d,
   doi     = {10.1016/j.camss.2017.07.005},
   url     = {https://doi.org/10.1016/j.camss.2017.07.005},
   year    = 2017,
@@ -1103,7 +1103,7 @@
   journal = {Acta Mechanica Solida Sinica}
 }
 
-@Article{liu.liang:prevalence,
+@Article{2017:liu.liang:prevalence,
   doi     = {10.1126/sciadv.1701872},
   url     = {https://doi.org/10.1126/sciadv.1701872},
   year    = 2017,
@@ -1117,7 +1117,7 @@
   journal = {Science Advances}
 }
 
-@TechReport{ljungkvist.kronbichler:multigrid-for-matrix-free-finite-element-computations-on-graphics-processors,
+@TechReport{2017:ljungkvist.kronbichler:multigrid-for-matrix-free-finite-element-computations-on-graphics-processors,
   title   = {{Multigrid for matrix-free finite element computations on graphics processors}},
   author  = {Ljungkvist, K and Kronbichler, M},
   institution = {Uppsala University},
@@ -1126,14 +1126,14 @@
   url     = {https://pdfs.semanticscholar.org/924a/734d1e402f8b562e18c28a681baeaf10e34a.pdf}
 }
 
-@PhDThesis{ljungkvist:finite,
+@PhDThesis{2017:ljungkvist:finite,
   author  = {K. Ljungkvist},
   title   = {Finite element computations on multicore and graphics processors},
   year    = 2017,
   school  = {University of Uppsala, Sweden}
 }
 
-@InProceedings{ljungkvist:matrix-free,
+@InProceedings{2017:ljungkvist:matrix-free,
   author  = {Ljungkvist, Karl},
   title   = {Matrix-free Finite-element Computations on Graphics Processors with Adaptively Refined Unstructured Meshes},
   booktitle = {Proceedings of the 25th High Performance Computing Symposium},
@@ -1150,7 +1150,7 @@
   address = {San Diego, CA, USA}
 }
 
-@Article{lovelace.demos.ea:numerically,
+@Article{2017:lovelace.demos.ea:numerically,
   doi     = {10.1088/1361-6382/aa9ccc},
   url     = {https://doi.org/10.1088/1361-6382/aa9ccc},
   year    = 2017,
@@ -1164,7 +1164,7 @@
   journal = {Classical and Quantum Gravity}
 }
 
-@InProceedings{luo.zhao:numerical-simulation-of-temperature-fields-in-powder-bed-fusion-process-by-using-hybrid-heat-source-model,
+@InProceedings{2017:luo.zhao:numerical-simulation-of-temperature-fields-in-powder-bed-fusion-process-by-using-hybrid-heat-source-model,
   title   = {{Numerical simulation of temperature fields in powder bed fusion process by using hybrid heat source model}},
   author  = {Luo, Z and Zhao, YF},
   journal = {sffsymposium.engr.utexas.edu},
@@ -1173,7 +1173,7 @@
   url     = {https://sffsymposium.engr.utexas.edu/sites/default/files/2017/Manuscripts/NumericalSimulationofTemperatureFieldsinPowd.pdf}
 }
 
-@Article{maier.margetis.ea:dipole,
+@Article{2017:maier.margetis.ea:dipole,
   author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
   title   = {Dipole excitation of surface plasmon on a conducting sheet: Finite element approximation and validation},
   journal = {Journal of Computational Physics},
@@ -1185,7 +1185,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Misc{maier.margetis.ea:generation,
+@Misc{2017:maier.margetis.ea:generation,
   title   = {Generation of surface plasmon-polaritons by edge effects},
   author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
   year    = 2017,
@@ -1194,7 +1194,7 @@
   primaryclass = {physics.comp-ph}
 }
 
-@Article{maier.nemilentsau.ea:ultracompact,
+@Article{2017:maier.nemilentsau.ea:ultracompact,
   doi     = {10.1021/acsphotonics.7b01094},
   url     = {https://doi.org/10.1021/acsphotonics.7b01094},
   year    = 2017,
@@ -1208,7 +1208,7 @@
   journal = {{ACS} Photonics}
 }
 
-@Misc{marojevic.goklu.ea:life,
+@Misc{2017:marojevic.goklu.ea:life,
   title   = {Life time of topological coherent modes of a Bose--Einstein condensate in a gravito optical surface trap},
   author  = {{\v{Z}}elimir Marojevi{\'c} and Ertan G{\"o}kl{\"u} and Hannes Uecker and Claus L{\"a}mmerzahl},
   year    = 2017,
@@ -1217,7 +1217,7 @@
   primaryclass = {quant-ph}
 }
 
-@Article{mcgovern.kollet.ea:novel,
+@Article{2017:mcgovern.kollet.ea:novel,
   doi     = {10.1007/s10596-017-9643-2},
   url     = {https://doi.org/10.1007/s10596-017-9643-2},
   year    = 2017,
@@ -1231,7 +1231,7 @@
   journal = {Computational Geosciences}
 }
 
-@Article{mehnert.pelteret.ea:numerical,
+@Article{2017:mehnert.pelteret.ea:numerical,
   doi     = {10.1177/1081286517729867},
   url     = {https://doi.org/10.1177/1081286517729867},
   year    = 2017,
@@ -1245,14 +1245,14 @@
   journal = {Mathematics and Mechanics of Solids}
 }
 
-@MastersThesis{mentler:high,
+@MastersThesis{2017:mentler:high,
   author  = {M. Mentler},
   title   = {High performance implementation of one-field elasticity using the deal.II Finite Element library},
   year    = 2017,
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
 }
 
-@Article{mohebujjaman.rebholz:efficient,
+@Article{2017:mohebujjaman.rebholz:efficient,
   doi     = {10.1515/cmam-2016-0033},
   url     = {https://doi.org/10.1515/cmam-2016-0033},
   year    = 2017,
@@ -1265,7 +1265,7 @@
   journal = {Computational Methods in Applied Mathematics}
 }
 
-@TechReport{mohebujjaman:c-parallel-implementation-of-incompressible-viscous-time-dependent-nse-simulation-using-projection-method-in-dealii,
+@TechReport{2017:mohebujjaman:c-parallel-implementation-of-incompressible-viscous-time-dependent-nse-simulation-using-projection-method-in-dealii,
   title   = {{C++ parallel implementation of incompressible viscous time-dependent NSE simulation using projection method in Dealii}},
   author  = {Mohebujjaman, M},
   institution = {Virginia Tech},
@@ -1273,7 +1273,7 @@
   url     = {http://mmohebu.people.clemson.edu/PDFDocuments/project_HPC_Projection_Method_NSE.pdf}
 }
 
-@PhDThesis{mohebujjaman:efficient,
+@PhDThesis{2017:mohebujjaman:efficient,
   title   = {Efficient Numerical Methods for Magnetohydrodynamic Flow},
   author  = {Muhammad Mohebujjaman},
   school  = {Clemson University},
@@ -1281,7 +1281,7 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/2027/}
 }
 
-@TechReport{mohebujjaman:high-order,
+@TechReport{2017:mohebujjaman:high-order,
   author  = {Mohebujjaman, M.},
   year    = 2017,
   title   = {High-order efficient algorithms for computation of {MHD} flow ensemble},
@@ -1289,7 +1289,7 @@
   url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/publication/327449710_HIGH_ORDER_EFFICIENT_ALGORITHM_FOR_COMPUTATION_OF_MHD_FLOW_ENSEMBLE/links/5b903a08a6fdcce8a4c3548d/HIGH-ORDER-EFFICIENT-ALGORITHM-FOR-COMPUTATION-OF-MHD-FLOW-ENSEMBLE.pdf}
 }
 
-@Article{mola.heitai.ea:wet,
+@Article{2017:mola.heitai.ea:wet,
   author  = {A. Mola and L. Heitai and A. DeSimone},
   title   = {Wet and Dry Transom Stern Treatment for Unsteady and Nonlinear Potential Flow Model for Naval Hydrodynamics Simulations},
   journal = {Journal of Ship Research, no. 1},
@@ -1299,7 +1299,7 @@
   url     = {http://texasamcolstattx.library.ingentaconnect.com/content/sname/jsr/2017/00000061/00000001/art00001}
 }
 
-@PhDThesis{monavari:continuum,
+@PhDThesis{2017:monavari:continuum,
   title   = {Continuum Dislocation Kinematics},
   author  = {Mehran Monavari},
   school  = {Friedrich-Alexander-Universit{\"a}t Erlangen-N{\"u}rnberg},
@@ -1307,7 +1307,7 @@
   url     = {https://opus4.kobv.de/opus4-fau/frontdoor/deliver/index/docId/8685/file/MehranMonavariDissertation.pdf}
 }
 
-@Article{na.sun.ea:effects,
+@Article{2017:na.sun.ea:effects,
   doi     = {10.1002/2016jb013374},
   url     = {https://doi.org/10.1002/2016jb013374},
   year    = 2017,
@@ -1321,7 +1321,7 @@
   journal = {Journal of Geophysical Research: Solid Earth}
 }
 
-@Article{na.sun:computational,
+@Article{2017:na.sun:computational,
   author  = {S. H. Na and W.C. Sun},
   title   = {Computational thermo-hydro-mechanics for multiphase freezing and thawing porous media in the finite deformation range},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1331,7 +1331,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516311240}
 }
 
-@InProceedings{narayanan.madduri:parallel,
+@InProceedings{2017:narayanan.madduri:parallel,
   doi     = {10.1109/ipdpsw.2017.160},
   url     = {https://doi.org/10.1109/ipdpsw.2017.160},
   year    = 2017,
@@ -1342,7 +1342,7 @@
   booktitle = {2017 {IEEE} International Parallel and Distributed Processing Symposium Workshops ({IPDPSW})}
 }
 
-@Article{odster.wheeler.ea:postprocessing,
+@Article{2017:odster.wheeler.ea:postprocessing,
   author  = {L. H. Ods\ae{}ter and M. F. Wheeler and T. Kvamsdal and M. G. Larson},
   title   = {Postprocessing of non-conservative flux for compatibility with transport in heterogeneous media},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1352,7 +1352,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782516303565}
 }
 
-@Article{oneill.marchi.ea:impact-driven,
+@Article{2017:oneill.marchi.ea:impact-driven,
   doi     = {10.1038/ngeo3029},
   title   = {Impact-driven subduction on the {H}adean {E}arth},
   author  = {O'Neill, C. and Marchi, S. and Zhang, S. and Bottke, W.},
@@ -1364,19 +1364,7 @@
   publisher = {Nature Publishing Group}
 }
 
-@Article{oneill.turner.ea:inception,
-  doi     = {10.1098/rsta.2017.0414},
-  title   = {The inception of plate tectonics: a record of failure},
-  author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
-  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
-  volume  = 376,
-  number  = 2132,
-  pages   = 20170414,
-  year    = 2018,
-  publisher = {The Royal Society Publishing}
-}
-
-@PhDThesis{patty:an-energy-formulation-of-surface-tension-or-willmore-force-for-two-phase-flow,
+@PhDThesis{2017:patty:an-energy-formulation-of-surface-tension-or-willmore-force-for-two-phase-flow,
   title   = {{An Energy Formulation of Surface Tension or Willmore Force For Two-Phase Flow}},
   author  = {Patty, S.},
   school  = {Texas A\&M University},
@@ -1384,7 +1372,7 @@
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/165987}
 }
 
-@Article{porcelli.simoncini.ea:preconditioning,
+@Article{2017:porcelli.simoncini.ea:preconditioning,
   doi     = {10.1016/j.camwa.2017.04.033},
   url     = {https://doi.org/10.1016/j.camwa.2017.04.033},
   year    = 2017,
@@ -1398,7 +1386,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{poy.bunel.ea:role,
+@Article{2017:poy.bunel.ea:role,
   author  = {G. Poy and F. Bunel and P. Oswald},
   title   = {Role of anchoring energy on the texture of cholesteric droplets: Finite-element simulations and experiments},
   journal = {Phs. Rev. E, article 012705},
@@ -1406,7 +1394,7 @@
   volume  = 96
 }
 
-@Article{pratik-rai:adjoint-based,
+@Article{2017:pratik-rai:adjoint-based,
   doi     = {10.13140/RG.2.2.23244.10884},
   url     = {http://rgdoi.net/10.13140/RG.2.2.23244.10884},
   author  = {{Pratik Rai}},
@@ -1415,14 +1403,14 @@
   year    = 2017
 }
 
-@PhDThesis{quinelato:mixed,
+@PhDThesis{2017:quinelato:mixed,
   author  = {T. O. Quinelato},
   title   = {Mixed Hybrid Finite Element Methods in Elasticity and Poroelasticity},
   year    = 2017,
   school  = {Laborat\'{o}rio Nacional de Computa\c{c}\~{a}o Cient\'{i}fica, Brazil}
 }
 
-@PhDThesis{ramirez:time-dependent,
+@PhDThesis{2017:ramirez:time-dependent,
   title   = {Time-dependent {S}tokes-{D}arcy Flow with Deposition},
   author  = {Javier Ruiz Ramirez},
   school  = {Clemson University},
@@ -1430,14 +1418,14 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/1968/}
 }
 
-@MastersThesis{rave:kopplung,
+@MastersThesis{2017:rave:kopplung,
   author  = {Rave, Kevin},
   title   = {Kopplung von {OpenFOAM} und {deal.II} {G}leichungsl{\"o}sern mit {preCICE} zur {S}imulation multiphysikalischer {P}robleme},
   school  = {Universit{\"a}t Siegen},
   year    = 2017
 }
 
-@Article{riedlbauer.scharowski.ea:macroscopic,
+@Article{2017:riedlbauer.scharowski.ea:macroscopic,
   author  = {D. Riedlbauer and T. Scharowski and R. F. Singer and P. Steinmann and C. K\"{o}rner and J. Mergheim},
   title   = {Macroscopic simulation and experimental measurement of melt pool characteristics in selective electron beam melting of Ti-6Al-4V},
   journal = {The International Journal of Advanced Manufacturing Technology},
@@ -1446,7 +1434,7 @@
   pages   = {1309--1317}
 }
 
-@Article{riehl.steinmann:on,
+@Article{2017:riehl.steinmann:on,
   author  = {S. Riehl and P. Steinmann},
   title   = {On structural shape optimization using an embedding domain discretization technique},
   journal = {International Journal for Numerical Methods in Engineering, issue 9},
@@ -1456,7 +1444,7 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/nme.5326/full}
 }
 
-@Misc{riviere.kanschat:finite,
+@Misc{2017:riviere.kanschat:finite,
   title   = {A finite element method with strong mass conservation for Biot's linear consolidation model},
   author  = {Beatrice Riviere and Guido Kanschat},
   year    = 2017,
@@ -1465,7 +1453,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{roland.tjardes.ea:personalized,
+@Article{2017:roland.tjardes.ea:personalized,
   doi     = {10.1002/pamm.201710078},
   url     = {https://doi.org/10.1002/pamm.201710078},
   year    = 2017,
@@ -1479,7 +1467,7 @@
   journal = {{PAMM}}
 }
 
-@Article{rose.buffett.ea:stability,
+@Article{2017:rose.buffett.ea:stability,
   author  = {I. Rose and B. Buffett and T. Heister},
   title   = {Stability and accuracy of free surface time integration in viscous flows},
   journal = {Physics of the Earth and Planetary Interiors},
@@ -1489,7 +1477,7 @@
   url     = {http://dx.doi.org/10.1016/j.pepi.2016.11.007}
 }
 
-@Article{rose.buffett:scaling,
+@Article{2017:rose.buffett:scaling,
   author  = {I. Rose and B. Buffett},
   title   = {Scaling rates of true polar wander in convecting planets and moons},
   journal = {Physics of the Earth and Planetary Interiors},
@@ -1499,7 +1487,7 @@
   url     = {https://doi.org/10.1016/j.pepi.2017.10.003}
 }
 
-@InCollection{russ.pacini:empirically-derived,
+@InCollection{2017:russ.pacini:empirically-derived,
   doi     = {10.1007/978-3-319-54735-0_8},
   url     = {https://doi.org/10.1007/978-3-319-54735-0_8},
   year    = 2017,
@@ -1510,7 +1498,7 @@
   booktitle = {Shock {\&} Vibration, Aircraft/Aerospace, Energy Harvesting, Acoustics {\&} Optics, Volume 9}
 }
 
-@PhDThesis{sabawi:adaptive-discontinuous-galerkin-methods-for-interface-problems,
+@PhDThesis{2017:sabawi:adaptive-discontinuous-galerkin-methods-for-interface-problems,
   title   = {{Adaptive discontinuous Galerkin methods for interface problems}},
   author  = {Sabawi, YA},
   year    = 2017,
@@ -1518,7 +1506,7 @@
   url     = {http://hdl.handle.net/2381/39386}
 }
 
-@InProceedings{santos.azeredo-coutinho:continuous,
+@InProceedings{2017:santos.azeredo-coutinho:continuous,
   doi     = {10.20906/cps/cilamce2017-0712},
   url     = {https://doi.org/10.20906/cps/cilamce2017-0712},
   year    = 2017,
@@ -1528,7 +1516,7 @@
   booktitle = {Proceedings of the {XXXVIII} Iberian Latin American Congress on Computational Methods in Engineering}
 }
 
-@Article{schoeder.kronbichler.ea:photoacoustic,
+@Article{2017:schoeder.kronbichler.ea:photoacoustic,
   author  = {S. Schoeder and M. Kronbichler and W. A. Wall},
   title   = {Photoacoustic Image Reconstruction: Material Detection and Acoustical Heterogeneities},
   journal = {Inverse Problems, No. 5},
@@ -1537,7 +1525,7 @@
   url     = {http://iopscience.iop.org/article/10.1088/1361-6420/aa635b/meta}
 }
 
-@Article{scovazzi.wheeler.ea:analytical,
+@Article{2017:scovazzi.wheeler.ea:analytical,
   author  = {G. Scovazzi and M. F. Wheeler and A. Mikelic and S. Lee},
   title   = {Analytical and variational numerical methods for unstable miscible displacement flows in porous media},
   journal = {Journal of Computational Physics},
@@ -1547,7 +1535,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999117300311}
 }
 
-@Article{seydel.schuster:identifying,
+@Article{2017:seydel.schuster:identifying,
   doi     = {10.1088/1361-6420/aa8d91},
   url     = {https://doi.org/10.1088/1361-6420/aa8d91},
   year    = 2017,
@@ -1561,7 +1549,7 @@
   journal = {Inverse Problems}
 }
 
-@PhDThesis{seydel:identifikation-der-verzerrungsenergiedichte-hyperelastischer-materialien-aus-zeitabhangigen-randmessungen,
+@PhDThesis{2017:seydel:identifikation-der-verzerrungsenergiedichte-hyperelastischer-materialien-aus-zeitabhangigen-randmessungen,
   title   = {{Identifikation der Verzerrungsenergiedichte hyperelastischer Materialien aus zeitabh{\"{a}}ngigen Randmessungen}},
   author  = {Seydel, J.},
   year    = 2017,
@@ -1570,7 +1558,7 @@
   doi     = {10.22028/D291-26782}
 }
 
-@PhDThesis{shakir:multilevel-schwarz-methods-for-incompressible-flow-problems,
+@PhDThesis{2017:shakir:multilevel-schwarz-methods-for-incompressible-flow-problems,
   title   = {{Multilevel Schwarz Methods for Incompressible Flow Problems}},
   author  = {Shakir, N.},
   year    = 2017,
@@ -1579,7 +1567,7 @@
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/23210}
 }
 
-@TechReport{song.west.ea:munition-penetration-depth-prediction,
+@TechReport{2017:song.west.ea:munition-penetration-depth-prediction,
   title   = {{Munition Penetration Depth Prediction}},
   author  = {Song, A. S. and West, B. A. and Taylor, O. D. S. and O'Connor, D. T.},
   year    = 2017,
@@ -1588,7 +1576,7 @@
   number  = {SERDP SEED Project MR 2629}
 }
 
-@MastersThesis{strom:preconditioned,
+@MastersThesis{2017:strom:preconditioned,
   author  = {A. Str\"{o}m},
   title   = {Preconditioned iterative methods for PDE-constrained optimization problems with pointwise state constraints},
   year    = 2017,
@@ -1596,7 +1584,7 @@
   url     = {http://www.diva-portal.org/smash/record.jsf?pid=diva2%3A1081649&dswid=292}
 }
 
-@PhDThesis{sutton:virtual-element-methods,
+@PhDThesis{2017:sutton:virtual-element-methods,
   title   = {{Virtual Element Methods}},
   author  = {Sutton, O. J.},
   year    = 2017,
@@ -1604,7 +1592,7 @@
   url     = {https://lra.le.ac.uk/handle/2381/39955}
 }
 
-@Article{takeyama.saitoh.ea:variable,
+@Article{2017:takeyama.saitoh.ea:variable,
   author  = {K. Takeyama and T. R. Saitoh and J. Makino},
   title   = {Variable inertia method: A novel numerical method for mantle convection simulation},
   journal = {New Astronomy},
@@ -1614,7 +1602,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S138410761630046X}
 }
 
-@PhDThesis{teichert:mathematical-framework-and-numerical-methods-for-the-modeling-of-mechanochemistry-in-multi-phase-materials,
+@PhDThesis{2017:teichert:mathematical-framework-and-numerical-methods-for-the-modeling-of-mechanochemistry-in-multi-phase-materials,
   title   = {{Mathematical Framework and Numerical Methods for the Modeling of Mechanochemistry in Multi-Phase Materials}},
   author  = {Teichert, Gregory},
   url     = {http://hdl.handle.net/2027.42/138690},
@@ -1622,7 +1610,7 @@
   school  = {University of Michigan}
 }
 
-@Article{thieulot:analytical,
+@Article{2017:thieulot:analytical,
   doi     = {10.5194/se-8-1181-2017},
   url     = {https://doi.org/10.5194/se-8-1181-2017},
   year    = 2017,
@@ -1636,7 +1624,7 @@
   journal = {Solid Earth}
 }
 
-@Article{toulopoulos.wick:numerical,
+@Article{2017:toulopoulos.wick:numerical,
   doi     = {10.1137/16m1067792},
   url     = {https://doi.org/10.1137/16m1067792},
   year    = 2017,
@@ -1650,7 +1638,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{verner.garikipati:computational,
+@Article{2017:verner.garikipati:computational,
   author  = {S. N. Verner and K. Garikipati},
   title   = {A computational study of the mechanisms of growth-driven folding patterns on shells, with application to the developing brain},
   journal = {arXiv:1709.05546},
@@ -1658,7 +1646,7 @@
   url     = {https://arxiv.org/abs/1709.05546}
 }
 
-@Article{vidal-ferrandiz.gonzalez-pintor.ea:schwarz,
+@Article{2017:vidal-ferrandiz.gonzalez-pintor.ea:schwarz,
   author  = {A. Vidal-Ferr{\`{a}}ndiz and S. Gonz{\'{a}}lez-Pintor and D. Ginestar and G. Verd{\'{u}} and C. Demazi{\`{e}}re},
   title   = {Schwarz type preconditioners for the neutron diffusion equation},
   journal = {Journal of Computational and Applied Mathematics},
@@ -1671,7 +1659,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716301157}
 }
 
-@PhDThesis{villiers:patient-specific,
+@PhDThesis{2017:villiers:patient-specific,
   author  = {A. M. De Villiers},
   title   = {A patient-specific FSI model for vascular access in haemodialysis},
   year    = 2017,
@@ -1679,7 +1667,7 @@
   url     = {http://hdl.handle.net/11427/24441}
 }
 
-@Article{wang.siegel.ea:intercalation,
+@Article{2017:wang.siegel.ea:intercalation,
   author  = {Z. Wang and J. B. Siegel and K. Garikipati},
   title   = {Intercalation driven porosity effects in coupled continuum models for the electrical, chemical, thermal and mechanical response of battery electrode materials},
   journal = {Journal of The Electrochemical Society, pp. A2199-A2212},
@@ -1687,7 +1675,7 @@
   volume  = 164
 }
 
-@Misc{wells.banks:using,
+@Misc{2017:wells.banks:using,
   title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates},
   author  = {David Wells and Jeffrey Banks},
   year    = 2017,
@@ -1696,7 +1684,7 @@
   primaryclass = {math.NA}
 }
 
-@Misc{welper:h,
+@Misc{2017:welper:h,
   title   = {$h$ and $hp$-adaptive Interpolation by Transformed Snapshots for Parametric and Stochastic Hyperbolic PDEs},
   author  = {G. Welper},
   year    = 2017,
@@ -1705,7 +1693,7 @@
   primaryclass = {math.NA}
 }
 
-@InCollection{wick:coupling,
+@InCollection{2017:wick:coupling,
   doi     = {10.1515/9783110494259-009},
   year    = 2017,
   month   = nov,
@@ -1717,7 +1705,7 @@
   booktitle = {Fluid-Structure Interaction}
 }
 
-@Article{wick:error-oriented,
+@Article{2017:wick:error-oriented,
   doi     = {10.1137/16m1063873},
   url     = {https://doi.org/10.1137/16m1063873},
   year    = 2017,
@@ -1731,7 +1719,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{wick:modified,
+@Article{2017:wick:modified,
   doi     = {10.1016/j.cma.2017.07.026},
   url     = {https://doi.org/10.1016/j.cma.2017.07.026},
   year    = 2017,
@@ -1744,7 +1732,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{wilmers.mcbride.ea:interface,
+@Article{2017:wilmers.mcbride.ea:interface,
   author  = {J. Wilmers and A. McBride and S. Bargmann},
   title   = {Interface elasticity effects in polymer-filled nanoporous metals},
   journal = {Journal of the Mechanics and Physics of Solids},
@@ -1753,7 +1741,7 @@
   pages   = {163--177}
 }
 
-@PhDThesis{wilmers:multiphysically,
+@PhDThesis{2017:wilmers:multiphysically,
   doi     = {10.15480/882.1438},
   url     = {https://tubdok.tub.tuhh.de/handle/11420/1441},
   author  = {Wilmers, Jana},
@@ -1763,7 +1751,7 @@
   year    = 2017
 }
 
-@TechReport{yoon:multiscale,
+@TechReport{2017:yoon:multiscale,
   title   = {Multiscale Characterization of Structural, Compositional, and Textural Heterogeneity of Nano-porous Geomaterials},
   institution = {Sandia National Laboratory},
   author  = {Yoon, H},
@@ -1771,7 +1759,7 @@
   url     = {http://prod.sandia.gov/techlib/access-control.cgi/2017/1710273.pdf}
 }
 
-@Article{yu.cheng.ea:residual-based,
+@Article{2017:yu.cheng.ea:residual-based,
   doi     = {10.1016/j.compfluid.2017.08.016},
   url     = {https://doi.org/10.1016/j.compfluid.2017.08.016},
   year    = 2017,
@@ -1784,7 +1772,7 @@
   journal = {Computers {\&} Fluids}
 }
 
-@Article{zhang.gain.ea:stress-based,
+@Article{2017:zhang.gain.ea:stress-based,
   doi     = {10.1016/j.cma.2017.06.025},
   url     = {https://doi.org/10.1016/j.cma.2017.06.025},
   year    = 2017,
@@ -1797,7 +1785,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{zhang.norato:optimal,
+@Article{2017:zhang.norato:optimal,
   doi     = {10.1115/1.4036999},
   url     = {https://doi.org/10.1115/1.4036999},
   year    = 2017,
@@ -1810,7 +1798,7 @@
   journal = {Journal of Mechanical Design}
 }
 
-@Article{zheng.mcclarren.ea:accurate,
+@Article{2017:zheng.mcclarren.ea:accurate,
   doi     = {10.1080/00295639.2017.1407592},
   url     = {https://doi.org/10.1080/00295639.2017.1407592},
   year    = 2017,
@@ -1824,7 +1812,7 @@
   journal = {Nuclear Science and Engineering}
 }
 
-@Article{zheng.mcclarren:accurate,
+@Article{2017:zheng.mcclarren:accurate,
   doi     = {10.1016/j.pnucene.2017.06.001},
   url     = {https://doi.org/10.1016/j.pnucene.2017.06.001},
   year    = 2017,
@@ -1837,7 +1825,7 @@
   journal = {Progress in Nuclear Energy}
 }
 
-@InProceedings{zheng.mcclarren:continuous-discontinuous,
+@InProceedings{2017:zheng.mcclarren:continuous-discontinuous,
   author  = {W. Zheng and R. G. McClarren},
   title   = {A Continuous-Discontinuous Hybrid Finite Element Method for $S_N$ Transport},
   booktitle = {Transactions of the American Nuclear Society},
@@ -1847,13 +1835,25 @@
   url     = {https://www.researchgate.net/publication/317620866_A_Continuous-Discontinuous_Hybrid_Finite_Element_Method_for_SN_Transport}
 }
 
-@Article{zhou.putz.ea:mixed,
+@Article{2017:zhou.putz.ea:mixed,
   author  = {J. Zhou and A. Putz and M. Secanell},
   title   = {A Mixed Wettability Pore Size Distribution Based Mathematical Model for Analyzing Two-Phase Flow in Porous Electrodes I. Mathematical Model},
   journal = {Journal of The Electrochemical Society, issue 6, F530-F539},
   year    = 2017,
   volume  = 164,
   url     = {http://jes.ecsdl.org/content/164/6/F530.short}
+}
+
+@Article{2018:oneill.turner.ea:inception,
+  doi     = {10.1098/rsta.2017.0414},
+  title   = {The inception of plate tectonics: a record of failure},
+  author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
+  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+  volume  = 376,
+  number  = 2132,
+  pages   = 20170414,
+  year    = 2018,
+  publisher = {The Royal Society Publishing}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1,24 +1,12 @@
 % Encoding: US-ASCII
 
-@Article{2016:harmon.gamba.ea:numerical,
-  doi     = {10.1016/j.jcp.2016.08.026},
-  url     = {https://doi.org/10.1016/j.jcp.2016.08.026},
-  year    = 2016,
-  month   = dec,
-  publisher = {Elsevier {BV}},
-  volume  = 327,
-  pages   = {140--167},
-  author  = {Michael Harmon and Irene M. Gamba and Kui Ren},
-  title   = {Numerical algorithms based on Galerkin methods for the modeling of reactive interfaces in photoelectrochemical ({PEC}) solar cells},
-  journal = {Journal of Computational Physics}
-}
-
 @Article{2017:adler.emerson.ea:combining,
   author  = {J. H. Adler and D. B. Emerson and P. E. Farrell and S. P. MacLachlan},
   title   = {Combining Deflation and Nested Iteration for Computing Multiple Solutions of Nonlinear Variational Problems},
   journal = {SIAM J. Sci. Comput., issue 1, B29-B52},
   year    = 2017,
   volume  = 39,
+  doi     = {10.1137/16M1058728},
   url     = {http://epubs.siam.org/doi/abs/10.1137/16M1058728}
 }
 
@@ -152,6 +140,15 @@
   volume  = 310,
   pages   = {5--18},
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302631}
+}
+
+@Misc{2017:badia.martin.ea:fempar,
+  title   = {FEMPAR: An object-oriented parallel finite element framework},
+  author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
+  year    = 2017,
+  eprint  = {1708.01773},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.CE}
 }
 
 @Article{2017:badnava.etemadi.ea:phase,
@@ -1842,18 +1839,6 @@
   year    = 2017,
   volume  = 164,
   url     = {http://jes.ecsdl.org/content/164/6/F530.short}
-}
-
-@Article{2018:oneill.turner.ea:inception,
-  doi     = {10.1098/rsta.2017.0414},
-  title   = {The inception of plate tectonics: a record of failure},
-  author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
-  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
-  volume  = 376,
-  number  = 2132,
-  pages   = 20170414,
-  year    = 2018,
-  publisher = {The Royal Society Publishing}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1,6 +1,75 @@
 % Encoding: US-ASCII
 
-@Article{aagesen.adams.ea:prisms,
+@MastersThesis{2016:c--a--h--blom:state-of-the-art-numerical-subduction-modelling-with-aspect--thermo-mechanically-coupled-viscoplastic-compressible-rheology--free-surface--phase-changes--latent-heat-and-open-sidewalls,
+  author  = {{C. A. H. Blom}},
+  school  = {Utrecht University},
+  title   = {{State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls}},
+  url     = {https://dspace.library.uu.nl/handle/1874/348133},
+  year    = 2016
+}
+
+@Misc{2017:badia.martin.ea:fempar,
+  title   = {FEMPAR: An object-oriented parallel finite element framework},
+  author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
+  year    = 2017,
+  eprint  = {1708.01773},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.CE}
+}
+
+@Article{2017:emerson.farrell.ea:computing,
+  doi     = {10.1080/02678292.2017.1365385},
+  url     = {https://doi.org/10.1080/02678292.2017.1365385},
+  year    = 2017,
+  month   = aug,
+  publisher = {Informa {UK} Limited},
+  volume  = 45,
+  number  = 3,
+  pages   = {341--350},
+  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
+  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
+  journal = {Liquid Crystals}
+}
+
+@InCollection{2017:gulpak.wernsing.ea:compensation,
+  doi     = {10.1007/978-3-319-57120-1_12},
+  url     = {https://doi.org/10.1007/978-3-319-57120-1_12},
+  year    = 2017,
+  month   = sep,
+  publisher = {Springer International Publishing},
+  pages   = {251--288},
+  author  = {M. Gulpak and H. Wernsing and J. S\"{o}lter and C. B\"{u}skens},
+  title   = {Compensation Strategies for Thermal Effects in Dry Milling},
+  booktitle = {Lecture Notes in Production Engineering}
+}
+
+@Article{2017:lambe.czekanski:topology,
+  doi     = {10.1002/nme.5617},
+  url     = {https://doi.org/10.1002/nme.5617},
+  year    = 2017,
+  month   = aug,
+  publisher = {Wiley},
+  volume  = 113,
+  number  = 3,
+  pages   = {357--373},
+  author  = {Andrew B. Lambe and Aleksander Czekanski},
+  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
+@InCollection{2017:schuster.schopfer:damage,
+  doi     = {10.1007/978-3-319-49715-0_16},
+  url     = {https://doi.org/10.1007/978-3-319-49715-0_16},
+  year    = 2017,
+  month   = aug,
+  publisher = {Springer International Publishing},
+  pages   = {373--397},
+  author  = {T. Schuster and F. Sch\"{o}pfer},
+  title   = {Damage Identification by Dynamic Load Monitoring},
+  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites}
+}
+
+@Article{2018:aagesen.adams.ea:prisms,
   author  = {L. K. Aagesen and J. F. Adams and J. E. Allison and W. B. Andrews and V. Araullo-Peters and T. Berman and Z. Chen and S. Daly and S. Das and S. DeWitt and S. Ganesan and K. Garikipati and V. Gavini and A. Githens and M. Hedstrom and Z. Huang and H. V. Jagadish and J. W. Jones and J. Luce and E. A. Marquis and A. Misra and D. Montiel and P. Motamarri and A. D. Murphy and A. R. Natarajan and S. Panwar and B. Puchala and L. Qi and S. Rudraraju and K. Sagiyama and E. L. S. Solomon and V. Sundararaghavan and G. Tarcea and G. H. Teichert and J. C. Thomas and K. Thornton and A. Van der Ven and Z. Wang and T. Weymouth and C. Yang},
   title   = {{PRISMS}: {A}n Integrated, Open-Source Framework for Accelerating Predictive Structural Materials Science},
   journal = {The Journal of The Minderals, Metals \& Materials Society (JOM)},
@@ -10,7 +79,7 @@
   doi     = {10.1007/s11837-018-3079-6}
 }
 
-@PhDThesis{aggul:high,
+@PhDThesis{2018:aggul:high,
   author  = {Aggul, Mustafa},
   title   = {High Accuracy Methods and Regularization Techniques for Fluid Flows and Fluid-Fluid interactions},
   url     = {https://digitalcommons.mtu.edu/etdr/642/},
@@ -18,19 +87,7 @@
   year    = 2018
 }
 
-@Article{alhazmi:exploring,
-  doi     = {10.14569/ijacsa.2019.0100372},
-  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
-  year    = 2019,
-  publisher = {The Science and Information Organization},
-  volume  = 10,
-  number  = 3,
-  author  = {Muflih Alhazmi},
-  title   = {Exploring Mechanisms for Pattern Formation through Coupled Bulk-Surface {PDEs} in Case of Non-linear Reactions},
-  journal = {International Journal of Advanced Computer Science and Applications}
-}
-
-@PhDThesis{alhazmi:exploring-mechanisms-for-pattern-formation-through-coupled-bulk-surface-pdes,
+@PhDThesis{2018:alhazmi:exploring-mechanisms-for-pattern-formation-through-coupled-bulk-surface-pdes,
   author  = {Alhazmi, M.},
   title   = {{Exploring mechanisms for pattern formation through coupled bulk-surface PDEs}},
   year    = 2018,
@@ -38,7 +95,7 @@
   school  = {University of Sussex}
 }
 
-@Article{alzetta.arndt.ea:deal-ii,
+@Article{2018:alzetta.arndt.ea:deal-ii,
   title   = {The \texttt{deal.II} Library, Version 9.0},
   author  = {G. Alzetta and D. Arndt and W. Bangerth and V. Boddu and B. Brands and D. Davydov and R. Gassmoeller and T. Heister and L. Heltai and K. Kormann and M. Kronbichler and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
   journal = {Journal of Numerical Mathematics},
@@ -49,7 +106,7 @@
   doi     = {10.1515/jnma-2018-0054}
 }
 
-@Article{araujo-cabarcas.engstrom.ea:efficient,
+@Article{2018:araujo-cabarcas.engstrom.ea:efficient,
   author  = {J. C. Araujo-Cabarcas and C. Engstr\"{o}m and E. Jarlebring},
   title   = {Efficient resonance computations for Helmholtz problems based on a Dirichlet-to-Neumann map},
   journal = {Journal of Computational and Applied Mathematics},
@@ -58,7 +115,7 @@
   pages   = {177--192}
 }
 
-@Misc{arbogast.tao:direct,
+@Misc{2018:arbogast.tao:direct,
   title   = {Direct Serendipity and Mixed Finite Elements on Convex Quadrilaterals},
   author  = {Todd Arbogast and Zhen Tao},
   year    = 2018,
@@ -67,7 +124,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{arndt.kanschat:a-c1-mapping-based-on-finite-elements-on-quadrilateral-and-hexahedral-meshes,
+@Article{2018:arndt.kanschat:a-c1-mapping-based-on-finite-elements-on-quadrilateral-and-hexahedral-meshes,
   author  = {Arndt, Daniel and Kanschat, Guido},
   title   = {{A C1-mapping based on finite elements on quadrilateral and hexahedral meshes}},
   journal = {arxiv: 1810.02473},
@@ -76,7 +133,7 @@
   url     = {https://arxiv.org/abs/1810.02473}
 }
 
-@Misc{arndt.kanschat:c1-mapping,
+@Misc{2018:arndt.kanschat:c1-mapping,
   title   = {A C1-mapping based on finite elements on quadrilateral and hexahedral meshes},
   author  = {Daniel Arndt and Guido Kanschat},
   year    = 2018,
@@ -85,7 +142,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{axelsson.neytcheva.ea:efficient,
+@Article{2018:axelsson.neytcheva.ea:efficient,
   doi     = {10.1515/jnma-2017-0047},
   url     = {https://doi.org/10.1515/jnma-2017-0047},
   year    = 2018,
@@ -99,7 +156,7 @@
   journal = {Journal of Numerical Mathematics}
 }
 
-@InCollection{babaei.levitas:phase,
+@InCollection{2018:babaei.levitas:phase,
   doi     = {10.1007/978-3-319-76968-4_26},
   url     = {https://doi.org/10.1007/978-3-319-76968-4_26},
   year    = 2018,
@@ -110,7 +167,7 @@
   booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
 }
 
-@Article{babaei.levitas:phase-field,
+@Article{2018:babaei.levitas:phase-field,
   doi     = {10.1016/j.ijplas.2018.04.006},
   url     = {https://doi.org/10.1016/j.ijplas.2018.04.006},
   year    = 2018,
@@ -123,16 +180,7 @@
   journal = {International Journal of Plasticity}
 }
 
-@Misc{badia.martin.ea:fempar,
-  title   = {FEMPAR: An object-oriented parallel finite element framework},
-  author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
-  year    = 2017,
-  eprint  = {1708.01773},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.CE}
-}
-
-@Article{badnava.msekh.ea:h-adaptive,
+@Article{2018:badnava.msekh.ea:h-adaptive,
   title   = {An h-adaptive thermo-mechanical phase field model for fracture},
   journal = {Finite Elements in Analysis and Design},
   volume  = 138,
@@ -144,7 +192,7 @@
   author  = {Hojjat Badnava and Mohammed A. Msekh and Elahe Etemadi and Timon Rabczuk}
 }
 
-@InCollection{basak.levitas:nanoscale,
+@InCollection{2018:basak.levitas:nanoscale,
   doi     = {10.1007/978-3-319-76968-4_25},
   url     = {https://doi.org/10.1007/978-3-319-76968-4_25},
   year    = 2018,
@@ -155,7 +203,7 @@
   booktitle = {Proceedings of the International Conference on Martensitic Transformations: Chicago}
 }
 
-@Article{basak.levitas:nanoscale*1,
+@Article{2018:basak.levitas:nanoscale*1,
   doi     = {10.1016/j.jmps.2018.01.014},
   url     = {https://doi.org/10.1016/j.jmps.2018.01.014},
   year    = 2018,
@@ -168,7 +216,7 @@
   journal = {Journal of the Mechanics and Physics of Solids}
 }
 
-@Article{basak.levitas:phase,
+@Article{2018:basak.levitas:phase,
   author  = {A. Basak and V. I. Levitas},
   title   = {Phase field study of surface-induced melting and solidification from a nanovoid: Effect of dimensionless width of void surface and void size},
   journal = {Applied Physics Letters, article 201602},
@@ -177,14 +225,14 @@
   url     = {https://doi.org/10.1063/1.5029911}
 }
 
-@Article{bause.kocher.ea:post-processed,
+@Article{2018:bause.kocher.ea:post-processed,
   author  = {M. Bause and U. K\"{o}cher and F. A. Radu and F. Schieweck},
   title   = {Post-processed Galerkin approximation of improved order for wave equations},
   note    = {Submitted},
   year    = 2018
 }
 
-@Article{beams.klockner.ea:high-order,
+@Article{2018:beams.klockner.ea:high-order,
   doi     = {10.1016/j.jcp.2018.08.032},
   url     = {https://doi.org/10.1016/j.jcp.2018.08.032},
   year    = 2018,
@@ -197,7 +245,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@InBook{boffi.gastaldi.ea:distributed,
+@InBook{2018:boffi.gastaldi.ea:distributed,
   author  = {Boffi, Daniele and Gastaldi, Lucia and Heltai, Luca},
   editor  = {Boffi, Daniele and Pavarino, Luca F. and Rozza, Gianluigi and Scacchi, Simone and Vergara, Christian},
   title   = {A Distributed Lagrange Formulation of the Finite Element Immersed Boundary Method for Fluids Interacting with Compressible Solids},
@@ -209,7 +257,7 @@
   doi     = {10.1007/978-3-319-96649-6}
 }
 
-@Article{bonito.borthagaray.ea:numerical,
+@Article{2018:bonito.borthagaray.ea:numerical,
   title   = {Numerical methods for fractional diffusion},
   volume  = 19,
   issn    = {1433-0369},
@@ -224,7 +272,7 @@
   pages   = {19--46}
 }
 
-@Article{bonito.demlow.ea:priori,
+@Article{2018:bonito.demlow.ea:priori,
   doi     = {10.1137/17m1163311},
   url     = {https://doi.org/10.1137/17m1163311},
   year    = 2018,
@@ -238,7 +286,7 @@
   journal = {{SIAM} Journal on Numerical Analysis}
 }
 
-@Misc{bonito.girault.ea:finite,
+@Misc{2018:bonito.girault.ea:finite,
   title   = {Finite Element Approximation of a Strain-Limiting Elastic Model},
   author  = {Andrea Bonito and Vivette Girault and Endre Suli},
   year    = 2018,
@@ -247,7 +295,7 @@
   primaryclass = {math.NA}
 }
 
-@Misc{bonito.lei.ea:finite,
+@Misc{2018:bonito.lei.ea:finite,
   title   = {Finite element approximation of an obstacle problem for a class of integro-differential operators},
   author  = {Andrea Bonito and Wenyu Lei and Abner J. Salgado},
   year    = 2018,
@@ -256,7 +304,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{borregales.radu.ea:robust,
+@Article{2018:borregales.radu.ea:robust,
   author  = {Manuel Borregales and Florin Adrian Radu and Kundan Kumar and Jan Martin Nordbotten},
   title   = {Robust iterative schemes for non-linear poromechanics},
   journal = {Computational Geosciences},
@@ -268,7 +316,7 @@
   url     = {http://hdl.handle.net/1956/22101}
 }
 
-@Article{brauss.meir:on,
+@Article{2018:brauss.meir:on,
   doi     = {10.1016/j.apnum.2018.01.014},
   year    = 2018,
   month   = nov,
@@ -280,7 +328,7 @@
   journal = {Applied Numerical Mathematics}
 }
 
-@Article{bredow.steinberger:variable,
+@Article{2018:bredow.steinberger:variable,
   doi     = {10.1002/2017gl075822},
   url     = {https://doi.org/10.1002/2017gl075822},
   year    = 2018,
@@ -294,7 +342,7 @@
   journal = {Geophysical Research Letters}
 }
 
-@Article{bruchhauser.schwegler.ea:dual,
+@Article{2018:bruchhauser.schwegler.ea:dual,
   title   = {Dual weighted residual based error control for nonstationary convection-dominated equations: potential or ballast?},
   author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
   journal = {arXiv:1812.06810},
@@ -302,7 +350,7 @@
   url     = {https://arxiv.org/abs/1812.06810}
 }
 
-@Misc{bruchhauser.schwegler.ea:numerical,
+@Misc{2018:bruchhauser.schwegler.ea:numerical,
   title   = {Numerical study of goal-oriented error control for stabilized finite element methods},
   author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
   year    = 2018,
@@ -311,7 +359,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{bruna-rosso.demir.ea:global,
+@Article{2018:bruna-rosso.demir.ea:global,
   author  = {Claire Bruna-Rosso and Ali G\"{o}khan Demir and Maurizio Vedani and Barbara Previtali},
   title   = {Global sensitivity analyses of a selective laser melting finite element model: influential parameters identification},
   journal = {The International Journal of Advanced Manufacturing Technology},
@@ -324,7 +372,7 @@
   publisher = {Springer Nature America, Inc}
 }
 
-@Article{bruna-rosso.demir.ea:selective,
+@Article{2018:bruna-rosso.demir.ea:selective,
   author  = {Claire Bruna-Rosso and Ali G\"{o}khan Demir and Barbara Previtali},
   title   = {Selective laser melting finite element modeling: Validation with high-speed imaging and lack of fusion defects prediction},
   journal = {Materials {\&} Design},
@@ -336,7 +384,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{bryant.sun:mixed-mode,
+@Article{2018:bryant.sun:mixed-mode,
   author  = {Eric C. Bryant and WaiChing Sun},
   title   = {A mixed-mode phase field fracture model in anisotropic rocks with consistent kinematics},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -348,7 +396,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{bunger.richter.ea:deterministic,
+@Article{2018:bunger.richter.ea:deterministic,
   doi     = {10.1088/1757-899x/304/1/012004},
   url     = {https://doi.org/10.1088/1757-899x/304/1/012004},
   year    = 2018,
@@ -361,7 +409,7 @@
   journal = {{IOP} Conference Series: Materials Science and Engineering}
 }
 
-@Misc{burstedde:parallel,
+@Misc{2018:burstedde:parallel,
   title   = {Parallel tree algorithms for AMR and non-standard data access},
   author  = {Carsten Burstedde},
   year    = 2018,
@@ -370,7 +418,7 @@
   primaryclass = {cs.DC}
 }
 
-@Article{bzowski.rauch.ea:application,
+@Article{2018:bzowski.rauch.ea:application,
   title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
   journal = {Procedia Manufacturing},
   volume  = 15,
@@ -382,15 +430,7 @@
   author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk}
 }
 
-@MastersThesis{c--a--h--blom:state-of-the-art-numerical-subduction-modelling-with-aspect--thermo-mechanically-coupled-viscoplastic-compressible-rheology--free-surface--phase-changes--latent-heat-and-open-sidewalls,
-  author  = {{C. A. H. Blom}},
-  school  = {Utrecht University},
-  title   = {{State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls}},
-  url     = {https://dspace.library.uu.nl/handle/1874/348133},
-  year    = 2016
-}
-
-@Article{caen.schutz.ea:high-throughput,
+@Article{2018:caen.schutz.ea:high-throughput,
   doi     = {10.1038/s41378-018-0033-2},
   url     = {https://doi.org/10.1038/s41378-018-0033-2},
   year    = 2018,
@@ -403,7 +443,7 @@
   journal = {Microsystems {\&} Nanoengineering}
 }
 
-@Article{cangiani.georgoulis.ea:adaptive,
+@Article{2018:cangiani.georgoulis.ea:adaptive,
   doi     = {10.1090/mcom/3322},
   url     = {https://doi.org/10.1090/mcom/3322},
   year    = 2018,
@@ -417,7 +457,7 @@
   journal = {Mathematics of Computation}
 }
 
-@Article{cangiani.georgoulis.ea:revealing,
+@Article{2018:cangiani.georgoulis.ea:revealing,
   doi     = {10.1098/rspa.2017.0608},
   url     = {https://doi.org/10.1098/rspa.2017.0608},
   year    = 2018,
@@ -431,7 +471,7 @@
   journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
 }
 
-@Article{carraro.dorsam.ea:adaptive,
+@Article{2018:carraro.dorsam.ea:adaptive,
   doi     = {10.1007/s10957-018-1242-4},
   url     = {https://doi.org/10.1007/s10957-018-1242-4},
   year    = 2018,
@@ -445,7 +485,7 @@
   journal = {Journal of Optimization Theory and Applications}
 }
 
-@Article{carraro.marusic-paloka.ea:effective,
+@Article{2018:carraro.marusic-paloka.ea:effective,
   doi     = {10.1016/j.nonrwa.2018.04.008},
   url     = {https://doi.org/10.1016/j.nonrwa.2018.04.008},
   year    = 2018,
@@ -458,7 +498,7 @@
   journal = {Nonlinear Analysis: Real World Applications}
 }
 
-@Misc{carraro.wetterauer.ea:level-set,
+@Misc{2018:carraro.wetterauer.ea:level-set,
   title   = {A level-set approach for a multi-scale cancer invasion model},
   author  = {Thomas Carraro and Sven E. Wetterauer and Ana Victoria Ponce Bobadilla and Dumitru Trucu},
   year    = 2018,
@@ -467,7 +507,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{carreno.vidal-ferrandiz.ea:block,
+@Article{2018:carreno.vidal-ferrandiz.ea:block,
   doi     = {10.1016/j.anucene.2018.08.010},
   url     = {https://doi.org/10.1016/j.anucene.2018.08.010},
   year    = 2018,
@@ -480,7 +520,7 @@
   journal = {Annals of Nuclear Energy}
 }
 
-@InCollection{carreno.vidal-ferrandiz.ea:solution,
+@InCollection{2018:carreno.vidal-ferrandiz.ea:solution,
   doi     = {10.1007/978-3-319-93701-4_67},
   url     = {https://doi.org/10.1007/978-3-319-93701-4_67},
   year    = 2018,
@@ -491,7 +531,7 @@
   booktitle = {Lecture Notes in Computer Science}
 }
 
-@InProceedings{castelletto.ferronato.ea:fully-implicit,
+@InProceedings{2018:castelletto.ferronato.ea:fully-implicit,
   doi     = {10.3997/2214-4609.201802132},
   url     = {https://doi.org/10.3997/2214-4609.201802132},
   year    = 2018,
@@ -502,7 +542,7 @@
   booktitle = {{ECMOR} {XVI} - 16th European Conference on the Mathematics of Oil Recovery}
 }
 
-@InProceedings{chandrashekar.gallego-valencia.ea:a-runge-kutta-discontinuous-galerkin-scheme-for-the-ideal-magnetohydrodynamical-model,
+@InProceedings{2018:chandrashekar.gallego-valencia.ea:a-runge-kutta-discontinuous-galerkin-scheme-for-the-ideal-magnetohydrodynamical-model,
   author  = {Chandrashekar, Praveen and Gallego-Valencia, Juan Pablo and Klingenberg, Christian},
   title   = {{A Runge-Kutta Discontinuous Galerkin Scheme for the Ideal Magnetohydrodynamical Model}},
   booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
@@ -516,7 +556,7 @@
   url     = {https://www.researchgate.net/profile/Christian_Klingenberg/publication/325949144_A_Runge-Kutta_Discontinuous_Galerkin_Scheme_for_the_Ideal_Magnetohydrodynamical_Model/links/5b640dafa6fdcc45b30cab8c/A-Runge-Kutta-Discontinuous-Galerkin-Scheme-for-the-Ideal-Magnetohydrodynamical-Model.pdf?origin=publication_detail}
 }
 
-@Article{chandrashekar:global,
+@Article{2018:chandrashekar:global,
   author  = {Praveen Chandrashekar},
   title   = {A global divergence conforming {DG} method for hyperbolic conservation laws with divergence constraint},
   journal = {Journal of Scientific Computing},
@@ -528,7 +568,7 @@
   url     = {https://rdcu.be/725Z}
 }
 
-@Article{chang.fabien.ea:comparative,
+@Article{2018:chang.fabien.ea:comparative,
   doi     = {10.1137/18m1172260},
   url     = {https://doi.org/10.1137/18m1172260},
   year    = 2018,
@@ -542,7 +582,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{charnyi.heister.ea:efficient,
+@Article{2018:charnyi.heister.ea:efficient,
   author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
   title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier-Stokes equations},
   journal = {Applied Numerical Mathematics},
@@ -552,7 +592,7 @@
   note    = {in press}
 }
 
-@PhDThesis{charnyi:emac,
+@PhDThesis{2018:charnyi:emac,
   title   = {The {EMAC} scheme for Navier-Stokes simulations, and application to flow past bluff bodies},
   author  = {Sergey Charnyi},
   school  = {Clemson University},
@@ -560,7 +600,7 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/2243/}
 }
 
-@Article{cheng.yue.ea:analysis,
+@Article{2018:cheng.yue.ea:analysis,
   doi     = {10.1016/j.jcp.2018.02.031},
   url     = {https://doi.org/10.1016/j.jcp.2018.02.031},
   year    = 2018,
@@ -573,7 +613,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{cheng:direct,
+@Article{2018:cheng:direct,
   doi     = {10.4208/aamm.oa-2017-0060},
   url     = {https://doi.org/10.4208/aamm.oa-2017-0060},
   year    = 2018,
@@ -587,7 +627,7 @@
   journal = {Advances in Applied Mathematics and Mechanics}
 }
 
-@InCollection{choo.lee:enriched,
+@InCollection{2018:choo.lee:enriched,
   doi     = {10.1007/978-3-319-97112-4_69},
   url     = {https://doi.org/10.1007/978-3-319-97112-4_69},
   year    = 2018,
@@ -598,7 +638,7 @@
   booktitle = {Springer Series in Geomechanics and Geoengineering}
 }
 
-@Article{choo.lee:enriched*1,
+@Article{2018:choo.lee:enriched*1,
   doi     = {10.1016/j.cma.2018.06.022},
   url     = {https://doi.org/10.1016/j.cma.2018.06.022},
   year    = 2018,
@@ -611,7 +651,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{choo.sun:coupled,
+@Article{2018:choo.sun:coupled,
   doi     = {10.1016/j.cma.2017.10.009},
   url     = {https://doi.org/10.1016/j.cma.2017.10.009},
   year    = 2018,
@@ -624,7 +664,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{choo.sun:cracking,
+@Article{2018:choo.sun:cracking,
   doi     = {10.1016/j.cma.2018.01.044},
   url     = {https://doi.org/10.1016/j.cma.2018.01.044},
   year    = 2018,
@@ -637,7 +677,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{choo:large,
+@Article{2018:choo:large,
   doi     = {10.1002/nme.5915},
   url     = {https://doi.org/10.1002/nme.5915},
   year    = 2018,
@@ -651,7 +691,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@MastersThesis{cinatl:finite,
+@MastersThesis{2018:cinatl:finite,
   title   = {Finite Element Discretizations for Linear Elasticity},
   author  = {Emma Cinatl},
   school  = {Clemson University},
@@ -659,7 +699,7 @@
   url     = {https://tigerprints.clemson.edu/all_theses/2977/}
 }
 
-@InCollection{dang.do.ea:fractured,
+@InCollection{2018:dang.do.ea:fractured,
   doi     = {10.1007/978-981-13-2306-5_15},
   url     = {https://doi.org/10.1007/978-981-13-2306-5_15},
   year    = 2018,
@@ -671,7 +711,7 @@
   booktitle = {Lecture Notes in Civil Engineering}
 }
 
-@PhDThesis{dang:hydro-mechanical,
+@PhDThesis{2018:dang:hydro-mechanical,
   author  = {Hong Lam Dang},
   title   = {A hydro-mechanical modeling of double porosity and double permeability fractured reservoirs},
   school  = {Universit\'{e} D'Orl\'{e}ans},
@@ -679,7 +719,7 @@
   url     = {ftp://ftp.univ-orleans.fr/theses/honglam-dang_3747.pdf}
 }
 
-@Article{dannberg.gassmoller:chemical,
+@Article{2018:dannberg.gassmoller:chemical,
   author  = {Dannberg, Juliane and Gassm{\"{o}}ller, Rene},
   journal = {Proceedings of the National Academy of Sciences},
   number  = 17,
@@ -691,7 +731,7 @@
   doi     = {10.1073/pnas.1714125115}
 }
 
-@Article{davydov.heister.ea:matrix-free,
+@Article{2018:davydov.heister.ea:matrix-free,
   title   = {Matrix-Free Locally Adaptive Finite Element Solution of Density-Functional Theory With Nonorthogonal Orbitals and Multigrid Preconditioning},
   author  = {Davydov, Denis and Heister, Timo and Kronbichler, Martin and Steinmann, Paul},
   journal = {physica status solidi (b)},
@@ -703,14 +743,14 @@
   doi     = {10.1002/pssb.201800069}
 }
 
-@Article{demo.tezzele.ea:efficient,
+@Article{2018:demo.tezzele.ea:efficient,
   author  = {N. Demo and M. Tezzele and A. Mola and G. Rozza},
   title   = {An efficient shape parametrisation by free-form deformation enhanced by active subspace for hull hydrodynamic ship design problems in open source environment},
   journal = {arXiv:1801.06369},
   year    = 2018
 }
 
-@InProceedings{deolmi.dahmen.ea:effective-boundary-conditions-for-turbulent-compressible-flows-over-a-riblet-surface,
+@InProceedings{2018:deolmi.dahmen.ea:effective-boundary-conditions-for-turbulent-compressible-flows-over-a-riblet-surface,
   author  = {Deolmi, G. and Dahmen, W. and M{\"{u}}ller, S. and Albers, M. and Meysonnat, P. S. and Schr{\"{o}}der, W.},
   title   = {{Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface}},
   booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
@@ -723,7 +763,7 @@
   journal = {Springer}
 }
 
-@Article{deolmi.muller:two-step,
+@Article{2018:deolmi.muller:two-step,
   doi     = {10.1016/j.matcom.2018.02.008},
   url     = {https://doi.org/10.1016/j.matcom.2018.02.008},
   year    = 2018,
@@ -736,14 +776,14 @@
   journal = {Mathematics and Computers in Simulation}
 }
 
-@MastersThesis{dommaraju:partition,
+@MastersThesis{2018:dommaraju:partition,
   author  = {N. Dommaraju},
   title   = {Partition of unity finite element method with overlapping enrichment domains},
   year    = 2018,
   school  = {Friedrich-Alexander-Universit\"{a}t Erlangen-N\"{u}rnberg}
 }
 
-@Article{dorschner.chikatamarla.ea:fluid-structure,
+@Article{2018:dorschner.chikatamarla.ea:fluid-structure,
   doi     = {10.1103/physreve.97.023305},
   url     = {https://doi.org/10.1103/physreve.97.023305},
   year    = 2018,
@@ -756,7 +796,7 @@
   journal = {Physical Review E}
 }
 
-@PhDThesis{dorschner:entropic,
+@PhDThesis{2018:dorschner:entropic,
   doi     = {10.3929/ETHZ-B-000278644},
   url     = {http://hdl.handle.net/20.500.11850/278644},
   author  = {Dorschner, Benedikt},
@@ -765,7 +805,7 @@
   year    = 2018
 }
 
-@Article{duijn.mikelic.ea:monolithic,
+@Article{2018:duijn.mikelic.ea:monolithic,
   doi     = {10.1177/1081286518801050},
   url     = {https://doi.org/10.1177/1081286518801050},
   year    = 2018,
@@ -779,7 +819,7 @@
   journal = {Mathematics and Mechanics of Solids}
 }
 
-@Article{dunkelberger.metaferia.ea:theoretical,
+@Article{2018:dunkelberger.metaferia.ea:theoretical,
   doi     = {10.1021/acs.jpcb.8b07638},
   url     = {https://doi.org/10.1021/acs.jpcb.8b07638},
   year    = 2018,
@@ -793,7 +833,7 @@
   journal = {The Journal of Physical Chemistry B}
 }
 
-@Article{ellam:bayesian,
+@Article{2018:ellam:bayesian,
   doi     = {10.25560/70367},
   url     = {http://spiral.imperial.ac.uk/handle/10044/1/70367},
   author  = {Ellam, Louis},
@@ -803,7 +843,7 @@
   copyright = {Creative Commons Attribution NonCommercial Licence}
 }
 
-@MastersThesis{ellowitz:dynamics-of-magma-recharge-and-mixing-at-mount-hood-volcano--oregon--insights-from-enclave-bearing-lavas,
+@MastersThesis{2018:ellowitz:dynamics-of-magma-recharge-and-mixing-at-mount-hood-volcano--oregon--insights-from-enclave-bearing-lavas,
   author  = {Ellowitz, Molly},
   doi     = {10.15760/etd.6429},
   school  = {Portland State University},
@@ -813,21 +853,7 @@
   year    = 2018
 }
 
-@Article{emerson.farrell.ea:computing,
-  doi     = {10.1080/02678292.2017.1365385},
-  url     = {https://doi.org/10.1080/02678292.2017.1365385},
-  year    = 2017,
-  month   = aug,
-  publisher = {Informa {UK} Limited},
-  volume  = 45,
-  number  = 3,
-  pages   = {341--350},
-  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
-  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
-  journal = {Liquid Crystals}
-}
-
-@Misc{emerson:error,
+@Misc{2018:emerson:error,
   title   = {Error Estimators and Marking Strategies for Electrically Coupled Liquid Crystal Systems},
   author  = {D. B. Emerson},
   year    = 2018,
@@ -836,7 +862,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{endtmayer.langer.ea:multiple,
+@Article{2018:endtmayer.langer.ea:multiple,
   doi     = {10.1002/pamm.201800048},
   url     = {https://doi.org/10.1002/pamm.201800048},
   year    = 2018,
@@ -849,7 +875,7 @@
   journal = {{PAMM}}
 }
 
-@InCollection{evgrafov:discontinuous,
+@InCollection{2018:evgrafov:discontinuous,
   doi     = {10.1007/978-3-319-97773-7_24},
   url     = {https://doi.org/10.1007/978-3-319-97773-7_24},
   year    = 2018,
@@ -861,7 +887,7 @@
   booktitle = {{EngOpt} 2018 Proceedings of the 6th International Conference on Engineering Optimization}
 }
 
-@Article{failer.wick:adaptive,
+@Article{2018:failer.wick:adaptive,
   doi     = {10.1016/j.jcp.2018.04.021},
   url     = {https://www.sciencedirect.com/science/article/pii/S0021999118302377},
   year    = 2018,
@@ -874,7 +900,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{fehn.wall.ea:efficiency,
+@Article{2018:fehn.wall.ea:efficiency,
   title   = {Efficiency of high-performance discontinuous Galerkin spectral element methods for under-resolved turbulent incompressible flows},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -887,7 +913,7 @@
   doi     = {10.1002/fld.4511}
 }
 
-@Article{fehn.wall.ea:robust,
+@Article{2018:fehn.wall.ea:robust,
   title   = {Robust and efficient discontinuous Galerkin methods for under-resolved turbulent incompressible flows},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
   journal = {Journal of Computational Physics},
@@ -899,7 +925,7 @@
   doi     = {10.1016/j.jcp.2018.06.037}
 }
 
-@PhDThesis{ferrandiz:development,
+@PhDThesis{2018:ferrandiz:development,
   doi     = {10.4995/thesis/10251/98522},
   url     = {https://doi.org/10.4995/thesis/10251/98522},
   year    = 2018,
@@ -908,7 +934,7 @@
   title   = {Development of a finite element method for neutron transport equation approximations}
 }
 
-@Article{freddi.sacco.ea:enriched,
+@Article{2018:freddi.sacco.ea:enriched,
   author  = {Freddi, F. and Sacco, E. and Serpieri, R.},
   title   = {An enriched damage-frictional cohesive-zone model incorporating stress multi-axiality},
   journal = {Meccanica},
@@ -918,7 +944,7 @@
   pages   = {573--592}
 }
 
-@Misc{frei.richter.ea:on,
+@Misc{2018:frei.richter.ea:on,
   title   = {On the implementation of a locally modified finite element method for interface problems in deal.II},
   author  = {Stefan Frei and Thomas Richter and Thomas Wick},
   year    = 2018,
@@ -927,7 +953,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{freund.kim.ea:field,
+@Article{2018:freund.kim.ea:field,
   doi     = {10.1016/j.jnnfm.2018.03.013},
   url     = {https://doi.org/10.1016/j.jnnfm.2018.03.013},
   year    = 2018,
@@ -940,7 +966,7 @@
   journal = {Journal of Non-Newtonian Fluid Mechanics}
 }
 
-@Article{galiano.velasco:on,
+@Article{2018:galiano.velasco:on,
   doi     = {10.1016/j.camwa.2018.05.035},
   url     = {https://doi.org/10.1016/j.camwa.2018.05.035},
   year    = 2018,
@@ -954,7 +980,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@InCollection{gantner.herrmann.ea:multilevel,
+@InCollection{2018:gantner.herrmann.ea:multilevel,
   doi     = {10.1007/978-3-319-72456-0_18},
   url     = {https://doi.org/10.1007/978-3-319-72456-0_18},
   year    = 2018,
@@ -965,7 +991,7 @@
   booktitle = {Contemporary Computational Mathematics - A Celebration of the 80th Birthday of Ian Sloan}
 }
 
-@Article{gassmoller.lokavarapu.ea:flexible,
+@Article{2018:gassmoller.lokavarapu.ea:flexible,
   doi     = {10.1029/2018gc007508},
   url     = {https://doi.org/10.1029/2018gc007508},
   year    = 2018,
@@ -979,7 +1005,7 @@
   journal = {Geochemistry, Geophysics, Geosystems}
 }
 
-@Article{ge.holmgren.ea:effective,
+@Article{2018:ge.holmgren.ea:effective,
   doi     = {10.1103/physrevfluids.3.054201},
   url     = {https://doi.org/10.1103/physrevfluids.3.054201},
   year    = 2018,
@@ -992,7 +1018,7 @@
   journal = {Physical Review Fluids}
 }
 
-@PhDThesis{ghesmati:residual-and-goal-oriented-h-and-hp-adaptive-finite-element--application-for-elliptic-and-saddle-point-problems,
+@PhDThesis{2018:ghesmati:residual-and-goal-oriented-h-and-hp-adaptive-finite-element--application-for-elliptic-and-saddle-point-problems,
   author  = {Ghesmati, Arezou},
   title   = {{Residual and Goal-Oriented h-and hp-adaptive Finite Element; Application for Elliptic and Saddle Point Problems}},
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/173289},
@@ -1000,7 +1026,7 @@
   year    = 2018
 }
 
-@Article{giuliani.heltai.ea:predicting,
+@Article{2018:giuliani.heltai.ea:predicting,
   doi     = {10.1089/soro.2017.0099},
   url     = {https://doi.org/10.1089/soro.2017.0099},
   year    = 2018,
@@ -1014,7 +1040,7 @@
   journal = {Soft Robotics}
 }
 
-@Article{giuliani.mola.ea:-bem,
+@Article{2018:giuliani.mola.ea:-bem,
   doi     = {10.1016/j.advengsoft.2018.03.008},
   url     = {https://doi.org/10.1016/j.advengsoft.2018.03.008},
   year    = 2018,
@@ -1027,7 +1053,7 @@
   journal = {Advances in Engineering Software}
 }
 
-@Article{glerum.thieulot.ea:nonlinear,
+@Article{2018:glerum.thieulot.ea:nonlinear,
   doi     = {10.5194/se-9-267-2018},
   url     = {https://doi.org/10.5194/se-9-267-2018},
   year    = 2018,
@@ -1041,7 +1067,7 @@
   journal = {Solid Earth}
 }
 
-@Article{goll.wick.ea:dopelib,
+@Article{2018:goll.wick.ea:dopelib,
   author  = {C. Goll and T. Wick and W. Wollner},
   title   = {DOpElib: Differential Equations and Optimization Environment; A Goal Oriented Software Library for Solving PDEs and Optimization Problems with PDEs},
   journal = {Archive of Numerical Software},
@@ -1050,7 +1076,7 @@
   pages   = {1--14}
 }
 
-@Article{gong.chen.ea:fast,
+@Article{2018:gong.chen.ea:fast,
   title   = {Fast simulations of a large number of crystals growth in centimeter-scale during alloy solidification via nonlinearly preconditioned quantitative phase-field formula},
   author  = {Tong Zhao Gong and Yun Chen and Yan Fei Cao and Xiu Hong Kang and Dian Zhong Li},
   doi     = {10.1016/j.commatsci.2018.02.003},
@@ -1063,7 +1089,7 @@
   journal = {Computational Materials Science}
 }
 
-@Article{gonzalez-valverde.garcia-aznar:mechanical,
+@Article{2018:gonzalez-valverde.garcia-aznar:mechanical,
   doi     = {10.1016/j.cma.2018.03.036},
   url     = {https://doi.org/10.1016/j.cma.2018.03.036},
   year    = 2018,
@@ -1076,7 +1102,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@PhDThesis{greene:a-bayesian-approach-to-spike-sorting-of-neural-data-via-source-localization,
+@PhDThesis{2018:greene:a-bayesian-approach-to-spike-sorting-of-neural-data-via-source-localization,
   author  = {Greene, P},
   title   = {{A Bayesian Approach to Spike Sorting of Neural Data via Source Localization}},
   url     = {https://repository.arizona.edu/handle/10150/628404},
@@ -1084,7 +1110,7 @@
   year    = 2018
 }
 
-@Article{guermond.nazarov.ea:second-order,
+@Article{2018:guermond.nazarov.ea:second-order,
   doi     = {10.1137/17m1149961},
   url     = {https://doi.org/10.1137/17m1149961},
   year    = 2018,
@@ -1098,14 +1124,14 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@TechReport{gulevich.gulevich:user-guide-for-mitmojco-1-2-microscopic-tunneling-model-for-josephson-contacts-mitmojco-1-2,
+@TechReport{2018:gulevich.gulevich:user-guide-for-mitmojco-1-2-microscopic-tunneling-model-for-josephson-contacts-mitmojco-1-2,
   author  = {Gulevich, Dmitry R and Gulevich, Dmitry R},
   title   = {{User Guide for MiTMoJCo 1.2 (Microscopic Tunneling Model for Josephson Contacts) MiTMoJCo 1.2}},
   url     = {https://github.com/drgulevich/mitmojco},
   year    = 2018
 }
 
-@Article{gulevich.koshelets.ea:bridging,
+@Article{2018:gulevich.koshelets.ea:bridging,
   author  = {D. R. Gulevich and V. P. Koshelets and F. V. Kusmartsev},
   title   = {Bridging the Terahertz gap for chaotic sources with superconducting junctions},
   journal = {arXiv:1709.04052},
@@ -1113,7 +1139,7 @@
   url     = {https://arxiv.org/abs/1709.04052}
 }
 
-@Misc{gulevich:mitmojco,
+@Misc{2018:gulevich:mitmojco,
   title   = {MiTMoJCo: Microscopic Tunneling Model for Josephson Contacts},
   author  = {Dmitry R. Gulevich},
   year    = 2018,
@@ -1122,26 +1148,14 @@
   primaryclass = {cond-mat.supr-con}
 }
 
-@TechReport{gulevich:mitmojco-1-2,
+@TechReport{2018:gulevich:mitmojco-1-2,
   author  = {Gulevich, D. R.},
   title   = {{MiTMoJCo 1.2}},
   year    = 2018,
   url     = {https://www.researchgate.net/profile/D_Gulevich/publication/318380494_User_Guide_for_MiTMoJCo_12_Microscopic_Tunneling_Model_for_Josephson_Contacts/links/5ba4005d92851ca9ed1a09b1/User-Guide-for-MiTMoJCo-12-Microscopic-Tunneling-Model-for-Josephson-Contacts.pdf}
 }
 
-@InCollection{gulpak.wernsing.ea:compensation,
-  doi     = {10.1007/978-3-319-57120-1_12},
-  url     = {https://doi.org/10.1007/978-3-319-57120-1_12},
-  year    = 2017,
-  month   = sep,
-  publisher = {Springer International Publishing},
-  pages   = {251--288},
-  author  = {M. Gulpak and H. Wernsing and J. S\"{o}lter and C. B\"{u}skens},
-  title   = {Compensation Strategies for Thermal Effects in Dry Milling},
-  booktitle = {Lecture Notes in Production Engineering}
-}
-
-@Article{guo.song.ea:pressure,
+@Article{2018:guo.song.ea:pressure,
   doi     = {10.1016/j.petrol.2017.12.038},
   url     = {https://doi.org/10.1016/j.petrol.2017.12.038},
   year    = 2018,
@@ -1154,7 +1168,7 @@
   journal = {Journal of Petroleum Science and Engineering}
 }
 
-@Article{guo.wu.ea:investigation,
+@Article{2018:guo.wu.ea:investigation,
   doi     = {10.2118/189974-pa},
   url     = {https://doi.org/10.2118/189974-pa},
   year    = 2018,
@@ -1168,7 +1182,7 @@
   journal = {{SPE} Journal}
 }
 
-@InProceedings{guo.wu.ea:understanding,
+@InProceedings{2018:guo.wu.ea:understanding,
   doi     = {10.15530/urtec-2018-2874464},
   url     = {https://doi.org/10.15530/urtec-2018-2874464},
   year    = 2018,
@@ -1178,7 +1192,7 @@
   booktitle = {Proceedings of the 6th Unconventional Resources Technology Conference}
 }
 
-@PhDThesis{guo:a-study-of-interwell-interference-and-well-performance-in-unconventional-reservoirs-based-on-coupled-flow-and-geomechanics-modeling-with-improved,
+@PhDThesis{2018:guo:a-study-of-interwell-interference-and-well-performance-in-unconventional-reservoirs-based-on-coupled-flow-and-geomechanics-modeling-with-improved,
   author  = {Guo, X.},
   title   = {{A Study of Interwell Interference and Well Performance in Unconventional Reservoirs Based on Coupled Flow and Geomechanics Modeling with Improved}},
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/173772},
@@ -1186,7 +1200,7 @@
   year    = 2018
 }
 
-@Article{gupta.langelaar.ea:qr-patterns,
+@Article{2018:gupta.langelaar.ea:qr-patterns,
   doi     = {10.1007/s00158-018-2048-6},
   url     = {https://doi.org/10.1007/s00158-018-2048-6},
   year    = 2018,
@@ -1200,7 +1214,7 @@
   journal = {Structural and Multidisciplinary Optimization}
 }
 
-@Article{ha.choo.ea:liquid,
+@Article{2018:ha.choo.ea:liquid,
   doi     = {10.1007/s00603-018-1542-x},
   url     = {https://doi.org/10.1007/s00603-018-1542-x},
   year    = 2018,
@@ -1214,14 +1228,14 @@
   journal = {Rock Mechanics and Rock Engineering}
 }
 
-@InProceedings{hai.bause:mathematical-modelling-of-structural-health-monitoring-systems--coupling-fluid-structure-interaction-with-wave-propagation-,
+@InProceedings{2018:hai.bause:mathematical-modelling-of-structural-health-monitoring-systems--coupling-fluid-structure-interaction-with-wave-propagation-,
   author  = {Hai, BSME and Bause, M},
   title   = {{Mathematical Modelling of Structural Health Monitoring Systems: Coupling Fluid-Structure Interaction with Wave Propagation.}},
   url     = {http://congress.cimne.com/eccm_ecfd2018/admin/files/filePaper/p1848.pdf},
   year    = 2018
 }
 
-@InProceedings{hai.bause:numerical,
+@InProceedings{2018:hai.bause:numerical,
   doi     = {10.1115/imece2018-87448},
   url     = {https://doi.org/10.1115/imece2018-87448},
   year    = 2018,
@@ -1232,7 +1246,7 @@
   booktitle = {Volume 9: Mechanics of Solids, Structures, and Fluids}
 }
 
-@Article{heister.wick:parallel,
+@Article{2018:heister.wick:parallel,
   title   = {Parallel solution, adaptivity, computational convergence, and open-source code of 2d and 3d pressurized phase-field fracture problems},
   author  = {Timo Heister and Thomas Wick},
   journal = {Proc. Appl. Math. Mech.},
@@ -1243,14 +1257,14 @@
   doi     = {10.1002/pamm.201800353}
 }
 
-@TechReport{hochbruck.kohler:on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-methods-on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-problems,
+@TechReport{2018:hochbruck.kohler:on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-methods-on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-problems,
   author  = {Hochbruck, Marlis and K{\"{o}}hler, Jonas},
   title   = {{On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type methods On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type problems}},
   url     = {https://www.waves.kit.edu/downloads/CRC1173_Preprint_2017-34.pdf},
   year    = 2018
 }
 
-@PhDThesis{huang:hybrid-analog-digital-co-processing-for-scientific-computation,
+@PhDThesis{2018:huang:hybrid-analog-digital-co-processing-for-scientific-computation,
   author  = {Huang, Y.},
   title   = {{Hybrid Analog-Digital Co-Processing for Scientific Computation}},
   url     = {https://academiccommons.columbia.edu/doi/10.7916/D8V711TR},
@@ -1258,7 +1272,7 @@
   year    = 2018
 }
 
-@Article{ilio.dorschner.ea:simulation,
+@Article{2018:ilio.dorschner.ea:simulation,
   doi     = {10.1017/jfm.2018.413},
   url     = {https://www.researchgate.net/publication/325069808_Simulation_of_turbulent_flows_with_the_entropic_multi-relaxation_time_lattice_Boltzmann_method_on_body-fitted_meshes},
   year    = 2018,
@@ -1271,7 +1285,7 @@
   journal = {Journal of Fluid Mechanics}
 }
 
-@Article{jadamba.khan.ea:elliptic,
+@Article{2018:jadamba.khan.ea:elliptic,
   url     = {http://www.ybook.co.jp/online2/oppafa/vol3/p309.html},
   year    = 2018,
   month   = jan,
@@ -1282,7 +1296,7 @@
   journal = {Pure and Applied Functional Analysis}
 }
 
-@PhDThesis{jansen:modeling-heat-and-fluid-flow-in-discrete-fracture-networks,
+@PhDThesis{2018:jansen:modeling-heat-and-fluid-flow-in-discrete-fracture-networks,
   author  = {Jansen, G.},
   title   = {{Modeling heat and fluid flow in discrete fracture networks}},
   url     = {https://doc.rero.ch/record/328092},
@@ -1290,7 +1304,7 @@
   year    = 2018
 }
 
-@Article{jithin-jith:acousto-elastic,
+@Article{2018:jithin-jith:acousto-elastic,
   doi     = {10.13140/RG.2.2.30755.14885},
   url     = {http://rgdoi.net/10.13140/RG.2.2.30755.14885},
   author  = {{Jithin Jith}},
@@ -1300,7 +1314,7 @@
   year    = 2018
 }
 
-@Article{jodlbauer.langer.ea:parallel,
+@Article{2018:jodlbauer.langer.ea:parallel,
   doi     = {10.1002/nme.5970},
   url     = {https://doi.org/10.1002/nme.5970},
   year    = 2018,
@@ -1314,7 +1328,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Article{k-gupta.keulen.ea:design,
+@Article{2018:k-gupta.keulen.ea:design,
   author  = {K. Gupta, Deepak and Keulen, Fred and Langelaar, Matthijs},
   year    = 2018,
   month   = nov,
@@ -1323,7 +1337,7 @@
   url     = {https://arxiv.org/abs/1811.09821}
 }
 
-@Article{kanschat.riviere:finite,
+@Article{2018:kanschat.riviere:finite,
   doi     = {10.1007/s10915-018-0843-2},
   url     = {https://doi.org/10.1007/s10915-018-0843-2},
   year    = 2018,
@@ -1337,7 +1351,7 @@
   journal = {Journal of Scientific Computing}
 }
 
-@Article{karban.kropik.ea:bayes,
+@Article{2018:karban.kropik.ea:bayes,
   doi     = {10.1016/j.amc.2017.07.043},
   url     = {https://doi.org/10.1016/j.amc.2017.07.043},
   year    = 2018,
@@ -1350,7 +1364,7 @@
   journal = {Applied Mathematics and Computation}
 }
 
-@PhDThesis{kauffman:overset,
+@PhDThesis{2018:kauffman:overset,
   author  = {Kauffman, Justin},
   title   = {An Overset Mesh Framework for the Hybridizable Discontinuous Galerkin Finite Element Method},
   school  = {Pennsylvania State University},
@@ -1358,7 +1372,7 @@
   month   = jan
 }
 
-@Article{kaufl.grayver.ea:topographic,
+@Article{2018:kaufl.grayver.ea:topographic,
   title   = {Topographic distortions of magnetotelluric transfer functions: a high-resolution 3-D modelling study using real elevation data},
   author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Kuvshinov, Alexey V},
   journal = {Geophysical Journal International},
@@ -1370,7 +1384,7 @@
   doi     = {10.1093/gji/ggy375}
 }
 
-@Article{kazemi.vaziri.ea:topology,
+@Article{2018:kazemi.vaziri.ea:topology,
   doi     = {10.1115/1.4040624},
   url     = {https://doi.org/10.1115/1.4040624},
   year    = 2018,
@@ -1383,21 +1397,7 @@
   journal = {Journal of Mechanical Design}
 }
 
-@Article{kerganer.mergheim.ea:modeling,
-  doi     = {10.1016/j.camwa.2018.05.016},
-  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
-  year    = 2019,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 78,
-  number  = 7,
-  pages   = {2338--2350},
-  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
-  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
-  journal = {Computers {\&} Mathematics with Applications}
-}
-
-@PhDThesis{khattatov:efficient,
+@PhDThesis{2018:khattatov:efficient,
   author  = {Eldar Khattatov},
   title   = {Efficient discretization techniques and domain decomposition methods for poroelasticity},
   school  = {University of Pittsburgh},
@@ -1405,7 +1405,7 @@
   url     = {http://d-scholarship.pitt.edu/34001/1/thesis_khattatov.pdf}
 }
 
-@Misc{kocher.bause:mixed,
+@Misc{2018:kocher.bause:mixed,
   title   = {A mixed discontinuous-continuous Galerkin time discretisation for Biot's system},
   author  = {Uwe K{\"o}cher and Markus Bause},
   year    = 2018,
@@ -1414,7 +1414,7 @@
   primaryclass = {math.NA}
 }
 
-@InProceedings{koepf.soldner.ea:3d,
+@InProceedings{2018:koepf.soldner.ea:3d,
   author  = {Koepf, Johannes and Soldner, Dominic and Gotterbarm, Martin and Markl, Matthias and Mergheim, Julia and K{\"o}rner, Carolin},
   year    = 2018,
   month   = may,
@@ -1422,7 +1422,7 @@
   booktitle = {NAFEMS Konferenz 2018}
 }
 
-@Article{krank.kronbichler.ea:direct,
+@Article{2018:krank.kronbichler.ea:direct,
   title   = {Direct Numerical Simulation of Flow over Periodic Hills up to Re$_{\textnormal{H}}$ = 10,595},
   author  = {Krank, Benjamin and Kronbichler, Martin and Wall, Wolfgang A},
   journal = {Flow, Turbulence, and Combustion},
@@ -1435,7 +1435,7 @@
   doi     = {10.1007/s10494-018-9941-3}
 }
 
-@Article{krank.kronbichler.ea:wall,
+@Article{2018:krank.kronbichler.ea:wall,
   author  = {B. Krank and M. Kronbichler and W. A. Wall},
   title   = {Wall modeling via function enrichment within a high-order DG method for RANS simulations of incompressible flow},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -1447,7 +1447,7 @@
   doi     = {10.1002/fld.4409}
 }
 
-@InProceedings{kronbichler.allalen:efficient,
+@InProceedings{2018:kronbichler.allalen:efficient,
   doi     = {10.1007/978-3-319-99654-7_7},
   url     = {https://doi.org/10.1007/978-3-319-99654-7_7},
   year    = 2018,
@@ -1460,7 +1460,7 @@
   series  = {Progress in {IS}}
 }
 
-@Article{kronbichler.diagne.ea:fast,
+@Article{2018:kronbichler.diagne.ea:fast,
   author  = {Martin Kronbichler and Ababacar Diagne and Hanna Holmgren},
   title   = {A fast massively parallel two-phase flow solver for microfluidic chip simulation},
   journal = {The International Journal of High Performance Computing Applications},
@@ -1473,7 +1473,7 @@
   eprint  = { https://doi.org/10.1177/1094342016671790 }
 }
 
-@InProceedings{kronbichler.krank.ea:new,
+@InProceedings{2018:kronbichler.krank.ea:new,
   author  = {Martin Kronbichler and Benjamin Krank and Niklas Fehn and Stefan Legat and Wolfgang A. Wall},
   title   = {A new high-order discontinuous Galerkin solver for {DNS} and {LES} of turbulent incompressible flow},
   editor  = {Andreas Dillmann and Gerd Heller and Ewald Kr\"amer and Claus Wagner and Stephan Bansmer and Rolf Radespiel and Richard Semaan},
@@ -1486,7 +1486,7 @@
   doi     = {10.1007/978-3-319-64519-3_42}
 }
 
-@Article{kronbichler.wall:performance,
+@Article{2018:kronbichler.wall:performance,
   author  = {Kronbichler, Martin and Wall, Wolfgang A.},
   title   = {A Performance Comparison of Continuous and Discontinuous Galerkin Methods with Fast Multigrid Solvers},
   journal = {SIAM Journal on Scientific Computing},
@@ -1498,7 +1498,7 @@
   url     = { https://doi.org/10.1137/16M110455X}
 }
 
-@Article{ladenheim.chen.ea:mta,
+@Article{2018:ladenheim.chen.ea:mta,
   author  = {Scott Ladenheim and Yi-Chung Chen and Milan D. Mihajlovi{\'c} and Vasilis F. Pavlidis},
   title   = {The {MTA}: {A}n Advanced and Versatile Thermal Simulator for Integrated Systems},
   journal = {IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems},
@@ -1510,7 +1510,7 @@
   doi     = {10.1109/TCAD.2018.2789729}
 }
 
-@Article{lambe.czekanski:density,
+@Article{2018:lambe.czekanski:density,
   doi     = {10.1002/nme.5843},
   year    = 2018,
   month   = jun,
@@ -1523,21 +1523,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Article{lambe.czekanski:topology,
-  doi     = {10.1002/nme.5617},
-  url     = {https://doi.org/10.1002/nme.5617},
-  year    = 2017,
-  month   = aug,
-  publisher = {Wiley},
-  volume  = 113,
-  number  = 3,
-  pages   = {357--373},
-  author  = {Andrew B. Lambe and Aleksander Czekanski},
-  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@Article{lee.mikelic.ea:phase-field,
+@Article{2018:lee.mikelic.ea:phase-field,
   doi     = {10.1137/17m1145239},
   url     = {https://doi.org/10.1137/17m1145239},
   year    = 2018,
@@ -1551,7 +1537,7 @@
   journal = {Multiscale Modeling {\&} Simulation}
 }
 
-@Article{lee.min.ea:optimal,
+@Article{2018:lee.min.ea:optimal,
   doi     = {10.1007/s10596-018-9728-6},
   url     = {https://doi.org/10.1007/s10596-018-9728-6},
   year    = 2018,
@@ -1565,7 +1551,7 @@
   journal = {Computational Geosciences}
 }
 
-@Article{lee.wheeler:enriched,
+@Article{2018:lee.wheeler:enriched,
   doi     = {10.1016/j.jcp.2018.03.031},
   url     = {https://doi.org/10.1016/j.jcp.2018.03.031},
   year    = 2018,
@@ -1578,7 +1564,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{lemenager.oneill.ea:effect,
+@Article{2018:lemenager.oneill.ea:effect,
   doi     = {10.1186/s40517-018-0092-5},
   url     = {https://doi.org/10.1186/s40517-018-0092-5},
   year    = 2018,
@@ -1591,7 +1577,7 @@
   journal = {Geothermal Energy}
 }
 
-@MastersThesis{lin:stabilized,
+@MastersThesis{2018:lin:stabilized,
   author  = {Sen Lin},
   title   = {Stabilized finite element methods and applications},
   school  = {Penn State University},
@@ -1599,7 +1585,7 @@
   url     = {https://etda.libraries.psu.edu/files/final_submissions/17393}
 }
 
-@Article{liu.reina:dynamic,
+@Article{2018:liu.reina:dynamic,
   doi     = {10.1007/s00466-018-1662-x},
   url     = {https://doi.org/10.1007/s00466-018-1662-x},
   year    = 2018,
@@ -1613,7 +1599,7 @@
   journal = {Computational Mechanics}
 }
 
-@Article{liu.yin:unconditionally,
+@Article{2018:liu.yin:unconditionally,
   author  = {H. Liu and P. Yin},
   title   = {Unconditionally energy stable DG schemes for the Swift-Hohenberg equation},
   journal = {Journal of Scientific Computing},
@@ -1621,7 +1607,7 @@
   note    = {submitted}
 }
 
-@PhDThesis{lucero-lorca:multilevel-schwarz-methods-for-multigroup-radiation-transport-problems,
+@PhDThesis{2018:lucero-lorca:multilevel-schwarz-methods-for-multigroup-radiation-transport-problems,
   author  = {Jose Pablo {Lucero Lorca}},
   title   = {{Multilevel Schwarz methods for multigroup radiation transport problems}},
   year    = 2018,
@@ -1630,7 +1616,7 @@
   doi     = {10.11588/heidok.00025216}
 }
 
-@Article{ludvigsson.steffen.ea:high-order,
+@Article{2018:ludvigsson.steffen.ea:high-order,
   author  = {Ludvigsson, Gustav and Steffen, Kyle R. and Sticko, Simon and Wang, Siyang and Xia, Qing and Epshteyn, Yekaterina and Kreiss, Gunilla},
   title   = {High-Order Numerical Methods for 2D Parabolic Problems in Single and Composite Domains},
   journal = {Journal of Scientific Computing},
@@ -1644,7 +1630,7 @@
   url     = {https://doi.org/10.1007/s10915-017-0637-y}
 }
 
-@InProceedings{luo.zhao:finite,
+@InProceedings{2018:luo.zhao:finite,
   doi     = {10.1115/detc2018-85701},
   url     = {https://doi.org/10.1115/detc2018-85701},
   year    = 2018,
@@ -1655,7 +1641,7 @@
   booktitle = {38th Computers and Information in Engineering Conference, Volume 1A}
 }
 
-@Misc{maday.marcati:regularity,
+@Misc{2018:maday.marcati:regularity,
   title   = {Regularity and $hp$ discontinuous {G}alerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
   author  = {Yvon Maday and Carlo Marcati},
   year    = 2018,
@@ -1664,7 +1650,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{maier.margetis.ea:generation,
+@Article{2018:maier.margetis.ea:generation,
   author  = {M. Maier and D. Margetis and M. Luskin},
   title   = {Generation of surface plasmon-polaritons by edge effects},
   journal = {Communications in Mathematical Sciences, Vol. 16},
@@ -1673,7 +1659,7 @@
   url     = {http://www.intlpress.com/site/pub/pages/journals/items/cms/content/vols/0016/0001/a004/}
 }
 
-@Misc{maier.mattheakis.ea:homogenization,
+@Misc{2018:maier.mattheakis.ea:homogenization,
   title   = {Homogenization of plasmonic crystals: Seeking the epsilon-near-zero effect},
   author  = {Matthias Maier and Marios Mattheakis and Efthimios Kaxiras and Mitchell Luskin and Dionisios Margetis},
   year    = 2018,
@@ -1682,7 +1668,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{maier.nemilentsau.ea:ultracompact,
+@Article{2018:maier.nemilentsau.ea:ultracompact,
   author  = {Matthias Maier and Andrei Nemilentsau and Tony Low and Mitchell Luskin},
   doi     = {10.1021/acsphotonics.7b01094},
   journal = {ACS Photonics},
@@ -1693,7 +1679,7 @@
   year    = 2018
 }
 
-@Article{maier.rannacher:duality-based,
+@Article{2018:maier.rannacher:duality-based,
   doi     = {10.1137/16m1105670},
   url     = {https://doi.org/10.1137/16m1105670},
   year    = 2018,
@@ -1707,7 +1693,7 @@
   journal = {Multiscale Modeling {\&} Simulation}
 }
 
-@PhDThesis{marcati:discontinuous,
+@PhDThesis{2018:marcati:discontinuous,
   author  = {Carlo Marcati},
   title   = {Discontinuous hp finite element methods for elliptic eigenvalue problems with singular potentials: with applications to quantum chemistry},
   school  = {Sorbonne University, Paris},
@@ -1715,7 +1701,7 @@
   url     = {https://tel.archives-ouvertes.fr/tel-02072774/}
 }
 
-@PhDThesis{massoudi:numerical-algorithms-for-the-linear-quadratic-optimal-control-of-well-posed-linear-systems,
+@PhDThesis{2018:massoudi:numerical-algorithms-for-the-linear-quadratic-optimal-control-of-well-posed-linear-systems,
   author  = {Massoudi, A},
   title   = {{Numerical Algorithms for the Linear-Quadratic Optimal Control of Well-Posed Linear Systems}},
   publisher = {Universit\"{a}t Hamburg},
@@ -1723,7 +1709,7 @@
   year    = 2018
 }
 
-@InProceedings{mehnert.hossain.ea:a-thermo-electro-viscoelastic-material-model-for-the-simulation-of-vhb-4905,
+@InProceedings{2018:mehnert.hossain.ea:a-thermo-electro-viscoelastic-material-model-for-the-simulation-of-vhb-4905,
   author  = {Mehnert, M and Hossain, M and Steinmann, P},
   journal = {congress.cimne.com},
   title   = {{A THERMO-ELECTRO-VISCOELASTIC MATERIAL MODEL FOR THE SIMULATION OF VHB 4905}},
@@ -1731,7 +1717,7 @@
   year    = 2018
 }
 
-@Article{mehnert.hossain.ea:numerical,
+@Article{2018:mehnert.hossain.ea:numerical,
   doi     = {10.1016/j.ijnonlinmec.2018.08.016},
   url     = {https://doi.org/10.1016/j.ijnonlinmec.2018.08.016},
   year    = 2018,
@@ -1744,7 +1730,7 @@
   journal = {International Journal of Non-Linear Mechanics}
 }
 
-@TechReport{mohebujjaman:high,
+@TechReport{2018:mohebujjaman:high,
   year    = 2018,
   author  = {Mohebujjaman, Muhammad},
   institution = {Virginia Tech University},
@@ -1752,7 +1738,7 @@
   url     = {https://mohebujjaman.github.io/Second_order_ensembleMHD_Mohebujjaman.pdf}
 }
 
-@Misc{mohebujjaman:second,
+@Misc{2018:mohebujjaman:second,
   title   = {Second order ensemble simulation for {MHD} flow in Els{\"a}sser variable with noisy input data},
   author  = {Muhammad Mohebujjaman},
   year    = 2018,
@@ -1761,7 +1747,7 @@
   primaryclass = {math.NA}
 }
 
-@MastersThesis{munch:efficient,
+@MastersThesis{2018:munch:efficient,
   author  = {M\"unch, Peter},
   title   = {An efficient hybrid multigrid solver for high-order discontinuous Galerkin methods},
   school  = {Technical University of Munich},
@@ -1770,7 +1756,7 @@
   url     = {https://mediatum.ub.tum.de/node?id=1514962}
 }
 
-@Article{murphy.venkataraman.ea:parameter,
+@Article{2018:murphy.venkataraman.ea:parameter,
   doi     = {10.1142/s1793524518500535},
   url     = {https://doi.org/10.1142/s1793524518500535},
   year    = 2018,
@@ -1784,7 +1770,7 @@
   journal = {International Journal of Biomathematics}
 }
 
-@Article{na.sun:computational,
+@Article{2018:na.sun:computational,
   author  = {SeonHong Na and WaiChing Sun},
   title   = {Computational thermomechanics of crystalline rock, Part I: A combined multi-phase-field/crystal plasticity approach for single crystal simulations},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -1796,7 +1782,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@PhDThesis{na:multiscale-thermo-hydro-mechanical-chemical-coupling-effects-for-fluid-infiltrating-crystalline-solids-and-geomaterials--theory--implementation--and-validation,
+@PhDThesis{2018:na:multiscale-thermo-hydro-mechanical-chemical-coupling-effects-for-fluid-infiltrating-crystalline-solids-and-geomaterials--theory--implementation--and-validation,
   author  = {Na, S. H.},
   title   = {{Multiscale thermo-hydro-mechanical-chemical coupling effects for fluid-infiltrating crystalline solids and geomaterials: theory, implementation, and validation}},
   url     = {https://academiccommons.columbia.edu/doi/10.7916/D8P85VM9},
@@ -1804,7 +1790,7 @@
   year    = 2018
 }
 
-@Article{neitzel.wick.ea:optimal,
+@Article{2018:neitzel.wick.ea:optimal,
   author  = {Ira Neitzel and Thomas Wick and Winnifried Wollner},
   title   = {An Optimal Control Problem Governed by a Regularized Phase-field Fracture Propagation Model. {P}art {I}{I} {T}he Regularization Limit},
   journal = {SIAM Journal on Control and Optimization},
@@ -1815,7 +1801,7 @@
   doi     = {10.1137/16M1062375}
 }
 
-@Article{neitzel.wollner:priori,
+@Article{2018:neitzel.wollner:priori,
   doi     = {10.1007/s00211-017-0906-6},
   url     = {https://doi.org/10.1007/s00211-017-0906-6},
   year    = 2018,
@@ -1829,14 +1815,14 @@
   journal = {Numerische Mathematik}
 }
 
-@Article{odster.kvamsdal.ea:simple,
+@Article{2018:odster.kvamsdal.ea:simple,
   author  = {L. Hov Ods\ae{}ter and T. Kvamsdal and M. G Larson},
   title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
   journal = {arXiv:1803.03423},
   year    = 2018
 }
 
-@Article{oneill.zhang:lateral,
+@Article{2018:oneill.zhang:lateral,
   doi     = {10.1029/2018JB015698},
   title   = {Lateral Mixing Processes in the {H}adean},
   author  = {O'Neill, C. J. and Zhang, S.},
@@ -1848,7 +1834,7 @@
   publisher = {Wiley Online Library}
 }
 
-@Misc{pearson.porcelli.ea:interior,
+@Misc{2018:pearson.porcelli.ea:interior,
   title   = {Interior Point Methods and Preconditioning for PDE-Constrained Optimization Problems Involving Sparsity Terms},
   author  = {John W. Pearson and Margherita Porcelli and Martin Stoll},
   year    = 2018,
@@ -1857,7 +1843,7 @@
   primaryclass = {math.OC}
 }
 
-@Article{pelteret.walter.ea:application,
+@Article{2018:pelteret.walter.ea:application,
   author  = {Jean-Paul Pelteret and Bastian Walter and Paul Steinmann},
   title   = {Application of metaheuristic algorithms to the identification of nonlinear magneto-viscoelastic constitutive parameters},
   journal = {Journal of Magnetism and Magnetic Materials},
@@ -1869,7 +1855,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{puckett.turcotte.ea:new,
+@Article{2018:puckett.turcotte.ea:new,
   doi     = {10.1016/j.pepi.2017.10.004},
   url     = {https://doi.org/10.1016/j.pepi.2017.10.004},
   year    = 2018,
@@ -1882,7 +1868,7 @@
   journal = {Physics of the Earth and Planetary Interiors}
 }
 
-@Article{qiao.bai.ea:blended,
+@Article{2018:qiao.bai.ea:blended,
   doi     = {10.1051/jnwpu/20183610057},
   url     = {https://doi.org/10.1051/jnwpu/20183610057},
   year    = 2018,
@@ -1896,7 +1882,7 @@
   journal = {Xibei Gongye Daxue Xuebao/Journal of Northwestern Polytechnical University}
 }
 
-@Article{roberge.norato:computational,
+@Article{2018:roberge.norato:computational,
   author  = {Jeffrey Roberge and Juli{\'{a}}n Norato},
   title   = {Computational design of curvilinear bone scaffolds fabricated via direct ink writing},
   doi     = {10.1016/j.cad.2017.09.003},
@@ -1907,7 +1893,7 @@
   journal = {Computer-Aided Design}
 }
 
-@Article{rom.muller:effective,
+@Article{2018:rom.muller:effective,
   doi     = {10.1016/j.triboint.2018.04.011},
   url     = {https://doi.org/10.1016/j.triboint.2018.04.011},
   year    = 2018,
@@ -1920,7 +1906,7 @@
   journal = {Tribology International}
 }
 
-@Article{ross.ryan.ea:size,
+@Article{2018:ross.ryan.ea:size,
   doi     = {10.1093/icb/icy021},
   url     = {https://doi.org/10.1093/icb/icy021},
   year    = 2018,
@@ -1934,7 +1920,7 @@
   journal = {Integrative and Comparative Biology}
 }
 
-@PhDThesis{sabawi:discontinuous,
+@PhDThesis{2018:sabawi:discontinuous,
   author  = {Sabawi, Mohammad},
   title   = {Discontinuous Galerkin timestepping for nonlinear parabolic problems},
   url     = {https://www.researchgate.net/publication/327546550},
@@ -1942,7 +1928,7 @@
   year    = 2018
 }
 
-@Article{sabharwal.gostick.ea:virtual,
+@Article{2018:sabharwal.gostick.ea:virtual,
   doi     = {10.1149/2.0921807jes},
   url     = {https://doi.org/10.1149/2.0921807jes},
   year    = 2018,
@@ -1955,7 +1941,7 @@
   journal = {Journal of The Electrochemical Society}
 }
 
-@PhDThesis{sacco:3d,
+@PhDThesis{2018:sacco:3d,
   author  = {Filippo Guido Davide Sacco},
   title   = {A 3D adaptive boundary element method for potential flow with nonlinear Kutta condition},
   school  = {Politecnico di Milano},
@@ -1964,7 +1950,7 @@
   url     = {https://www.politesi.polimi.it/handle/10589/140106}
 }
 
-@Article{safin.minkoff.ea:preconditioned,
+@Article{2018:safin.minkoff.ea:preconditioned,
   author  = {Safin, Artur and Minkoff, Susan E. and Zweck, John},
   title   = {A preconditioned finite element solution of the coupled pressure-temperature equations used to model trace gas sensors},
   journal = {SIAM Journal on Scientific Computing},
@@ -1976,7 +1962,7 @@
   url     = {https://doi.org/10.1137/17M1145823}
 }
 
-@PhDThesis{safin:modeling,
+@PhDThesis{2018:safin:modeling,
   author  = {Safin, Artur},
   title   = {Modeling Trace Gas Sensors with the Coupled Pressure-Temperature Equations},
   school  = {The University of Texas at Dallas},
@@ -1985,7 +1971,7 @@
   url     = {https://hdl.handle.net/10735.1/6420}
 }
 
-@Article{salvadori.damioli.ea:modeling,
+@Article{2018:salvadori.damioli.ea:modeling,
   author  = {A. Salvadori and V. Damioli and C. Ravelli and S. Mitola},
   title   = {Modeling and Simulation of {VEGF} Receptors Recruitment in Angiogenesis},
   journal = {Mathematical Problems in Engineering},
@@ -1997,7 +1983,7 @@
   publisher = {Hindawi Limited}
 }
 
-@Article{samrock.grayver.ea:magnetotelluric,
+@Article{2018:samrock.grayver.ea:magnetotelluric,
   title   = {Magnetotelluric image of transcrustal magmatic system beneath the {Tulu Moye} geothermal prospect in the {Ethiopian Rift}},
   author  = {Samrock, Friedemann and Grayver, Alexander V and Eysteinsson, Hjalmar and Saar, Martin O},
   journal = {Geophysical Research Letters},
@@ -2009,7 +1995,7 @@
   doi     = {10.1029/2018GL080333}
 }
 
-@Article{sarna.torrilhon:entropy,
+@Article{2018:sarna.torrilhon:entropy,
   doi     = {10.1016/j.jcp.2018.04.050},
   year    = 2018,
   month   = sep,
@@ -2021,7 +2007,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{sartori.giuliani.ea:deal2lkit,
+@Article{2018:sartori.giuliani.ea:deal2lkit,
   doi     = {10.1016/j.softx.2018.09.004},
   url     = {https://linkinghub.elsevier.com/retrieve/pii/S2352711018302048},
   year    = 2018,
@@ -2035,7 +2021,7 @@
   journal = {{SoftwareX}}
 }
 
-@Article{scacchi.brader:local,
+@Article{2018:scacchi.brader:local,
   author  = {A. Scacchi and J. M. Brader},
   title   = {Local phase transitions in driven colloidal suspensions},
   journal = {Molecular Physics},
@@ -2046,7 +2032,7 @@
   doi     = {10.1080/00268976.2017.1393117}
 }
 
-@Article{schneider.hu.ea:decoupling,
+@Article{2018:schneider.hu.ea:decoupling,
   title   = {Decoupling Simulation Accuracy from Mesh Quality},
   url     = {http://par.nsf.gov/biblio/10080686},
   journal = {ACM Transactions on Graphics},
@@ -2055,7 +2041,7 @@
   month   = dec
 }
 
-@MastersThesis{schneider:simulation,
+@MastersThesis{2018:schneider:simulation,
   author  = {Schneider, David},
   title   = {Simulation von Fluid-Struktur-Interaktion mit der Kopplungsbibliothek preCICE},
   school  = {Universit{\"a}t Siegen},
@@ -2063,7 +2049,7 @@
   note    = {Bachelorarbeit}
 }
 
-@Article{schoeder.kormann.ea:efficient,
+@Article{2018:schoeder.kormann.ea:efficient,
   title   = {Efficient explicit time stepping of high order discontinuous {G}alerkin schemes for waves},
   author  = {Schoeder, Svenja and Kormann, Katharina and Wall, Wolfgang A and Kronbichler, Martin},
   journal = {SIAM Journal on Scientific Computing},
@@ -2076,7 +2062,7 @@
   doi     = {10.1137/18M1185399}
 }
 
-@Article{schoeder.kronbichler.ea:arbitrary,
+@Article{2018:schoeder.kronbichler.ea:arbitrary,
   title   = {Arbitrary high-order explicit hybridizable discontinuous {G}alerkin methods for the acoustic wave equation},
   author  = {Schoeder, Svenja and Kronbichler, Martin and Wall, Wolfgang A},
   journal = {Journal of Scientific Computing},
@@ -2088,7 +2074,7 @@
   doi     = {10.1007/s10915-018-0649-2}
 }
 
-@Article{schoeder.olefir.ea:optoacoustic,
+@Article{2018:schoeder.olefir.ea:optoacoustic,
   author  = {Svenja Schoeder and Ivan Olefir and Martin Kronbichler and Vasilis Ntziachristos and Wolfgang A. Wall},
   title   = {Optoacoustic image reconstruction: the full inverse problem with variable bases},
   journal = {Proceedings of the Royal Society A},
@@ -2099,19 +2085,7 @@
   doi     = {10.1098/rspa.2018.0369}
 }
 
-@InCollection{schuster.schopfer:damage,
-  doi     = {10.1007/978-3-319-49715-0_16},
-  url     = {https://doi.org/10.1007/978-3-319-49715-0_16},
-  year    = 2017,
-  month   = aug,
-  publisher = {Springer International Publishing},
-  pages   = {373--397},
-  author  = {T. Schuster and F. Sch\"{o}pfer},
-  title   = {Damage Identification by Dynamic Load Monitoring},
-  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites}
-}
-
-@Article{schutz:3d,
+@Article{2018:schutz:3d,
   title   = {3D Boundary Element Simulation of Droplet Dynamics in Microchannels: How Droplets Squeeze Through Constrictions and Move in Electric Fields},
   author  = {Sch\"{u}tz, Simon Sebastian},
   publisher = {EPFL},
@@ -2122,7 +2096,7 @@
   doi     = {10.5075/epfl-thesis-8621}
 }
 
-@MastersThesis{schuurmans:numerical-modelling-of-overriding-plate-deformation-and-slab-rollback-in-the-western-mediterranean,
+@MastersThesis{2018:schuurmans:numerical-modelling-of-overriding-plate-deformation-and-slab-rollback-in-the-western-mediterranean,
   author  = {Schuurmans, L. F. J.},
   title   = {{Numerical modelling of overriding plate deformation and slab rollback in the Western Mediterranean}},
   school  = {Utrecht University},
@@ -2130,7 +2104,7 @@
   url     = {https://dspace.library.uu.nl/handle/1874/366408}
 }
 
-@PhDThesis{shannon:hybridized-discontinuous-galerkin-methods-for-magnetohydrodynamics,
+@PhDThesis{2018:shannon:hybridized-discontinuous-galerkin-methods-for-magnetohydrodynamics,
   author  = {Shannon, S. J.},
   title   = {{Hybridized discontinuous Galerkin methods for magnetohydrodynamics}},
   url     = {https://repositories.lib.utexas.edu/handle/2152/75763},
@@ -2138,7 +2112,7 @@
   year    = 2018
 }
 
-@Article{sharma.kanschat:contraction,
+@Article{2018:sharma.kanschat:contraction,
   doi     = {10.1515/jnma-2016-1132},
   url     = {https://doi.org/10.1515/jnma-2016-1132},
   year    = 2018,
@@ -2152,7 +2126,7 @@
   journal = {Journal of Numerical Mathematics}
 }
 
-@Article{sheldon.miller.ea:improved,
+@Article{2018:sheldon.miller.ea:improved,
   title   = {An Improved Formulation for Hybridizable Discontinuous Galerkin Fluid-Structure Interaction Modeling with Reduced Computational Expense},
   author  = {Sheldon, Jason P. and Miller, Scott T. and Pitt, Jonathan S.},
   doi     = {10.4208/cicp.OA-2017-0114},
@@ -2164,7 +2138,7 @@
   month   = jun
 }
 
-@PhDThesis{shovkun:coupled-chemo-mechanical-processes-in-reservoir-geomechanics,
+@PhDThesis{2018:shovkun:coupled-chemo-mechanical-processes-in-reservoir-geomechanics,
   author  = {Shovkun, I},
   title   = {{Coupled chemo-mechanical processes in reservoir geomechanics}},
   url     = {https://repositories.lib.utexas.edu/handle/2152/72439},
@@ -2172,7 +2146,7 @@
   year    = 2018
 }
 
-@InProceedings{smolyanov.karban:optimal,
+@InProceedings{2018:smolyanov.karban:optimal,
   doi     = {10.1109/elektro.2018.8398325},
   url     = {https://doi.org/10.1109/elektro.2018.8398325},
   year    = 2018,
@@ -2183,7 +2157,7 @@
   booktitle = {2018 {ELEKTRO}}
 }
 
-@Article{steinberger.bredow.ea:widespread-volcanism-in-the-greenland-north-atlantic-region-explained-by-the-iceland-plume,
+@Article{2018:steinberger.bredow.ea:widespread-volcanism-in-the-greenland-north-atlantic-region-explained-by-the-iceland-plume,
   author  = {B. Steinberger and E. Bredow and S. Lebedev and A. Schaeffer and T. H. Torsvik},
   title   = {{Widespread volcanism in the Greenland-North Atlantic region explained by the Iceland plume}},
   journal = {Nature Geoscience},
@@ -2192,7 +2166,7 @@
   doi     = {10.1038/s41561-018-0251-0}
 }
 
-@PhDThesis{sticko:high,
+@PhDThesis{2018:sticko:high,
   author  = {Sticko, Simon},
   title   = {High Order Cut Finite Element Methods for Wave Equations},
   school  = {Uppsala University},
@@ -2204,7 +2178,7 @@
   url     = {http://urn.kb.se/resolve?urn=urn%3Anbn%3Ase%3Auu%3Adiva-347439}
 }
 
-@Article{tezzele.salmoiraghi.ea:dimension,
+@Article{2018:tezzele.salmoiraghi.ea:dimension,
   doi     = {10.1186/s40323-018-0118-3},
   url     = {https://doi.org/10.1186/s40323-018-0118-3},
   year    = 2018,
@@ -2217,7 +2191,7 @@
   journal = {Advanced Modeling and Simulation in Engineering Sciences}
 }
 
-@Article{truster:deip,
+@Article{2018:truster:deip,
   doi     = {10.1016/j.softx.2018.05.002},
   url     = {https://doi.org/10.1016/j.softx.2018.05.002},
   year    = 2018,
@@ -2230,7 +2204,7 @@
   journal = {{SoftwareX}}
 }
 
-@Article{verner.garikipati:computational,
+@Article{2018:verner.garikipati:computational,
   doi     = {10.1016/j.eml.2017.11.003},
   url     = {https://doi.org/10.1016/j.eml.2017.11.003},
   year    = 2018,
@@ -2243,7 +2217,7 @@
   journal = {Extreme Mechanics Letters}
 }
 
-@Article{veske.kyritsakis.ea:dynamic,
+@Article{2018:veske.kyritsakis.ea:dynamic,
   doi     = {10.1016/j.jcp.2018.04.031},
   url     = {https://doi.org/10.1016/j.jcp.2018.04.031},
   year    = 2018,
@@ -2256,7 +2230,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{villiers.mcbride.ea:a-validated-patient-specific-fsi-model-for-vascular-access-in-haemodialysis,
+@Article{2018:villiers.mcbride.ea:a-validated-patient-specific-fsi-model-for-vascular-access-in-haemodialysis,
   author  = {de Villiers, A. M. and McBride, A. T. and Reddy, B. D. and Franz, T. and Spottiswoode, B. S.},
   doi     = {10.1007/s10237-017-0973-8},
   issn    = 16177940,
@@ -2271,7 +2245,7 @@
   year    = 2018
 }
 
-@MastersThesis{vundla:numerical,
+@MastersThesis{2018:vundla:numerical,
   author  = {Vundla, Nkosilathi},
   title   = {Numerical modelling of the Oldroyd-B fluid},
   url     = {http://hdl.handle.net/11427/30996},
@@ -2280,7 +2254,7 @@
   school  = {University of Cape Town}
 }
 
-@Article{wang.garikipati:multi-physics,
+@Article{2018:wang.garikipati:multi-physics,
   doi     = {10.1149/2.0141811jes},
   url     = {https://doi.org/10.1149/2.0141811jes},
   year    = 2018,
@@ -2293,7 +2267,7 @@
   journal = {Journal of The Electrochemical Society}
 }
 
-@Article{wang.triantafyllou.ea:entropy-viscosity,
+@Article{2018:wang.triantafyllou.ea:entropy-viscosity,
   doi     = {10.1017/jfm.2018.808},
   url     = {https://doi.org/10.1017/jfm.2018.808},
   year    = 2018,
@@ -2306,7 +2280,7 @@
   journal = {Journal of Fluid Mechanics}
 }
 
-@Article{wei.wang.ea:study,
+@Article{2018:wei.wang.ea:study,
   doi     = {10.3390/en11020329},
   url     = {https://doi.org/10.3390/en11020329},
   year    = 2018,
@@ -2320,7 +2294,7 @@
   journal = {Energies}
 }
 
-@Article{weier.wick:dual-weighted,
+@Article{2018:weier.wick:dual-weighted,
   author  = {Steffen Wei{\ss}er and Thomas Wick},
   title   = {The Dual-Weighted Residual Estimator Realized on Polygonal Meshes},
   journal = {Computational Methods in Applied Mathematics},
@@ -2334,14 +2308,14 @@
   url     = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf}
 }
 
-@Article{wells.banks:using,
+@Article{2018:wells.banks:using,
   author  = {D. Wells and J. W. Banks},
   title   = {Using p-Refinement to Increase Boundary Derivative Convergence Rates.},
   journal = {arXiv:1711.05922},
   year    = 2018
 }
 
-@InProceedings{wichrowski:multigrid-method-for-stokes-problem-with-discontinuous-viscosity,
+@InProceedings{2018:wichrowski:multigrid-method-for-stokes-problem-with-discontinuous-viscosity,
   author  = {Wichrowski, M l},
   journal = {congress.cimne.com},
   title   = {{Multigrid method for Stokes problem with discontinuous viscosity}},
@@ -2349,7 +2323,7 @@
   year    = 2018
 }
 
-@Article{wick:numerical,
+@Article{2018:wick:numerical,
   author  = {T. Wick},
   title   = {Numerical Methods for Partial Differential Equations},
   journal = {Lecture notes, Institute of Applied Mathematics, Leibniz Universit\"{a}t Hannover, Germany},
@@ -2357,7 +2331,7 @@
   url     = {https://www.ifam.uni-hannover.de/1562.html}
 }
 
-@Article{wick:zielorientierte-numerik-fur-multiphysiksimulationen,
+@Article{2018:wick:zielorientierte-numerik-fur-multiphysiksimulationen,
   author  = {T. Wick},
   title   = {{Zielorientierte Numerik f{\"u}r Multiphysiksimulationen}},
   journal = {GAMM-Rundbrief},
@@ -2366,7 +2340,7 @@
   pages   = {4--10}
 }
 
-@Article{wilmers.bargmann:functionalisation,
+@Article{2018:wilmers.bargmann:functionalisation,
   doi     = {10.1016/j.eml.2018.03.002},
   url     = {https://doi.org/10.1016/j.eml.2018.03.002},
   year    = 2018,
@@ -2379,7 +2353,7 @@
   journal = {Extreme Mechanics Letters}
 }
 
-@PhDThesis{xiao:efficient,
+@PhDThesis{2018:xiao:efficient,
   title   = {Efficient and Accurate Splitting Methods for Flow Problems},
   author  = {Mengying Xiao},
   school  = {Clemson University},
@@ -2387,7 +2361,7 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/2174/}
 }
 
-@PhDThesis{zareei:transformation-based-wave-control,
+@PhDThesis{2018:zareei:transformation-based-wave-control,
   author  = {Zareei, Ahmad},
   title   = {{Transformation Based Wave Control}},
   url     = {https://escholarship.org/uc/item/21d6c40m},
@@ -2395,7 +2369,7 @@
   year    = 2018
 }
 
-@Article{zhang.gain.ea:geometry,
+@Article{2018:zhang.gain.ea:geometry,
   doi     = {10.1002/nme.5737},
   url     = {https://doi.org/10.1002/nme.5737},
   year    = 2018,
@@ -2409,7 +2383,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Misc{zhang.guo.ea:runge-kutta,
+@Misc{2018:zhang.guo.ea:runge-kutta,
   title   = {Runge-Kutta symmetric interior penalty discontinuous Galerkin methods for modified Buckley-Leverett equations},
   author  = {Hong Zhang and Yunrui Guo and Weibin Li and Paul Andries Zegeling},
   year    = 2018,
@@ -2418,7 +2392,7 @@
   primaryclass = {math.NA}
 }
 
-@Article{zhang.li:formation,
+@Article{2018:zhang.li:formation,
   author  = {N. Zhang and Z.-X. Li},
   title   = {Formation of mantle ``lone plumes'' in the global downwelling zone -- A case for subduction-controlled plume generation beneath the South China Sea},
   journal = {Tectonophysics},
@@ -2429,7 +2403,7 @@
   doi     = {10.1016/j.tecto.2017.11.038}
 }
 
-@InProceedings{zhang.norato:finding,
+@InProceedings{2018:zhang.norato:finding,
   doi     = {10.1115/detc2018-86116},
   url     = {https://doi.org/10.1115/detc2018-86116},
   year    = 2018,
@@ -2440,7 +2414,7 @@
   booktitle = {Volume 2B: 44th Design Automation Conference}
 }
 
-@Article{zhang.zegeling:simulation,
+@Article{2018:zhang.zegeling:simulation,
   doi     = {10.1016/j.amc.2018.06.017},
   url     = {https://doi.org/10.1016/j.amc.2018.06.017},
   year    = 2018,
@@ -2453,7 +2427,7 @@
   journal = {Applied Mathematics and Computation}
 }
 
-@Article{zhao.tan:postvoiding,
+@Article{2018:zhao.tan:postvoiding,
   doi     = {10.1109/tvlsi.2018.2861358},
   url     = {https://doi.org/10.1109/tvlsi.2018.2861358},
   year    = 2018,
@@ -2467,7 +2441,7 @@
   journal = {{IEEE} Transactions on Very Large Scale Integration ({VLSI}) Systems}
 }
 
-@PhDThesis{zhao:fem-based-multiphysics-analysis-of-electromigration-voiding-process-in-nanometer-integrated-circuits,
+@PhDThesis{2018:zhao:fem-based-multiphysics-analysis-of-electromigration-voiding-process-in-nanometer-integrated-circuits,
   author  = {Zhao, H.},
   title   = {{FEM Based Multiphysics Analysis of Electromigration Voiding Process in Nanometer Integrated Circuits}},
   year    = 2018,
@@ -2475,7 +2449,7 @@
   school  = {University of California, Davis}
 }
 
-@PhDThesis{zhao:numerical,
+@PhDThesis{2018:zhao:numerical,
   title   = {A numerical method for the Navier Stokes equations in {Velocity-Vorticity} form},
   author  = {Liang Zhao},
   school  = {Clemson University},
@@ -2483,7 +2457,7 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/2288/}
 }
 
-@Article{zhou.shukla.ea:analysis,
+@Article{2018:zhou.shukla.ea:analysis,
   author  = {J. J. Zhou and S. Shukla and A. Putz and M. Secanell},
   title   = {Analysis of the role of the microporous layer in improving polymer electrolyte fuel cell performance},
   journal = {Electrochimica Acta},
@@ -2492,6 +2466,32 @@
   pages   = {366--382},
   url     = {https://www.sciencedirect.com/science/article/pii/S0013468618304043?via%3Dihub},
   doi     = {10.1016/j.electacta.2018.02.100}
+}
+
+@Article{2019:alhazmi:exploring,
+  doi     = {10.14569/ijacsa.2019.0100372},
+  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
+  year    = 2019,
+  publisher = {The Science and Information Organization},
+  volume  = 10,
+  number  = 3,
+  author  = {Muflih Alhazmi},
+  title   = {Exploring Mechanisms for Pattern Formation through Coupled Bulk-Surface {PDEs} in Case of Non-linear Reactions},
+  journal = {International Journal of Advanced Computer Science and Applications}
+}
+
+@Article{2019:kerganer.mergheim.ea:modeling,
+  doi     = {10.1016/j.camwa.2018.05.016},
+  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
+  year    = 2019,
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = 78,
+  number  = 7,
+  pages   = {2338--2350},
+  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
+  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
+  journal = {Computers {\&} Mathematics with Applications}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1,74 +1,5 @@
 % Encoding: US-ASCII
 
-@MastersThesis{2016:c--a--h--blom:state-of-the-art-numerical-subduction-modelling-with-aspect--thermo-mechanically-coupled-viscoplastic-compressible-rheology--free-surface--phase-changes--latent-heat-and-open-sidewalls,
-  author  = {{C. A. H. Blom}},
-  school  = {Utrecht University},
-  title   = {{State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent heat and open sidewalls}},
-  url     = {https://dspace.library.uu.nl/handle/1874/348133},
-  year    = 2016
-}
-
-@Misc{2017:badia.martin.ea:fempar,
-  title   = {FEMPAR: An object-oriented parallel finite element framework},
-  author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
-  year    = 2017,
-  eprint  = {1708.01773},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.CE}
-}
-
-@Article{2017:emerson.farrell.ea:computing,
-  doi     = {10.1080/02678292.2017.1365385},
-  url     = {https://doi.org/10.1080/02678292.2017.1365385},
-  year    = 2017,
-  month   = aug,
-  publisher = {Informa {UK} Limited},
-  volume  = 45,
-  number  = 3,
-  pages   = {341--350},
-  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
-  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
-  journal = {Liquid Crystals}
-}
-
-@InCollection{2017:gulpak.wernsing.ea:compensation,
-  doi     = {10.1007/978-3-319-57120-1_12},
-  url     = {https://doi.org/10.1007/978-3-319-57120-1_12},
-  year    = 2017,
-  month   = sep,
-  publisher = {Springer International Publishing},
-  pages   = {251--288},
-  author  = {M. Gulpak and H. Wernsing and J. S\"{o}lter and C. B\"{u}skens},
-  title   = {Compensation Strategies for Thermal Effects in Dry Milling},
-  booktitle = {Lecture Notes in Production Engineering}
-}
-
-@Article{2017:lambe.czekanski:topology,
-  doi     = {10.1002/nme.5617},
-  url     = {https://doi.org/10.1002/nme.5617},
-  year    = 2017,
-  month   = aug,
-  publisher = {Wiley},
-  volume  = 113,
-  number  = 3,
-  pages   = {357--373},
-  author  = {Andrew B. Lambe and Aleksander Czekanski},
-  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
-  journal = {International Journal for Numerical Methods in Engineering}
-}
-
-@InCollection{2017:schuster.schopfer:damage,
-  doi     = {10.1007/978-3-319-49715-0_16},
-  url     = {https://doi.org/10.1007/978-3-319-49715-0_16},
-  year    = 2017,
-  month   = aug,
-  publisher = {Springer International Publishing},
-  pages   = {373--397},
-  author  = {T. Schuster and F. Sch\"{o}pfer},
-  title   = {Damage Identification by Dynamic Load Monitoring},
-  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites}
-}
-
 @Article{2018:aagesen.adams.ea:prisms,
   author  = {L. K. Aagesen and J. F. Adams and J. E. Allison and W. B. Andrews and V. Araullo-Peters and T. Berman and Z. Chen and S. Daly and S. Das and S. DeWitt and S. Ganesan and K. Garikipati and V. Gavini and A. Githens and M. Hedstrom and Z. Huang and H. V. Jagadish and J. W. Jones and J. Luce and E. A. Marquis and A. Misra and D. Montiel and P. Motamarri and A. D. Murphy and A. R. Natarajan and S. Panwar and B. Puchala and L. Qi and S. Rudraraju and K. Sagiyama and E. L. S. Solomon and V. Sundararaghavan and G. Tarcea and G. H. Teichert and J. C. Thomas and K. Thornton and A. Van der Ven and Z. Wang and T. Weymouth and C. Yang},
   title   = {{PRISMS}: {A}n Integrated, Open-Source Framework for Accelerating Predictive Structural Materials Science},
@@ -853,6 +784,19 @@
   year    = 2018
 }
 
+@Article{2018:emerson.farrell.ea:computing,
+  doi     = {10.1080/02678292.2017.1365385},
+  url     = {https://doi.org/10.1080/02678292.2017.1365385},
+  year    = 2018,
+  publisher = {Informa {UK} Limited},
+  volume  = 45,
+  number  = 3,
+  pages   = {341--350},
+  author  = {David B. Emerson and Patrick E. Farrell and James H. Adler and Scott P. MacLachlan and Timothy J. Atherton},
+  title   = {Computing equilibrium states of cholesteric liquid crystals in elliptical channels with deflation algorithms},
+  journal = {Liquid Crystals}
+}
+
 @Misc{2018:emerson:error,
   title   = {Error Estimators and Marking Strategies for Electrically Coupled Liquid Crystal Systems},
   author  = {D. B. Emerson},
@@ -1153,6 +1097,17 @@
   title   = {{MiTMoJCo 1.2}},
   year    = 2018,
   url     = {https://www.researchgate.net/profile/D_Gulevich/publication/318380494_User_Guide_for_MiTMoJCo_12_Microscopic_Tunneling_Model_for_Josephson_Contacts/links/5ba4005d92851ca9ed1a09b1/User-Guide-for-MiTMoJCo-12-Microscopic-Tunneling-Model-for-Josephson-Contacts.pdf}
+}
+
+@InCollection{2018:gulpak.wernsing.ea:compensation,
+  doi     = {10.1007/978-3-319-57120-1_12},
+  url     = {https://doi.org/10.1007/978-3-319-57120-1_12},
+  year    = 2018,
+  publisher = {Springer International Publishing},
+  pages   = {251--288},
+  author  = {M. Gulpak and H. Wernsing and J. S\"{o}lter and C. B\"{u}skens},
+  title   = {Compensation Strategies for Thermal Effects in Dry Milling},
+  booktitle = {Lecture Notes in Production Engineering}
 }
 
 @Article{2018:guo.song.ea:pressure,
@@ -1523,6 +1478,20 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
+@Article{2018:lambe.czekanski:topology,
+  doi     = {10.1002/nme.5617},
+  url     = {https://doi.org/10.1002/nme.5617},
+  year    = 2018,
+  month   = jan,
+  publisher = {Wiley},
+  volume  = 113,
+  number  = 3,
+  pages   = {357--373},
+  author  = {Andrew B. Lambe and Aleksander Czekanski},
+  title   = {Topology optimization using a continuous density field and adaptive mesh refinement},
+  journal = {International Journal for Numerical Methods in Engineering}
+}
+
 @Article{2018:lee.mikelic.ea:phase-field,
   doi     = {10.1137/17m1145239},
   url     = {https://doi.org/10.1137/17m1145239},
@@ -1822,6 +1791,18 @@
   year    = 2018
 }
 
+@Article{2018:oneill.turner.ea:inception,
+  doi     = {10.1098/rsta.2017.0414},
+  title   = {The inception of plate tectonics: a record of failure},
+  author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
+  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+  volume  = 376,
+  number  = 2132,
+  pages   = 20170414,
+  year    = 2018,
+  publisher = {The Royal Society Publishing}
+}
+
 @Article{2018:oneill.zhang:lateral,
   doi     = {10.1029/2018JB015698},
   title   = {Lateral Mixing Processes in the {H}adean},
@@ -2083,6 +2064,17 @@
   pages   = 20180369,
   url     = {https://doi.org/10.1098/rspa.2018.0369},
   doi     = {10.1098/rspa.2018.0369}
+}
+
+@InCollection{2018:schuster.schopfer:damage,
+  doi     = {10.1007/978-3-319-49715-0_16},
+  url     = {https://doi.org/10.1007/978-3-319-49715-0_16},
+  year    = 2018,
+  publisher = {Springer International Publishing},
+  pages   = {373--397},
+  author  = {T. Schuster and F. Sch\"{o}pfer},
+  title   = {Damage Identification by Dynamic Load Monitoring},
+  booktitle = {Lamb-Wave Based Structural Health Monitoring in Polymer Composites}
 }
 
 @Article{2018:schutz:3d,
@@ -2466,32 +2458,6 @@
   pages   = {366--382},
   url     = {https://www.sciencedirect.com/science/article/pii/S0013468618304043?via%3Dihub},
   doi     = {10.1016/j.electacta.2018.02.100}
-}
-
-@Article{2019:alhazmi:exploring,
-  doi     = {10.14569/ijacsa.2019.0100372},
-  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
-  year    = 2019,
-  publisher = {The Science and Information Organization},
-  volume  = 10,
-  number  = 3,
-  author  = {Muflih Alhazmi},
-  title   = {Exploring Mechanisms for Pattern Formation through Coupled Bulk-Surface {PDEs} in Case of Non-linear Reactions},
-  journal = {International Journal of Advanced Computer Science and Applications}
-}
-
-@Article{2019:kerganer.mergheim.ea:modeling,
-  doi     = {10.1016/j.camwa.2018.05.016},
-  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
-  year    = 2019,
-  month   = oct,
-  publisher = {Elsevier {BV}},
-  volume  = 78,
-  number  = 7,
-  pages   = {2338--2350},
-  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
-  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
-  journal = {Computers {\&} Mathematics with Applications}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{adler.he.ea:vector-potential,
+@Article{2019:adler.he.ea:vector-potential,
   doi     = {10.1016/j.camwa.2018.09.051},
   year    = 2019,
   month   = jan,
@@ -13,7 +13,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@PhDThesis{africa:scalable,
+@PhDThesis{2019:africa:scalable,
   author  = {Pasquale Claudio Africa},
   title   = {Scalable adaptive simulation of organic thin-film transistors},
   school  = {Politecnico di Milano},
@@ -22,7 +22,7 @@
   url     = {http://hdl.handle.net/10589/144819}
 }
 
-@Article{aggul.kaya.ea:two,
+@Article{2019:aggul.kaya.ea:two,
   doi     = {10.1016/j.amc.2018.12.074},
   year    = 2019,
   month   = oct,
@@ -34,7 +34,7 @@
   journal = {Applied Mathematics and Computation}
 }
 
-@Article{al-arydah.carraro:reviewing,
+@Article{2019:al-arydah.carraro:reviewing,
   doi     = {10.1016/j.camwa.2018.08.001},
   year    = 2019,
   month   = mar,
@@ -47,7 +47,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@PhDThesis{alzetta:coupling,
+@PhDThesis{2019:alzetta:coupling,
   author  = {Alzetta, Giovanni},
   title   = {Coupling methods for non-matching meshes through distributed Lagrange multipliers},
   url     = {http://hdl.handle.net/20.500.11767/103034},
@@ -55,7 +55,7 @@
   year    = 2019
 }
 
-@Article{ambartsumyan.khattatov.ea:higher,
+@Article{2019:ambartsumyan.khattatov.ea:higher,
   doi     = {10.1142/s0218202519500167},
   year    = 2019,
   month   = jun,
@@ -68,7 +68,7 @@
   journal = {Mathematical Models and Methods in Applied Sciences}
 }
 
-@MastersThesis{ameri:improving,
+@MastersThesis{2019:ameri:improving,
   doi     = {10.13140/RG.2.2.25335.78247},
   url     = {http://rgdoi.net/10.13140/RG.2.2.25335.78247},
   author  = {Abtin Ameri},
@@ -79,7 +79,7 @@
   note    = {Honors thesis}
 }
 
-@PhDThesis{araujo-cabarcas:reliable,
+@PhDThesis{2019:araujo-cabarcas:reliable,
   author  = {Araujo-Cabarcas, J. C.},
   title   = {Reliable hp finite element computations of scattering resonances in nano optics},
   url     = {https://www.diva-portal.org/smash/record.jsf?pid=diva2:1316711},
@@ -87,7 +87,7 @@
   year    = 2019
 }
 
-@InProceedings{arbogast.huang.ea:von,
+@InProceedings{2019:arbogast.huang.ea:von,
   doi     = {10.2118/193817-ms},
   year    = 2019,
   publisher = {Society of Petroleum Engineers},
@@ -96,7 +96,7 @@
   booktitle = {{SPE} Reservoir Simulation Conference}
 }
 
-@Article{arbogast.tao:direct,
+@Article{2019:arbogast.tao:direct,
   doi     = {10.1007/s10596-019-09871-2},
   year    = 2019,
   month   = aug,
@@ -109,7 +109,7 @@
   journal = {Computational Geosciences}
 }
 
-@Article{arndt.bangerth.ea:deal-ii,
+@Article{2019:arndt.bangerth.ea:deal-ii,
   title   = {The \texttt{deal.II} Library, Version 9.1},
   author  = {D. Arndt and W. Bangerth and T. C. Clevenger and D. Davydov and M. Fehling and D. Garcia-Sanchez and G. Harper and T. Heister and L. Heltai and M. Kronbichler and R. M. Kynch and M. Maier and J.-P. Pelteret and B. Turcksin and D. Wells},
   journal = {Journal of Numerical Mathematics},
@@ -121,7 +121,7 @@
   url     = {https://dealii.org/deal91-preprint.pdf}
 }
 
-@Article{aulisa.capodaglio.ea:construction,
+@Article{2019:aulisa.capodaglio.ea:construction,
   doi     = {10.1137/18m1175409},
   year    = 2019,
   month   = jan,
@@ -134,7 +134,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{babaei.basak.ea:algorithmic,
+@Article{2019:babaei.basak.ea:algorithmic,
   doi     = {10.1007/s00466-019-01699-y},
   year    = 2019,
   month   = apr,
@@ -147,7 +147,7 @@
   journal = {Computational Mechanics}
 }
 
-@Article{babaei.levitas:effect,
+@Article{2019:babaei.levitas:effect,
   doi     = {10.1016/j.actamat.2019.07.021},
   year    = 2019,
   month   = sep,
@@ -159,7 +159,7 @@
   journal = {Acta Materialia}
 }
 
-@MastersThesis{balicki:abstrakte,
+@MastersThesis{2019:balicki:abstrakte,
   doi     = {10.25673/13842},
   url     = {https://opendata.uni-halle.de//handle/1981185920/13968},
   author  = {Balicki, Linus},
@@ -172,7 +172,7 @@
   note    = {Bachelor's thesis}
 }
 
-@Article{basak.levitas:finite,
+@Article{2019:basak.levitas:finite,
   author  = {Anup Basak and Valery I. Levitas},
   title   = {Finite element procedure and simulations for a multiphase phase field approach to martensitic phase transformations at large strains and with interfacial stresses},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -185,7 +185,7 @@
   url     = {https://www.researchgate.net/profile/Anup_Basak/publication/326847352_Finite_element_procedure_and_simulations_for_a_multiphase_phase_field_approach_to_martensitic_phase_transformations_at_large_strains_and_with_interfacial_stresses/links/5baae99da6fdccd3cb733c04/Finite-element-procedure-and-simulations-for-a-multiphase-phase-field-approach-to-martensitic-phase-transformations-at-large-strains-and-with-interfacial-stresses.pdf}
 }
 
-@InProceedings{berselli.wells.ea:spatial,
+@InProceedings{2019:berselli.wells.ea:spatial,
   author  = {Berselli, L. C. and Wells, D. and Xie, X. and Iliescu, T.},
   editor  = {Salvetti, Maria Vittoria and Armenio, Vincenzo and Fr{\"o}hlich, Jochen and Geurts, Bernard J. and Kuerten, Hans},
   title   = {Spatial Filtering for Reduced Order Modeling},
@@ -197,7 +197,7 @@
   doi     = {10.1007/978-3-030-04915-7_21}
 }
 
-@PhDThesis{bettendorf:optimum,
+@PhDThesis{2019:bettendorf:optimum,
   doi     = {10.11588/HEIDOK.00027345},
   url     = {http://archiv.ub.uni-heidelberg.de/volltextserver/id/eprint/27345},
   author  = {Bettendorf, Anja},
@@ -206,7 +206,7 @@
   year    = 2019
 }
 
-@Article{bobadilla.carraro.ea:age,
+@Article{2019:bobadilla.carraro.ea:age,
   doi     = {10.1007/s11538-019-00625-w},
   year    = 2019,
   month   = jun,
@@ -219,7 +219,7 @@
   journal = {Bulletin of Mathematical Biology}
 }
 
-@Article{boddu.davydov.ea:cutoff-based,
+@Article{2019:boddu.davydov.ea:cutoff-based,
   doi     = {10.1007/s42493-019-00027-z},
   year    = 2019,
   month   = oct,
@@ -232,7 +232,7 @@
   journal = {Multiscale Science and Engineering}
 }
 
-@Article{bonetti.cavaterra.ea:nonlinear,
+@Article{2019:bonetti.cavaterra.ea:nonlinear,
   author  = {Bonetti, E. and Cavaterra, C. and Freddi, F. and Grasselli, M. and Natalini, R.},
   title   = {A nonlinear model for marble sulphation including surface rugosity: Theoretical and numerical results},
   journal = {Communications on Pure and Applied Analysis},
@@ -242,7 +242,7 @@
   pages   = {977--998}
 }
 
-@Article{bonito.demlow:posteriori,
+@Article{2019:bonito.demlow:posteriori,
   doi     = {10.1137/18m1169278},
   year    = 2019,
   month   = jan,
@@ -255,7 +255,7 @@
   journal = {{SIAM} Journal on Numerical Analysis}
 }
 
-@Article{bonito.lei.ea:numerical,
+@Article{2019:bonito.lei.ea:numerical,
   doi     = {10.1007/s00211-019-01025-x},
   year    = 2019,
   month   = feb,
@@ -268,7 +268,7 @@
   journal = {Numerische Mathematik}
 }
 
-@Article{borregales.kumar.ea:partially,
+@Article{2019:borregales.kumar.ea:partially,
   doi     = {10.1016/j.camwa.2018.09.005},
   year    = 2019,
   month   = mar,
@@ -281,7 +281,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@InProceedings{borregales.radu:higher,
+@InProceedings{2019:borregales.radu:higher,
   doi     = {10.1007/978-3-319-96415-7_49},
   author  = {Borregales, Manuel and Radu, Florin Adrian},
   editor  = {Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin},
@@ -293,7 +293,7 @@
   pages   = {541--549}
 }
 
-@InCollection{both.kocher:numerical,
+@InCollection{2019:both.kocher:numerical,
   doi     = {10.1007/978-3-319-96415-7_74},
   year    = 2019,
   publisher = {Springer International Publishing},
@@ -303,7 +303,7 @@
   booktitle = {Lecture Notes in Computational Science and Engineering}
 }
 
-@Article{brands.davydov.ea:reduced-order,
+@Article{2019:brands.davydov.ea:reduced-order,
   doi     = {10.3390/mca24010020},
   year    = 2019,
   month   = feb,
@@ -316,7 +316,7 @@
   journal = {Mathematical and Computational Applications}
 }
 
-@Article{bruchhauser.schwegler.ea:numerical,
+@Article{2019:bruchhauser.schwegler.ea:numerical,
   title   = {Numerical {S}tudy of {G}oal-{O}riented {E}rror {C}ontrol for {S}tabilized {F}inite {E}lement {M}ethods},
   isbn    = 9783030142445,
   issn    = {2197-7100},
@@ -328,7 +328,7 @@
   pages   = {85--106}
 }
 
-@PhDThesis{brun:upscaling,
+@PhDThesis{2019:brun:upscaling,
   author  = {Brun, Mats Kirkes{\ae}ther},
   title   = {Upscaling, analysis, and iterative numerical solution schemes for thermo-poroelasticity},
   url     = {http://bora.uib.no/handle/1956/20657},
@@ -336,7 +336,7 @@
   year    = 2019
 }
 
-@Article{bryant.sun:micromorphically,
+@Article{2019:bryant.sun:micromorphically,
   doi     = {10.1016/j.cma.2019.05.003},
   year    = 2019,
   month   = sep,
@@ -348,7 +348,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{bucci.christensen:modeling,
+@Article{2019:bucci.christensen:modeling,
   doi     = {10.1016/j.jpowsour.2019.227186},
   year    = 2019,
   month   = nov,
@@ -360,7 +360,7 @@
   journal = {Journal of Power Sources}
 }
 
-@Article{bzowski.rauch.ea:selection,
+@Article{2019:bzowski.rauch.ea:selection,
   doi     = {10.1088/1757-899x/627/1/012018},
   year    = 2019,
   month   = oct,
@@ -372,7 +372,7 @@
   journal = {{IOP} Conference Series: Materials Science and Engineering}
 }
 
-@PhDThesis{bzowski:application,
+@PhDThesis{2019:bzowski:application,
   author  = {Krzysztof Bzowski},
   title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},
   school  = {AGH University of Science and Technology},
@@ -380,7 +380,7 @@
   note    = {Available in Polish only}
 }
 
-@PhDThesis{cajuhi:fracture,
+@PhDThesis{2019:cajuhi:fracture,
   author  = {Cajuhi, Tuanny},
   title   = {Fracture in porous media: phase-field modeling, simulation and experimental validation},
   url     = {https://core.ac.uk/download/pdf/196653165.pdf},
@@ -388,7 +388,7 @@
   year    = 2019
 }
 
-@Article{carreno.bergamaschi.ea:block,
+@Article{2019:carreno.bergamaschi.ea:block,
   doi     = {10.3390/mca24010009},
   year    = 2019,
   month   = jan,
@@ -401,7 +401,7 @@
   journal = {Mathematical and Computational Applications}
 }
 
-@InCollection{carreno.vidal-ferrandiz.ea:matrix-free,
+@InCollection{2019:carreno.vidal-ferrandiz.ea:matrix-free,
   doi     = {10.1007/978-3-030-22750-0_68},
   year    = 2019,
   publisher = {Springer International Publishing},
@@ -411,7 +411,7 @@
   booktitle = {Lecture Notes in Computer Science}
 }
 
-@Article{carreno.vidal-ferrandiz.ea:modal,
+@Article{2019:carreno.vidal-ferrandiz.ea:modal,
   doi     = {10.1016/j.pnucene.2019.03.040},
   year    = 2019,
   month   = aug,
@@ -423,7 +423,7 @@
   journal = {Progress in Nuclear Energy}
 }
 
-@InProceedings{castelli.dorfler:efficient,
+@InProceedings{2019:castelli.dorfler:efficient,
   author  = {Castelli, G. F. and D{\"o}rfler, W.},
   title   = {An Efficient Matrix-Free Finite Element Solver for the {Cahn--Hiliard} Equation},
   editor  = {Gleim, T. and Lange, S.},
@@ -434,7 +434,7 @@
   doi     = {10.19211/KUP978737650939}
 }
 
-@Article{castelli.dorfler:numerical,
+@Article{2019:castelli.dorfler:numerical,
   author  = {Castelli, G. F. and D{\"o}rfler, W.},
   title   = {The numerical study of a microscale model for lithium-ion batteries},
   journal = {Computers \& Mathematics with Applications},
@@ -445,7 +445,7 @@
   doi     = {10.1016/j.camwa.2018.08.067}
 }
 
-@Article{cerroni.penati.ea:multiscale,
+@Article{2019:cerroni.penati.ea:multiscale,
   doi     = {10.3390/geosciences9110465},
   year    = 2019,
   month   = oct,
@@ -458,7 +458,7 @@
   journal = {Geosciences}
 }
 
-@Article{charnyi.heister.ea:efficient,
+@Article{2019:charnyi.heister.ea:efficient,
   doi     = {10.1016/j.apnum.2018.11.013},
   year    = 2019,
   month   = jul,
@@ -470,7 +470,7 @@
   journal = {Applied Numerical Mathematics}
 }
 
-@Article{cheng.yu.ea:openifem,
+@Article{2019:cheng.yu.ea:openifem,
   doi     = {10.32604/cmes.2019.04318},
   year    = 2019,
   publisher = {Computers, Materials and Continua (Tech Science Press)},
@@ -482,7 +482,7 @@
   journal = {Computer Modeling in Engineering {\&} Sciences}
 }
 
-@Article{choo:stabilized,
+@Article{2019:choo:stabilized,
   doi     = {10.1016/j.cma.2019.112568},
   year    = 2019,
   month   = dec,
@@ -494,7 +494,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@PhDThesis{clevenger:parallel,
+@PhDThesis{2019:clevenger:parallel,
   title   = {A {P}arallel {G}eometric {M}ultigrid {M}ethod for {A}daptive {F}inite {E}lements},
   author  = {Thomas C. Clevenger},
   school  = {Clemson University},
@@ -502,7 +502,7 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/2523/}
 }
 
-@Article{corti.cioni.ea:aborted-propagation-of-the-ethiopian-rift-caused-by-linkage-with-the-kenyan-rift,
+@Article{2019:corti.cioni.ea:aborted-propagation-of-the-ethiopian-rift-caused-by-linkage-with-the-kenyan-rift,
   author  = {Giacomo Corti and Raffaello Cioni and Zara Franceschini and Federico Sani and St{\'{e}}phane Scaillet and Paola Molin and Ilaria Isola and Francesco Mazzarini and Sascha Brune and Derek Keir and Asfaw Erbello and Ameha Muluneh and Finnigan Illsley-Kemp and Anne Glerum},
   doi     = {10.1038/s41467-019-09335-2},
   journal = {Nature Communications},
@@ -512,7 +512,7 @@
   year    = 2019
 }
 
-@Article{dang.do.ea:effective,
+@Article{2019:dang.do.ea:effective,
   doi     = {10.1155/2019/7560724},
   year    = 2019,
   month   = feb,
@@ -524,7 +524,7 @@
   journal = {Advances in Civil Engineering}
 }
 
-@Article{dang:modeling,
+@Article{2019:dang:modeling,
   doi     = {10.1155/2019/4034860},
   year    = 2019,
   month   = jul,
@@ -536,7 +536,7 @@
   journal = {Modelling and Simulation in Engineering}
 }
 
-@Article{dannberg.gassmoller.ea:new,
+@Article{2019:dannberg.gassmoller.ea:new,
   doi     = {10.1093/gji/ggz190},
   title   = {A new formulation for coupled magma/mantle dynamics},
   author  = {Dannberg, Juliane and Gassm{\"o}ller, Rene and Grove, Ryan and Heister, Timo},
@@ -548,7 +548,7 @@
   publisher = {Oxford University Press}
 }
 
-@InProceedings{das.motamarri.ea:fast,
+@InProceedings{2019:das.motamarri.ea:fast,
   author  = {Sambit Das and Phani Motamarri and Vikram Gavini and Bruno Turcksin and Ying Wai Li and Brent Leback},
   title   = {{F}ast, {S}calable and {A}ccurate {F}inite-{E}lements {B}ased {A}b {I}nitio {C}alculations {U}sing {M}ixed {P}recision {C}omputing: 46 {PFLOPS} {S}imulation of a {M}etallic {D}islocation {S}ystem},
   booktitle = {Proceedings of the International Conference for High Performance Computing, Networking, Storage, and Analysis},
@@ -562,7 +562,7 @@
   address = {New York, NY, USA}
 }
 
-@PhDThesis{das:large,
+@PhDThesis{2019:das:large,
   author  = {Das, Sambit},
   title   = {Large Scale Electronic Structure Studies on the Energetics of Dislocations in Al-Mg Materials System and Its Connection to Mesoscale Models},
   url     = {https://deepblue.lib.umich.edu/handle/2027.42/153417},
@@ -570,7 +570,7 @@
   year    = 2019
 }
 
-@Article{deolmi.muller.ea:reduced,
+@Article{2019:deolmi.muller.ea:reduced,
   doi     = {10.1016/j.amc.2018.11.059},
   year    = 2019,
   month   = may,
@@ -582,7 +582,7 @@
   journal = {Applied Mathematics and Computation}
 }
 
-@InProceedings{dong.lee.ea:numerical,
+@InProceedings{2019:dong.lee.ea:numerical,
   doi     = {10.2118/193862-ms},
   year    = 2019,
   publisher = {Society of Petroleum Engineers},
@@ -591,7 +591,7 @@
   booktitle = {{SPE} Reservoir Simulation Conference}
 }
 
-@Article{duijn.mikelic.ea:thermoporoelasticity,
+@Article{2019:duijn.mikelic.ea:thermoporoelasticity,
   doi     = {10.1016/j.ijengsci.2019.02.005},
   year    = 2019,
   month   = may,
@@ -603,7 +603,7 @@
   journal = {International Journal of Engineering Science}
 }
 
-@Article{endtmayer.langer.ea:mesh,
+@Article{2019:endtmayer.langer.ea:mesh,
   author  = {Endtmayer, Bernhard and Langer, Ulrich and Neitzel, Ira and Wick, Thomas and Wollner, Winnifried},
   title   = {Mesh adaptivity and error estimates applied to a regularized p-Laplacian constrainted optimal control problem for multiple quantities of interest},
   journal = {PAMM},
@@ -616,7 +616,7 @@
   year    = 2019
 }
 
-@PhDThesis{exner:extended,
+@PhDThesis{2019:exner:extended,
   doi     = {10.13140/RG.2.2.18015.41123},
   url     = {https://dspace.tul.cz/handle/15240/153160},
   author  = {Exner, Pavel},
@@ -626,7 +626,7 @@
   year    = 2019
 }
 
-@InProceedings{fan.wick.ea:phase-field,
+@InProceedings{2019:fan.wick.ea:phase-field,
   author  = {Meng Fan and Thomas Wick and Yan Jin},
   editor  = {Tobias Gleim and Stephan Lange},
   title   = {A phase-field model for mixed-mode fracture},
@@ -637,7 +637,7 @@
   url     = {https://www.upress.uni-kassel.de/katalog/abstract.php?978-3-7376-5093-9}
 }
 
-@Article{fehn.kronbichler.ea:high-order,
+@Article{2019:fehn.kronbichler.ea:high-order,
   title   = {High-order DG solvers for underresolved turbulent incompressible flows: A comparison of L2 and H(div) methods},
   author  = {Fehn, Niklas and Kronbichler, Martin and Lehrenfeld, Christoph and Lube, Gert and Schroeder, Philipp W},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -649,7 +649,7 @@
   doi     = {10.1002/fld.4763}
 }
 
-@Article{fehn.wall.ea:matrix-free,
+@Article{2019:fehn.wall.ea:matrix-free,
   title   = {A matrix-free high-order discontinuous Galerkin compressible Navier-Stokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
   journal = {International Journal for Numerical Methods in Fluids},
@@ -661,7 +661,7 @@
   doi     = {10.1002/fld.4683}
 }
 
-@Article{fehn.wall.ea:modern,
+@Article{2019:fehn.wall.ea:modern,
   title   = {Modern discontinuous Galerkin methods for the simulation of transitional and turbulent flows in biomedical engineering: A comprehensive LES study of the FDA benchmark nozzle model},
   author  = {Fehn, Niklas and Wall, Wolfgang A and Kronbichler, Martin},
   journal = {International journal for numerical methods in biomedical engineering},
@@ -673,7 +673,7 @@
   doi     = {10.1002/cnm.3228}
 }
 
-@Article{fei.choo:phase-field,
+@Article{2019:fei.choo:phase-field,
   doi     = {10.1002/nme.6242},
   year    = 2019,
   month   = nov,
@@ -686,7 +686,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Article{fraters.bangerth.ea:efficient,
+@Article{2019:fraters.bangerth.ea:efficient,
   author  = {M. R. T. Fraters and W. Bangerth and C. Thieulot and A. C. Glerum and W. Spakman},
   title   = {Efficient and practical {N}ewton solvers for nonlinear {S}tokes systems in geodynamics problems},
   journal = {Geophysics Journal International},
@@ -700,7 +700,7 @@
   eprint  = {http://oup.prod.sis.lan/gji/article-pdf/218/2/873/28693654/ggz183.pdf}
 }
 
-@PhDThesis{fraters:towards,
+@PhDThesis{2019:fraters:towards,
   author  = {Fraters, Menno R. T.},
   title   = {Towards numerical modelling of natural subduction systems with an application to Eastern Caribbean subduction},
   url     = {https://dspace.library.uu.nl/handle/1874/379767},
@@ -708,7 +708,7 @@
   year    = 2019
 }
 
-@Article{freddi:fracture,
+@Article{2019:freddi:fracture,
   doi     = {10.1016/j.mechrescom.2019.01.009},
   year    = 2019,
   month   = mar,
@@ -720,7 +720,7 @@
   journal = {Mechanics Research Communications}
 }
 
-@Article{fu.jin.ea:parameter-free,
+@Article{2019:fu.jin.ea:parameter-free,
   doi     = {10.1093/imanum/dry001},
   year    = 2019,
   month   = apr,
@@ -733,7 +733,7 @@
   journal = {{IMA} Journal of Numerical Analysis}
 }
 
-@Article{gassmoller.lokavarapu.ea:evaluating,
+@Article{2019:gassmoller.lokavarapu.ea:evaluating,
   doi     = {10.1093/gji/ggz405},
   title   = {Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible Stokes flow},
   author  = {Gassm{\"o}ller, Rene and Lokavarapu, Harsha and Bangerth, Wolfgang and Puckett, Elbridge Gerry},
@@ -745,7 +745,7 @@
   publisher = {Oxford University Press}
 }
 
-@Article{gedicke.khan:divergence-conforming,
+@Article{2019:gedicke.khan:divergence-conforming,
   doi     = {10.1007/s00211-019-01095-x},
   year    = 2019,
   month   = dec,
@@ -758,7 +758,7 @@
   journal = {Numerische Mathematik}
 }
 
-@PhDThesis{gerken:dynamic,
+@PhDThesis{2019:gerken:dynamic,
   title   = {Dynamic Inverse Problems for Wave Phenomena},
   url     = {http://nbn-resolving.de/urn:nbn:de:gbv:46-00107730-18},
   author  = {Gerken, Thies},
@@ -766,7 +766,7 @@
   school  = {Universit{\"a}t Bremen}
 }
 
-@Article{german.ragusa:reduced-order,
+@Article{2019:german.ragusa:reduced-order,
   doi     = {10.1016/j.anucene.2019.05.049},
   year    = 2019,
   month   = dec,
@@ -778,7 +778,7 @@
   journal = {Annals of Nuclear Energy}
 }
 
-@Article{ghesmati.bangerth.ea:residual-based,
+@Article{2019:ghesmati.bangerth.ea:residual-based,
   doi     = {10.1515/jnma-2018-0047},
   year    = 2019,
   month   = dec,
@@ -791,7 +791,7 @@
   journal = {Journal of Numerical Mathematics}
 }
 
-@Article{giuliani:blacknufft,
+@Article{2019:giuliani:blacknufft,
   doi     = {10.1016/j.cpc.2018.10.005},
   year    = 2019,
   month   = feb,
@@ -803,7 +803,7 @@
   journal = {Computer Physics Communications}
 }
 
-@PhDThesis{glerum:geodynamics-of-complex-plate-boundary-regions,
+@PhDThesis{2019:glerum:geodynamics-of-complex-plate-boundary-regions,
   author  = {Glerum, Anne},
   school  = {{Universiteit Utrecht}},
   title   = {{Geodynamics of complex plate boundary regions}},
@@ -811,7 +811,7 @@
   year    = 2019
 }
 
-@Article{gong.chen.ea:quantitative,
+@Article{2019:gong.chen.ea:quantitative,
   doi     = {10.1016/j.ijheatmasstransfer.2019.01.104},
   year    = 2019,
   month   = jun,
@@ -823,7 +823,7 @@
   journal = {International Journal of Heat and Mass Transfer}
 }
 
-@Article{gonzalez-valverde.garcia-aznar:agent-based,
+@Article{2019:gonzalez-valverde.garcia-aznar:agent-based,
   doi     = {10.1007/s40571-018-0199-2},
   year    = 2019,
   month   = jan,
@@ -836,7 +836,7 @@
   journal = {Computational Particle Mechanics}
 }
 
-@Article{grayver.driel.ea:three-dimensional,
+@Article{2019:grayver.driel.ea:three-dimensional,
   title   = {Three-dimensional magnetotelluric modelling in spherical {Earth}},
   author  = {Grayver, Alexander V. and van Driel, Martin and Kuvshinov, Alexey V.},
   journal = {Geophysical Journal International},
@@ -848,7 +848,7 @@
   doi     = {10.1093/gji/ggz030}
 }
 
-@Article{grayver.olsen:magnetic,
+@Article{2019:grayver.olsen:magnetic,
   doi     = {10.1029/2019gl082400},
   year    = 2019,
   month   = apr,
@@ -861,7 +861,7 @@
   journal = {Geophysical Research Letters}
 }
 
-@InCollection{guermond.popov.ea:arbitrary,
+@InCollection{2019:guermond.popov.ea:arbitrary,
   doi     = {10.1007/978-3-319-78325-3_14},
   year    = 2019,
   publisher = {Springer International Publishing},
@@ -871,7 +871,7 @@
   booktitle = {Computational Methods in Applied Sciences}
 }
 
-@Article{gulevich.koshelets.ea:bridging,
+@Article{2019:gulevich.koshelets.ea:bridging,
   doi     = {10.1103/physrevb.99.060501},
   year    = 2019,
   month   = feb,
@@ -883,7 +883,7 @@
   journal = {Physical Review B}
 }
 
-@Article{guo.wu.ea:numerical,
+@Article{2019:guo.wu.ea:numerical,
   doi     = {10.2118/195580-pa},
   year    = 2019,
   month   = aug,
@@ -896,7 +896,7 @@
   journal = {{SPE} Journal}
 }
 
-@Article{guo.wu.ea:understanding,
+@Article{2019:guo.wu.ea:understanding,
   doi     = {10.2118/194493-pa},
   year    = 2019,
   month   = feb,
@@ -909,7 +909,7 @@
   journal = {{SPE} Reservoir Evaluation {\&} Engineering}
 }
 
-@Article{gupta.keulen.ea:design,
+@Article{2019:gupta.keulen.ea:design,
   doi     = {10.1002/nme.6217},
   year    = 2019,
   month   = oct,
@@ -922,7 +922,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Article{hagstrom.kim:complete,
+@Article{2019:hagstrom.kim:complete,
   doi     = {10.1007/s00211-018-1012-0},
   year    = 2019,
   month   = jan,
@@ -935,7 +935,7 @@
   journal = {Numerische Mathematik}
 }
 
-@Article{hai.bause.ea:modeling,
+@Article{2019:hai.bause.ea:modeling,
   doi     = {10.1016/j.jfluidstructs.2019.04.014},
   year    = 2019,
   month   = jul,
@@ -947,7 +947,7 @@
   journal = {Journal of Fluids and Structures}
 }
 
-@Article{hai.bause.ea:modeling*1,
+@Article{2019:hai.bause.ea:modeling*1,
   doi     = {10.1016/j.apm.2019.07.007},
   year    = 2019,
   month   = nov,
@@ -959,7 +959,7 @@
   journal = {Applied Mathematical Modelling}
 }
 
-@Article{hai.bause:numerical,
+@Article{2019:hai.bause:numerical,
   doi     = {10.1016/j.camwa.2019.01.009},
   year    = 2019,
   month   = nov,
@@ -972,7 +972,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{han.park.ea:dteq,
+@Article{2019:han.park.ea:dteq,
   doi     = {10.1080/15361055.2018.1554391},
   year    = 2019,
   month   = feb,
@@ -985,7 +985,7 @@
   journal = {Fusion Science and Technology}
 }
 
-@MastersThesis{hanophy:performance,
+@MastersThesis{2019:hanophy:performance,
   author  = {Hanophy, Joshua Thomas},
   title   = {Performance of parallel approximate ideal restriction multigrid for transport applications},
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/187540},
@@ -993,7 +993,7 @@
   year    = 2019
 }
 
-@Article{hao.yang:convergence,
+@Article{2019:hao.yang:convergence,
   doi     = {10.1051/m2an/2018046},
   year    = 2019,
   month   = aug,
@@ -1006,7 +1006,7 @@
   journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
 }
 
-@Misc{he:simulating,
+@Misc{2019:he:simulating,
   title   = {Simulating the scattering of low-frequency Gravitational Waves by compact objects using the finite element method},
   author  = {Jian-hua He},
   year    = 2019,
@@ -1015,7 +1015,7 @@
   primaryclass = {gr-qc}
 }
 
-@Article{heinlein.rheinbach.ea:applying,
+@Article{2019:heinlein.rheinbach.ea:applying,
   doi     = {10.1002/pamm.201900337},
   year    = 2019,
   month   = nov,
@@ -1027,7 +1027,7 @@
   journal = {{PAMM}}
 }
 
-@Article{heltai.caiazzo:multiscale,
+@Article{2019:heltai.caiazzo:multiscale,
   doi     = {10.1002/cnm.3264},
   year    = 2019,
   month   = dec,
@@ -1039,7 +1039,7 @@
   journal = {International Journal for Numerical Methods in Biomedical Engineering}
 }
 
-@Article{heltai.rotundo:error,
+@Article{2019:heltai.rotundo:error,
   doi     = {10.1016/j.camwa.2019.05.029},
   year    = 2019,
   month   = dec,
@@ -1052,7 +1052,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{heron.peace.ea:segmentation,
+@Article{2019:heron.peace.ea:segmentation,
   author  = {Heron, P. J. and Peace, A. L. and McCaffrey, K. J. W. and Welford, J. K. and Wilson, R. and van Hunen, J. and Pysklywec, R. N.},
   title   = {Segmentation of Rifts Through Structural Inheritance: Creation of the Davis Strait},
   journal = {Tectonics},
@@ -1065,7 +1065,7 @@
   year    = 2019
 }
 
-@Article{heron.pysklywec.ea:deformation,
+@Article{2019:heron.pysklywec.ea:deformation,
   doi     = {10.1130/g45690.1},
   year    = 2019,
   month   = dec,
@@ -1078,18 +1078,7 @@
   journal = {Geology}
 }
 
-@Article{hochbruck.leibold:finite,
-  doi     = {10.1553/etna_vol53s522},
-  year    = 2020,
-  publisher = {Osterreichische Akademie der Wissenschaften},
-  volume  = 53,
-  pages   = {522--540},
-  author  = {Marlis Hochbruck and Jan Leibold},
-  title   = {Finite element discretization of semilinear acoustic wave equations with kinetic boundary conditions},
-  journal = {{ETNA} - Electronic Transactions on Numerical Analysis}
-}
-
-@Article{hochbruck.maier.ea:heterogeneous,
+@Article{2019:hochbruck.maier.ea:heterogeneous,
   doi     = {10.1137/18m1234072},
   year    = 2019,
   month   = jan,
@@ -1102,7 +1091,7 @@
   journal = {Multiscale Modeling {\&} Simulation}
 }
 
-@Misc{holmgren.kreiss:hydrodynamic,
+@Misc{2019:holmgren.kreiss:hydrodynamic,
   title   = {A Hydrodynamic Model of Movement of a Contact Line Over a Curved Wall},
   author  = {Hanna Holmgren and Gunilla Kreiss},
   year    = 2019,
@@ -1111,7 +1100,7 @@
   primaryclass = {physics.flu-dyn}
 }
 
-@MastersThesis{janssen:comparison,
+@MastersThesis{2019:janssen:comparison,
   title   = {A comparison of {GOCO05c} satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
   author  = {Janssen, W. J.},
   year    = 2019,
@@ -1119,7 +1108,7 @@
   url     = {https://dspace.library.uu.nl/handle/1874/393839}
 }
 
-@Article{jiang.garikipati.ea:diffuse,
+@Article{2019:jiang.garikipati.ea:diffuse,
   doi     = {10.1007/s11538-019-00577-1},
   year    = 2019,
   month   = feb,
@@ -1132,7 +1121,7 @@
   journal = {Bulletin of Mathematical Biology}
 }
 
-@PhDThesis{jonathan-perry-hout:geodynamic-origin-of-the-columbia-river-flood-basalts,
+@PhDThesis{2019:jonathan-perry-hout:geodynamic-origin-of-the-columbia-river-flood-basalts,
   author  = {{Jonathan Perry-Hout}},
   school  = {University of Oregon},
   title   = {{Geodynamic Origin of the Columbia River Flood Basalts}},
@@ -1140,7 +1129,7 @@
   year    = 2019
 }
 
-@InProceedings{kauffman.george.ea:overset,
+@InProceedings{2019:kauffman.george.ea:overset,
   doi     = {10.2514/6.2019-1986},
   year    = 2019,
   month   = jan,
@@ -1150,7 +1139,7 @@
   booktitle = {{AIAA} Scitech 2019 Forum}
 }
 
-@InProceedings{kazemi.vaziri.ea:topology,
+@InProceedings{2019:kazemi.vaziri.ea:topology,
   doi     = {10.1115/detc2019-97370},
   year    = 2019,
   month   = aug,
@@ -1160,7 +1149,7 @@
   booktitle = {Volume 2A: 45th Design Automation Conference}
 }
 
-@Article{khattatov.yotov:domain,
+@Article{2019:khattatov.yotov:domain,
   doi     = {10.1051/m2an/2019057},
   year    = 2019,
   month   = nov,
@@ -1173,7 +1162,7 @@
   journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
 }
 
-@Article{kim.singh.ea:uncertainty,
+@Article{2019:kim.singh.ea:uncertainty,
   doi     = {10.1016/j.jnnfm.2019.07.002},
   year    = 2019,
   month   = sep,
@@ -1185,7 +1174,7 @@
   journal = {Journal of Non-Newtonian Fluid Mechanics}
 }
 
-@Article{kim:error,
+@Article{2019:kim:error,
   doi     = {10.1051/m2an/2019026},
   year    = 2019,
   month   = jul,
@@ -1198,7 +1187,7 @@
   journal = {{ESAIM}: Mathematical Modelling and Numerical Analysis}
 }
 
-@Article{kocher.bruchhauser.ea:efficient,
+@Article{2019:kocher.bruchhauser.ea:efficient,
   doi     = {10.1016/j.softx.2019.100239},
   year    = 2019,
   month   = jul,
@@ -1210,7 +1199,7 @@
   journal = {{SoftwareX}}
 }
 
-@InCollection{kocher:influence,
+@InCollection{2019:kocher:influence,
   doi     = {10.1007/978-3-319-96415-7_18},
   year    = 2019,
   publisher = {Springer International Publishing},
@@ -1220,7 +1209,7 @@
   booktitle = {Lecture Notes in Computational Science and Engineering}
 }
 
-@Article{koepf.soldner.ea:numerical,
+@Article{2019:koepf.soldner.ea:numerical,
   doi     = {10.1016/j.commatsci.2019.03.004},
   year    = 2019,
   month   = may,
@@ -1232,7 +1221,7 @@
   journal = {Computational Materials Science}
 }
 
-@Article{kohler.rheinbach.ea:feti-dp,
+@Article{2019:kohler.rheinbach.ea:feti-dp,
   doi     = {10.1002/pamm.201900292},
   year    = 2019,
   month   = nov,
@@ -1244,7 +1233,7 @@
   journal = {{PAMM}}
 }
 
-@Article{konig.rom.ea:numerical,
+@Article{2019:konig.rom.ea:numerical,
   doi     = {10.2514/1.t5457},
   year    = 2019,
   month   = apr,
@@ -1257,7 +1246,7 @@
   journal = {Journal of Thermophysics and Heat Transfer}
 }
 
-@Article{konschin.lechleiter:reconstruction,
+@Article{2019:konschin.lechleiter:reconstruction,
   doi     = {10.1088/1361-6420/ab1c66},
   year    = 2019,
   month   = oct,
@@ -1270,7 +1259,7 @@
   journal = {Inverse Problems}
 }
 
-@PhDThesis{konschin:direkte,
+@PhDThesis{2019:konschin:direkte,
   author  = {Konschin, Alexander},
   title   = {Direkte und inverse elektromagnetische Streuprobleme f{\"u}r lokal gest{\"o}rte periodische Medien},
   url     = {https://core.ac.uk/download/pdf/297283589.pdf},
@@ -1278,7 +1267,7 @@
   year    = 2019
 }
 
-@Article{kottapalli.shams.ea:numerical,
+@Article{2019:kottapalli.shams.ea:numerical,
   doi     = {10.1016/j.anucene.2019.01.001},
   year    = 2019,
   month   = jun,
@@ -1290,7 +1279,7 @@
   journal = {Annals of Nuclear Energy}
 }
 
-@Article{krank.kronbichler.ea:multiscale,
+@Article{2019:krank.kronbichler.ea:multiscale,
   doi     = {10.1002/fld.4712},
   year    = 2019,
   publisher = {Wiley},
@@ -1302,7 +1291,7 @@
   journal = {International Journal for Numerical Methods in Fluids}
 }
 
-@Article{krank.kronbichler.ea:wall,
+@Article{2019:krank.kronbichler.ea:wall,
   doi     = {10.1016/j.compfluid.2018.07.019},
   year    = 2019,
   publisher = {Elsevier {BV}},
@@ -1313,7 +1302,7 @@
   journal = {Computers {\&} Fluids}
 }
 
-@PhDThesis{krank:wall,
+@PhDThesis{2019:krank:wall,
   author  = {Krank, Benjamin},
   title   = {Wall Modeling via Function Enrichment for Computational Fluid Dynamics},
   type    = {Dissertation},
@@ -1322,7 +1311,7 @@
   year    = 2019
 }
 
-@InProceedings{kronbichler.kormann.ea:fast,
+@InProceedings{2019:kronbichler.kormann.ea:fast,
   author  = {Martin Kronbichler and Katharina Kormann and Wolfgang A. Wall},
   title   = {Fast matrix-free evaluation of hybridizable discontinuous Galerkin operators},
   editor  = {Florin A. Radu and Kundan Kumar and Inga Berre and Jan M. Nordbotten and Iuliu S. Pop},
@@ -1334,14 +1323,14 @@
   doi     = {10.1007/978-3-319-96415-7_53}
 }
 
-@Article{kronbichler.kormann.ea:hermite-like,
+@Article{2019:kronbichler.kormann.ea:hermite-like,
   title   = {A Hermite-like basis for faster matrix-free evaluation of interior penalty discontinuous Galerkin operators},
   author  = {Kronbichler, Martin and Kormann, Katharina and Fehn, Niklas and Munch, Peter and Witte, Julius},
   journal = {arXiv preprint arXiv:1907.08492},
   year    = 2019
 }
 
-@Article{kronbichler.kormann:fast,
+@Article{2019:kronbichler.kormann:fast,
   title   = {Fast matrix-free evaluation of discontinuous Galerkin finite element operators},
   author  = {Kronbichler, Martin and Kormann, Katharina},
   journal = {ACM Transactions on Mathematical Software (TOMS)},
@@ -1353,7 +1342,7 @@
   doi     = {10.1145/3325864}
 }
 
-@Article{kronbichler.ljungkvist:multigrid,
+@Article{2019:kronbichler.ljungkvist:multigrid,
   title   = {Multigrid for matrix-free high-order finite element computations on graphics processors},
   author  = {Kronbichler, Martin and Ljungkvist, Karl},
   journal = {ACM Transactions on Parallel Computing (TOPC)},
@@ -1365,7 +1354,7 @@
   doi     = {10.1145/3322813}
 }
 
-@Article{lin.xu.ea:mantle,
+@Article{2019:lin.xu.ea:mantle,
   title   = {Mantle upwelling beneath the South China Sea and links to surrounding subduction systems},
   author  = {Lin, Jian and Xu, Yigang and Sun, Zhen and Zhou, Zhiyuan},
   journal = {National Science Review},
@@ -1377,7 +1366,7 @@
   doi     = {10.1093/nsr/nwz123}
 }
 
-@Article{liu.king:benchmark,
+@Article{2019:liu.king:benchmark,
   doi     = {10.1093/gji/ggz036},
   year    = 2019,
   month   = jan,
@@ -1390,7 +1379,7 @@
   journal = {Geophysical Journal International}
 }
 
-@Article{liu.reina:dynamic,
+@Article{2019:liu.reina:dynamic,
   doi     = {10.1007/s00466-018-1662-x},
   year    = 2019,
   month   = jul,
@@ -1403,7 +1392,7 @@
   journal = {Computational Mechanics}
 }
 
-@Article{liu.yin:unconditionally,
+@Article{2019:liu.yin:unconditionally,
   doi     = {10.1007/s10915-019-01038-6},
   year    = 2019,
   month   = aug,
@@ -1416,7 +1405,7 @@
   journal = {Journal of Scientific Computing}
 }
 
-@Article{luo.zhao:numerical,
+@Article{2019:luo.zhao:numerical,
   doi     = {10.1007/s00170-019-03947-0},
   year    = 2019,
   month   = jun,
@@ -1429,7 +1418,7 @@
   journal = {International Journal of Advanced Manufacturing Technology}
 }
 
-@Article{ma.bakhti.ea:laser-generated,
+@Article{2019:ma.bakhti.ea:laser-generated,
   doi     = {10.1021/acs.jpcc.9b05561},
   year    = 2019,
   month   = sep,
@@ -1442,7 +1431,7 @@
   journal = {The Journal of Physical Chemistry C}
 }
 
-@Article{maday.marcati:regularity,
+@Article{2019:maday.marcati:regularity,
   doi     = {10.1142/s0218202519500295},
   year    = 2019,
   month   = jul,
@@ -1455,7 +1444,7 @@
   journal = {Mathematical Models and Methods in Applied Sciences}
 }
 
-@Article{maier.mattheakis.ea:homogenization,
+@Article{2019:maier.mattheakis.ea:homogenization,
   doi     = {10.1098/rspa.2019.0220},
   year    = 2019,
   month   = oct,
@@ -1468,7 +1457,7 @@
   journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences}
 }
 
-@Article{mang.walloth.ea:mesh,
+@Article{2019:mang.walloth.ea:mesh,
   doi     = {10.1002/gamm.202000003},
   year    = 2019,
   month   = aug,
@@ -1480,7 +1469,7 @@
   journal = {{GAMM}-Mitteilungen}
 }
 
-@Article{mang.wick.ea:phase-field,
+@Article{2019:mang.wick.ea:phase-field,
   doi     = {10.1007/s00466-019-01752-w},
   year    = 2019,
   month   = jul,
@@ -1493,7 +1482,7 @@
   journal = {Computational Mechanics}
 }
 
-@Misc{mang.wick:numerical,
+@Misc{2019:mang.wick:numerical,
   doi     = {10.15488/5129},
   url     = {https://www.repo.uni-hannover.de/handle/123456789/5175},
   author  = {Mang, Katrin and Wick, Thomas},
@@ -1504,7 +1493,7 @@
   copyright = {CC BY 3.0 DE}
 }
 
-@InProceedings{mcbride.davydov.ea:modelling,
+@InProceedings{2019:mcbride.davydov.ea:modelling,
   doi     = {10.1201/9780429426506},
   url     = {https://books.google.com/books?id=4natDwAAQBAJ&pg=PA278},
   year    = 2019,
@@ -1514,7 +1503,7 @@
   booktitle = {Advances in Engineering Materials, Structures and Systems: Innovations, Mechanics and Applications. Proceedings of the 7th International Conference on Structural Engineering, Mechanics and Computation (SEMC 2019), September 2-4, 2019, Cape Town, South Africa.}
 }
 
-@Article{mehnert.hossain.ea:experimental,
+@Article{2019:mehnert.hossain.ea:experimental,
   doi     = {10.1016/j.euromechsol.2019.103797},
   year    = 2019,
   month   = sep,
@@ -1526,7 +1515,7 @@
   journal = {European Journal of Mechanics - A/Solids}
 }
 
-@Article{mikelic.wheeler.ea:phase-field,
+@Article{2019:mikelic.wheeler.ea:phase-field,
   doi     = {10.1007/s13137-019-0113-y},
   year    = 2019,
   month   = jan,
@@ -1538,7 +1527,7 @@
   journal = {{GEM} -- International Journal on Geomathematics}
 }
 
-@Article{morschhauser.grayver.ea:tippers,
+@Article{2019:morschhauser.grayver.ea:tippers,
   title   = {Tippers at island geomagnetic observatories constrain electrical conductivity of oceanic lithosphere and upper mantle},
   author  = {Morschhauser, Achim and Grayver, Alexander and Kuvshinov, Alexey and Samrock, Friedemann and Matzka, J{\"u}rgen},
   journal = {Earth, Planets and Space},
@@ -1550,7 +1539,7 @@
   doi     = {10.1186/s40623-019-0991-0}
 }
 
-@PhDThesis{mousavi:crustal,
+@PhDThesis{2019:mousavi:crustal,
   author  = {Naeim Mousavi},
   title   = {Crustal and (sub)lithospheric structure beneath the Iranian Plateau from geophysical modeling},
   school  = {University of Kiel, Germany},
@@ -1558,7 +1547,7 @@
   url     = {https://macau.uni-kiel.de/receive/diss_mods_00025884}
 }
 
-@PhDThesis{mulita:smoothed-adaptive-finite-element-methods,
+@PhDThesis{2019:mulita:smoothed-adaptive-finite-element-methods,
   title   = {{Smoothed Adaptive Finite Element Methods}},
   author  = {Mulita, Ornela},
   url     = {http://hdl.handle.net/20.500.11767/103102},
@@ -1568,7 +1557,7 @@
   pdf     = {https://iris.sissa.it/retrieve/handle/20.500.11767/103102/107276/PhD_thesis_dissertation_Mulita.pdf}
 }
 
-@PhDThesis{murphy:mathematical,
+@PhDThesis{2019:murphy:mathematical,
   author  = {Murphy, Laura},
   title   = {Mathematical studies of a mechanobiochemical model for 3D cell migration},
   url     = {http://sro.sussex.ac.uk/id/eprint/83522/},
@@ -1576,7 +1565,7 @@
   year    = 2019
 }
 
-@Article{na.bryant.ea:configurational,
+@Article{2019:na.bryant.ea:configurational,
   doi     = {10.1016/j.cma.2019.112572},
   year    = 2019,
   month   = dec,
@@ -1588,7 +1577,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{neitzel.wick.ea:optimal,
+@Article{2019:neitzel.wick.ea:optimal,
   doi     = {10.1137/18m122385x},
   year    = 2019,
   month   = jan,
@@ -1601,7 +1590,7 @@
   journal = {{SIAM} Journal on Control and Optimization}
 }
 
-@Article{njinju.atekwana.ea:lithospheric,
+@Article{2019:njinju.atekwana.ea:lithospheric,
   doi     = {10.1029/2019tc005549},
   year    = 2019,
   month   = oct,
@@ -1611,7 +1600,7 @@
   journal = {Tectonics}
 }
 
-@Article{noii.wick:phase-field,
+@Article{2019:noii.wick:phase-field,
   title   = {A phase-field description for pressurized and non-isothermal propagating fractures},
   volume  = 351,
   issn    = {0045-7825},
@@ -1624,7 +1613,7 @@
   pages   = {860--890}
 }
 
-@Article{odster.kvamsdal.ea:simple,
+@Article{2019:odster.kvamsdal.ea:simple,
   doi     = {10.1016/j.cma.2018.09.003},
   year    = 2019,
   month   = jan,
@@ -1636,7 +1625,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Book{pelteret.steinmann:magneto-active,
+@Book{2019:pelteret.steinmann:magneto-active,
   title   = {{M}agneto-{A}ctive {P}olymers: {F}abrication, characterisation, modelling and simulation at the micro- and macro-scale},
   publisher = {Walter de Gruyter {GmbH}},
   year    = 2019,
@@ -1646,7 +1635,7 @@
   url     = {https://www.degruyter.com/view/product/455548}
 }
 
-@Article{perry-houts.karlstrom:anisotropic-viscosity-and-time-evolving-lithospheric-instabilities-due-to-aligned-igneous-intrusions,
+@Article{2019:perry-houts.karlstrom:anisotropic-viscosity-and-time-evolving-lithospheric-instabilities-due-to-aligned-igneous-intrusions,
   author  = {Perry-Houts, Jonathan and Karlstrom, Leif},
   journal = {Geophysical Journal International},
   number  = 2,
@@ -1658,7 +1647,7 @@
   doi     = {10.1093/gji/ggy466}
 }
 
-@Article{pitton.heltai:accelerating,
+@Article{2019:pitton.heltai:accelerating,
   doi     = {10.1002/nla.2211},
   year    = 2019,
   month   = jan,
@@ -1671,7 +1660,7 @@
   journal = {Numerical Linear Algebra with Applications}
 }
 
-@Article{ponce-bobadilla.carraro.ea:age-structure,
+@Article{2019:ponce-bobadilla.carraro.ea:age-structure,
   author  = {Ponce Bobadilla, Ana Victoria and Carraro, Thomas and Byrne, Helen M. and Maini, Philip K. and Alarcon, Tomas},
   title   = {Age-structure as key to delayed logistic proliferation of scratch assays},
   year    = 2019,
@@ -1681,7 +1670,7 @@
   journal = {bioRxiv}
 }
 
-@PhDThesis{ponce-bobadilla:mathematical,
+@PhDThesis{2019:ponce-bobadilla:mathematical,
   doi     = {10.11588/HEIDOK.00027466},
   url     = {http://www.ub.uni-heidelberg.de/archiv/27466},
   author  = {Ponce Bobadilla, Ana Victoria},
@@ -1690,7 +1679,7 @@
   year    = 2019
 }
 
-@Article{potschka:backward,
+@Article{2019:potschka:backward,
   doi     = {10.1007/s11075-018-0539-6},
   year    = 2019,
   month   = may,
@@ -1703,7 +1692,7 @@
   journal = {Numerical Algorithms}
 }
 
-@PhDThesis{prince:reduced-order-modeling-of-neutron-diffusion-and-transport-using-proper-generalized-decomposition,
+@PhDThesis{2019:prince:reduced-order-modeling-of-neutron-diffusion-and-transport-using-proper-generalized-decomposition,
   title   = {{Reduced Order Modeling of Neutron Diffusion and Transport Using Proper Generalized Decomposition}},
   author  = {Prince, Zachary Merritt},
   url     = {https://hdl.handle.net/1969.1/186463},
@@ -1713,7 +1702,7 @@
   pdf     = {https://oaktrust.library.tamu.edu/bitstream/handle/1969.1/186463/PRINCE-DISSERTATION-2019.pdf}
 }
 
-@Article{qinami.bryant.ea:circumventing,
+@Article{2019:qinami.bryant.ea:circumventing,
   doi     = {10.1007/s10704-019-00349-x},
   year    = 2019,
   month   = feb,
@@ -1723,7 +1712,7 @@
   journal = {International Journal of Fracture}
 }
 
-@PhDThesis{renaud:study,
+@PhDThesis{2019:renaud:study,
   title   = {A Study of the Tidal and Thermal Evolution of Rocky \& Icy Worlds Utilizing Advanced Rheological Models},
   author  = {Renaud, Joseph P.},
   year    = 2019,
@@ -1731,7 +1720,7 @@
   url     = {https://search.proquest.com/docview/2303307944}
 }
 
-@PhDThesis{reveron:iterative,
+@PhDThesis{2019:reveron:iterative,
   author  = {Manuel Antonio Borregales Rever\'on},
   title   = {Iterative solvers for poromechanics},
   school  = {Department of Mathematics, University of Bergen},
@@ -1740,7 +1729,7 @@
   url     = {http://bora.uib.no/handle/1956/21143}
 }
 
-@Article{robey.puckett:implementation,
+@Article{2019:robey.puckett:implementation,
   doi     = {10.1016/j.compfluid.2019.05.015},
   year    = 2019,
   month   = aug,
@@ -1752,7 +1741,7 @@
   journal = {Computers {\&} Fluids}
 }
 
-@PhDThesis{robey:on,
+@PhDThesis{2019:robey:on,
   author  = {Robey, Jonathan Michael},
   title   = {On the Design, Implementation, and Use of a Volume-of-fluid Interface Tracking Algorithm for Modeling Convection and Other Processes in the Earth's Mantle},
   url     = {https://search.proquest.com/openview/9b5da8487a6316441916616dcd4b2de4/1?pq-origsite=gscholar&cbl=51922&diss=y},
@@ -1760,7 +1749,7 @@
   year    = 2019
 }
 
-@Article{roelofs.dovizio.ea:core,
+@Article{2019:roelofs.dovizio.ea:core,
   doi     = {10.1016/j.nucengdes.2019.110322},
   year    = 2019,
   month   = dec,
@@ -1772,7 +1761,7 @@
   journal = {Nuclear Engineering and Design}
 }
 
-@Article{rom.muller:new,
+@Article{2019:rom.muller:new,
   doi     = {10.1016/j.triboint.2018.12.030},
   year    = 2019,
   month   = may,
@@ -1784,7 +1773,7 @@
   journal = {Tribology International}
 }
 
-@Article{rudraraju.moulton.ea:computational,
+@Article{2019:rudraraju.moulton.ea:computational,
   doi     = {10.1371/journal.pcbi.1007213},
   year    = 2019,
   month   = jul,
@@ -1798,7 +1787,7 @@
   journal = {{PLOS} Computational Biology}
 }
 
-@Article{samii.kazhyken.ea:comparison,
+@Article{2019:samii.kazhyken.ea:comparison,
   doi     = {10.1007/s10915-019-01007-z},
   year    = 2019,
   month   = jul,
@@ -1811,7 +1800,7 @@
   journal = {Journal of Scientific Computing}
 }
 
-@Article{santis.shams:advanced,
+@Article{2019:santis.shams:advanced,
   doi     = {10.1016/j.anucene.2019.02.049},
   year    = 2019,
   month   = aug,
@@ -1823,7 +1812,7 @@
   journal = {Annals of Nuclear Energy}
 }
 
-@PhDThesis{sarna:entropy,
+@PhDThesis{2019:sarna:entropy,
   doi     = {10.18154/RWTH-2019-05544},
   url     = {http://publications.rwth-aachen.de/record/762264},
   author  = {Sarna, Neeraj},
@@ -1836,14 +1825,14 @@
   year    = 2019
 }
 
-@MastersThesis{sashko:enhancing,
+@MastersThesis{2019:sashko:enhancing,
   title   = {Enhancing data locality in a matrix-free conjugate gradient method on modern computer architectures},
   author  = {Dmytro Sashko},
   school  = {Technical University of Munich},
   year    = 2019
 }
 
-@PhDThesis{scherff:modellierung,
+@PhDThesis{2019:scherff:modellierung,
   doi     = {10.22028/D291-28367},
   url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/27748},
   author  = {Scherff, Marc Frederik},
@@ -1852,7 +1841,7 @@
   year    = 2019
 }
 
-@Article{schoeder.wall.ea:exwave,
+@Article{2019:schoeder.wall.ea:exwave,
   doi     = {10.1016/j.softx.2019.01.001},
   year    = 2019,
   month   = jan,
@@ -1864,7 +1853,7 @@
   journal = {{SoftwareX}}
 }
 
-@PhDThesis{schoeder:efficient,
+@PhDThesis{2019:schoeder:efficient,
   author  = {Schoeder, Svenja Madeleine},
   title   = {Efficient Discontinuous Galerkin Methods for Wave Propagation and Iterative Optoacoustic Image Reconstruction},
   school  = {Technical University of Munich},
@@ -1872,7 +1861,7 @@
   url     = {https://mediatum.ub.tum.de/1451984}
 }
 
-@Article{schussnig.fries:concept,
+@Article{2019:schussnig.fries:concept,
   doi     = {10.1002/pamm.201900100},
   year    = 2019,
   month   = sep,
@@ -1884,7 +1873,7 @@
   journal = {{PAMM}}
 }
 
-@Article{schutz.beneyton.ea:rational,
+@Article{2019:schutz.beneyton.ea:rational,
   doi     = {10.1039/c9lc00149b},
   year    = 2019,
   publisher = {Royal Society of Chemistry ({RSC})},
@@ -1896,7 +1885,7 @@
   journal = {Lab on a Chip}
 }
 
-@Article{shiozawa.lee.ea:effect,
+@Article{2019:shiozawa.lee.ea:effect,
   author  = {Shiozawa, Sogo and Lee, Sanghyun and Wheeler, Mary F.},
   title   = {The effect of stress boundary conditions on fluid-driven fracture propagation in porous media using a phase-field modeling approach},
   journal = {International Journal for Numerical and Analytical Methods in Geomechanics},
@@ -1909,7 +1898,7 @@
   eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nag.2899}
 }
 
-@Article{silva.igreja.ea:formulacao,
+@Article{2019:silva.igreja.ea:formulacao,
   author  = {Emerson J. da Silva and Iury Igreja and Bernardo M. Rocha},
   title   = {Formula{\c{c}}{\~{a}}o H{\'{i}}brida de Elementos Finitos de Alta Ordem para a Resolu{\c{c}}{\~{a}}o de Problemas de Rea{\c{c}}{\~{a}}o-Difus{\~{a}}o},
   journal = {Mec{\'{a}}nica Computacional},
@@ -1922,7 +1911,7 @@
   pdf     = {http://venus.ceride.gov.ar/ojs/index.php/mc/article/download/5882/5869}
 }
 
-@Article{soldner.mergheim:thermal,
+@Article{2019:soldner.mergheim:thermal,
   doi     = {10.1016/j.camwa.2018.04.036},
   year    = 2019,
   month   = oct,
@@ -1935,7 +1924,7 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
-@Article{song.maier.ea:adaptive,
+@Article{2019:song.maier.ea:adaptive,
   author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
   doi     = {10.1016/j.cma.2019.03.039},
   title   = {Adaptive finite element simulations of waveguide configurations involving parallel 2D material sheets},
@@ -1945,7 +1934,7 @@
   pages   = {20--34}
 }
 
-@Article{steinberger.bredow.ea:widespread,
+@Article{2019:steinberger.bredow.ea:widespread,
   author  = {Steinberger, Bernhard and Bredow, Eva and Lebedev, Sergei and Schaeffer, Andrew and Torsvik, Trond H},
   journal = {Nature Geoscience},
   number  = 1,
@@ -1957,7 +1946,7 @@
   doi     = {10.1038/s41561-018-0251-0}
 }
 
-@Article{steinmann.kerganer.ea:novel,
+@Article{2019:steinmann.kerganer.ea:novel,
   doi     = {10.1016/j.jmps.2019.103680},
   year    = 2019,
   month   = nov,
@@ -1969,7 +1958,7 @@
   journal = {Journal of the Mechanics and Physics of Solids}
 }
 
-@Article{sticko.kreiss:higher,
+@Article{2019:sticko.kreiss:higher,
   doi     = {10.1007/s10915-019-01004-2},
   year    = 2019,
   month   = jul,
@@ -1982,7 +1971,7 @@
   journal = {Journal of Scientific Computing}
 }
 
-@Article{stoop.waisbord.ea:disorder-induced,
+@Article{2019:stoop.waisbord.ea:disorder-induced,
   doi     = {10.1016/j.jnnfm.2019.05.002},
   year    = 2019,
   month   = jun,
@@ -1994,7 +1983,7 @@
   journal = {Journal of Non-Newtonian Fluid Mechanics}
 }
 
-@TechReport{sun:integrated,
+@TechReport{2019:sun:integrated,
   doi     = {10.2172/1604128},
   year    = 2019,
   month   = dec,
@@ -2003,7 +1992,7 @@
   title   = {An integrated multiscale experimental-numerical analysis on reconsolidation of salt-clay mixture for disposal of heat-generating waste}
 }
 
-@MastersThesis{tahhan:topology,
+@MastersThesis{2019:tahhan:topology,
   author  = {Manal Tahhan},
   title   = {Topology Optimization of Space Frames via Geometry Projection},
   url     = {https://opencommons.uconn.edu/gs_theses/1325},
@@ -2012,7 +2001,7 @@
   school  = {University of Connecticut}
 }
 
-@Article{teichert.garikipati:machine,
+@Article{2019:teichert.garikipati:machine,
   doi     = {10.1016/j.cma.2018.10.025},
   year    = 2019,
   month   = feb,
@@ -2024,7 +2013,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@PhDThesis{uatay:multiscale,
+@PhDThesis{2019:uatay:multiscale,
   author  = {Uatay, Aydar},
   title   = {Multiscale mathematical modeling of cell migration: from single cells to populations},
   url     = {https://kluedo.ub.uni-kl.de/frontdoor/index/index/docId/5625},
@@ -2032,7 +2021,7 @@
   year    = 2019
 }
 
-@Article{uluocak.pysklywec.ea:multi-dimensional,
+@Article{2019:uluocak.pysklywec.ea:multi-dimensional,
   doi     = {10.1029/2019gc008277},
   year    = 2019,
   month   = jun,
@@ -2042,7 +2031,7 @@
   journal = {Geochemistry, Geophysics, Geosystems}
 }
 
-@PhDThesis{van-liedekerke:quantitative-modeling-of-cell-and-tissue-mechanics-with-agent-based-models,
+@PhDThesis{2019:van-liedekerke:quantitative-modeling-of-cell-and-tissue-mechanics-with-agent-based-models,
   title   = {{Quantitative modeling of cell and tissue mechanics with agent-based models}},
   author  = {Van Liedekerke, Paul},
   url     = {https://hal.inria.fr/tel-02064216},
@@ -2055,7 +2044,7 @@
   hal_version = {v1}
 }
 
-@Article{vassaux.richardson.ea:heterogeneous,
+@Article{2019:vassaux.richardson.ea:heterogeneous,
   doi     = {10.1098/rsta.2018.0150},
   year    = 2019,
   month   = feb,
@@ -2068,7 +2057,7 @@
   journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences}
 }
 
-@Article{vassaux.sinclair.ea:role,
+@Article{2019:vassaux.sinclair.ea:role,
   doi     = {10.1002/adts.201800168},
   year    = 2019,
   month   = feb,
@@ -2081,7 +2070,7 @@
   journal = {Advanced Theory and Simulations}
 }
 
-@Article{walker.kramer.ea:accelerating,
+@Article{2019:walker.kramer.ea:accelerating,
   doi     = {10.1002/cpe.5265},
   year    = 2019,
   month   = apr,
@@ -2092,7 +2081,7 @@
   journal = {Concurrency and Computation: Practice and Experience}
 }
 
-@InCollection{wang.harper.ea:deal,
+@InCollection{2019:wang.harper.ea:deal,
   doi     = {10.1007/978-3-030-22747-0_37},
   year    = 2019,
   publisher = {Springer International Publishing},
@@ -2102,7 +2091,7 @@
   booktitle = {Lecture Notes in Computer Science}
 }
 
-@PhDThesis{wei:numerical,
+@PhDThesis{2019:wei:numerical,
   author  = {Wei, Peng},
   title   = {Numerical Approximation of Time Dependent Fractional Diffusion With Drift: Numerical Analysis and Applications to Surface Quasi-Geostrophic Dynamics and Electroconvection},
   url     = {https://oaktrust.library.tamu.edu/handle/1969.1/186239},
@@ -2110,7 +2099,7 @@
   year    = 2019
 }
 
-@InProceedings{wheeler.srinivasan.ea:unconventional,
+@InProceedings{2019:wheeler.srinivasan.ea:unconventional,
   doi     = {10.2118/193830-ms},
   year    = 2019,
   publisher = {Society of Petroleum Engineers},
@@ -2119,7 +2108,7 @@
   booktitle = {{SPE} Reservoir Simulation Conference}
 }
 
-@Article{white.castelletto.ea:two-stage,
+@Article{2019:white.castelletto.ea:two-stage,
   doi     = {10.1016/j.cma.2019.112575},
   year    = 2019,
   month   = dec,
@@ -2131,7 +2120,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@PhDThesis{wichmann:performance,
+@PhDThesis{2019:wichmann:performance,
   author  = {Wichmann, Karl-Robert Klaus},
   title   = {Performance Aspects of Incompressible {N}avier-{S}tokes Solvers: {L}attice-{B}oltzmann Method vs. Finite Difference Method},
   school  = {Technical University of Munich},
@@ -2139,7 +2128,7 @@
   url     = {https://mediatum.ub.tum.de/1437209}
 }
 
-@Article{wick.wollner:on,
+@Article{2019:wick.wollner:on,
   doi     = {10.1007/s00021-019-0439-0},
   year    = 2019,
   month   = jun,
@@ -2151,7 +2140,7 @@
   journal = {Journal of Mathematical Fluid Mechanics}
 }
 
-@Article{yaghoobi.ganesan.ea:prisms-plasticity,
+@Article{2019:yaghoobi.ganesan.ea:prisms-plasticity,
   doi     = {10.1016/j.commatsci.2019.109078},
   year    = 2019,
   month   = nov,
@@ -2163,7 +2152,7 @@
   journal = {Computational Materials Science}
 }
 
-@Article{zhang.choo.ea:on,
+@Article{2019:zhang.choo.ea:on,
   doi     = {10.1016/j.cma.2019.04.037},
   year    = 2019,
   month   = aug,
@@ -2175,7 +2164,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{zhang.yue:high-order,
+@Article{2019:zhang.yue:high-order,
   title   = {A high-order and interface-preserving discontinuous Galerkin method for level-set reinitialization},
   journal = {Journal of Computational Physics},
   volume  = 378,
@@ -2187,7 +2176,7 @@
   author  = {Jiaqi Zhang and Pengtao Yue}
 }
 
-@PhDThesis{zhang:topology,
+@PhDThesis{2019:zhang:topology,
   author  = {Zhang, Shanglong},
   title   = {Topology Optimization with Geometric Primitives},
   url     = {https://www.researchgate.net/profile/Shanglong_Zhang/publication/330873130_Topology_Optimization_with_Geometric_Primitives/links/5e62bf364585153fb3c818d9/Topology-Optimization-with-Geometric-Primitives.pdf},
@@ -2195,7 +2184,7 @@
   year    = 2019
 }
 
-@Article{zhao.heister:preconditioner,
+@Article{2019:zhao.heister:preconditioner,
   author  = {Liang Zhao and Timo Heister},
   title   = {A preconditioner for the incompressible Navier-Stokes equations in velocity-vorticity form},
   journal = {submitted},
@@ -2203,7 +2192,7 @@
   note    = {submitted}
 }
 
-@Article{zhao.li.ea:linear,
+@Article{2019:zhao.li.ea:linear,
   doi     = {10.1016/j.aml.2019.05.029},
   year    = 2019,
   month   = dec,
@@ -2215,12 +2204,23 @@
   journal = {Applied Mathematics Letters}
 }
 
-@MastersThesis{zimmerman:modeling,
+@MastersThesis{2019:zimmerman:modeling,
   title   = {Modeling and simulation of heat source trajectories through phase-change materials},
   author  = {Alexander Gary Zimmerman},
   year    = 2019,
   school  = {RWTH Aachen},
   url     = {https://arxiv.org/abs/1909.08882}
+}
+
+@Article{2020:hochbruck.leibold:finite,
+  doi     = {10.1553/etna_vol53s522},
+  year    = 2020,
+  publisher = {Osterreichische Akademie der Wissenschaften},
+  volume  = 53,
+  pages   = {522--540},
+  author  = {Marlis Hochbruck and Jan Leibold},
+  title   = {Finite element discretization of semilinear acoustic wave equations with kinetic boundary conditions},
+  journal = {{ETNA} - Electronic Transactions on Numerical Analysis}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -47,6 +47,18 @@
   journal = {Computers {\&} Mathematics with Applications}
 }
 
+@Article{2019:alhazmi:exploring,
+  doi     = {10.14569/ijacsa.2019.0100372},
+  url     = {https://doi.org/10.14569/ijacsa.2019.0100372},
+  year    = 2019,
+  publisher = {The Science and Information Organization},
+  volume  = 10,
+  number  = 3,
+  author  = {Muflih Alhazmi},
+  title   = {Exploring Mechanisms for Pattern Formation through Coupled Bulk-Surface {PDEs} in Case of Non-linear Reactions},
+  journal = {International Journal of Advanced Computer Science and Applications}
+}
+
 @PhDThesis{2019:alzetta:coupling,
   author  = {Alzetta, Giovanni},
   title   = {Coupling methods for non-matching meshes through distributed Lagrange multipliers},
@@ -1149,6 +1161,20 @@
   booktitle = {Volume 2A: 45th Design Automation Conference}
 }
 
+@Article{2019:kerganer.mergheim.ea:modeling,
+  doi     = {10.1016/j.camwa.2018.05.016},
+  url     = {https://doi.org/10.1016/j.camwa.2018.05.016},
+  year    = 2019,
+  month   = oct,
+  publisher = {Elsevier {BV}},
+  volume  = 78,
+  number  = 7,
+  pages   = {2338--2350},
+  author  = {Andreas Kerga{\ss}ner and Julia Mergheim and Paul Steinmann},
+  title   = {Modeling of additively manufactured materials using gradient-enhanced crystal plasticity},
+  journal = {Computers {\&} Mathematics with Applications}
+}
+
 @Article{2019:khattatov.yotov:domain,
   doi     = {10.1051/m2an/2019057},
   year    = 2019,
@@ -2210,17 +2236,6 @@
   year    = 2019,
   school  = {RWTH Aachen},
   url     = {https://arxiv.org/abs/1909.08882}
-}
-
-@Article{2020:hochbruck.leibold:finite,
-  doi     = {10.1553/etna_vol53s522},
-  year    = 2020,
-  publisher = {Osterreichische Akademie der Wissenschaften},
-  volume  = 53,
-  pages   = {522--540},
-  author  = {Marlis Hochbruck and Jan Leibold},
-  title   = {Finite element discretization of semilinear acoustic wave equations with kinetic boundary conditions},
-  journal = {{ETNA} - Electronic Transactions on Numerical Analysis}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -466,6 +466,17 @@
   year    = 2020
 }
 
+@Article{2020:hochbruck.leibold:finite,
+  doi     = {10.1553/etna_vol53s522},
+  year    = 2020,
+  publisher = {Osterreichische Akademie der Wissenschaften},
+  volume  = 53,
+  pages   = {522--540},
+  author  = {Marlis Hochbruck and Jan Leibold},
+  title   = {Finite element discretization of semilinear acoustic wave equations with kinetic boundary conditions},
+  journal = {{ETNA} - Electronic Transactions on Numerical Analysis}
+}
+
 @Article{2020:jerg.austermuhl.ea:diffuse,
   title   = {Diffuse domain method for needle insertion simulations},
   author  = {Jerg, Katharina I and Austerm{\"u}hl, Ren{\'e} Phillip and Roth, Karsten and Gro{\ss}e Sundrup, Jonas and Kanschat, Guido and Hesser, J{\"u}rgen W and Wittmayer, Lisa},
@@ -556,6 +567,20 @@
   author  = {Sora Lee and Yejin Shon and Dong-gil Kim and Deuk-Chul Kwon and Hee Hwan Choe},
   title   = {Adaptive Mesh Method Applied to Poisson Solver Module for 3D Capacitively Coupled Plasma Discharge Simulation},
   journal = {Applied Science and Convergence Technology}
+}
+
+@Article{2020:lees.rudge.ea:gravity,
+  author  = {Lees, Matthew E. and Rudge, John F. and McKenzie, Dan},
+  title   = {Gravity, Topography, and Melt Generation Rates From Simple 3-D Models of Mantle Convection},
+  journal = {Geochemistry, Geophysics, Geosystems},
+  volume  = 21,
+  number  = 4,
+  pages   = {e2019GC008809},
+  doi     = {10.1029/2019GC008809},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
+  note    = {e2019GC008809 10.1029/2019GC008809},
+  year    = 2020
 }
 
 @Article{2020:lesher.dannberg.ea:iron,
@@ -996,18 +1021,6 @@
   author  = {Yidong Zhao and Jinhyun Choo},
   title   = {Stabilized material point methods for coupled large deformation and fluid flow in porous materials},
   journal = {Computer Methods in Applied Mechanics and Engineering}
-}
-
-@InBook{2021:hoggard.austermann.ea:mantle,
-  author  = {Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon},
-  editor  = {H. Marquardt, M. Ballmer},
-  chapter = {Observational estimates of dynamic topography through space and time},
-  title   = {Mantle convection and surface expressions},
-  series  = {AGU Geophysical Monograph Series},
-  year    = 2021,
-  address = {Washington, D.C.},
-  publisher = {AGU},
-  doi     = {10.1002/9781119528609.ch15}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Article{alzetta.heltai:multiscale,
+@Article{2020:alzetta.heltai:multiscale,
   author  = {Giovanni Alzetta and Luca Heltai},
   journal = {Computers {\&} Structures},
   pages   = 106334,
@@ -10,7 +10,7 @@
   doi     = {10.1016/j.compstruc.2020.106334}
 }
 
-@Article{anzt.cojean.ea:ginkgo,
+@Article{2020:anzt.cojean.ea:ginkgo,
   doi     = {10.21105/joss.02260},
   year    = 2020,
   month   = aug,
@@ -23,7 +23,7 @@
   journal = {Journal of Open Source Software}
 }
 
-@Article{araujo.campos.ea:computation,
+@Article{2020:araujo.campos.ea:computation,
   author  = {Ara\'{u}jo, Juan C. and Campos, Carmen and Engstr\"{o}m, Christian and Roman, Jose E.},
   title   = {Computation of scattering resonances in absorptive and dispersive media with applications to metal-dielectric nano-structures},
   journal = {Journal of Computational Physics},
@@ -35,7 +35,7 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0021999119309258}
 }
 
-@Article{arndt.bangerth.ea:deal-ii,
+@Article{2020:arndt.bangerth.ea:deal-ii,
   title   = {The \texttt{deal.II} Library, Version 9.2},
   author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Thomas C. Clevenger and Marc Fehling and Alexander V. Grayver and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Reza Rastak and Ignacio Thomas and Bruno Turcksin and Zhuoran Wang and David Wells},
   journal = {Journal of Numerical Mathematics},
@@ -48,7 +48,7 @@
   url     = {https://dealii.org/deal92-preprint.pdf}
 }
 
-@InProceedings{arndt.fehn.ea:exadg,
+@InProceedings{2020:arndt.fehn.ea:exadg,
   author  = {Arndt, Daniel and Fehn, Niklas and Kanschat, Guido and Kormann, Katharina and Kronbichler, Martin and Munch, Peter and Wall, Wolfgang A. and Witte, Julius},
   editor  = {Bungartz, Hans-Joachim and Reiz, Severin and Uekermann, Benjamin and Neumann, Philipp and Nagel, Wolfgang E.},
   title   = {Exa{DG}: {H}igh-{O}rder {D}iscontinuous {G}alerkin for the {E}xa-{S}cale},
@@ -61,7 +61,7 @@
   doi     = {10.1007/978-3-030-47956-5_8}
 }
 
-@Article{arndt.kanschat:differentiable,
+@Article{2020:arndt.kanschat:differentiable,
   title   = {A Differentiable Mapping of Mesh Cells Based on Finite Elements on Quadrilateral and Hexahedral Meshes},
   author  = {Arndt, Daniel and Kanschat, Guido},
   journal = {Computational Methods in Applied Mathematics},
@@ -71,7 +71,7 @@
   doi     = {10.1515/cmam-2020-0159}
 }
 
-@Article{assanelli.luoni.ea:tectono-metamorphic,
+@Article{2020:assanelli.luoni.ea:tectono-metamorphic,
   author  = {Assanelli, M. and Luoni, P. and Rebay, G. and Roda, M. and Spalla, M. I.},
   title   = {Tectono-Metamorphic Evolution of Serpentinites from Lanzo Valleys Subduction Complex (Piemonte--Sesia-Lanzo Zone Boundary, Western Italian Alps)},
   journal = {Minerals},
@@ -84,7 +84,7 @@
   url     = {https://www.mdpi.com/2075-163X/10/11/985}
 }
 
-@Article{badia.martin.ea:generic,
+@Article{2020:badia.martin.ea:generic,
   doi     = {10.1137/20m1328786},
   year    = 2020,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
@@ -96,7 +96,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{benbow.kawama.ea:coupled,
+@Article{2020:benbow.kawama.ea:coupled,
   doi     = {10.3390/cryst10090767},
   year    = 2020,
   month   = aug,
@@ -109,7 +109,7 @@
   journal = {Crystals}
 }
 
-@Article{blais.barbeau.ea:lethe,
+@Article{2020:blais.barbeau.ea:lethe,
   doi     = {10.1016/j.softx.2020.100579},
   year    = 2020,
   month   = jul,
@@ -121,7 +121,7 @@
   journal = {{SoftwareX}}
 }
 
-@Article{brun.wick.ea:iterative,
+@Article{2020:brun.wick.ea:iterative,
   doi     = {10.1016/j.cma.2019.112752},
   year    = 2020,
   month   = apr,
@@ -133,7 +133,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{bruna-rosso.mergheim.ea:finite,
+@Article{2020:bruna-rosso.mergheim.ea:finite,
   doi     = {10.1177/0954406220943225},
   year    = 2020,
   month   = aug,
@@ -144,7 +144,7 @@
   journal = {Proceedings of the Institution of Mechanical Engineers, Part C: Journal of Mechanical Engineering Science}
 }
 
-@Article{cangiani.georgoulis.ea:posteriori,
+@Article{2020:cangiani.georgoulis.ea:posteriori,
   doi     = {10.1007/s10915-020-01130-2},
   year    = 2020,
   month   = jan,
@@ -156,7 +156,7 @@
   journal = {Journal of Scientific Computing}
 }
 
-@Article{choi.lee:optimal,
+@Article{2020:choi.lee:optimal,
   doi     = {10.1016/j.apnum.2019.09.010},
   year    = 2020,
   month   = apr,
@@ -168,7 +168,7 @@
   journal = {Applied Numerical Mathematics}
 }
 
-@Article{citron.lourenco.ea:effects,
+@Article{2020:citron.lourenco.ea:effects,
   title   = {Effects of Heat-Producing Elements on the Stability of Deep Mantle Thermochemical Piles},
   author  = {Citron, Robert I. and Louren{\c{c}}o, Diogo L. and Wilson, Alfred J. and Grima, Antoniette G. and Wipperfurth, Scott A. and Rudolph, Maxwell L. and Cottaar, Sanne and Mont{\'e}si, Laurent G. J.},
   journal = {Geochemistry, Geophysics, Geosystems},
@@ -180,7 +180,7 @@
   doi     = {10.1029/2019GC008895}
 }
 
-@Article{cobb.dommain.ea:carbon,
+@Article{2020:cobb.dommain.ea:carbon,
   doi     = {10.1088/1748-9326/aba867},
   year    = 2020,
   month   = oct,
@@ -193,7 +193,7 @@
   journal = {Environmental Research Letters}
 }
 
-@Article{comellas.budday.ea:modeling,
+@Article{2020:comellas.budday.ea:modeling,
   doi     = {10.1016/J.CMA.2020.113128},
   issn    = {0045-7825},
   journal = {Computer Methods in Applied Mechanics and Engineering},
@@ -206,7 +206,7 @@
   year    = 2020
 }
 
-@Article{davydov.kronbichler:algorithms,
+@Article{2020:davydov.kronbichler:algorithms,
   doi     = {10.1145/3399736},
   title   = {Algorithms and data structures for matrix-free finite element operators with MPI-parallel sparse multi-vectors},
   author  = {Davydov, Denis and Kronbichler, Martin},
@@ -218,7 +218,7 @@
   month   = jun
 }
 
-@Article{davydov.pelteret.ea:matrix-free,
+@Article{2020:davydov.pelteret.ea:matrix-free,
   doi     = {10.1002/nme.6336},
   year    = 2020,
   month   = jul,
@@ -231,7 +231,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Article{dewitt.rudraraju.ea:prisms-pf,
+@Article{2020:dewitt.rudraraju.ea:prisms-pf,
   doi     = {10.1038/s41524-020-0298-5},
   year    = 2020,
   month   = mar,
@@ -243,7 +243,7 @@
   journal = {npj Computational Materials}
 }
 
-@InCollection{endtmayer.langer.ea:hierarchical,
+@InCollection{2020:endtmayer.langer.ea:hierarchical,
   doi     = {10.1007/978-3-030-55874-1_35},
   year    = 2020,
   month   = aug,
@@ -254,7 +254,7 @@
   booktitle = {Lecture Notes in Computational Science and Engineering}
 }
 
-@Article{endtmayer.langer.ea:multigoal-oriented,
+@Article{2020:endtmayer.langer.ea:multigoal-oriented,
   title   = {Multigoal-oriented optimal control problems with nonlinear PDE constraints},
   journal = {Computers {\&} Mathematics with Applications},
   volume  = 79,
@@ -266,7 +266,7 @@
   author  = {B. Endtmayer and U. Langer and I. Neitzel and T. Wick and W. Wollner}
 }
 
-@Article{endtmayer.langer.ea:two-side,
+@Article{2020:endtmayer.langer.ea:two-side,
   doi     = {10.1137/18m1227275},
   year    = 2020,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
@@ -278,7 +278,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@InCollection{engwer.pop.ea:dynamic,
+@InCollection{2020:engwer.pop.ea:dynamic,
   doi     = {10.1007/978-3-030-55874-1_117},
   year    = 2020,
   month   = aug,
@@ -289,7 +289,7 @@
   booktitle = {Lecture Notes in Computational Science and Engineering}
 }
 
-@Article{farangitakis.heron.ea:impact,
+@Article{2020:farangitakis.heron.ea:impact,
   doi     = {10.1016/j.epsl.2020.116277},
   year    = 2020,
   month   = jul,
@@ -301,7 +301,7 @@
   journal = {Earth and Planetary Science Letters}
 }
 
-@PhDThesis{fehling:algorithms,
+@PhDThesis{2020:fehling:algorithms,
   author  = {Marc Fehling},
   title   = {Algorithms for massively parallel generic $hp$-adaptive finite element methods},
   school  = {Bergische Universit{\"a}t Wuppertal},
@@ -317,7 +317,7 @@
   urn     = {urn:nbn:de:0001-2020071402}
 }
 
-@Article{fehn.munch.ea:hybrid,
+@Article{2020:fehn.munch.ea:hybrid,
   doi     = {10.1016/j.jcp.2020.109538},
   year    = 2020,
   month   = aug,
@@ -329,7 +329,7 @@
   journal = {Journal of Computational Physics}
 }
 
-@Article{finlay.kloss.ea:chaos-7,
+@Article{2020:finlay.kloss.ea:chaos-7,
   title   = {The CHAOS-7 geomagnetic field model and observed changes in the South Atlantic Anomaly},
   author  = {Finlay, Christopher C and Kloss, Clemens and Olsen, Nils and Hammer, Magnus D and T{\o}ffner-Clausen, Lars and Grayver, Alexander and Kuvshinov, Alexey},
   journal = {Earth, Planets and Space},
@@ -341,7 +341,7 @@
   doi     = {10.1186/s40623-020-01252-9}
 }
 
-@Article{fischer.min.ea:scalability,
+@Article{2020:fischer.min.ea:scalability,
   doi     = {10.1177/1094342020915762},
   year    = 2020,
   month   = jun,
@@ -354,7 +354,7 @@
   journal = {The International Journal of High Performance Computing Applications}
 }
 
-@Article{gassmoller.dannberg.ea:on,
+@Article{2020:gassmoller.dannberg.ea:on,
   doi     = {10.1093/gji/ggaa078},
   year    = 2020,
   month   = feb,
@@ -367,7 +367,7 @@
   journal = {Geophysical Journal International}
 }
 
-@Article{glerum.brune.ea:victoria,
+@Article{2020:glerum.brune.ea:victoria,
   author  = {Glerum, A. and Brune, S. and Stamps, D. S. and Strecker, M. R.},
   title   = {Victoria continental microplate dynamics controlled by the lithospheric strength distribution of the East African Rift},
   journal = {Nature Communications},
@@ -379,7 +379,7 @@
   url     = {http://www.nature.com/articles/s41467-020-16176-x}
 }
 
-@Article{grieshaber.mcbride.ea:convergence,
+@Article{2020:grieshaber.mcbride.ea:convergence,
   doi     = {10.1016/j.cma.2020.113233},
   year    = 2020,
   month   = oct,
@@ -391,7 +391,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{gurkan.sticko.ea:stabilized,
+@Article{2020:gurkan.sticko.ea:stabilized,
   title   = {Stabilized {Cut} {Discontinuous} {Galerkin} {Methods} for {Advection}-{Reaction} {Problems}},
   volume  = 42,
   issn    = {1064-8275, 1095-7197},
@@ -406,7 +406,7 @@
   pages   = {A2620--A2654}
 }
 
-@Article{heister.wick:pfm-cracks,
+@Article{2020:heister.wick:pfm-cracks,
   title   = {pfm-cracks: A parallel-adaptive framework for phase-field fracture propagation},
   journal = {Software Impacts},
   volume  = 6,
@@ -418,7 +418,7 @@
   author  = {Timo Heister and Thomas Wick}
 }
 
-@Article{heltai.lei:priori,
+@Article{2020:heltai.lei:priori,
   author  = {Luca Heltai and Wenyu Lei},
   journal = {Numerische Mathematik},
   number  = 3,
@@ -429,7 +429,7 @@
   doi     = {10.1007/s00211-020-01152-w}
 }
 
-@Article{heron.murphy.ea:pannotias,
+@Article{2020:heron.murphy.ea:pannotias,
   author  = {Heron, Philip J. and Murphy, J. Brendan and Nance, R. Damian and Pysklywec, R. N.},
   title   = {Pannotia{\textquoteright}s mantle signature: the quest for supercontinent identification},
   volume  = 503,
@@ -442,7 +442,7 @@
   journal = {Geological Society, London, Special Publications}
 }
 
-@Article{heyn.conrad.ea:core-mantle,
+@Article{2020:heyn.conrad.ea:core-mantle,
   title   = {Core-mantle boundary topography and its relation to the viscosity structure of the lowermost mantle},
   journal = {Earth and Planetary Science Letters},
   volume  = 543,
@@ -454,7 +454,7 @@
   author  = {Bj{\"o}rn H. Heyn and Clinton P. Conrad and Reidar G. Tr{\o}nnes}
 }
 
-@Article{heyn.conrad.ea:how,
+@Article{2020:heyn.conrad.ea:how,
   author  = {Heyn, Bj{\"o}rn H. and Conrad, Clinton P. and Tr{\o}nnes, Reidar G.},
   title   = {How Thermochemical Piles Can (Periodically) Generate Plumes at Their Edges},
   journal = {Journal of Geophysical Research: Solid Earth},
@@ -466,19 +466,7 @@
   year    = 2020
 }
 
-@InBook{hoggard.austermann.ea:mantle,
-  author  = {Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon},
-  editor  = {H. Marquardt, M. Ballmer},
-  chapter = {Observational estimates of dynamic topography through space and time},
-  title   = {Mantle convection and surface expressions},
-  series  = {AGU Geophysical Monograph Series},
-  year    = 2021,
-  address = {Washington, D.C.},
-  publisher = {AGU},
-  doi     = {10.1002/9781119528609.ch15}
-}
-
-@Article{jerg.austermuhl.ea:diffuse,
+@Article{2020:jerg.austermuhl.ea:diffuse,
   title   = {Diffuse domain method for needle insertion simulations},
   author  = {Jerg, Katharina I and Austerm{\"u}hl, Ren{\'e} Phillip and Roth, Karsten and Gro{\ss}e Sundrup, Jonas and Kanschat, Guido and Hesser, J{\"u}rgen W and Wittmayer, Lisa},
   journal = {International journal for numerical methods in biomedical engineering},
@@ -490,7 +478,7 @@
   doi     = {10.1002/cnm.3377}
 }
 
-@Article{jodlbauer.langer.ea:matrix-free,
+@Article{2020:jodlbauer.langer.ea:matrix-free,
   title   = {Matrix-free multigrid solvers for phase-field fracture problems},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   volume  = 372,
@@ -501,7 +489,7 @@
   author  = {D. Jodlbauer and U. Langer and T. Wick}
 }
 
-@Article{jodlbauer.langer.ea:parallel,
+@Article{2020:jodlbauer.langer.ea:parallel,
   author  = {Jodlbauer, D. and Langer, U. and Wick, T.},
   title   = {Parallel Matrix-Free Higher-Order Finite Element Solvers for Phase-Field Fracture Problems},
   journal = {Mathematical and Computational Applications},
@@ -512,7 +500,7 @@
   doi     = {10.3390/mca25030040}
 }
 
-@Article{kaufl.grayver.ea:magnetotelluric,
+@Article{2020:kaufl.grayver.ea:magnetotelluric,
   title   = {Magnetotelluric multiscale 3-{D} inversion reveals crustal and upper mantle structure beneath the Hangai and {G}obi-{A}ltai region in {M}ongolia},
   author  = {K{\"a}ufl, Johannes S and Grayver, Alexander V and Comeau, Matthew J and Kuvshinov, Alexey V and Becken, Michael and Kamm, Jochen and Batmagnai, Erdenechimeg and Demberel, Sodnomsambuu},
   journal = {Geophysical Journal International},
@@ -524,7 +512,7 @@
   doi     = {10.1093/gji/ggaa039}
 }
 
-@MastersThesis{khimin:numerische,
+@MastersThesis{2020:khimin:numerische,
   author  = {D. Khimin},
   title   = {Numerische Modellierung von Optimalsteuerungsproblemen f{\"u}r Phasenfeld-Riss-Ausbreitung},
   school  = {Leibniz University Hannover},
@@ -532,7 +520,7 @@
   year    = 2020
 }
 
-@Article{kim:application,
+@Article{2020:kim:application,
   doi     = {10.1016/j.cam.2019.112458},
   year    = 2020,
   month   = mar,
@@ -544,7 +532,7 @@
   journal = {Journal of Computational and Applied Mathematics}
 }
 
-@Article{kramer.wilde.ea:lattice-boltzmann-simulations-on-irregular-grids--introduction-of-the-natrium-library,
+@Article{2020:kramer.wilde.ea:lattice-boltzmann-simulations-on-irregular-grids--introduction-of-the-natrium-library,
   author  = {Kr{\"{a}}mer, Andreas and Wilde, Dominik and K{\"{u}}llmer, Knut and Reith, Dirk and Foysi, Holger and Joppich, Wolfgang},
   doi     = {10.1016/j.camwa.2018.10.041},
   issn    = 08981221,
@@ -557,7 +545,7 @@
   year    = 2020
 }
 
-@Article{lee.shon.ea:adaptive,
+@Article{2020:lee.shon.ea:adaptive,
   doi     = {10.5757/asct.2020.29.3.062},
   year    = 2020,
   month   = may,
@@ -570,7 +558,7 @@
   journal = {Applied Science and Convergence Technology}
 }
 
-@Article{lesher.dannberg.ea:iron,
+@Article{2020:lesher.dannberg.ea:iron,
   title   = {Iron isotope fractionation at the core--mantle boundary by thermodiffusion},
   author  = {Lesher, Charles E. and Dannberg, Juliane and Barfod, Gry H. and Bennett, Neil R. and Glessner, Justin J. G. and Lacks, Daniel J. and Brenan, James M.},
   journal = {Nature Geoscience},
@@ -582,7 +570,7 @@
   doi     = {10.1038/s41561-020-0560-y}
 }
 
-@Article{liu.mcbride.ea:assessment-of-an-isogeometric-approach-with-catmull-clark-subdivision-surfaces-using-the-laplace-beltrami-problems,
+@Article{2020:liu.mcbride.ea:assessment-of-an-isogeometric-approach-with-catmull-clark-subdivision-surfaces-using-the-laplace-beltrami-problems,
   author  = {Liu, Zhaowei and McBride, Andrew and Saxena, Prashant and Steinmann, Paul},
   doi     = {10.1007/s00466-020-01877-3},
   issn    = 14320924,
@@ -591,7 +579,7 @@
   year    = 2020
 }
 
-@Article{lorentzon.revstedt:numerical,
+@Article{2020:lorentzon.revstedt:numerical,
   author  = {Lorentzon, Johan and Revstedt, Johan},
   title   = {A numerical study of partitioned fluid-structure interaction applied to a cantilever in incompressible turbulent flow},
   journal = {International Journal for Numerical Methods in Engineering},
@@ -602,7 +590,7 @@
   year    = 2020
 }
 
-@Article{louis-napoleon.gerbault.ea:3-d,
+@Article{2020:louis-napoleon.gerbault.ea:3-d,
   title   = {3-D numerical modelling of crustal polydiapirs with volume-of-fluid methods},
   author  = {Louis-Napol{\'e}on, Aur{\'e}lie and Gerbault, Muriel and Bonometti, Thomas and Thieulot, C{\'e}dric and Martin, Roland and Vanderhaeghe, Olivier},
   journal = {Geophysical Journal International},
@@ -614,7 +602,7 @@
   doi     = {10.1093/gji/ggaa141}
 }
 
-@Article{maier.margetis.ea:finite-size,
+@Article{2020:maier.margetis.ea:finite-size,
   author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
   title   = {Finite-size effects in wave transmission through plasmonic crystals: A tale of two scales},
   doi     = {10.1103/PhysRevB.102.075308},
@@ -624,7 +612,7 @@
   pages   = 075308
 }
 
-@Article{mcbride.davydov.ea:modelling,
+@Article{2020:mcbride.davydov.ea:modelling,
   doi     = {10.1016/j.cma.2020.113320},
   year    = 2020,
   month   = nov,
@@ -636,7 +624,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@PhDThesis{mcgovern:high,
+@PhDThesis{2020:mcgovern:high,
   author  = {Sean McGovern},
   title   = {High Performance Computing in Basin Modeling: Simulating Mechanical Compaction with the Level Set Method},
   school  = {Rheinische Friedrich-Wilhelms-Universit{\"a}t Bonn},
@@ -644,7 +632,7 @@
   url     = {https://hdl.handle.net/20.500.11811/8443}
 }
 
-@Article{mitrovica.austermann.ea:dynamic,
+@Article{2020:mitrovica.austermann.ea:dynamic,
   author  = {Mitrovica, J. X. and Austermann, J. and Coulson, S. and Creveling, J. R. and Hoggard, M. J. and Jarvis, G. T. and Richards, F. D.},
   title   = {Dynamic Topography and Ice Age Paleoclimate},
   journal = {Annual Review of Earth and Planetary Sciences},
@@ -655,7 +643,7 @@
   doi     = {10.1146/annurev-earth-082517-010225}
 }
 
-@Article{motamarri.das.ea:dft-fe,
+@Article{2020:motamarri.das.ea:dft-fe,
   doi     = {10.1016/j.cpc.2019.07.016},
   year    = 2020,
   month   = jan,
@@ -667,7 +655,7 @@
   journal = {Computer Physics Communications}
 }
 
-@Article{muluneh.brune.ea:mechanism,
+@Article{2020:muluneh.brune.ea:mechanism,
   author  = {Muluneh, Ameha A. and Brune, Sascha and Illsley-Kemp, Finnigan and Corti, Giacomo and Keir, Derek and Glerum, Anne and Kidane, Tesfaye and Mori, Jim},
   title   = {Mechanism for Deep Crustal Seismicity: Insight From Modeling of Deformation Processes at the Main Ethiopian Rift},
   journal = {Geochemistry, Geophysics, Geosystems},
@@ -681,7 +669,7 @@
   year    = 2020
 }
 
-@Article{murphy.madzvamuse:moving,
+@Article{2020:murphy.madzvamuse:moving,
   doi     = {10.1016/j.apnum.2020.08.004},
   year    = 2020,
   month   = dec,
@@ -693,7 +681,7 @@
   journal = {Applied Numerical Mathematics}
 }
 
-@Article{naliboff.glerum.ea:development,
+@Article{2020:naliboff.glerum.ea:development,
   author  = {Naliboff, J.B. and Glerum, A. and Brune, S. and Peron-Pinvidic, G. and Wrona, T.},
   title   = {Development of 3-D rift heterogeneity through fault network evolution},
   journal = {Geophysical Research Letters},
@@ -704,7 +692,7 @@
   opturl  = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GL086611}
 }
 
-@Article{nayak.cojean.ea:evaluating,
+@Article{2020:nayak.cojean.ea:evaluating,
   doi     = {10.1177/1094342020946814},
   year    = 2020,
   month   = aug,
@@ -715,7 +703,7 @@
   journal = {The International Journal of High Performance Computing Applications}
 }
 
-@Article{negredo.mancilla.ea:geodynamic,
+@Article{2020:negredo.mancilla.ea:geodynamic,
   author  = {Negredo, A. M. and Mancilla, F. d. L. and Clemente, C. and Morales, J. and Fullea, J.},
   title   = {Geodynamic Modeling of Edge-Delamination Driven by Subduction-Transform Edge Propagator Faults: The Westernmost Mediterranean Margin (Central Betic Orogen) Case Study},
   journal = {Frontiers in Earth Science},
@@ -727,14 +715,14 @@
   issn    = {2296-6463}
 }
 
-@Article{nitzler.biehler.ea:generalized,
+@Article{2020:nitzler.biehler.ea:generalized,
   title   = {A Generalized Probabilistic Learning Approach for Multi-Fidelity Uncertainty Propagation in Complex Physical Simulations},
   author  = {Nitzler, Jonas and Biehler, Jonas and Fehn, Niklas and Koutsourelakis, Phaedon-Stelios and Wall, Wolfgang A},
   journal = {arXiv preprint arXiv:2001.02892},
   year    = 2020
 }
 
-@Article{njinju.stamps.ea:lithospheric,
+@Article{2020:njinju.stamps.ea:lithospheric,
   doi     = {10.1002/essoar.10503939.1},
   pages   = 37,
   year    = 2020,
@@ -744,7 +732,7 @@
   title   = {Lithospheric Control of Melt Generation Beneath the Rungwe Volcanic Province, East Africa}
 }
 
-@InCollection{paula.quinelato.ea:numerical,
+@InCollection{2020:paula.quinelato.ea:numerical,
   doi     = {10.1007/978-3-030-50436-6_2},
   year    = 2020,
   publisher = {Springer International Publishing},
@@ -754,7 +742,7 @@
   booktitle = {Lecture Notes in Computer Science}
 }
 
-@Article{rajaonarison.stamps.ea:numerical,
+@Article{2020:rajaonarison.stamps.ea:numerical,
   title   = {Numerical Modeling of Mantle Flow Beneath Madagascar to Constrain Upper Mantle Rheology Beneath Continental Regions},
   author  = {Rajaonarison, T. A. and Stamps, D. S. and Fishwick, S. and Brune, Sascha and Glerum, A. and Hu, J.},
   journal = {Journal of Geophysical Research. Solid Earth},
@@ -766,7 +754,7 @@
   doi     = {10.1029/2019JB018560}
 }
 
-@Article{reveron.kumar.ea:iterative,
+@Article{2020:reveron.kumar.ea:iterative,
   doi     = {10.1007/s10596-020-09983-0},
   year    = 2020,
   month   = jul,
@@ -779,7 +767,7 @@
   journal = {Computational Geosciences}
 }
 
-@MastersThesis{roth:geometric,
+@MastersThesis{2020:roth:geometric,
   author  = {Roth, Julian},
   title   = {Geometric Multigrid Methods for Maxwell's Equations},
   school  = {Leibniz Universit{\"a}t Hannover},
@@ -789,7 +777,7 @@
   note    = {Bachelor's Thesis}
 }
 
-@Article{ryan.dominguez.ea:energy,
+@Article{2020:ryan.dominguez.ea:energy,
   doi     = {10.3389/fphys.2020.538522},
   year    = 2020,
   month   = nov,
@@ -800,7 +788,7 @@
   journal = {Frontiers in Physiology}
 }
 
-@Article{schoeder.sticko.ea:high-order,
+@Article{2020:schoeder.sticko.ea:high-order,
   doi     = {10.1002/nme.6343},
   year    = 2020,
   month   = jul,
@@ -813,7 +801,7 @@
   journal = {International Journal for Numerical Methods in Engineering}
 }
 
-@Article{schroder.wick.ea:selection,
+@Article{2020:schroder.wick.ea:selection,
   title   = {A Selection of Benchmark Problems in Solid Mechanics and Applied Mathematics},
   author  = {Schr\"{o}der, J\"{o}rg and Wick, Thomas and Reese, Stefanie and Wriggers, Peter and M\"{u}ller, Ralf and Kollmannsberger, Stefan and K\"{a}stner, Markus and Schwarz, Alexander and Igelb\"{u}scher, Maximilian and Viebahn, Nils and Bayat, Hamid Reza and Wulfinghoff, Stephan and Mang, Katrin and Rank, Ernst and Bog, Tino and D'Angella, Davide and Elhaddad, Mohamed and Hennig, Paul and D\"{u}ster, Alexander and Garhuom, Wadhah and Hubrich, Simeon and Walloth, Mirjam and Wollner, Winnifried and Kuhn, Charlotte and Heister, Timo},
   journal = {Archives of Computational Methods in Engineering},
@@ -821,7 +809,7 @@
   doi     = {10.1007/s11831-020-09477-3}
 }
 
-@Article{schuh-senlis.thieulot.ea:towards,
+@Article{2020:schuh-senlis.thieulot.ea:towards,
   doi     = {10.5194/se-11-1909-2020},
   year    = 2020,
   month   = oct,
@@ -834,7 +822,7 @@
   journal = {Solid Earth}
 }
 
-@Article{song.maier.ea:nonlinear,
+@Article{2020:song.maier.ea:nonlinear,
   author  = {Song, Jung Heon and Matthias Maier and Mitchell Luskin},
   title   = {Nonlinear eigenvalue problems for coupled {H}elmholtz equations modeling gradient-index graphene waveguides},
   doi     = {10.1016/j.jcp.2020.109871},
@@ -845,7 +833,7 @@
   pages   = 109871
 }
 
-@Article{stella.vergara.ea:integration,
+@Article{2020:stella.vergara.ea:integration,
   doi     = {10.1016/j.compbiomed.2020.104047},
   url     = {http://www.sciencedirect.com/science/article/pii/S0010482520303784},
   year    = 2020,
@@ -858,7 +846,7 @@
   journal = {Computers in Biology and Medicine}
 }
 
-@Article{sticko.ludvigsson.ea:high-order,
+@Article{2020:sticko.ludvigsson.ea:high-order,
   title   = {High-order cut finite elements for the elastic wave equation},
   volume  = 46,
   issn    = {1572-9044},
@@ -872,7 +860,7 @@
   pages   = 45
 }
 
-@Article{wakeling.ross.ea:energy,
+@Article{2020:wakeling.ross.ea:energy,
   doi     = {10.3389/fphys.2020.00813},
   year    = 2020,
   month   = aug,
@@ -883,7 +871,7 @@
   journal = {Frontiers in Physiology}
 }
 
-@Article{wang.marshak.ea:cpu,
+@Article{2020:wang.marshak.ea:cpu,
   doi     = {10.1111/cgf.13958},
   year    = 2020,
   month   = jun,
@@ -896,7 +884,7 @@
   journal = {Computer Graphics Forum}
 }
 
-@PhDThesis{wang:two-field,
+@PhDThesis{2020:wang:two-field,
   author  = {Zhuoran Wang},
   title   = {Two-field finite element solvers for poroelasticity},
   school  = {Colorado State University},
@@ -904,7 +892,7 @@
   url     = {https://hdl.handle.net/10217/211801}
 }
 
-@Article{welper:transformed,
+@Article{2020:welper:transformed,
   doi     = {10.1137/19m126356x},
   year    = 2020,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
@@ -916,7 +904,7 @@
   journal = {{SIAM} Journal on Scientific Computing}
 }
 
-@Article{wheeler.wick.ea:ipacs--integrated-phase-field-advanced-crack-propagation-simulator--an-adaptive--parallel--physics-based-discretization-phase-field-framework-for-fracture-propagation-in-porous-media,
+@Article{2020:wheeler.wick.ea:ipacs--integrated-phase-field-advanced-crack-propagation-simulator--an-adaptive--parallel--physics-based-discretization-phase-field-framework-for-fracture-propagation-in-porous-media,
   title   = {{IPACS: Integrated Phase-Field Advanced Crack Propagation Simulator. An adaptive, parallel, physics-based-discretization phase-field framework for fracture propagation in porous media}},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   volume  = 367,
@@ -928,7 +916,7 @@
   author  = {Mary F. Wheeler and Thomas Wick and Sanghyun Lee}
 }
 
-@Article{wick.wollner:optimization,
+@Article{2020:wick.wollner:optimization,
   author  = {Wick, Thomas and Wollner, Winnifried},
   title   = {Optimization with nonstationary, nonlinear monolithic fluid-structure interaction},
   journal = {International Journal for Numerical Methods in Engineering},
@@ -939,7 +927,7 @@
   eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6372}
 }
 
-@Book{wick:multiphysics,
+@Book{2020:wick:multiphysics,
   author  = {Thomas Wick},
   title   = {Multiphysics Phase-Field Fracture: Modeling, Adaptive Discretizations, and Solvers},
   year    = 2020,
@@ -950,7 +938,7 @@
   url     = {https://www.degruyter.com/view/title/523232}
 }
 
-@Article{wilde.kramer.ea:semi-lagrangian-lattice-boltzmann-method-for-compressible-flows,
+@Article{2020:wilde.kramer.ea:semi-lagrangian-lattice-boltzmann-method-for-compressible-flows,
   author  = {Wilde, Dominik and Kr{\"{a}}mer, Andreas and Reith, Dirk and Foysi, Holger},
   doi     = {10.1103/PhysRevE.101.053306},
   issn    = 24700053,
@@ -965,7 +953,7 @@
   year    = 2020
 }
 
-@Article{witte.arndt.ea:fast,
+@Article{2020:witte.arndt.ea:fast,
   doi     = {10.1515/cmam-2020-0078},
   year    = 2020,
   month   = nov,
@@ -977,7 +965,7 @@
   journal = {Computational Methods in Applied Mathematics}
 }
 
-@Article{zhang.yue:level-set,
+@Article{2020:zhang.yue:level-set,
   title   = {A level-set method for moving contact lines with contact angle hysteresis},
   author  = {Zhang, Jiaqi and Yue, Pengtao},
   journal = {Journal of Computational Physics},
@@ -989,7 +977,7 @@
   publisher = {Elsevier}
 }
 
-@PhDThesis{zhang:finite-element,
+@PhDThesis{2020:zhang:finite-element,
   title   = {Finite-element simulations of interfacial flows with moving contact lines},
   author  = {Zhang, Jiaqi},
   year    = 2020,
@@ -998,7 +986,7 @@
   school  = {Virginia Tech}
 }
 
-@Article{zhao.choo:stabilized,
+@Article{2020:zhao.choo:stabilized,
   doi     = {10.1016/j.cma.2019.112742},
   year    = 2020,
   month   = apr,
@@ -1008,6 +996,18 @@
   author  = {Yidong Zhao and Jinhyun Choo},
   title   = {Stabilized material point methods for coupled large deformation and fluid flow in porous materials},
   journal = {Computer Methods in Applied Mechanics and Engineering}
+}
+
+@InBook{2021:hoggard.austermann.ea:mantle,
+  author  = {Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon},
+  editor  = {H. Marquardt, M. Ballmer},
+  chapter = {Observational estimates of dynamic topography through space and time},
+  title   = {Mantle convection and surface expressions},
+  series  = {AGU Geophysical Monograph Series},
+  year    = 2021,
+  address = {Washington, D.C.},
+  publisher = {AGU},
+  doi     = {10.1002/9781119528609.ch15}
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -1,6 +1,20 @@
 % Encoding: US-ASCII
 
-@Article{anselmann.bause:higher,
+@Article{2020:lees.rudge.ea:gravity,
+  author  = {Lees, Matthew E. and Rudge, John F. and McKenzie, Dan},
+  title   = {Gravity, Topography, and Melt Generation Rates From Simple 3-D Models of Mantle Convection},
+  journal = {Geochemistry, Geophysics, Geosystems},
+  volume  = 21,
+  number  = 4,
+  pages   = {e2019GC008809},
+  doi     = {10.1029/2019GC008809},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
+  note    = {e2019GC008809 10.1029/2019GC008809},
+  year    = 2020
+}
+
+@Article{2021:anselmann.bause:higher,
   doi     = {10.1016/j.matcom.2020.10.027},
   year    = 2021,
   month   = nov,
@@ -12,7 +26,7 @@
   journal = {Mathematics and Computers in Simulation}
 }
 
-@Article{araujo.engstrom:on,
+@Article{2021:araujo.engstrom:on,
   title   = {On spurious solutions encountered in Helmholtz scattering resonance computations in {$R^d$} with applications to nano-photonics and acoustics},
   author  = {Ara\'{u}jo, Juan C. and Engstr\"{o}m, Christian},
   journal = {Journal of Computational Physics},
@@ -23,7 +37,7 @@
   doi     = {10.1016/j.jcp.2020.110024}
 }
 
-@Article{araujo.wadbro:shape,
+@Article{2021:araujo.wadbro:shape,
   author  = {Ara\'{u}jo, Juan C. and Wadbro, Eddie},
   title   = {Shape optimization for the strong directional scattering of dielectric nanorods},
   journal = {International Journal for Numerical Methods in Engineering},
@@ -34,7 +48,7 @@
   eprint  = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.6677}
 }
 
-@Article{arndt.bangerth.ea:deal-ii,
+@Article{2021:arndt.bangerth.ea:deal-ii,
   title   = {The \texttt{deal.II} Library, Version 9.3},
   author  = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Uwe K{\"o}cher and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Sebastian Proell and Konrad Simon and Bruno Turcksin and David Wells and Jiaqi Zhang},
   journal = {Journal of Numerical Mathematics},
@@ -46,7 +60,7 @@
   pages   = {171--186}
 }
 
-@Article{arndt.bangerth.ea:deal-ii*1,
+@Article{2021:arndt.bangerth.ea:deal-ii*1,
   title   = {The {deal.II} finite element library: design, features, and insights},
   author  = {Daniel Arndt and Wolfgang Bangerth and Denis Davydov and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Jean-Paul Pelteret and Bruno Turcksin and David Wells},
   journal = {Computers \& Mathematics with Applications},
@@ -57,7 +71,7 @@
   issn    = {0898-1221}
 }
 
-@Article{barrionuevo.liu.ea:influence,
+@Article{2021:barrionuevo.liu.ea:influence,
   author  = {Barrionuevo, M. and Liu, S. and Mescua, J. and Yagupsky, D. and Quinteros, J. and Giambiagi, L. and Sobolev, S. V. and Piceda, C. R. and Strecker, M. R.},
   title   = {The influence of variations in crustal composition and lithospheric strength on the evolution of deformation processes in the southern Central Andes: insights from geodynamic models},
   journal = {International Journal of Earth Sciences},
@@ -65,7 +79,7 @@
   doi     = {10.1007/s00531-021-01982-5}
 }
 
-@Article{beuchler.endtmayer.ea:goal,
+@Article{2021:beuchler.endtmayer.ea:goal,
   author  = {Beuchler, Sven and Endtmayer, Bernhard and Wick, Thomas},
   title   = {Goal oriented error control for stationary incompressible flow coupled to a heat equation},
   journal = {PAMM},
@@ -78,7 +92,7 @@
   year    = 2021
 }
 
-@Article{beuchler.kinnewig.ea:residual-based,
+@Article{2021:beuchler.kinnewig.ea:residual-based,
   author  = {Beuchler, Sven and Kinnewig, Sebastian and Koenig, Philipp and Wick, Thomas},
   title   = {A residual-based error estimator and mesh adaptivity for the time harmonic Maxwell equations applied to a Y-beam splitter},
   journal = {PAMM},
@@ -91,7 +105,7 @@
   year    = 2021
 }
 
-@Article{bonito.nochetto.ea:dg,
+@Article{2021:bonito.nochetto.ea:dg,
   doi     = {10.1142/s0218202521500044},
   year    = 2021,
   publisher = {World Scientific Pub Co Pte Lt},
@@ -103,7 +117,7 @@
   journal = {Mathematical Models and Methods in Applied Sciences}
 }
 
-@Article{bredow.steinberger:mantle,
+@Article{2021:bredow.steinberger:mantle,
   author  = {Bredow, Eva and Steinberger, Bernhard},
   title   = {Mantle Convection and Possible Mantle Plumes beneath Antarctica - Insights from Geodynamic Models and Implications for Topography},
   volume  = 56,
@@ -117,7 +131,7 @@
   journal = {Geological Society, London, Memoirs}
 }
 
-@Article{camargo.white.ea:macroelement,
+@Article{2021:camargo.white.ea:macroelement,
   doi     = {10.1007/s10596-020-09964-3},
   year    = 2021,
   month   = apr,
@@ -130,7 +144,7 @@
   journal = {Computational Geosciences}
 }
 
-@Article{castelli.dorfler:parallel,
+@Article{2021:castelli.dorfler:parallel,
   author  = {Castelli, G. F. and D{\"o}rfler, W.},
   title   = {A parallel matrix-free finite element solver for phase separation in electrode particles of lithium ion batteries},
   journal = {Proceedings in Applied Mathematics \& Mechanics},
@@ -141,7 +155,7 @@
   doi     = {10.1002/pamm.202100169}
 }
 
-@InProceedings{castelli.dorfler:study,
+@InProceedings{2021:castelli.dorfler:study,
   author  = {Castelli, G. F. and D{\"o}rfler, W.},
   title   = {Study on an Adaptive Finite Element Solver for the {Cahn--Hilliard} Equation},
   editor  = {Vermolen, F. J. and Vuik, C.},
@@ -154,7 +168,7 @@
   doi     = {10.1007/978-3-030-55874-1_23}
 }
 
-@Article{castelli.kolzenberg.ea:efficient,
+@Article{2021:castelli.kolzenberg.ea:efficient,
   author  = {Castelli, G. F. and von Kolzenberg, L. and Horstmann, B. and Latz, A. and D{\"o}rfler, W.},
   title   = {Efficient Simulation of Chemical-Mechanical Coupling in Battery Active Particles},
   journal = {Energy Technology},
@@ -165,7 +179,7 @@
   doi     = {10.1002/ente.202000835}
 }
 
-@PhDThesis{castelli:numerical,
+@PhDThesis{2021:castelli:numerical,
   author  = {Castelli, G. F.},
   title   = {Numerical Investigation of {Cahn--Hilliard}-Type Phase-Field Models for Battery Active Particles},
   school  = {Karlsruhe Institute of Technology (KIT)},
@@ -173,7 +187,7 @@
   doi     = {10.5445/IR/1000141249}
 }
 
-@Article{clevenger.heister.ea:flexible,
+@Article{2021:clevenger.heister.ea:flexible,
   doi     = {10.1145/3425193},
   year    = 2021,
   month   = mar,
@@ -186,7 +200,7 @@
   journal = {{ACM} Transactions on Mathematical Software}
 }
 
-@Article{clevenger.heister:comparison,
+@Article{2021:clevenger.heister:comparison,
   title   = {Comparison Between Algebraic and Matrix-free Geometric Multigrid for a {S}tokes Problem on an Adaptive Mesh with Variable Viscosity},
   author  = {Thomas C. Clevenger and Timo Heister},
   journal = {Numerical Linear Algebra with Applications},
@@ -196,7 +210,7 @@
   publisher = {Wiley}
 }
 
-@Article{comeau.stein.ea:geodynamic,
+@Article{2021:comeau.stein.ea:geodynamic,
   doi     = {10.1029/2020jb021304},
   year    = 2021,
   month   = may,
@@ -208,7 +222,7 @@
   journal = {Journal of Geophysical Research: Solid Earth}
 }
 
-@InProceedings{d-jodlbauer:efficient,
+@InProceedings{2021:d-jodlbauer:efficient,
   author  = {D. Jodlbauer, U. Langer, T. Wick},
   title   = {Efficient monolithic solvers for fluid-structure interaction applied to flapping membranes},
   booktitle = {Domain Decomposition Methods in Science and Engineering XXVI},
@@ -218,7 +232,7 @@
   pages   = {accepted}
 }
 
-@InProceedings{d-jodlbauer:parallel,
+@InProceedings{2021:d-jodlbauer:parallel,
   author  = {D. Jodlbauer, U. Langer, T. Wick},
   title   = {Parallel domain decomposition solvers for the time harmonic Maxwell equations},
   booktitle = {Domain Decomposition Methods in Science and Engineering XXVI},
@@ -228,7 +242,7 @@
   pages   = {accepted}
 }
 
-@Article{dal-maso.heltai:numerical,
+@Article{2021:dal-maso.heltai:numerical,
   author  = {Gianni {Dal Maso} and Luca Heltai},
   journal = {Journal of Convex Analysis},
   number  = 2,
@@ -239,7 +253,7 @@
   url     = {https://www.heldermann.de/JCA/JCA28/JCA282/jca28030.htm}
 }
 
-@Article{dede.quarteroni.ea:mathematical,
+@Article{2021:dede.quarteroni.ea:mathematical,
   title   = {Mathematical and numerical models for the cardiac electromechanical function},
   author  = {Ded{\`e}, L. and Quarteroni, A. and Regazzoni, F.},
   journal = {Atti della Accademia Nazionale dei Lincei, Classe di Scienze Fisiche, Matematiche e Naturali. Rendiconti Lincei - Matematica e Applicazioni},
@@ -251,7 +265,7 @@
   issn    = {1120-6330}
 }
 
-@Article{dede.regazzoni.ea:modeling,
+@Article{2021:dede.regazzoni.ea:modeling,
   title   = {Modeling the cardiac response to hemodynamic changes associated with COVID-19: a computational study},
   author  = {Ded{\`e}, Luca and Regazzoni, Francesco and Vergara, Christian and Zunino, Paolo and Guglielmo, Marco and Scrofani, Roberto and Fusini, Laura and Cogliati, Chiara and Pontone, Gianluca and Quarteroni, Alfio},
   journal = {Mathematical Biosciences and Engineering},
@@ -261,7 +275,7 @@
   year    = 2021
 }
 
-@Article{endtmayer.langer.ea:reliability,
+@Article{2021:endtmayer.langer.ea:reliability,
   author  = {Bernhard Endtmayer and Ulrich Langer and Thomas Wick},
   doi     = {10.1515/cmam-2020-0036},
   title   = {Reliability and Efficiency of DWR-Type A Posteriori Error Estimates with Smart Sensitivity Weight Recovering},
@@ -271,7 +285,7 @@
   year    = 2021
 }
 
-@Article{faccenna.becker.ea:mountain,
+@Article{2021:faccenna.becker.ea:mountain,
   title   = {Mountain building, mantle convection, and supercontinents: Holmes (1931) revisited},
   journal = {Earth and Planetary Science Letters},
   volume  = 564,
@@ -283,7 +297,7 @@
   author  = {Claudio Faccenna and Thorsten W. Becker and Adam F. Holt and Jean Pierre Brun}
 }
 
-@Article{fan.jin.ea:quasi-monolithic,
+@Article{2021:fan.jin.ea:quasi-monolithic,
   doi     = {10.1007/s00366-021-01423-6},
   author  = {M. Fan and Y. Jin and T. Wick},
   title   = {A quasi-monolithic phase-field description for mixed-mode fracture using predictor-corrector mesh adaptivity},
@@ -292,7 +306,7 @@
   year    = 2021
 }
 
-@Article{fehn.heinz.ea:high-order,
+@Article{2021:fehn.heinz.ea:high-order,
   title   = {High-order arbitrary {L}agrangian--{E}ulerian discontinuous {G}alerkin methods for the incompressible {N}avier--{S}tokes equations},
   journal = {Journal of Computational Physics},
   volume  = 430,
@@ -304,7 +318,7 @@
   author  = {Niklas Fehn and Johannes Heinz and Wolfgang A. Wall and Martin Kronbichler}
 }
 
-@Article{fehn.kronbichler.ea:numerical,
+@Article{2021:fehn.kronbichler.ea:numerical,
   doi     = {10.1017/jfm.2021.1003},
   year    = 2021,
   month   = dec,
@@ -315,7 +329,7 @@
   journal = {Journal of Fluid Mechanics}
 }
 
-@PhDThesis{fehn:robust,
+@PhDThesis{2021:fehn:robust,
   title   = {Robust and Efficient Discontinuous {G}alerkin Methods for Incompressible Flows},
   author  = {Fehn, Niklas},
   year    = 2021,
@@ -323,7 +337,7 @@
   url     = {https://mediatum.ub.tum.de/1601025}
 }
 
-@Article{fehse.kroger.ea:crack,
+@Article{2021:fehse.kroger.ea:crack,
   author  = {Fehse, Andreas and Kr{\"o}ger, Nils Hendrik and Mang, Katrin and Wick, Thomas},
   title   = {Crack path comparisons of a mixed phase-field fracture model and experiments in punctured EPDM strips},
   journal = {PAMM},
@@ -336,7 +350,7 @@
   year    = 2021
 }
 
-@Article{fraters.billen:on,
+@Article{2021:fraters.billen:on,
   doi     = {10.1029/2021gc009846},
   year    = 2021,
   month   = oct,
@@ -348,7 +362,7 @@
   journal = {Geochemistry, Geophysics, Geosystems}
 }
 
-@Article{frei.richter.ea:locmodfe--locally-modified-finite-elements-for-approximating-interface-problems-in-deal-ii,
+@Article{2021:frei.richter.ea:locmodfe--locally-modified-finite-elements-for-approximating-interface-problems-in-deal-ii,
   title   = {{LocModFE: Locally modified finite elements for approximating interface problems in deal.II}},
   journal = {Software Impacts},
   volume  = 8,
@@ -360,7 +374,7 @@
   author  = {Stefan Frei and Thomas Richter and Thomas Wick}
 }
 
-@Article{giani.grubisic.ea:smoothed-adaptive,
+@Article{2021:giani.grubisic.ea:smoothed-adaptive,
   author  = {Stefano Giani and Luka Grubisic and Luca Heltai and Ornela Mulita},
   journal = {Computational Methods in Applied Mathematics},
   number  = 2,
@@ -371,7 +385,7 @@
   doi     = {10.1515/cmam-2020-0027}
 }
 
-@Article{golshan.blais:load-balancing,
+@Article{2021:golshan.blais:load-balancing,
   title   = {Load-Balancing Strategies in Discrete Element Method Simulations},
   author  = {Golshan, Shahab and Blais, Bruno},
   journal = {Processes},
@@ -383,7 +397,7 @@
   publisher = {MDPI}
 }
 
-@Article{gouiza.naliboff:rheological,
+@Article{2021:gouiza.naliboff:rheological,
   author  = {Gouiza, M. and Naliboff, J.},
   title   = {Rheological inheritance controls the formation of segmented rifted margins in cratonic lithosphere},
   journal = {Nature Communications},
@@ -395,7 +409,7 @@
   doi     = {10.1038/s41467-021-24945-5}
 }
 
-@Article{grayver.kuvshinov.ea:time-domain,
+@Article{2021:grayver.kuvshinov.ea:time-domain,
   author  = {Grayver, Alexander V. and Kuvshinov, Alexey and Werthm{\"u}ller, Dieter},
   title   = {Time-domain modeling of 3-D Earth's and planetary electromagnetic induction effect in ground and satellite observations},
   journal = {Journal of Geophysical Research: Space Physics},
@@ -405,7 +419,7 @@
   doi     = {10.1029/2020JA028672}
 }
 
-@Article{greiner.reiter.ea:poro-viscoelastic,
+@Article{2021:greiner.reiter.ea:poro-viscoelastic,
   author  = {Greiner, Alexander and Reiter, Nina and Paulsen, Friedrich and Holzapfel, Gerhard A. and Steinmann, Paul and Comellas, Ester and Budday, Silvia},
   doi     = {10.3389/fmech.2021.708350},
   journal = {Frontiers in Mechanical Engineering},
@@ -416,7 +430,7 @@
   year    = 2021
 }
 
-@Article{guermond.maier.ea:second-order,
+@Article{2021:guermond.maier.ea:second-order,
   author  = {Jean-Luc Guermond and Matthias Maier and Bojan Popov and Ignacio Tomas},
   title   = {Second-order invariant domain preserving approximation of the compressible Navier--Stokes equations},
   doi     = {10.1016/j.cma.2020.113608},
@@ -427,7 +441,7 @@
   pages   = 113608
 }
 
-@Article{he:gwsim,
+@Article{2021:he:gwsim,
   doi     = {10.1093/mnras/stab2080},
   year    = 2021,
   month   = jul,
@@ -440,7 +454,7 @@
   journal = {Monthly Notices of the Royal Astronomical Society}
 }
 
-@Article{heckenbach.brune.ea:is,
+@Article{2021:heckenbach.brune.ea:is,
   author  = {Heckenbach, Esther L. and Brune, Sascha and Glerum, Anne C. and Bott, Judith},
   title   = {Is there a Speed Limit for the Thermal Steady-State Assumption in Continental Rifts?},
   journal = {Geochemistry, Geophysics, Geosystems},
@@ -452,7 +466,7 @@
   year    = 2021
 }
 
-@Article{heister.mang.ea:schur-type,
+@Article{2021:heister.mang.ea:schur-type,
   author  = {Timo Heister and Katrin Mang and Thomas Wick},
   title   = {Schur-type preconditioning of a phase-field fracture model in mixed form},
   journal = {{PAMM}},
@@ -464,7 +478,7 @@
   publisher = {Wiley}
 }
 
-@Article{heltai.bangerth.ea:propagating,
+@Article{2021:heltai.bangerth.ea:propagating,
   author  = {Luca Heltai and Wolfgang Bangerth and Martin Kronbichler and Andrea Mola},
   journal = {Transactions on Mathematical Software},
   number  = 4,
@@ -475,7 +489,7 @@
   doi     = {10.1145/3468428}
 }
 
-@Article{heltai.caiazzo.ea:multiscale,
+@Article{2021:heltai.caiazzo.ea:multiscale,
   author  = {Luca Heltai and Alfonso Caiazzo and Lucas O. M\"{u}ller},
   journal = {Annals of Biomedical Engineering},
   title   = {Multiscale Coupling of One-dimensional Vascular Models and Elastic Tissues},
@@ -485,7 +499,7 @@
   doi     = {10.1007/s10439-021-02804-0}
 }
 
-@Article{herrnbock.kumar.ea:geometrically,
+@Article{2021:herrnbock.kumar.ea:geometrically,
   doi     = {10.1007/s00466-020-01957-4},
   year    = 2021,
   month   = feb,
@@ -498,7 +512,7 @@
   journal = {Computational Mechanics}
 }
 
-@Article{jammoul.wheeler.ea:phase-field,
+@Article{2021:jammoul.wheeler.ea:phase-field,
   title   = {A phase-field multirate scheme with stabilized iterative coupling for pressure driven fracture propagation in porous media},
   journal = {Computers {\&} Mathematics with Applications},
   volume  = 91,
@@ -511,7 +525,7 @@
   author  = {Mohamad Jammoul and Mary F. Wheeler and Thomas Wick}
 }
 
-@Article{kinnewig.roth.ea:geometric,
+@Article{2021:kinnewig.roth.ea:geometric,
   title   = {Geometric multigrid with multiplicative Schwarz smoothers for eddy-current and Maxwell's equations in deal.II},
   journal = {Examples and Counterexamples},
   volume  = 1,
@@ -523,7 +537,7 @@
   author  = {Sebastian Kinnewig and Julian Roth and Thomas Wick}
 }
 
-@InCollection{klein.schuster.ea:sequential,
+@InCollection{2021:klein.schuster.ea:sequential,
   doi     = {10.1007/978-3-030-57784-1_6},
   year    = 2021,
   publisher = {Springer International Publishing},
@@ -533,7 +547,7 @@
   booktitle = {Time-dependent Problems in Imaging and Parameter Identification}
 }
 
-@Article{kourakos.harter:simulation,
+@Article{2021:kourakos.harter:simulation,
   author  = {Kourakos, Georgios and Harter, Thomas},
   title   = {Simulation of Unconfined Aquifer Flow Based on Parallel Adaptive Mesh Refinement},
   journal = {Water Resources Research},
@@ -545,7 +559,7 @@
   url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020WR029354}
 }
 
-@InProceedings{kronbichler.fehn.ea:next-generation,
+@InProceedings{2021:kronbichler.fehn.ea:next-generation,
   author  = {Kronbichler, Martin and Fehn, Niklas and Munch, Peter and Bergbauer, Maximilian and Wichmann, Karl-Robert and Geitner, Carolin and Allalen, Momme and Schulz, Martin and Wall, Wolfgang A.},
   title   = {A Next-Generation Discontinuous {G}alerkin Fluid Dynamics Solver with Application to High-Resolution Lung Airflow Simulations},
   year    = 2021,
@@ -560,7 +574,7 @@
   series  = {SC '21}
 }
 
-@Article{lee.saxena.ea:contributions-from-lithospheric-and-upper-mantle-heterogeneities-to-upper-crustal-seismicity-in-the-korean-peninsula,
+@Article{2021:lee.saxena.ea:contributions-from-lithospheric-and-upper-mantle-heterogeneities-to-upper-crustal-seismicity-in-the-korean-peninsula,
   author  = {Lee, Sungho and Saxena, Arushi and Song, Jung-Hun and Rhie, Junkee and Choi, Eunseo},
   title   = {{Contributions from lithospheric and upper-mantle heterogeneities to upper crustal seismicity in the {K}orean {P}eninsula}},
   journal = {Geophysical Journal International},
@@ -572,21 +586,7 @@
   eprint  = {https://academic.oup.com/gji/advance-article-pdf/doi/10.1093/gji/ggab527/41971016/ggab527.pdf}
 }
 
-@Article{lees.rudge.ea:gravity,
-  author  = {Lees, Matthew E. and Rudge, John F. and McKenzie, Dan},
-  title   = {Gravity, Topography, and Melt Generation Rates From Simple 3-D Models of Mantle Convection},
-  journal = {Geochemistry, Geophysics, Geosystems},
-  volume  = 21,
-  number  = 4,
-  pages   = {e2019GC008809},
-  doi     = {10.1029/2019GC008809},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
-  note    = {e2019GC008809 10.1029/2019GC008809},
-  year    = 2020
-}
-
-@Article{li.lipton.ea:lorentz,
+@Article{2021:li.lipton.ea:lorentz,
   author  = {Wei Li and Robert Lipton and Matthias Maier},
   title   = {{L}orentz resonance in the homogenization of plasmonic crystals},
   doi     = {10.1098/rspa.2021.0609},
@@ -596,7 +596,7 @@
   pages   = 20210609
 }
 
-@Article{liu.moller.ea:balancing,
+@Article{2021:liu.moller.ea:balancing,
   doi     = {10.1016/j.cam.2020.113219},
   year    = 2021,
   month   = apr,
@@ -608,7 +608,7 @@
   journal = {Journal of Computational and Applied Mathematics}
 }
 
-@Article{lundin.dore.ea:utilization,
+@Article{2021:lundin.dore.ea:utilization,
   author  = {Lundin, E. R. and Dor{\'e}, A. G. and Naliboff, J. and Van Wijk, J.},
   title   = {Utilization of continental transforms in break-up: observations, models, and a potential link to magmatism},
   volume  = 524,
@@ -622,7 +622,7 @@
   journal = {Geological Society, London, Special Publications}
 }
 
-@Article{magni.naliboff.ea:ridge,
+@Article{2021:magni.naliboff.ea:ridge,
   doi     = {10.3390/geosciences11110475},
   year    = 2021,
   month   = nov,
@@ -635,7 +635,7 @@
   journal = {Geosciences}
 }
 
-@Article{maier.kronbichler:efficient,
+@Article{2021:maier.kronbichler:efficient,
   author  = {Matthias Maier and Martin Kronbichler},
   title   = {Efficient parallel 3D computation of the compressible Euler equations with an invariant-domain preserving second-order finite-element scheme},
   doi     = {10.1145/3470637},
@@ -646,7 +646,7 @@
   pages   = {16:1--30}
 }
 
-@Article{mang.fehse.ea:mixed,
+@Article{2021:mang.fehse.ea:mixed,
   doi     = {10.1016/j.tafmec.2021.103076},
   year    = 2021,
   month   = aug,
@@ -657,7 +657,7 @@
   journal = {Theoretical and Applied Fracture Mechanics}
 }
 
-@InProceedings{mang.wick:numerical-studies-of-different-mixed-phase-field-fracture-models-for-simulating-crack-propagation-in-punctured-epdm-strips,
+@InProceedings{2021:mang.wick:numerical-studies-of-different-mixed-phase-field-fracture-models-for-simulating-crack-propagation-in-punctured-epdm-strips,
   author  = {K. Mang and T. Wick},
   title   = {{Numerical Studies of Different Mixed Phase-Field Fracture Models for Simulating Crack Propagation in Punctured EPDM Strips}},
   booktitle = {WCCM-ECCOMAS2020 conference proceedings},
@@ -665,7 +665,7 @@
   url     = {https://www.scipedia.com/public/Mang_Wick_2021a}
 }
 
-@Article{meier.fuchs.ea:physics-based,
+@Article{2021:meier.fuchs.ea:physics-based,
   author  = {Meier, Christoph and Fuchs, Sebastian L. and Much, Nils and Nitzler, Jonas and Penny, Ryan W. and Praegla, Patrick M. and Proell, Sebastian D. and Sun, Yushen and Weissbach, Reimar and Schreter, Magdalena and Hodge, Neil E. and John Hart, A. and Wall, Wolfgang A.},
   title   = {Physics-based modeling and predictive simulation of powder bed fusion additive manufacturing across length scales},
   journal = {GAMM-Mitteilungen},
@@ -674,7 +674,7 @@
   doi     = {10.1002/gamm.202100014}
 }
 
-@Article{mulita.giani.ea:quasi-optimal,
+@Article{2021:mulita.giani.ea:quasi-optimal,
   author  = {Ornela Mulita and Stefano Giani and Luca Heltai},
   journal = {{SIAM} Journal on Scientific Computing},
   number  = 3,
@@ -685,7 +685,7 @@
   doi     = {10.1137/19m1262097}
 }
 
-@Article{munch.kormann.ea:hyper,
+@Article{2021:munch.kormann.ea:hyper,
   title   = {hyper.deal: An Efficient, Matrix-Free Finite-Element Library for High-Dimensional Partial Differential Equations},
   author  = {Munch, Peter and Kormann, Katharina and Kronbichler, Martin},
   year    = 2021,
@@ -702,7 +702,7 @@
   numpages = 34
 }
 
-@Article{neuharth.brune.ea:formation,
+@Article{2021:neuharth.brune.ea:formation,
   doi     = {10.1029/2020gc009615},
   year    = 2021,
   month   = apr,
@@ -714,7 +714,7 @@
   journal = {Geochemistry, Geophysics, Geosystems}
 }
 
-@Article{noii.fan.ea:quasi-monolithic,
+@Article{2021:noii.fan.ea:quasi-monolithic,
   title   = {A quasi-monolithic phase-field description for orthotropic anisotropic fracture with adaptive mesh refinement and primal-dual active set method},
   journal = {Engineering Fracture Mechanics},
   volume  = 258,
@@ -726,7 +726,7 @@
   author  = {Nima Noii and Meng Fan and Thomas Wick and Yan Jin}
 }
 
-@Article{pacheco.schussnig.ea:efficient,
+@Article{2021:pacheco.schussnig.ea:efficient,
   author  = {Douglas R.Q. Pacheco and Richard Schussnig and Thomas-Peter Fries},
   doi     = {10.1016/j.cma.2021.113888},
   issn    = 00457825,
@@ -739,7 +739,7 @@
   year    = 2021
 }
 
-@Article{pacheco.schussnig.ea:global,
+@Article{2021:pacheco.schussnig.ea:global,
   author  = {Douglas R. Q. Pacheco and Richard Schussnig and Olaf Steinbach and Thomas-Peter Fries},
   doi     = {10.1002/nme.6615},
   issn    = {0029-5981},
@@ -752,7 +752,7 @@
   year    = 2021
 }
 
-@Article{pagani.dede.ea:computational,
+@Article{2021:pagani.dede.ea:computational,
   doi     = {10.3389/fphys.2021.673612},
   author  = {Pagani, S. and Ded{\`{e}}, L. and Frontera, A. and Salvador, M. and Limite, L. R. and Manzoni, A. and Lipartiti, F. and Tsitsinakis, G. and Hadjis, A. and Della Bella, P. and Quarteroni, A.},
   title   = {A Computational Study of the Electrophysiological Substrate in Patients Suffering From Atrial Fibrillation},
@@ -762,7 +762,7 @@
   publisher = {Frontiers Media SA}
 }
 
-@Article{piersanti.africa.ea:modeling,
+@Article{2021:piersanti.africa.ea:modeling,
   doi     = {10.1016/j.cma.2020.113468},
   url     = {http://www.sciencedirect.com/science/article/pii/S0045782520306538},
   year    = 2021,
@@ -775,7 +775,7 @@
   journal = {Computer Methods in Applied Mechanics and Engineering}
 }
 
-@Article{regazzoni.quarteroni:accelerating,
+@Article{2021:regazzoni.quarteroni:accelerating,
   author  = {Regazzoni, F. and Quarteroni, A.},
   title   = {Accelerating the convergence to a limit cycle in 3D cardiac electromechanical simulations through a data-driven 0D emulator},
   journal = {Computers in Biology and Medicine},
@@ -785,7 +785,7 @@
   issn    = {0010-4825}
 }
 
-@MastersThesis{rigsby:analysis,
+@MastersThesis{2021:rigsby:analysis,
   author  = {Christina Rigsby},
   title   = {An analysis of domain decomposition methods using {deal.II}},
   school  = {Colorado State University},
@@ -793,7 +793,7 @@
   url     = {https://mountainscholar.org/handle/10217/234190}
 }
 
-@MastersThesis{rocha:bifurcating,
+@MastersThesis{2021:rocha:bifurcating,
   author  = {Lucas Almeida Rocha},
   title   = {Bifurcating solutions of anisotropic disk problem in a constrained minimization theory of elasticity},
   school  = {University of S{\~{a}}o Paulo},
@@ -802,7 +802,7 @@
   url     = {http://web.set.eesc.usp.br/static/media/producao/2021ME_LucasAlmeidaRocha.pdf}
 }
 
-@Article{ross.domnguez.ea:energy,
+@Article{2021:ross.domnguez.ea:energy,
   doi     = {10.3389/fphys.2021.628819},
   year    = 2021,
   month   = apr,
@@ -813,7 +813,7 @@
   journal = {Frontiers in Physiology}
 }
 
-@MastersThesis{roth:proper,
+@MastersThesis{2021:roth:proper,
   author  = {Roth, Julian},
   title   = {Proper Orthogonal Decomposition for Fluid Mechanics Problems},
   school  = {Leibniz Universit{\"a}t Hannover},
@@ -822,7 +822,7 @@
   url     = {https://julianroth.org/res/Master_Thesis_Julian_Roth.pdf}
 }
 
-@Article{sabanskis.plate.ea:evaluation,
+@Article{2021:sabanskis.plate.ea:evaluation,
   author  = {Sabanskis, Andrejs and Pl{\={a}}te, Mat{\={\i}}ss and Sattler, Andreas and Miller, Alfred and Virbulis, J{\={a}}nis},
   journal = {Crystals},
   title   = {Evaluation of the performance of published point defect parameter sets in cone and body phase of a 300 mm {Czochralski} silicon crystal},
@@ -835,7 +835,7 @@
   publisher = {{MDPI} {AG}}
 }
 
-@Article{salvador.fedele.ea:electromechanical,
+@Article{2021:salvador.fedele.ea:electromechanical,
   author  = {Salvador, Matteo and Fedele, Marco and Africa, Pasquale Claudio and Sung, Eric and Ded{\`{e}}, Luca and Prakosa, Adityo and Trayanova, Natalia and Chrispin, Jonathan and Quarteroni, Alfio},
   title   = {Electromechanical modeling of human ventricles with ischemic cardiomyopathy: numerical simulations in sinus rhythm and under arrhythmia},
   journal = {Computers in Biology and Medicine},
@@ -845,7 +845,7 @@
   doi     = {10.1016/j.compbiomed.2021.104674}
 }
 
-@Article{samrock.grayver.ea:integrated,
+@Article{2021:samrock.grayver.ea:integrated,
   title   = {Integrated magnetotelluric and petrological analysis of felsic magma reservoirs: Insights from Ethiopian rift volcanoes},
   author  = {Samrock, Friedemann and Grayver, Alexander V and Bachmann, Olivier and Karakas, {\"O}zge and Saar, Martin O},
   journal = {Earth and Planetary Science Letters},
@@ -855,7 +855,7 @@
   publisher = {Elsevier}
 }
 
-@Article{saxena.choi.ea:seismicity-in-the-central-and-southeastern-united-states-due-to-upper-mantle-heterogeneities,
+@Article{2021:saxena.choi.ea:seismicity-in-the-central-and-southeastern-united-states-due-to-upper-mantle-heterogeneities,
   author  = {Saxena, Arushi and Choi, Eunseo and Powell, Christine A and Aslam, Khurram S},
   title   = {{Seismicity in the central and southeastern United States due to upper mantle heterogeneities}},
   journal = {Geophysical Journal International},
@@ -867,7 +867,7 @@
   doi     = {10.1093/gji/ggab051}
 }
 
-@Article{schussnig.pacheco.ea:robust,
+@Article{2021:schussnig.pacheco.ea:robust,
   title   = {Robust stabilised finite element solvers for generalised {N}ewtonian fluid flows},
   journal = {Journal of Computational Physics},
   volume  = 442,
@@ -879,7 +879,7 @@
   author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
 }
 
-@Article{stark:on,
+@Article{2021:stark:on,
   author  = {Sebastian Stark},
   title   = {On a certain class of one step temporal integration methods for standard dissipative continua},
   journal = {Computational Mechanics},
@@ -889,7 +889,7 @@
   doi     = {10.1007/s00466-020-01931-0}
 }
 
-@Article{thiele.wick:space-time,
+@Article{2021:thiele.wick:space-time,
   author  = {Thiele, Jan Philipp and Wick, Thomas},
   title   = {Space-time PU-DWR error control and adaptivity for the heat equation},
   journal = {PAMM},
@@ -902,7 +902,7 @@
   year    = 2021
 }
 
-@Article{uluocak.gogus.ea:geodynamics,
+@Article{2021:uluocak.gogus.ea:geodynamics,
   doi     = {10.1029/2021tc007031},
   year    = 2021,
   month   = dec,
@@ -914,7 +914,7 @@
   journal = {Tectonics}
 }
 
-@Article{veszelka.queisser.ea:impact,
+@Article{2021:veszelka.queisser.ea:impact,
   author  = {Veszelka, Z. and Queisser, O. and Gontscharow, M. and Wetzel, T. and D{\"o}rfler, W.},
   title   = {Impact of Numerical Methods in Thermal Modeling of {Li}-Ion Batteries on Temperature Distribution and Computation Time},
   journal = {Energy Technology},
@@ -925,7 +925,7 @@
   doi     = {10.1002/ente.202000906}
 }
 
-@InProceedings{wick:adjoint-based,
+@InProceedings{2021:wick:adjoint-based,
   author  = {T. Wick},
   title   = {Adjoint-based methods for optimization and goal-oriented error control applied to fluid-structure interaction: implementation of a partition-of-unity dual-weighted residual estimator for stationary forward FSI problems in deal.II},
   booktitle = {Book of VI ECCOMAS Young Investigators Conference YIC2021},
@@ -935,7 +935,7 @@
   pages   = {257--266}
 }
 
-@Article{wick:dual-weighted,
+@Article{2021:wick:dual-weighted,
   doi     = {10.1515/cmam-2020-0038},
   year    = 2021,
   month   = jun,
@@ -948,7 +948,7 @@
   journal = {Computational Methods in Applied Mathematics}
 }
 
-@InProceedings{wick:on-the-adjoint-equation-in-fluid-structure-interaction,
+@InProceedings{2021:wick:on-the-adjoint-equation-in-fluid-structure-interaction,
   author  = {T. Wick},
   title   = {{On the Adjoint Equation in Fluid-Structure Interaction}},
   booktitle = {WCCM-ECCOMAS2020 conference proceedings},
@@ -956,7 +956,7 @@
   url     = {https://www.scipedia.com/public/Wick_2021}
 }
 
-@Article{wilde.kramer.ea:high-order,
+@Article{2021:wilde.kramer.ea:high-order,
   doi     = {10.1103/physreve.104.025301},
   year    = 2021,
   month   = aug,
@@ -968,7 +968,7 @@
   journal = {Physical Review E}
 }
 
-@MastersThesis{withers:modelling,
+@MastersThesis{2021:withers:modelling,
   author  = {Withers, Craig},
   title   = {Modelling slab age and crustal thickness: numerical approaches to drivers of compressive stresses in the overriding plate in Andean style subduction zone systems},
   year    = 2021,

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -1,19 +1,5 @@
 % Encoding: US-ASCII
 
-@Article{2020:lees.rudge.ea:gravity,
-  author  = {Lees, Matthew E. and Rudge, John F. and McKenzie, Dan},
-  title   = {Gravity, Topography, and Melt Generation Rates From Simple 3-D Models of Mantle Convection},
-  journal = {Geochemistry, Geophysics, Geosystems},
-  volume  = 21,
-  number  = 4,
-  pages   = {e2019GC008809},
-  doi     = {10.1029/2019GC008809},
-  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GC008809},
-  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2019GC008809},
-  note    = {e2019GC008809 10.1029/2019GC008809},
-  year    = 2020
-}
-
 @Article{2021:anselmann.bause:higher,
   doi     = {10.1016/j.matcom.2020.10.027},
   year    = 2021,
@@ -510,6 +496,18 @@
   author  = {Ludwig Herrnb\"{o}ck and Ajeet Kumar and Paul Steinmann},
   title   = {Geometrically exact elastoplastic rods: determination of yield surface in terms of stress resultants},
   journal = {Computational Mechanics}
+}
+
+@InBook{2021:hoggard.austermann.ea:mantle,
+  author  = {Hoggard, Mark and Austermann, Jacqueline and Randel, Cody and Stephenson, Simon},
+  editor  = {H. Marquardt, M. Ballmer},
+  chapter = {Observational estimates of dynamic topography through space and time},
+  title   = {Mantle convection and surface expressions},
+  series  = {AGU Geophysical Monograph Series},
+  year    = 2021,
+  address = {Washington, D.C.},
+  publisher = {AGU},
+  doi     = {10.1002/9781119528609.ch15}
 }
 
 @Article{2021:jammoul.wheeler.ea:phase-field,

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -1,6 +1,6 @@
 % Encoding: US-ASCII
 
-@Misc{africa:lifex,
+@Misc{2022:africa:lifex,
   doi     = {10.48550/ARXIV.2207.14668},
   author  = {Africa, Pasquale Claudio},
   title   = {lifex: a flexible, high performance library for the numerical solution of complex finite element problems},
@@ -8,7 +8,7 @@
   year    = 2022
 }
 
-@Article{aggul.labovsky.ea:ns-,
+@Article{2022:aggul.labovsky.ea:ns-,
   title   = {{NS}-$\omega$ model for fluid--fluid interaction problems at high {Reynolds} numbers},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   volume  = 395,
@@ -22,7 +22,7 @@
   author  = {Mustafa Aggul and Alexander E. Labovsky and Kyle J. Schwiebert}
 }
 
-@Article{ahuja.endtmayer.ea:multigoal-oriented,
+@Article{2022:ahuja.endtmayer.ea:multigoal-oriented,
   author  = {K. Ahuja and B. Endtmayer and M.C. Steinbach and T. Wick},
   title   = {Multigoal-oriented error estimation and mesh adaptivity for fluid-structure interaction},
   journal = {Journal of Computational and Applied Mathematics},
@@ -34,7 +34,7 @@
   url     = {https://www.sciencedirect.com/science/article/pii/S0377042722001340}
 }
 
-@Article{arndt.bangerth.ea:deal-ii,
+@Article{2022:arndt.bangerth.ea:deal-ii,
   title   = {The \texttt{deal.II} Library, Version 9.4},
   author  = {Daniel Arndt and Wolfgang Bangerth and Marco Feder and Marc Fehling and Rene Gassm{\"o}ller and Timo Heister and Luca Heltai and Martin Kronbichler and Matthias Maier and Peter Munch and Jean-Paul Pelteret and Simon Sticko and Bruno Turcksin and David Wells},
   journal = {Journal of Numerical Mathematics},
@@ -46,7 +46,7 @@
   url     = {https://dealii.org/deal94-preprint.pdf}
 }
 
-@Article{axelsson.dravins.ea:stage-parallel,
+@Article{2022:axelsson.dravins.ea:stage-parallel,
   title   = {Stage-parallel preconditioners for implicit Runge-Kutta methods of arbitrary high order. Linear problems},
   author  = {Owe Axelsson and Ivo Dravins and Maya Neytcheva},
   journal = {submitted},
@@ -54,7 +54,7 @@
   url     = {http://www.it.uu.se/research/publications/reports/2022-004/2022-004-nc.pdf}
 }
 
-@Article{barbeau.etienne.ea:development,
+@Article{2022:barbeau.etienne.ea:development,
   title   = {Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems},
   author  = {Barbeau, Lucka and {\'E}tienne, St{\'e}phane and B{\'e}guin, C{\'e}dric and Blais, Bruno},
   journal = {Computers \& Fluids},
@@ -65,7 +65,7 @@
   publisher = {Elsevier}
 }
 
-@InCollection{basava.mang.ea:adaptive,
+@InCollection{2022:basava.mang.ea:adaptive,
   doi     = {10.1007/978-3-030-92672-4_8},
   year    = 2022,
   publisher = {Springer International Publishing},
@@ -75,7 +75,7 @@
   booktitle = {Non-standard Discretisation Methods in Solid Mechanics}
 }
 
-@Article{behr.holt.ea:effects,
+@Article{2022:behr.holt.ea:effects,
   doi     = {10.1093/gji/ggac075},
   url     = {https://doi.org/10.1093/gji/ggac075},
   year    = 2022,
@@ -86,7 +86,7 @@
   journal = {Geophysical Journal International}
 }
 
-@Article{comellas.farkas.ea:local,
+@Article{2022:comellas.farkas.ea:local,
   author  = {Comellas, Ester and Farkas, Johanna E. and Kleinberg, Giona and Lloyd, Katlyn and Mueller, Thomas and Duerr, Timothy J. and Mu{\~{n}}oz, Jose J. and Monaghan, James R. and Shefelbine, Sandra J.},
   doi     = {10.1098/RSPB.2022.0621},
   journal = {Proceedings of the Royal Society B},
@@ -98,7 +98,7 @@
   year    = 2022
 }
 
-@Article{davies.kramer.ea:towards,
+@Article{2022:davies.kramer.ea:towards,
   author  = {Davies, D. R. and Kramer, S. C. and Ghelichkhan, S. and Gibson, A.},
   title   = {Towards automatic finite-element methods for geodynamics via {F}iredrake},
   journal = {Geoscientific Model Development},
@@ -110,7 +110,7 @@
   doi     = {10.5194/gmd-15-5127-2022}
 }
 
-@Article{diehl.lipton.ea:comparative,
+@Article{2022:diehl.lipton.ea:comparative,
   author  = {Diehl, Patrick and Lipton, Robert and Wick, Thomas and Tyagi, Mayank},
   title   = {A comparative review of peridynamics and phase-field models for engineering fracture mechanics},
   journal = {Computational Mechanics},
@@ -122,7 +122,7 @@
   doi     = {10.1007/s00466-022-02147-0}
 }
 
-@Article{fang.zhang.ea:causal,
+@Article{2022:fang.zhang.ea:causal,
   title   = {The causal mechanism of the {S}angihe Forearc Thrust, {M}olucca {S}ea, northeast {I}ndonesia, from numerical simulation},
   journal = {Journal of Asian Earth Sciences},
   volume  = 237,
@@ -134,7 +134,7 @@
   author  = {Gui Fang and Jian Zhang and Tianyao Hao and Miao Dong and Chenghao Jiang and Yubei He}
 }
 
-@Misc{fehling.bangerth:algorithms,
+@Misc{2022:fehling.bangerth:algorithms,
   doi     = {10.48550/ARXIV.2206.06512},
   url     = {https://arxiv.org/abs/2206.06512},
   author  = {Fehling, Marc and Bangerth, Wolfgang},
@@ -144,7 +144,7 @@
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
-@Misc{fuest.heydari.ea:global,
+@Misc{2022:fuest.heydari.ea:global,
   author  = {Fuest, Mario and Heydari, Shahin and Knobloch, Petr and Lankeit, Johannes and Wick, Thomas},
   title   = {Global existence of classical solutions and numerical simulations of a cancer invasion model},
   doi     = {10.48550/ARXIV.2205.08168},
@@ -154,7 +154,7 @@
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
-@Article{fumagalli.vitullo.ea:image-based,
+@Article{2022:fumagalli.vitullo.ea:image-based,
   doi     = {10.3389/fphys.2021.787082},
   title   = {Image-based computational hemodynamics analysis of systolic obstruction in hypertrophic cardiomyopathy},
   author  = {Fumagalli, Ivan and Vitullo, Piermario and Vergara, Christian and Fedele, Marco and Corno, Antonio F and Ippolito, Sonia and Scrofani, Roberto and Quarteroni, Alfio},
@@ -165,7 +165,7 @@
   publisher = {Frontiers}
 }
 
-@Article{golshan.munch.ea:lethe-dem,
+@Article{2022:golshan.munch.ea:lethe-dem,
   title   = {Lethe-DEM: An open-source parallel discrete element solver with load balancing},
   author  = {Golshan, Shahab and Munch, Peter and Gassm{\"o}ller, Rene and Kronbichler, Martin and Blais, Bruno},
   journal = {Computational Particle Mechanics},
@@ -175,7 +175,7 @@
   publisher = {Springer}
 }
 
-@Article{guermond.kronbichler.ea:on,
+@Article{2022:guermond.kronbichler.ea:on,
   author  = {Jean-Luc~Guermond and Martin Kronbichler and Matthias Maier and Bojan Popov and Ignacio Tomas},
   title   = {On the implementation of a robust and efficient finite element-based parallel solver for the compressible Navier-stokes equations},
   doi     = {10.1016/j.cma.2021.114250},
@@ -185,7 +185,7 @@
   pages   = 114250
 }
 
-@Article{heyn.conrad:on,
+@Article{2022:heyn.conrad:on,
   author  = {Heyn, Bj{\"o}rn H. and Conrad, Clinton P.},
   title   = {On the relation between basal erosion of the lithosphere and surface heat flux for continental plume tracks},
   journal = {Geophysical Research Letters},
@@ -199,7 +199,7 @@
   note    = {e2022GL098003 2022GL098003}
 }
 
-@InProceedings{j-p-thiele:space-time,
+@InProceedings{2022:j-p-thiele:space-time,
   author  = {J. P. Thiele, T. Wick},
   title   = {Space-time error control using a partition-of-unity dual-weighted residual method applied to low mach number combustion},
   booktitle = {Proceedings of ICOSAHOM, 2020+1},
@@ -207,7 +207,7 @@
   pages   = {accepted}
 }
 
-@PhDThesis{janbakhsh:numerical,
+@PhDThesis{2022:janbakhsh:numerical,
   author  = {Janbakhsh, Payman},
   title   = {Numerical Modeling Of Tectonic Plates \& Application of Artificial Neural Networks in Earthquake Seismology},
   school  = {University of Toronto},
@@ -215,7 +215,7 @@
   year    = 2022
 }
 
-@Article{jingchun.chengli.ea:on,
+@Article{2022:jingchun.chengli.ea:on,
   title   = {On the formation of thrust fault-related landforms in {M}ercury's {N}orthern {S}mooth {P}lains: {A} new mechanical model of the lithosphere},
   journal = {Icarus},
   pages   = 115197,
@@ -226,7 +226,7 @@
   author  = {Xie Jingchun and Huang Chengli and Zhang Mian}
 }
 
-@Misc{jodlbauer.langer.ea:matrix-free,
+@Misc{2022:jodlbauer.langer.ea:matrix-free,
   author  = {Jodlbauer, Daniel and Langer, Ulrich and Wick, Thomas and Zulehner, Walter},
   title   = {Matrix-free Monolithic Multigrid Methods for Stokes and Generalized Stokes Problems},
   doi     = {10.48550/ARXIV.2205.15770},
@@ -236,7 +236,7 @@
   copyright = {Creative Commons Attribution 4.0 International}
 }
 
-@Misc{khimin.steinbach.ea:computational,
+@Misc{2022:khimin.steinbach.ea:computational,
   author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
   title   = {Computational performance studies for space-time phase-field fracture optimal control problems},
   doi     = {10.48550/ARXIV.2203.14643},
@@ -246,7 +246,7 @@
   copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
 }
 
-@InBook{khimin.steinbach.ea:optimal,
+@InBook{2022:khimin.steinbach.ea:optimal,
   author  = {Khimin, Denis and Steinbach, Marc C. and Wick, Thomas},
   editor  = {Aldakheel, Fadi and Hudobivnik, Bla{\v{z}} and Soleimani, Meisam and Wessels, Henning and Wei{\ss}enfels, Christian and Marino, Michele},
   title   = {Optimal Control for Phase-Field Fracture: Algorithmic Concepts and Computations},
@@ -259,7 +259,7 @@
   doi     = {10.1007/978-3-030-87312-7_24}
 }
 
-@Article{liu.king:dynamics,
+@Article{2022:liu.king:dynamics,
   author  = {Liu, Shangxin and King, Scott D.},
   title   = {Dynamics of the {N}orth {A}merican Plate: {L}arge-Scale Driving Mechanism From Far-Field Slabs and the Interpretation of Shallow Negative Seismic Anomalies},
   journal = {Geochemistry, Geophysics, Geosystems},
@@ -273,7 +273,7 @@
   year    = 2022
 }
 
-@Article{liu.mcbride.ea:vibration,
+@Article{2022:liu.mcbride.ea:vibration,
   author  = {Zhaowei Liu and Andrew McBride and Prashant Saxena and Luca Heltai and Yilin Qu and Paul Steinmann},
   journal = {International Journal for Numerical Methods in Engineering},
   title   = {Vibration Analysis of Piezoelectric {Kirchhoff-Love} shells based on {Catmull-Clark} Subdivision Surfaces},
@@ -281,7 +281,7 @@
   doi     = {10.1002/nme.7010}
 }
 
-@MastersThesis{lorencio-abril:modelo,
+@MastersThesis{2022:lorencio-abril:modelo,
   author  = {Lorencio Abril, Jose Antonio},
   title   = {Un modelo en elementos finitos para estudiar las deformaciones del tejido mamario},
   school  = {Universidad de Murcia},
@@ -291,7 +291,7 @@
   note    = {Bachelor's Thesis}
 }
 
-@PhDThesis{mang:phase-field,
+@PhDThesis{2022:mang:phase-field,
   title   = {Phase-field fracture modeling, numerical solution, and simulations for compressible and incompressible solids},
   author  = {Mang, Katrin},
   year    = 2022,
@@ -300,14 +300,14 @@
   school  = {Hannover: Institutionelles Repositorium der Leibniz Universit{\"a}t Hannover}
 }
 
-@Article{munch.dravins.ea:stage-parallel,
+@Article{2022:munch.dravins.ea:stage-parallel,
   author  = {Peter Munch and Ivo Dravins and Martin Kronbichler and Maya Neytcheva},
   title   = {Stage-parallel fully implicit Runge-Kutta implementations with optimal multilevel preconditioners at the scaling limit},
   journal = {submitted},
   year    = 2022
 }
 
-@Article{munch.heister.ea:efficient,
+@Article{2022:munch.heister.ea:efficient,
   doi     = {10.48550/ARXIV.2203.12292},
   url     = {https://arxiv.org/abs/2203.12292},
   author  = {Peter Munch and Timo Heister and Laura Prieto Saavedra and Martin Kronbichler},
@@ -317,7 +317,7 @@
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
-@InProceedings{munch.ljungkvist.ea:efficient,
+@InProceedings{2022:munch.ljungkvist.ea:efficient,
   author  = {Peter Munch and Karl Ljungkvist and Martin Kronbichler},
   title   = {Efficient Application of~Hanging-Node Constraints for~Matrix-Free High-Order {FEM} Computations on~{CPU} and~{GPU}},
   booktitle = {Lecture Notes in Computer Science},
@@ -327,7 +327,7 @@
   doi     = {10.1007/978-3-031-07312-0_7}
 }
 
-@Article{murer.formica.ea:coupled,
+@Article{2022:murer.formica.ea:coupled,
   author  = {Murer, Mauro and Formica, Giovanni and Milicchio, Franco and Morganti, Simone and Auricchio, Ferdinando},
   journal = {The International Journal of Advanced Manufacturing Technology},
   number  = 5,
@@ -338,7 +338,7 @@
   doi     = {10.1007/s00170-022-08763-7}
 }
 
-@Article{negredo.van-hunen.ea:on,
+@Article{2022:negredo.van-hunen.ea:on,
   title   = {On the origin of the {C}anary {I}slands: {I}nsights from mantle convection modelling},
   journal = {Earth and Planetary Science Letters},
   volume  = 584,
@@ -350,7 +350,7 @@
   author  = {Ana M. Negredo and Jeroen {van Hunen} and Juan Rodr\'{i}guez-Gonz\'{a}lez and Javier Fullea}
 }
 
-@Article{oneill.aulbach:destabilization,
+@Article{2022:oneill.aulbach:destabilization,
   author  = {Craig O'Neill and Sonja Aulbach },
   title   = {Destabilization of deep oxidized mantle drove the Great Oxidation Event},
   journal = {Science Advances},
@@ -363,7 +363,7 @@
   eprint  = {https://www.science.org/doi/pdf/10.1126/sciadv.abg1626}
 }
 
-@Article{orlando.della-rocca.ea:efficient,
+@Article{2022:orlando.della-rocca.ea:efficient,
   title   = {An efficient and accurate implicit {DG} solver for the incompressible {N}avier-{S}tokes equations},
   author  = {Orlando, G. and Della Rocca, A. and Barbante, P.F. and Bonaventura, L. and Parolini, N.},
   doi     = {10.1002/fld.5098},
@@ -371,7 +371,7 @@
   journal = {International Journal for Numerical Methods in Fluids}
 }
 
-@Article{palmiotto.ficini.ea:back-arc,
+@Article{2022:palmiotto.ficini.ea:back-arc,
   author  = {Palmiotto, Camilla and Ficini, Eleonora and Loreto, Maria Filomena and Muccini, Filippo and Cuffaro, Marco},
   title   = {Back-Arc Spreading Centers and Superfast Subduction: {T}he Case of the {N}orthern {L}au Basin ({SW} {P}acific Ocean)},
   journal = {Geosciences},
@@ -384,7 +384,7 @@
   doi     = {10.3390/geosciences12020050}
 }
 
-@Article{peschka.heltai:model,
+@Article{2022:peschka.heltai:model,
   author  = {Dirk Peschka and Luca Heltai},
   journal = {Journal of Computational Physics},
   pages   = 111325,
@@ -394,7 +394,7 @@
   doi     = {10.1016/j.jcp.2022.111325}
 }
 
-@Article{piersanti.regazzoni.ea:3d-0d,
+@Article{2022:piersanti.regazzoni.ea:3d-0d,
   doi     = {10.1016/j.cma.2022.114607},
   title   = {3D--0D closed-loop model for the simulation of cardiac biventricular electromechanics},
   author  = {Piersanti, Roberto and Regazzoni, Francesco and Salvador, Matteo and Corno, Antonio F and Vergara, Christian and Quarteroni, Alfio and others},
@@ -406,7 +406,7 @@
   publisher = {Elsevier}
 }
 
-@Article{quarteroni.dedee.ea:modeling,
+@Article{2022:quarteroni.dedee.ea:modeling,
   doi     = {10.1090/bull/1738},
   title   = {Modeling the cardiac electromechanical function: A mathematical journey},
   author  = {Quarteroni, Alfio and Dede{\`{e}}, Luca and Regazzoni, Francesco},
@@ -419,7 +419,7 @@
   publisher = {American Mathematical Society ({AMS})}
 }
 
-@MastersThesis{quiroga:numerical,
+@MastersThesis{2022:quiroga:numerical,
   author  = {Quiroga, David},
   title   = {Numerical Models of Lithosphere Removal in the {S}ierra {N}evada de {S}anta {M}arta, {C}olombia},
   pages   = 178,
@@ -428,7 +428,7 @@
   doi     = {10.7939/r3-6mk4-sj26}
 }
 
-@Article{regazzoni.salvador.ea:cardiac,
+@Article{2022:regazzoni.salvador.ea:cardiac,
   doi     = {10.1016/j.jcp.2022.111083},
   author  = {F. Regazzoni and M. Salvador and P.C. Africa and M. Fedele and L. Dede{\`{e}} and A. Quarteroni},
   title   = {A cardiac electromechanical model coupled with a lumped-parameter model for closed-loop blood circulation},
@@ -440,7 +440,7 @@
   publisher = {Elsevier {BV}}
 }
 
-@Article{regazzoni.salvador.ea:machine,
+@Article{2022:regazzoni.salvador.ea:machine,
   doi     = {10.1016/j.cma.2022.114825},
   title   = {A machine learning method for real-time numerical simulations of cardiac electromechanics},
   author  = {Regazzoni, Francesco and Salvador, Matteo and Ded{\`{e}}, Luca and Quarteroni, Alfio},
@@ -452,7 +452,7 @@
   publisher = {Elsevier}
 }
 
-@Article{root.sebera.ea:benchmark,
+@Article{2022:root.sebera.ea:benchmark,
   author  = {Root, B. C. and Sebera, J. and Szwillus, W. and Thieulot, C. and Martinec, Z. and Fullea, J.},
   title   = {Benchmark forward gravity schemes: the gravity field of a realistic lithosphere model {WINTERC-G}},
   journal = {Solid Earth},
@@ -464,7 +464,7 @@
   doi     = {10.5194/se-13-849-2022}
 }
 
-@Article{roth.schroder.ea:neural,
+@Article{2022:roth.schroder.ea:neural,
   author  = {Julian Roth and Max Schr{\"o}der and Thomas Wick},
   title   = {Neural network guided adjoint computations in dual weighted residual error estimation},
   journal = {SN Applied Sciences},
@@ -478,7 +478,7 @@
   doi     = {10.1007/s42452-022-04938-9}
 }
 
-@Article{sabanskis.dadzis.ea:application,
+@Article{2022:sabanskis.dadzis.ea:application,
   doi     = {10.3390/cryst12020174},
   year    = 2022,
   month   = jan,
@@ -491,7 +491,7 @@
   journal = {Crystals}
 }
 
-@Article{salvador.regazzoni.ea:role,
+@Article{2022:salvador.regazzoni.ea:role,
   doi     = {10.1016/j.compbiomed.2021.105203},
   title   = {The role of mechano-electric feedbacks and hemodynamic coupling in scar-related ventricular tachycardia},
   author  = {Salvador, Matteo and Regazzoni, Francesco and Pagani, Stefano and Ded{\`{e}}, Luca and Trayanova, Natalia and Quarteroni, Alfio},
@@ -503,7 +503,7 @@
   publisher = {Elsevier}
 }
 
-@Article{schussnig.pacheco.ea:efficient,
+@Article{2022:schussnig.pacheco.ea:efficient,
   title   = {Efficient split-step schemes for fluid--structure interaction involving incompressible generalised {N}ewtonian flows},
   journal = {Computers \& Structures},
   volume  = 260,
@@ -515,7 +515,7 @@
   author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries}
 }
 
-@Article{stein.comeau.ea:numerical,
+@Article{2022:stein.comeau.ea:numerical,
   title   = {Numerical study on the style of delamination},
   journal = {Tectonophysics},
   pages   = 229276,
@@ -526,7 +526,7 @@
   author  = {Claudia Stein and Matthew Comeau and Michael Becken and Ulrich Hansen}
 }
 
-@Article{tsagkari.connelly.ea:role,
+@Article{2022:tsagkari.connelly.ea:role,
   doi     = {10.1038/s41522-022-00300-4},
   year    = 2022,
   month   = apr,
@@ -538,7 +538,7 @@
   journal = {npj Biofilms and Microbiomes}
 }
 
-@Article{vergara.stella.ea:computational,
+@Article{2022:vergara.stella.ea:computational,
   author  = {Vergara, Christian and Stella, Simone and Maines, Massimiliano and Africa, Pasquale Claudio and Catanzariti, Domenico and Dematt\`{e}, Cristina and Centonze, Maurizio and Nobile, Fabio and Quarteroni, Alfio and Del Greco, Maurizio},
   title   = {Computational electrophysiology of the coronary sinus branches based on electro-anatomical mapping for the prediction of the latest activated region},
   journal = {Medical \& Biological Engineering \& Computing},
@@ -550,7 +550,7 @@
   doi     = {10.1007/s11517-022-02610-3}
 }
 
-@MastersThesis{wik:high-performance,
+@MastersThesis{2022:wik:high-performance,
   author  = {Wik, Niklas},
   pages   = 60,
   school  = {Uppsala University, Division of Scientific Computing},
@@ -563,7 +563,7 @@
   month   = jun
 }
 
-@Article{zha.lin.ea:effects,
+@Article{2022:zha.lin.ea:effects,
   author  = {Zha, Caicai and Lin, Jian and Zhou, Zhiyuan and Xu, Min and Zhang, Xubo},
   title   = {Effects of Hotspot-Induced Long-Wavelength Mantle Melting Variations on Magmatic Segmentation at the {R}eykjanes Ridge: Insights From 3D Geodynamic Modeling},
   journal = {Journal of Geophysical Research: Solid Earth},
@@ -577,7 +577,7 @@
   year    = 2022
 }
 
-@Article{zhang.shahabad.ea:3-dimensional,
+@Article{2022:zhang.shahabad.ea:3-dimensional,
   author  = {Zhang, Zhi-Dong and Shahabad, Shahriar Imani and Ibhadode, Osezua and Dibia, Chinedu Francis and Bonakdar, Ali and Toyserkani, Ehsan},
   title   = {3-Dimensional Heat Transfer Modeling for Laser Powder Bed Fusion Additive Manufacturing Using Parallel Computing and Adaptive Mesh},
   journal = {SSRN Electronic Journal},
@@ -586,7 +586,7 @@
   doi     = {10.2139/ssrn.4108005}
 }
 
-@Misc{zingaro.bucelli.ea:modeling,
+@Misc{2022:zingaro.bucelli.ea:modeling,
   doi     = {10.48550/ARXIV.2208.09435},
   url     = {https://arxiv.org/abs/2208.09435},
   author  = {Zingaro, Alberto and Bucelli, Michele and Fumagalli, Ivan and Ded{\`{e}}, Luca and Quarteroni, Alfio},
@@ -596,7 +596,7 @@
   copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
 }
 
-@Article{zingaro.fumagalli.ea:geometric,
+@Article{2022:zingaro.fumagalli.ea:geometric,
   author  = {Zingaro, Alberto and Fumagalli, Ivan and Fedele, Marco and Africa, Pasquale Claudio and Ded{\`{e}}, Luca and Quarteroni, Alfio and Corno, Antonio Francesco},
   title   = {A geometric multiscale model for the numerical simulation of blood flow in the human left heart},
   journal = {Discrete and Continuous Dynamical Systems - S},


### PR DESCRIPTION
Part of #389. This should fix part 2 of #405.

I've changed the citekey that in starts with the year.

The nice thing about this approach is that the publications are now also sorted by year first, which lets us easily identify articles that are in the wrong file. I moved some articles around in the second commit and found a few duplicates.