### PR TITLE
Add format check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,24 @@ pipeline
           }
         }
 
+        stage("sort")
+        {
+          post {
+            failure {
+              githubNotify context: 'CI', description: 'invalid formatting found',  status: 'FAILURE'
+            }
+          }
+          steps
+          {
+            // check if predefined format is matched:
+            sh '''#!/bin/bash
+               make sort || exit $?
+               git diff
+               git diff-files --quiet || exit $?
+               '''
+          }
+        }
+
         stage("latex")
         {
           post {


### PR DESCRIPTION
I am adopting the formatting with bibtool for my personal references repository and implemented a CI job checking the format on each push. Maybe this is interesting for the dealii/publication-list too? I have not worked with Jenkinsfiles yet, but I hope this small change is valid.