### PR TITLE
Also show column number of non-ASCII character.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline
           {
             // check for non-ascii characters and fail if they are present:
             sh '''#!/bin/bash
-               grep -n -P "[^\\x00-\\x7F]" publications*.bib || true
+               grep -n -b -P "[^\\x00-\\x7F]" publications*.bib || true
                ! { grep -q -P "[^\\x00-\\x7F]" publications*.bib && echo "ERROR: found non-ASCII characters!"; }
                '''
             // check that doi numbers do not include the https://doi.org/ URL component


### PR DESCRIPTION
When adding entries, I usually use doi2bib.py, which frequently gives me page ranges XX-XX that use a unicode hyphen. Sometimes, it also gives me long lists of author names where somewhere in the middle there is a non-ASCII letter. I find it surprisingly difficult to visually find which the offending character is.

This patch makes `grep` also show us the column index. It's unfortunately zero based, but it's better than nothing.