### PR TITLE
Articles that mention, but do not use deal.II.

### DIFF
--- a/publications-2014.bib
+++ b/publications-2014.bib
@@ -531,11 +531,12 @@
   pages   = {108--126}
 }
 
-@Article{2014:janssen.wihler:existence,
-  author  = {B. Janssen and T. Wihler},
+@Misc{2014:janssen.wihler:existence,
+  author  = {Janssen, B{\"a}rbel and Wihler, Thomas P.},
   title   = {Existence Results for the Continuous and Discontinuous Galerkin Time Stepping Methods for Nonlinear Initial Value Problems},
-  journal = {arXiv:1407.5520},
-  year    = 2014
+  year    = 2014,
+  url     = {https://arxiv.org/abs/1407.5520v1},
+  publisher = {arXiv}
 }
 
 @Article{2014:javili.mcbride.ea:unified,

--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -1233,10 +1233,11 @@
 }
 
 @Article{2015:wells.wang.ea:regularized,
-  author  = {D. Wells and Z. Wang and X. Xie and T. Iliescu},
+  author  = {Wells, David and Wang, Zhu and Xie, Xuping and Iliescu, Traian},
   title   = {Regularized Reduced Order Models},
-  journal = {arXiv:1506.07555},
-  year    = 2015
+  journal = {arXiv},
+  year    = 2015,
+  url     = {https://arxiv.org/abs/1506.07555v1}
 }
 
 @Article{2015:wells:stabilization,

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -592,15 +592,6 @@
   url     = {http://onlinelibrary.wiley.com/doi/10.1002/2015GC006177/full}
 }
 
-@Misc{2016:gersbacher:implementation,
-  author  = {Christoph Gersbacher},
-  title   = {Implementation of $hp$-adaptive discontinuous finite element methods in Dune-Fem},
-  year    = 2016,
-  eprint  = {1604.07242},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.MS}
-}
-
 @Article{2016:gholami.malhotra.ea:fft,
   author  = {Gholami, Amir and Malhotra, Dhairya and Sundar, Hari and Biros, George},
   title   = {{FFT}, {FMM}, or Multigrid? A comparative Study of State-Of-the-Art Poisson Solvers for Uniform and Nonuniform Grids in the Unit Cube},
@@ -628,20 +619,6 @@
   title   = {CFD modeling of a small case solar pond},
   journal = {Proceedings of the EuroSun 2016 conference, Palma de Mallorca, Spain, 11-14 October 2016; International Solar Energy Society},
   year    = 2016
-}
-
-@Article{2016:giuliani.krivodonova:edge,
-  author  = {Giuliani, Andrew and Krivodonova, Lilia},
-  title   = {Edge coloring in unstructured CFD codes},
-  journal = {arxiv.org},
-  year    = 2016,
-  month   = jan,
-  archiveprefix = {arXiv},
-  arxivid = {1601.07613},
-  eprint  = {http://arxiv.org/abs/1601.07613v2},
-  eprintclass = {cs.DC},
-  eprinttype = {arXiv},
-  url     = {http://arxiv.org/abs/1601.07613}
 }
 
 @PhDThesis{2016:guittet:simulation-of-incompressible-viscous-flows-on-distributed-octree-grids,
@@ -1075,18 +1052,6 @@
   title   = {Advancement of a semi-explicit discontinuous Galerkin approach for simulation of turbulent incompressible flow},
   school  = {Technical University of Munich},
   year    = 2016
-}
-
-@Article{2016:leibner.milk.ea:extending-dune--the-dune-xt-modules,
-  author  = {Leibner, Tobias and Milk, Ren{\'{e}} and Schindler, Felix},
-  title   = {{Extending DUNE: The dune-xt modules}},
-  journal = {arxiv.org},
-  year    = 2016,
-  month   = feb,
-  archiveprefix = {arXiv},
-  arxivid = {1602.08991},
-  eprint  = {1602.08991},
-  url     = {http://arxiv.org/abs/1602.08991}
 }
 
 @Article{2016:lemenager.oneill.ea:numerical-modelling-of-the-sydney-basin-using-temperature-dependent-thermal-conductivity-measurements,

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -143,15 +143,6 @@
   url     = {http://www.sciencedirect.com/science/article/pii/S0377042716302631}
 }
 
-@Misc{2017:badia.martin.ea:fempar,
-  author  = {Santiago Badia and Alberto F. Mart{\'i}n and Javier Principe},
-  title   = {FEMPAR: An object-oriented parallel finite element framework},
-  year    = 2017,
-  eprint  = {1708.01773},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.CE}
-}
-
 @Article{2017:badnava.etemadi.ea:phase,
   author  = {H. Badnava and E. Etemadi and M. A. Msekh},
   title   = {A Phase Field Model for Rate-Dependent Ductile Fracture},

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -325,15 +325,6 @@
   publisher = {{IOP} Publishing}
 }
 
-@Misc{2018:burstedde:parallel,
-  author  = {Carsten Burstedde},
-  title   = {Parallel tree algorithms for AMR and non-standard data access},
-  year    = 2018,
-  eprint  = {1803.08432},
-  archiveprefix = {arXiv},
-  primaryclass = {cs.DC}
-}
-
 @Article{2018:bzowski.rauch.ea:application,
   author  = {Krzysztof Bzowski and Lukasz Rauch and Maciej Pietrzyk},
   title   = {Application of statistical representation of the microstructure to modeling of phase transformations in DP steels by solution of the diffusion equation},


### PR DESCRIPTION
Follow-up to #536. Part of #289.

I got suspicious when titles of articles clearly referred to other FEM libraries (as DUNE or FEMPAR), so I started to check articles for their content. I found a few that cite deal.II, but do not actually use it, and thus I suggest to remove them.