### PR TITLE
bibtool: parse exit on error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ sort: Makefile
 	fi ; \
 	for f in publications-*.bib ; do \
 		sed -i 's/% Encoding: US-ASCII//' $$f ; \
-		bibtool -r bibtool.rsc -i $$f -o $$f ; \
+		bibtool -r bibtool.rsc -i $$f -o $$f || exit 1 ; \
 		sed -i '1s/^/% Encoding: US-ASCII\n/' $$f ; \
 		sed -i '$$s/$$/\n\n@Comment{jabref-meta: databaseType:bibtex;}/' $$f ; \
 	done

--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -5,6 +5,9 @@ delete.field = {abstract}
 key.format = {%d(year):%-2n(author):%-W(title)}
 key.generation = on
 
+% exit on first error (avoids contamination of bib files or loss of data)
+parse.exit.on.error = on
+
 print.align = 12
 print.align.key = 0
 print.align.string = 0


### PR DESCRIPTION
Lets `bibtool` exit with error code 1 on the first error encountered.

Otherwise `bibtool` would ignore the entry with the error, which would remove it from the bib file. We don't want that. I learned it the hard way (no bibtex entries have been forgotten since the introduction of `make sort`) :-)