### PR TITLE
Update preprints for 2018.

### DIFF
--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -396,15 +396,6 @@
   publisher = {Elsevier {BV}}
 }
 
-@Misc{2018:carraro.wetterauer.ea:level-set,
-  author  = {Thomas Carraro and Sven E. Wetterauer and Ana Victoria Ponce Bobadilla and Dumitru Trucu},
-  title   = {A level-set approach for a multi-scale cancer invasion model},
-  year    = 2018,
-  eprint  = {1805.07485},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
 @Article{2018:carreno.vidal-ferrandiz.ea:block,
   author  = {A. Carre{\~{n}}o and A. Vidal-Ferr{\`{a}}ndiz and D. Ginestar and G. Verd{\'{u}}},
   title   = {Block hybrid multilevel method to compute the dominant $\lambda$-modes of the neutron diffusion equation},
@@ -641,11 +632,16 @@
   doi     = {10.1002/pssb.201800069}
 }
 
-@Article{2018:demo.tezzele.ea:efficient,
-  author  = {N. Demo and M. Tezzele and A. Mola and G. Rozza},
+@InProceedings{2018:demo.tezzele.ea:efficient,
+  author  = {Nicola Demo and Marco Tezzele and Andrea Mola and Gianluigi Rozza},
   title   = {An efficient shape parametrisation by free-form deformation enhanced by active subspace for hull hydrodynamic ship design problems in open source environment},
-  journal = {arXiv:1801.06369},
-  year    = 2018
+  editor  = {Jin S. Chung and Beom-Soo Hyun and Dmitri Matskevitch and Alan M. Wang},
+  booktitle = {ISOPE 2018: The Proceedings of the 28th (2018) International Ocean and Polar Engineering Conference, Volume 3},
+  year    = 2018,
+  pages   = {565--572},
+  month   = jun,
+  url     = {http://publications.isope.org/proceedings/ISOPE/ISOPE%202018/data/volume-iii.html},
+  preprint = {https://arxiv.org/abs/1801.06369}
 }
 
 @InProceedings{2018:deolmi.dahmen.ea:effective-boundary-conditions-for-turbulent-compressible-flows-over-a-riblet-surface,
@@ -1183,13 +1179,6 @@
   number  = 1,
   pages   = {e201800353},
   doi     = {10.1002/pamm.201800353}
-}
-
-@TechReport{2018:hochbruck.kohler:on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-methods-on-the-efficiency-of-the-peaceman-rachford-adi-dg-method-for-wave-type-problems,
-  author  = {Hochbruck, Marlis and K{\"{o}}hler, Jonas},
-  title   = {{On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type methods On the efficiency of the Peaceman-Rachford ADI-dG method for wave-type problems}},
-  year    = 2018,
-  url     = {https://www.waves.kit.edu/downloads/CRC1173_Preprint_2017-34.pdf}
 }
 
 @PhDThesis{2018:huang:hybrid-analog-digital-co-processing-for-scientific-computation,

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -48,24 +48,6 @@
   pages   = {177--192}
 }
 
-@Article{2018:arndt.kanschat:a-c1-mapping-based-on-finite-elements-on-quadrilateral-and-hexahedral-meshes,
-  author  = {Arndt, Daniel and Kanschat, Guido},
-  title   = {{A C1-mapping based on finite elements on quadrilateral and hexahedral meshes}},
-  journal = {arxiv: 1810.02473},
-  year    = 2018,
-  month   = oct,
-  url     = {https://arxiv.org/abs/1810.02473}
-}
-
-@Misc{2018:arndt.kanschat:c1-mapping,
-  author  = {Daniel Arndt and Guido Kanschat},
-  title   = {A C1-mapping based on finite elements on quadrilateral and hexahedral meshes},
-  year    = 2018,
-  eprint  = {1810.02473},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
 @Article{2018:axelsson.neytcheva.ea:efficient,
   author  = {Owe Axelsson and Maya Neytcheva and Anders Str\"{o}m},
   title   = {An efficient preconditioning method for state box-constrained optimal control problems},
@@ -247,23 +229,6 @@
   doi     = {10.1002/2017gl075822},
   url     = {https://doi.org/10.1002/2017gl075822},
   publisher = {American Geophysical Union ({AGU})}
-}
-
-@Article{2018:bruchhauser.schwegler.ea:dual,
-  author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
-  title   = {Dual weighted residual based error control for nonstationary convection-dominated equations: potential or ballast?},
-  journal = {arXiv:1812.06810},
-  year    = 2018,
-  url     = {https://arxiv.org/abs/1812.06810}
-}
-
-@Misc{2018:bruchhauser.schwegler.ea:numerical,
-  author  = {Marius Paul Bruchh{\"a}user and Kristina Schwegler and Markus Bause},
-  title   = {Numerical study of goal-oriented error control for stabilized finite element methods},
-  year    = 2018,
-  eprint  = {1803.10643},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
 }
 
 @Article{2018:bruna-rosso.demir.ea:global,
@@ -469,16 +434,6 @@
   doi     = {10.1137/18m1172260},
   url     = {https://doi.org/10.1137/18m1172260},
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
-}
-
-@Article{2018:charnyi.heister.ea:efficient,
-  author  = {Sergey Charnyi and Timo Heister and Maxim A. Olshanskii and Leo G. Rebholz},
-  title   = {Efficient discretizations for the {EMAC} formulation of the incompressible Navier-Stokes equations},
-  journal = {Applied Numerical Mathematics},
-  year    = 2018,
-  note    = {in press},
-  doi     = {10.1016/j.apnum.2018.11.013},
-  url     = {https://arxiv.org/abs/1712.00857}
 }
 
 @PhDThesis{2018:charnyi:emac,
@@ -1037,35 +992,11 @@
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})}
 }
 
-@TechReport{2018:gulevich.gulevich:user-guide-for-mitmojco-1-2-microscopic-tunneling-model-for-josephson-contacts-mitmojco-1-2,
-  author  = {Gulevich, Dmitry R and Gulevich, Dmitry R},
-  title   = {{User Guide for MiTMoJCo 1.2 (Microscopic Tunneling Model for Josephson Contacts) MiTMoJCo 1.2}},
+@TechReport{2018:gulevich:user,
+  author  = {Gulevich, Dmitry R.},
+  title   = {User Guide for {MiTMoJCo} 1.2 (Microscopic Tunneling Model for Josephson Contacts)},
   year    = 2018,
-  url     = {https://github.com/drgulevich/mitmojco}
-}
-
-@Article{2018:gulevich.koshelets.ea:bridging,
-  author  = {D. R. Gulevich and V. P. Koshelets and F. V. Kusmartsev},
-  title   = {Bridging the Terahertz gap for chaotic sources with superconducting junctions},
-  journal = {arXiv:1709.04052},
-  year    = 2018,
-  url     = {https://arxiv.org/abs/1709.04052}
-}
-
-@Misc{2018:gulevich:mitmojco,
-  author  = {Dmitry R. Gulevich},
-  title   = {MiTMoJCo: Microscopic Tunneling Model for Josephson Contacts},
-  year    = 2018,
-  eprint  = {1809.04706},
-  archiveprefix = {arXiv},
-  primaryclass = {cond-mat.supr-con}
-}
-
-@TechReport{2018:gulevich:mitmojco-1-2,
-  author  = {Gulevich, D. R.},
-  title   = {{MiTMoJCo 1.2}},
-  year    = 2018,
-  url     = {https://www.researchgate.net/profile/D_Gulevich/publication/318380494_User_Guide_for_MiTMoJCo_12_Microscopic_Tunneling_Model_for_Josephson_Contacts/links/5ba4005d92851ca9ed1a09b1/User-Guide-for-MiTMoJCo-12-Microscopic-Tunneling-Model-for-Josephson-Contacts.pdf}
+  url     = {https://www.researchgate.net/publication/318380494}
 }
 
 @InCollection{2018:gulpak.wernsing.ea:compensation,
@@ -1229,15 +1160,6 @@
   url     = {http://rgdoi.net/10.13140/RG.2.2.30755.14885},
   language = {en},
   publisher = {Unpublished}
-}
-
-@Article{2018:k-gupta.keulen.ea:design,
-  author  = {K. Gupta, Deepak and Keulen, Fred and Langelaar, Matthijs},
-  title   = {Design and analysis adaptivity in multi-resolution topology optimization},
-  journal = {arXiv:1811.09821},
-  year    = 2018,
-  month   = nov,
-  url     = {https://arxiv.org/abs/1811.09821}
 }
 
 @Article{2018:kanschat.riviere:finite,
@@ -1558,15 +1480,6 @@
   url     = {https://doi.org/10.1115/detc2018-85701}
 }
 
-@Misc{2018:maday.marcati:regularity,
-  author  = {Yvon Maday and Carlo Marcati},
-  title   = {Regularity and $hp$ discontinuous {G}alerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
-  year    = 2018,
-  eprint  = {1810.09010},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
-}
-
 @Article{2018:maier.margetis.ea:generation,
   author  = {Matthias Maier and Dionisios Margetis and Mitchell Luskin},
   title   = {Generation of surface plasmon-polaritons by edge effects},
@@ -1579,15 +1492,6 @@
   doi     = {10.4310/cms.2018.v16.n1.a4},
   url     = {http://www.intlpress.com/site/pub/pages/journals/items/cms/content/vols/0016/0001/a004/},
   preprint = {https://arxiv.org/abs/1702.00848}
-}
-
-@Misc{2018:maier.mattheakis.ea:homogenization,
-  author  = {Matthias Maier and Marios Mattheakis and Efthimios Kaxiras and Mitchell Luskin and Dionisios Margetis},
-  title   = {Homogenization of plasmonic crystals: Seeking the epsilon-near-zero effect},
-  year    = 2018,
-  eprint  = {1809.08276},
-  archiveprefix = {arXiv},
-  primaryclass = {math.NA}
 }
 
 @Article{2018:maier.nemilentsau.ea:ultracompact,
@@ -1728,13 +1632,6 @@
   publisher = {Springer Science and Business Media {LLC}}
 }
 
-@Article{2018:odster.kvamsdal.ea:simple,
-  author  = {L. Hov Ods\ae{}ter and T. Kvamsdal and M. G Larson},
-  title   = {A simple embedded discrete fracture-matrix model for a coupled flow and transport problem in porous media},
-  journal = {arXiv:1803.03423},
-  year    = 2018
-}
-
 @Article{2018:oneill.turner.ea:inception,
   author  = {O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
   title   = {The inception of plate tectonics: a record of failure},
@@ -1757,15 +1654,6 @@
   pages   = {7074--7089},
   doi     = {10.1029/2018JB015698},
   publisher = {Wiley Online Library}
-}
-
-@Misc{2018:pearson.porcelli.ea:interior,
-  author  = {John W. Pearson and Margherita Porcelli and Martin Stoll},
-  title   = {Interior Point Methods and Preconditioning for PDE-Constrained Optimization Problems Involving Sparsity Terms},
-  year    = 2018,
-  eprint  = {1806.05896},
-  archiveprefix = {arXiv},
-  primaryclass = {math.OC}
 }
 
 @Article{2018:pelteret.walter.ea:application,

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -599,17 +599,16 @@
   preprint = {https://arxiv.org/abs/1801.06369}
 }
 
-@InProceedings{2018:deolmi.dahmen.ea:effective-boundary-conditions-for-turbulent-compressible-flows-over-a-riblet-surface,
+@InProceedings{2018:deolmi.dahmen.ea:effective,
   author  = {Deolmi, G. and Dahmen, W. and M{\"{u}}ller, S. and Albers, M. and Meysonnat, P. S. and Schr{\"{o}}der, W.},
-  title   = {{Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface}},
+  title   = {Effective Boundary Conditions for Turbulent Compressible Flows over a Riblet Surface},
   booktitle = {HYP 2016: Theory, Numerics and Applications of Hyperbolic Problems I},
   year    = 2018,
   series  = {Springer Proceedings in Mathematics \& Statistics},
   volume  = 236,
   pages   = {473--485},
   publisher = {Springer International Publishing},
-  doi     = {10.1007/978-3-319-91545-6_36},
-  journal = {Springer}
+  doi     = {10.1007/978-3-319-91545-6_36}
 }
 
 @Article{2018:deolmi.muller:two-step,
@@ -2139,7 +2138,8 @@
   month   = oct,
   doi     = {10.1515/cmam-2017-0046},
   publisher = {Walter de Gruyter {GmbH}},
-  url     = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf}
+  url     = {https://www.degruyter.com/document/doi/10.1515/cmam-2017-0046/html},
+  preprint = {https://www.math.uni-sb.de/service/preprints/preprint384.pdf}
 }
 
 @InProceedings{2018:wichrowski:multigrid-method-for-stokes-problem-with-discontinuous-viscosity,

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -1115,6 +1115,23 @@
   publisher = {Geological Society of America}
 }
 
+@InProceedings{2019:hochbruck.kohler:on,
+  author  = {Hochbruck, Marlis and K{\"o}hler, Jonas},
+  title   = {On the Efficiency of the Peaceman--Rachford ADI-dG Method for Wave-Type Problems},
+  editor  = {Radu, Florin Adrian and Kumar, Kundan and Berre, Inga and Nordbotten, Jan Martin and Pop, Iuliu Sorin},
+  booktitle = {Numerical Mathematics and Advanced Applications ENUMATH 2017},
+  year    = 2019,
+  series  = {Lecture Notes in Computational Science and Engineering},
+  volume  = 126,
+  pages   = {135--144},
+  publisher = {Springer International Publishing},
+  isbn    = 9783319964157,
+  issn    = {2197-7100},
+  url     = {https://link.springer.com/chapter/10.1007/978-3-319-96415-7_10},
+  doi     = {10.1007/978-3-319-96415-7_10},
+  preprint = {https://www.waves.kit.edu/downloads/CRC1173_Preprint_2017-34.pdf}
+}
+
 @Article{2019:hochbruck.maier.ea:heterogeneous,
   author  = {Marlis Hochbruck and Bernhard Maier and Christian Stohrer},
   title   = {Heterogeneous Multiscale Method for Maxwell's Equations},

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -334,16 +334,21 @@
   publisher = {{MDPI} {AG}}
 }
 
-@Article{2019:bruchhauser.schwegler.ea:numerical,
-  author  = {Bruchh{\"a}user, Marius Paul and Schwegler, Kristina and Bause, Markus},
-  title   = {Numerical {S}tudy of {G}oal-{O}riented {E}rror {C}ontrol for {S}tabilized {F}inite {E}lement {M}ethods},
-  journal = {Advanced Finite Element Methods with Applications},
+@InProceedings{2019:bruchhauser.schwegler.ea:numerical,
+  author  = {Marius Paul Bruchh\"{a}user and Kristina Schwegler and Markus Bause},
+  title   = {Numerical Study of Goal-Oriented Error Control for Stabilized Finite Element Methods},
+  editor  = {Thomas Apel and Ulrich Langer and Arnd Meyer and Olaf Steinbach},
+  booktitle = {Advanced Finite Element Methods with Applications},
   year    = 2019,
+  series  = {Lecture Notes in Computational Science and Engineering},
+  volume  = 128,
   pages   = {85--106},
+  publisher = {Springer International Publishing},
   isbn    = 9783030142445,
   issn    = {2197-7100},
   doi     = {10.1007/978-3-030-14244-5_5},
-  publisher = {Springer International Publishing}
+  url     = {https://link.springer.com/chapter/10.1007/978-3-030-14244-5_5},
+  preprint = {https://arxiv.org/abs/1803.10643}
 }
 
 @PhDThesis{2019:brun:upscaling,
@@ -917,7 +922,8 @@
   number  = 6,
   month   = feb,
   doi     = {10.1103/physrevb.99.060501},
-  publisher = {American Physical Society ({APS})}
+  publisher = {American Physical Society ({APS})},
+  preprint = {https://arxiv.org/abs/1709.04052}
 }
 
 @Article{2019:guo.wu.ea:numerical,
@@ -944,19 +950,6 @@
   month   = feb,
   doi     = {10.2118/194493-pa},
   publisher = {Society of Petroleum Engineers ({SPE})}
-}
-
-@Article{2019:gupta.keulen.ea:design,
-  author  = {Deepak K. Gupta and Fred Keulen and Matthijs Langelaar},
-  title   = {Design and analysis adaptivity in multiresolution topology optimization},
-  journal = {International Journal for Numerical Methods in Engineering},
-  year    = 2019,
-  volume  = 121,
-  number  = 3,
-  pages   = {450--476},
-  month   = oct,
-  doi     = {10.1002/nme.6217},
-  publisher = {Wiley}
 }
 
 @Article{2019:hagstrom.kim:complete,
@@ -1516,7 +1509,7 @@
 
 @Article{2019:maday.marcati:regularity,
   author  = {Yvon Maday and Carlo Marcati},
-  title   = {Regularity and hp discontinuous Galerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
+  title   = {Regularity and $hp$ discontinuous {G}alerkin finite element approximation of linear elliptic eigenvalue problems with singular potentials},
   journal = {Mathematical Models and Methods in Applied Sciences},
   year    = 2019,
   volume  = 29,
@@ -1524,11 +1517,12 @@
   pages   = {1585--1617},
   month   = jul,
   doi     = {10.1142/s0218202519500295},
-  publisher = {World Scientific Pub Co Pte Lt}
+  publisher = {World Scientific Pub Co Pte Lt},
+  preprint = {https://arxiv.org/abs/1810.09010}
 }
 
 @Article{2019:maier.mattheakis.ea:homogenization,
-  author  = {M. Maier and M. Mattheakis and E. Kaxiras and M. Luskin and D. Margetis},
+  author  = {Matthias Maier and Marios Mattheakis and Efthimios Kaxiras and Mitchell Luskin and Dionisios Margetis},
   title   = {Homogenization of plasmonic crystals: seeking the epsilon-near-zero effect},
   journal = {Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences},
   year    = 2019,
@@ -1537,7 +1531,8 @@
   pages   = 20190220,
   month   = oct,
   doi     = {10.1098/rspa.2019.0220},
-  publisher = {The Royal Society}
+  publisher = {The Royal Society},
+  preprint = {https://arxiv.org/abs/1809.08276}
 }
 
 @Article{2019:mang.walloth.ea:mesh,
@@ -1706,7 +1701,8 @@
   pages   = {572--601},
   month   = jan,
   doi     = {10.1016/j.cma.2018.09.003},
-  publisher = {Elsevier {BV}}
+  publisher = {Elsevier {BV}},
+  preprint = {https://arxiv.org/abs/1803.03423}
 }
 
 @Book{2019:pelteret.steinmann:magneto-active,

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -490,6 +490,7 @@
   pages   = {220--233},
   month   = jul,
   doi     = {10.1016/j.apnum.2018.11.013},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0168927418302629},
   publisher = {Elsevier {BV}},
   preprint = {https://arxiv.org/abs/1712.00857}
 }

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -318,7 +318,8 @@
   doi     = {10.1007/978-3-030-41800-7_1},
   url     = {https://link.springer.com/chapter/10.1007/978-3-030-41800-7_1},
   issn    = 21977100,
-  isbn    = 9783030417994
+  isbn    = 9783030417994,
+  preprint = {https://arxiv.org/abs/1812.06810}
 }
 
 @Article{2020:brun.wick.ea:iterative,
@@ -695,11 +696,12 @@
   month   = jun,
   doi     = {10.1016/j.cpc.2019.107091},
   url     = {https://www.sciencedirect.com/science/article/pii/S0010465519304011},
-  publisher = {Elsevier {BV}}
+  publisher = {Elsevier {BV}},
+  preprint = {https://arxiv.org/abs/1809.04706}
 }
 
 @Article{2020:gupta.keulen.ea:design,
-  author  = {Deepak K. Gupta and Fred Keulen and Matthijs Langelaar},
+  author  = {Deepak K. Gupta and Fred van Keulen and Matthijs Langelaar},
   title   = {Design and analysis adaptivity in multiresolution topology optimization},
   journal = {International Journal for Numerical Methods in Engineering},
   year    = 2020,
@@ -709,7 +711,8 @@
   month   = feb,
   doi     = {10.1002/nme.6217},
   url     = {https://onlinelibrary.wiley.com/doi/10.1002/nme.6217},
-  publisher = {Wiley}
+  publisher = {Wiley},
+  preprint = {https://arxiv.org/abs/1811.09821}
 }
 
 @Article{2020:gurkan.sticko.ea:stabilized,
@@ -1531,7 +1534,8 @@
   month   = mar,
   doi     = {10.1002/nla.2276},
   url     = {https://onlinelibrary.wiley.com/doi/10.1002/nla.2276},
-  publisher = {Wiley}
+  publisher = {Wiley},
+  preprint = {https://arxiv.org/abs/1806.05896}
 }
 
 @Article{2020:prince.ragusa:space-energy,

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -396,6 +396,21 @@
   publisher = {Wiley}
 }
 
+@Article{2021:carraro.wetterauer.ea:level-set,
+  author  = {Thomas Carraro and Sven E. Wetterauer and Ana Victoria Ponce Bobadilla and Dumitru Trucu},
+  title   = {A level-set approach for a multi-scale cancer invasion model},
+  journal = {Mathematics in Applied Sciences and Engineering},
+  year    = 2021,
+  volume  = 2,
+  number  = 1,
+  pages   = {32--54},
+  month   = mar,
+  doi     = {10.5206/mase/11087},
+  url     = {https://ojs.lib.uwo.ca/index.php/mase/article/view/11087},
+  publisher = {University of Western Ontario, Western Libraries},
+  preprint = {https://arxiv.org/abs/1805.07485}
+}
+
 @Article{2021:carreno.vidal-ferrandiz.ea:adaptive,
   author  = {A. Carre{\~n}o and A. Vidal-Ferr{\`a}ndiz and D. Ginestar and G. Verd{\'u}},
   title   = {Adaptive time-step control for modal methods to integrate the neutron diffusion equation},

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -165,7 +165,8 @@
   pages   = {1--11},
   doi     = {10.1515/cmam-2020-0159},
   url     = {https://www.degruyter.com/document/doi/10.1515/cmam-2020-0159/html},
-  publisher = {Walter de Gruyter {GmbH}}
+  publisher = {Walter de Gruyter {GmbH}},
+  preprint = {https://arxiv.org/abs/1810.02473}
 }
 
 @Article{2021:ashby.bortolozo.ea:adaptive,


### PR DESCRIPTION
Part of #289. Follow-up to #536.

When I feel too sleepy to program in the morning, I made it a habit to update a few of our preprints in the publication list to help me wake up. Little by little I made it through the 2018 publications, which contained lots of duplicates.

This patch effectively removes 15 articles from the 2018 list, either by moving them to the correct year or by removing duplicates. Thus 2018 will fall from second to fourth place in the list of the years with the most publications.