### PR TITLE
Update articles of Mohebujjaman.

### DIFF
--- a/publications-2015.bib
+++ b/publications-2015.bib
@@ -891,6 +891,15 @@
   url     = {http://hdl.handle.net/2152/34222}
 }
 
+@Misc{2015:mohebujjaman.heister:c,
+  author  = {Muhammad Mohebujjaman and Timo Heister},
+  title   = {C++ implementation of the solution of incompressible viscous time-dependent {N}avier-{S}tokes equations using projection method in Dealii},
+  year    = 2015,
+  note    = {MTHSC9830 Spring 2015 Project},
+  institution = {Clemson University},
+  url     = {https://github.com/Mohebujjaman/Projection-Method-for-NSE/}
+}
+
 @Article{2015:muddamallappa:on,
   author  = {M. S. Muddamallappa},
   title   = {On Two Theories for Brittle Fracture: Modeling and Direct Numerical Simulations},

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1251,13 +1251,6 @@
   url     = {https://riunet.upv.es/handle/10251/65353}
 }
 
-@Misc{2016:mohebujjaman:solution,
-  author  = {Muhammad Mohebujjaman},
-  title   = {Solution of incompressible viscous time-dependent Navier-Stokes equations using projection method},
-  year    = 2016,
-  url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/project/Solution-of-incompressible-viscous-time-dependent-Navier-Stokes-equations-using-projection-method/attachment/57ad503e08aef1b475aef153/AS:394116325232643@1470976062899/download/project+_write.pdf?context=ProjectUpdatesLog}
-}
-
 @Article{2016:moinger.forster-zugel.ea:simulation,
   author  = {H. M\"{o}{\ss}inger and F. F\"{o}rster-Z\"{u}gel and H. F. Schlaak},
   title   = {Simulation of the Transient Electromechanical Behaviour of Dielectric Elastomer Transducers},

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1221,7 +1221,7 @@
   number  = 1,
   month   = jan,
   doi     = {10.1515/cmam-2016-0033},
-  url     = {https://doi.org/10.1515/cmam-2016-0033},
+  url     = {https://www.degruyter.com/document/doi/10.1515/cmam-2016-0033/html},
   publisher = {Walter de Gruyter {GmbH}}
 }
 

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1241,14 +1241,6 @@
   url     = {https://tigerprints.clemson.edu/all_dissertations/2027/}
 }
 
-@TechReport{2017:mohebujjaman:high-order,
-  author  = {Mohebujjaman, M.},
-  title   = {High-order efficient algorithms for computation of {MHD} flow ensemble},
-  institution = {Virginia Tech},
-  year    = 2017,
-  url     = {https://www.researchgate.net/profile/Muhammad_Mohebujjaman/publication/327449710_HIGH_ORDER_EFFICIENT_ALGORITHM_FOR_COMPUTATION_OF_MHD_FLOW_ENSEMBLE/links/5b903a08a6fdcce8a4c3548d/HIGH-ORDER-EFFICIENT-ALGORITHM-FOR-COMPUTATION-OF-MHD-FLOW-ENSEMBLE.pdf}
-}
-
 @Article{2017:mola.heitai.ea:wet,
   author  = {A. Mola and L. Heitai and A. DeSimone},
   title   = {Wet and Dry Transom Stern Treatment for Unsteady and Nonlinear Potential Flow Model for Naval Hydrodynamics Simulations},

--- a/publications-2017.bib
+++ b/publications-2017.bib
@@ -1225,14 +1225,6 @@
   publisher = {Walter de Gruyter {GmbH}}
 }
 
-@TechReport{2017:mohebujjaman:c-parallel-implementation-of-incompressible-viscous-time-dependent-nse-simulation-using-projection-method-in-dealii,
-  author  = {Mohebujjaman, M},
-  title   = {{C++ parallel implementation of incompressible viscous time-dependent NSE simulation using projection method in Dealii}},
-  institution = {Virginia Tech},
-  year    = 2017,
-  url     = {http://mmohebu.people.clemson.edu/PDFDocuments/project_HPC_Projection_Method_NSE.pdf}
-}
-
 @PhDThesis{2017:mohebujjaman:efficient,
   author  = {Muhammad Mohebujjaman},
   title   = {Efficient Numerical Methods for Magnetohydrodynamic Flow},

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -1681,12 +1681,13 @@
   publisher = {Elsevier {BV}}
 }
 
-@TechReport{2018:mohebujjaman:high,
-  author  = {Mohebujjaman, Muhammad},
-  title   = {High order efficient algorithm for computation of {MHD} flow ensemble},
-  institution = {Virginia Tech University},
+@Misc{2018:mohebujjaman:high,
+  author  = {Muhammad Mohebujjaman},
+  title   = {High order efficient algorithm for computation of {MHD} flow ensembles},
   year    = 2018,
-  url     = {https://mohebujjaman.github.io/Second_order_ensembleMHD_Mohebujjaman.pdf}
+  month   = sep,
+  note    = {Preprint},
+  url     = {https://www.researchgate.net/publication/327449710}
 }
 
 @Misc{2018:mohebujjaman:second,

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -5,9 +5,9 @@
   title   = {Cavitation over solid surfaces: microbubble collapse, shock waves, and elastic response},
   journal = {Meccanica},
   year    = 2022,
-  month   = nov,
   volume  = 58,
   pages   = {1109--1119},
+  month   = nov,
   doi     = {10.1007/s11012-022-01606-5},
   url     = {https://link.springer.com/article/10.1007/s11012-022-01606-5},
   publisher = {Springer Science and Business Media {LLC}}


### PR DESCRIPTION
After going through some articles in the 2018 publication list, I spotted a couple of duplicates of Mohebujjaman, and many of the URL fields had links that lead to nowhere. I tried my best to update them.