### PR TITLE
Make sure the 9.6 release paper is listed at the top.

### DIFF
--- a/publications.include
+++ b/publications.include
@@ -12,47 +12,51 @@
 
     <ol>
       <li>
-        Daniel Arndt,
-        Wolfgang Bangerth,
-        Maximilian Bergbauer,
-        Marco Feder,
-        Marc Fehling,
-        Johannes Heinz,
-        Timo Heister,
-        Luca Heltai,
-        Martin Kronbichler,
-        Matthias Maier,
-        Peter Munch,
-        Jean-Paul Pelteret,
-        Bruno Turcksin,
-        David Wells,
-        Stefano Zampini
+    Pasquale Claudio Africa,
+    Daniel Arndt,
+    Wolfgang Bangerth,
+    Bruno Blais,
+    Marc Fehling,
+    Rene Gassm&ouml;ller,
+    Timo Heister,
+    Luca Heltai,
+    Martin Kronbichler,
+    Matthias Maier,
+    Peter Munch,
+    Magdalena Schreter-Fleischhacker,
+    Jan Philipp Thiele,
+    Bruno Turcksin,
+    David Wells,
+    Vladimir Yushutin
         <br />
-        <strong>The <abbr>deal.II</abbr> Library, Version 9.5
+        <strong>The <abbr>deal.II</abbr> Library, Version 9.6
         </strong>
         <br>
-        Journal of Numerical Mathematics, vol. 31, no. 3, pages 231-246, 2023.
+        Journal of Numerical Mathematics, accepted, 2024.
         <br>
-        <a href="https://doi.org/10.1515/jnma-2023-0089">DOI: 10.1515/jnma-2023-0089</a>;
-        <a href="https://dealii.org/deal95-preprint.pdf" target="_top">preprint</a>
+        <!-- UPDATE: <a href="https://doi.org/10.1515/jnma-2023-0089">DOI: 10.1515/jnma-2023-0089</a>; -->
+        <a href="https://dealii.org/deal96-preprint.pdf" target="_top">preprint</a>
         <br>
+<!-- UPDATE ALL OF THE XXX:
 <pre>
-@Article{dealII95,
-  title   = {The \texttt{deal.II} Library, Version 9.5},
-  author  = {Daniel Arndt and Wolfgang Bangerth and Maximilian Bergbauer and
-             Marco Feder and Marc Fehling and Johannes Heinz and
-             Timo Heister and Luca Heltai and Martin Kronbichler and
-             Matthias Maier and Peter Munch and Jean-Paul Pelteret and
-             Bruno Turcksin and David Wells and Stefano Zampini},
+@Article{dealII96,
+  title   = {The \texttt{deal.II} Library, Version 9.6},
+  author  = {Pasquale Claudio Africa and Daniel Arndt and Wolfgang
+      Bangerth and Bruno Blais and Marc Fehling and Rene
+      Gassm{\"o}ller and Timo Heister and Luca Heltai and Martin
+      Kronbichler and Matthias Maier and Peter Munch and Magdalena
+      Schreter-Fleischhacker and Jan Philipp Thiele and Bruno Turcksin
+      and David Wells and Vladimir Yushutin},
   journal = {Journal of Numerical Mathematics},
-  year    = {2023},
-  doi     = {10.1515/jnma-2023-0089},
-  pages   = {231--246},
-  volume  = {31},
-  number  = {3},
-  url     = {https://dealii.org/deal95-preprint.pdf}
+  year    = {2024},
+  doi     = {XXX},
+  pages   = {XXX},
+  volume  = {XXX},
+  number  = {XXX},
+  url     = {https://dealii.org/deal96-preprint.pdf}
 }
 </pre>
+-->
       </li>
 
       <li>
@@ -92,6 +96,36 @@
     <p>
     Older releases are announced in the following preprints:
     <ul>
+      <li>
+        Daniel Arndt,
+        Wolfgang Bangerth,
+        Maximilian Bergbauer,
+        Marco Feder,
+        Marc Fehling,
+        Johannes Heinz,
+        Timo Heister,
+        Luca Heltai,
+        Martin Kronbichler,
+        Matthias Maier,
+        Peter Munch,
+        Jean-Paul Pelteret,
+        Bruno Turcksin,
+        David Wells,
+        Stefano Zampini
+        <br />
+        <strong>The <abbr>deal.II</abbr> Library, Version 9.5
+        </strong>
+        <br>
+        Journal of Numerical Mathematics, vol. 31, no. 3, pages 231-246, 2023.
+        <br>
+        <a href="https://doi.org/10.1515/jnma-2023-0089">DOI: 10.1515/jnma-2023-0089</a>;
+        <a href="https://dealii.org/deal95-preprint.pdf" target="_top">preprint</a>
+        <a
+          href="https://github.com/dealii/publication-list/blob/master/publications-2023.bib#L160-L173">bibtex</a>
+        <br>
+      </li>
+
+
       <li>
         Daniel Arndt,
         Wolfgang Bangerth,


### PR DESCRIPTION
We never updated the publications list for the 9.6 release paper.