### PR TITLE
Added 'preprint' field.

### DIFF
--- a/jabref-template/listrefs.book.layout
+++ b/jabref-template/listrefs.book.layout
@@ -42,12 +42,16 @@
       [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
 
       \begin{doi}
-	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+        [<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
       \end{doi}
 
       \begin{url}
         [<a href="\format{\url}" target="_blank">URL</a>]
       \end{url}
+
+      \begin{preprint}
+        [<a href="\format{\preprint}" target="_blank">PREPRINT</a>]
+      \end{preprint}
 
       \begin{file}
         [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]

--- a/jabref-template/listrefs.inproceedings.layout
+++ b/jabref-template/listrefs.inproceedings.layout
@@ -49,12 +49,16 @@
       [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
 
       \begin{doi}
-	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+        [<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
       \end{doi}
 
       \begin{url}
         [<a href="\format{\url}" target="_blank">URL</a>]
       \end{url}
+
+      \begin{preprint}
+        [<a href="\format{\preprint}" target="_blank">PREPRINT</a>]
+      \end{preprint}
 
       \begin{file}
         [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]

--- a/jabref-template/listrefs.layout
+++ b/jabref-template/listrefs.layout
@@ -50,12 +50,16 @@
       [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
 
       \begin{doi}
-	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+        [<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
       \end{doi}
 
       \begin{url}
         [<a href="\format{\url}" target="_blank">URL</a>]
       \end{url}
+
+      \begin{preprint}
+        [<a href="\format{\preprint}" target="_blank">PREPRINT</a>]
+      \end{preprint}
 
       \begin{file}
         [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]

--- a/jabref-template/listrefs.mastersthesis.layout
+++ b/jabref-template/listrefs.mastersthesis.layout
@@ -43,12 +43,16 @@
       [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
 
       \begin{doi}
-	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+        [<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
       \end{doi}
 
       \begin{url}
         [<a href="\format{\url}" target="_blank">URL</a>]
       \end{url}
+
+      \begin{preprint}
+        [<a href="\format{\preprint}" target="_blank">PREPRINT</a>]
+      \end{preprint}
 
       \begin{file}
         [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]

--- a/jabref-template/listrefs.misc.layout
+++ b/jabref-template/listrefs.misc.layout
@@ -66,7 +66,7 @@
       [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
 
       \begin{doi}
-	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+        [<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
       \end{doi}
 
 
@@ -83,6 +83,10 @@
           [<a href="https://arxiv.org/abs/\format{\eprint}" target="_blank">URL</a>]
         \end{archivePrefix}
       \end{!url}
+
+      \begin{preprint}
+        [<a href="\format{\preprint}" target="_blank">PREPRINT</a>]
+      \end{preprint}
 
       \begin{file}
         [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]

--- a/jabref-template/listrefs.phdthesis.layout
+++ b/jabref-template/listrefs.phdthesis.layout
@@ -43,12 +43,16 @@
       [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
 
       \begin{doi}
-	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+        [<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
       \end{doi}
 
       \begin{url}
         [<a href="\format{\url}" target="_blank">URL</a>]
       \end{url}
+
+      \begin{preprint}
+        [<a href="\format{\preprint}" target="_blank">PREPRINT</a>]
+      \end{preprint}
 
       \begin{file}
         [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]

--- a/offline/publication_list.tex
+++ b/offline/publication_list.tex
@@ -13,14 +13,33 @@
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage[colorlinks,urlcolor=blue]{hyperref}
+
+% add custom field for preprint urls to biblatex datamodel
+\begin{filecontents}{preprint-uri.dbx}
+\DeclareDatamodelFields[type=field, datatype=uri]{preprint}
+\DeclareDatamodelEntryfields{preprint}
+\end{filecontents}
+
 \usepackage[
   backend=biber,
   sorting=ydnt,
   defernumbers=true,
   doi=true,
-  refsection=section
+  refsection=section,
+  datamodel=preprint-uri
   ]{biblatex}
 \AtBeginBibliography{\small}
+
+% teach 'printfield' how to present the preprint field
+\DeclareFieldFormat{preprint}{\textsc{preprint:} \url{#1}.}
+% write the preprint field at the end of each bibitem
+\AtEveryBibitem{%
+  \csappto{blx@bbx@\thefield{entrytype}}{%
+    \iffieldundef{preprint}{}{%
+      \space \printfield{preprint}
+    }
+  }
+}
 
 \newcommand{\addnewbibyear}[1]{%
 \begin{refsection}[../publications-#1.bib]

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -105,7 +105,8 @@
   year    = 2017,
   volume  = 25,
   pages   = {137--146},
-  doi     = {10.1515/jnma-2017-0058}
+  doi     = {10.1515/jnma-2017-0058},
+  preprint = {https://dealii.org/deal85-preprint.pdf}
 }
 
 @Article{2017:austermann.mitrovica.ea:detection,

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -34,7 +34,8 @@
   volume  = 26,
   number  = 4,
   pages   = {173--183},
-  doi     = {10.1515/jnma-2018-0054}
+  doi     = {10.1515/jnma-2018-0054},
+  preprint = {https://dealii.org/deal90-preprint.pdf}
 }
 
 @Article{2018:araujo-cabarcas.engstrom.ea:efficient,

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -130,7 +130,7 @@
   number  = 4,
   pages   = {203--213},
   doi     = {10.1515/jnma-2019-0064},
-  url     = {https://dealii.org/deal91-preprint.pdf}
+  preprint = {https://dealii.org/deal91-preprint.pdf}
 }
 
 @Article{2019:aulisa.capodaglio.ea:construction,

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -45,7 +45,7 @@
   pages   = {131--146},
   publisher = {De Gruyter},
   doi     = {10.1515/jnma-2020-0043},
-  url     = {https://dealii.org/deal92-preprint.pdf}
+  preprint = {https://dealii.org/deal92-preprint.pdf}
 }
 
 @InProceedings{2020:arndt.fehn.ea:exadg,

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -42,7 +42,7 @@
   volume  = 29,
   number  = 3,
   pages   = {171--186},
-  url     = {https://dealii.org/deal93-preprint.pdf},
+  preprint = {https://dealii.org/deal93-preprint.pdf},
   doi     = {10.1515/jnma-2021-0081}
 }
 

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -43,7 +43,7 @@
   number  = 3,
   pages   = {231--246},
   doi     = {10.1515/jnma-2022-0054},
-  url     = {https://dealii.org/deal94-preprint.pdf}
+  preprint = {https://dealii.org/deal94-preprint.pdf}
 }
 
 @Article{2022:axelsson.dravins.ea:stage-parallel,


### PR DESCRIPTION
Based on the discussion in https://github.com/dealii/publication-list/pull/382#pullrequestreview-1093840819.

I've added a new field `preprint` to the biblatex datamodel and the jabref templates. Here is the idea:
- Users who do not have access to journal publications can now at least have a look at the preprint (insofar as it is public, e.g. on arxiv).
- If we replace preprints with the published articles in the future, we can still connect the preprint to the article in a clear way without loss of information.

The patch manifests as follows:
- In the online publication list, another link pointing to the preprint the will be displayed. No preprint field will be part of the bibtex entry if you click on the `BIBTEX` button to expand it.
```
\begin{preprint}
  [<a href="\format{\preprint}" target="_blank">PREPRINT</a>]
\end{preprint}
```
- In the offline publication list, entries with a preprint field will look like this:
![preprint](https://user-images.githubusercontent.com/18285973/190275942-68e04513-b890-4cd0-95c7-83e27b58cdeb.png)

bibtex and biblatex configurations that do not know about the preprint field will simply ignore them.

Right now, I've added the preprint fields to the release publications.