### PR TITLE
Unicode :-(

### DIFF
--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -1200,7 +1200,7 @@
 
 @Article{2021:karban.panek.ea:fem,
   author  = {Pavel Karban and David P{\'a}nek and Tam{\'a}s Orosz and Iveta Petr{\'a}{\v{s}}ov{\'a} and Ivo Dole{\v{z}}el},
-  title   = {{FEM} based robust design optimization with Agros and Artap},
+  title   = {{FEM} based robust design optimization with Agros and {\=A}rtap},
   journal = {Computers {\&} Mathematics with Applications},
   year    = 2021,
   volume  = 81,


### PR DESCRIPTION
See also https://github.com/dealii/publication-list/pull/443#issuecomment-1256704541

The TeX distribution on the CI does not like the Ā character, which we set with `\=A`.
```
! Package inputenc Error: Unicode char \u8:Ā not set up for use with LaTeX.
```
I don't encounter this problem on my machine when running make latex.
![image](https://user-images.githubusercontent.com/18285973/192080925-75ab5da6-6953-4b20-b065-9594dab4f71c.png)

Is it time to update the CI? Alternatively, I can turn the character into A without the bar.