### PR TITLE
fix symbol

### DIFF
--- a/publications-2023.bib
+++ b/publications-2023.bib
@@ -270,7 +270,7 @@
 
 @Article{2023:stolte.tsvetkov:-mera,
   author  = {Kristin N. Stolte and Pavel V. Tsvetkov},
-  title   = {{\chi-MeRA}: Computationally efficient adaptive mesh refinement of Monte Carlo mesh based tallies},
+  title   = {{$\chi$-MeRA}: Computationally efficient adaptive mesh refinement of Monte Carlo mesh based tallies},
   journal = {Annals of Nuclear Energy},
   year    = 2023,
   volume  = 182,


### PR DESCRIPTION
Follow-up to #512.

The `\chi` symbol only works in math mode. We only spotted this after we included the 2023 publications into the global file. So my https://github.com/dealii/publication-list/pull/512#issuecomment-1460121117 was actually wrong.