### PR TITLE
bibtool: Disable iso2tex.

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -25,9 +25,6 @@ resource check_y
 % style improvements: no empty fields, fix page ranges, pure numerical fields
 resource improve
 
-% translate iso 8859/1 characters to latex
-resource iso2tex
-
 # sort order for fields
 resource sort_fld
 


### PR DESCRIPTION
The `iso2tex` resource doesn't work reliably for me: I encountered corner cases where unicode characters got transformed into junk.

Let's disable it before it does any harm!