### PR TITLE
Remove article that doesn't use deal.II

### DIFF
--- a/publications-2023.bib
+++ b/publications-2023.bib
@@ -811,21 +811,6 @@
   url     = {https://www.dzxb.org/en/article/doi/10.11939/jass.20210192}
 }
 
-@Article{2023:harmon.corrado.ea:refinement-by-superposition,
-  author  = {Harmon, Jake J. and Corrado, Jeremiah and Notaro\v{s}, Branislav M.},
-  title   = {A Refinement-by-Superposition hp-Method for H(curl)- and H(div)-Conforming Discretizations},
-  journal = {IEEE Transactions on Antennas and Propagation},
-  year    = 2023,
-  volume  = 71,
-  number  = 12,
-  pages   = {9357--9364},
-  month   = dec,
-  issn    = {1558-2221},
-  url     = {https://ieeexplore.ieee.org/document/10319330},
-  doi     = {10.1109/tap.2023.3331574},
-  publisher = {Institute of Electrical and Electronics Engineers (IEEE)}
-}
-
 @Article{2023:he.kapp:basin,
   author  = {He, John J. Y. and Kapp, Paul},
   title   = {Basin record of a Miocene lithosphere drip beneath the Colorado Plateau},


### PR DESCRIPTION
In #575 I have added an article that actually does not use deal.II. Mea culpa.

They cited the parallel hp article and I guess I got too excited about that.