### PR TITLE
Add 2022:schoof.castelli.ea:parallelization

### DIFF
--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -1130,6 +1130,15 @@
   publisher = {Elsevier {BV}}
 }
 
+@InProceedings{2022:schoof.castelli.ea:parallelization,
+  author  = {Schoof, R. and Castelli, G. F. and D\"orfler, W.},
+  title   = {Parallelization of a Finite Element Solver for Chemo-Mechanical Coupled Anode and Cathode Particles in Lithium-Ion Batteries},
+  year    = 2022,
+  journal = {eccomas2022},
+  fjournal = {8th European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS Congress 2022)},
+  doi     = {10.23967/eccomas.2022.106}
+}
+
 @Article{2022:schussnig.pacheco.ea:efficient,
   author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   title   = {Efficient split-step schemes for fluid--structure interaction involving incompressible generalised {N}ewtonian flows},

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -1131,13 +1131,16 @@
 }
 
 @InProceedings{2022:schoof.castelli.ea:parallelization,
-  author  = {Schoof, R. and Castelli, G. F. and D\"orfler, W.},
-  title   = {Parallelization of a Finite Element Solver for Chemo-Mechanical Coupled Anode and Cathode Particles in Lithium-Ion Batteries},
-  year    = 2022,
-  journal = {eccomas2022},
-  fjournal = {8th European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS Congress 2022)},
-  doi     = {10.23967/eccomas.2022.106}
+  author   = {Schoof, R. and Castelli, G. F. and D\"orfler, W.},
+  title    = {Parallelization of a Finite Element Solver for Chemo-Mechanical Coupled Anode and Cathode Particles in Lithium-Ion Batteries},
+  editor   = {Kvamsdal, T. and Mathisen, K. M. and Lie, K.-A. and Larson, M. G.},
+  booktitle = {8th European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS Congress 2022)},
+  publisher = {{CIMNE}},
+  year     = 2022,
+  doi      = {10.23967/eccomas.2022.106},
+  url      = {https://doi.org/10.23967/eccomas.2022.106}
 }
+
 
 @Article{2022:schussnig.pacheco.ea:efficient,
   author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -1134,7 +1134,7 @@
   author   = {Schoof, R. and Castelli, G. F. and D\"orfler, W.},
   title    = {Parallelization of a Finite Element Solver for Chemo-Mechanical Coupled Anode and Cathode Particles in Lithium-Ion Batteries},
   editor   = {Kvamsdal, T. and Mathisen, K. M. and Lie, K.-A. and Larson, M. G.},
-  booktitle = {8th European Congress on Computational Methods in Applied Sciences and Engineering (ECCOMAS Congress 2022)},
+  booktitle = {8th European Congress on Computational Methods in Applied Sciences and Engineering ({ECCOMAS} Congress 2022)},
   publisher = {{CIMNE}},
   year     = 2022,
   doi      = {10.23967/eccomas.2022.106},

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -1141,7 +1141,6 @@
   url      = {https://doi.org/10.23967/eccomas.2022.106}
 }
 
-
 @Article{2022:schussnig.pacheco.ea:efficient,
   author  = {Richard Schussnig and Douglas R.Q. Pacheco and Thomas-Peter Fries},
   title   = {Efficient split-step schemes for fluid--structure interaction involving incompressible generalised {N}ewtonian flows},


### PR DESCRIPTION
Add our latest publication: ECCOMAS 2022 proceeding.