### PR TITLE
Fix preprint link.

### DIFF
--- a/publications-2023.bib
+++ b/publications-2023.bib
@@ -21,7 +21,7 @@
   doi     = {10.1186/s12859-023-05513-8},
   url     = {https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-023-05513-8},
   publisher = {Springer Science and Business Media LLC},
-  preprint = {10.48550/ARXIV.2308.01651}
+  preprint = {https://arxiv.org/abs/2308.01651}
 }
 
 @Article{2023:africa.piersanti.ea:lifex-fiber,


### PR DESCRIPTION
This entry previously referred to `https://www.dealii.org/10.48550/ARXIV.2308.01651` which of course does not exist.