### PR TITLE
Fix field name.

### DIFF
--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -966,7 +966,6 @@
   year    = 2022,
   volume  = 12,
   number  = 2,
-  article-number = 50,
   url     = {https://www.mdpi.com/2076-3263/12/2/50},
   issn    = {2076-3263},
   doi     = {10.3390/geosciences12020050}


### PR DESCRIPTION
`article-number` is not a common field in bibtex. [doi2bib](https://www.doi2bib.org/bib/10.3390/geosciences12020050) reports this field as `pages`, so I changed it accordingly.