### PR TITLE
Fix make sort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ sort: Makefile
 	fi ; \
 	for f in publications-*.bib ; do \
 		sed -i 's/% Encoding: US-ASCII//' $$f ; \
-		bibtool -r bibtool.rsc -i $$f -o $$f || exit 1 ; \
+		bibtool -r bibtool.rsc -i ./$$f -o ./$$f || exit 1 ; \
 		sed -i '1s/^/% Encoding: US-ASCII\n/' $$f ; \
 		sed -i '$$s/$$/\n\n@Comment{jabref-meta: databaseType:bibtex;}/' $$f ; \
 	done


### PR DESCRIPTION
The current version in master deletes all the content of the ``publications-*.bib`` files on my machine. With the fix it works.