### PR TITLE
Added 8 articles. Updated 1 article. Removed 4 duplicates.

### DIFF
--- a/offline/publication_list.tex
+++ b/offline/publication_list.tex
@@ -69,7 +69,7 @@
 
 \maketitle
 
-\foreach \year in {1998,...,2025}{
+\foreach \year in {1998,...,2026}{
   \addnewbibyear{\year}
 }
 

--- a/publications-2024.bib
+++ b/publications-2024.bib
@@ -2384,30 +2384,4 @@
   preprint = {https://arxiv.org/abs/2301.02148}
 }
 
-@Article{2024:jin.li.chen:lbfgs-phasefield,
-  author = {Jin, Tao and Li, Zhao and Chen, Kuiying},
-  title = {A novel phase-field monolithic scheme for brittle crack propagation based on the limited-memory BFGS method with adaptive mesh refinement},
-  journal = {International Journal for Numerical Methods in Engineering},
-  volume = {125},
-  number = {22},
-  pages = {e7572},
-  doi = {10.1002/nme.7572},
-  url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.7572},
-  year = {2024},
-  publisher = {Wiley}
-}
-
-@Article{2024:jin:magnetoelastic,
-  author = {Tao Jin},
-  title = {A three-field based finite element analysis for a class of magnetoelastic materials},
-  journal = {Finite Elements in Analysis and Design},
-  volume = {233},
-  pages = {104126},
-  year = {2024},
-  issn = {0168-874X},
-  doi = {10.1016/j.finel.2024.104126},
-  url = {https://www.sciencedirect.com/science/article/pii/S0168874X24000209},
-  publisher = {Elsevier BV}
-}
-
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2025.bib
+++ b/publications-2025.bib
@@ -1520,30 +1520,4 @@
   url     = {https://www.science.org/doi/abs/10.1126/sciadv.adr3418}
 }
 
-@Article{2025:jin:grad-proj-phasefield,
-  author = {Tao Jin},
-  title = {Gradient projection method for enforcing crack irreversibility as box constraints in a robust monolithic phase-field scheme},
-  journal = {Computer Methods in Applied Mechanics and Engineering},
-  volume = {435},
-  pages = {117622},
-  year = {2025},
-  issn = {0045-7825},
-  doi = {10.1016/j.cma.2024.117622},
-  url = {https://www.sciencedirect.com/science/article/pii/S0045782524008764},
-  publisher = {Elsevier BV}
-}
-
-@Article{2025:li.chen.jin:coating,
-  author = {Zhao Li and Kuiying Chen and Tao Jin},
-  title = {Finite element simulations of the thermomechanically coupled responses of thermal barrier coating systems using an unconditionally stable staggered approach},
-  journal = {Applied Mathematical Modelling},
-  volume = {138},
-  pages = {115750},
-  year = {2025},
-  issn = {0307-904X},
-  doi = {10.1016/j.apm.2024.115750},
-  url = {https://www.sciencedirect.com/science/article/pii/S0307904X24005031},
-  publisher = {Elsevier BV}
-}
-
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/publications-2025.bib
+++ b/publications-2025.bib
@@ -484,6 +484,20 @@
   eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2024GC011895}
 }
 
+@Article{2025:freddi.mingazzi:moisture-driven,
+  author  = {Freddi, Francesco and Mingazzi, Lorenzo},
+  title   = {Moisture-driven failure mechanisms in historical paintings: A phase-field approach},
+  journal = {Journal of the Mechanics and Physics of Solids},
+  year    = 2025,
+  volume  = 204,
+  pages   = 106303,
+  month   = nov,
+  issn    = {0022-5096},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0022509625002790},
+  doi     = {10.1016/j.jmps.2025.106303},
+  publisher = {Elsevier BV}
+}
+
 @InProceedings{2025:frei.knoke.ea:modeling,
   author  = {Frei, Stefan and Knoke, Tobias and Steinbach, Marc C. and Wenske, Anne-Kathrin and Wick, Thomas},
   title   = {Modeling and Numerical Simulation of Fully Eulerian Fluid-Structure Interaction Using Cut Finite Elements},
@@ -807,6 +821,20 @@
   url     = {https://www.researchgate.net/publication/393464714}
 }
 
+@Article{2025:kuzmin.lee.ea:bound-preserving,
+  author  = {Kuzmin, Dmitri and Lee, Sanghyun and Yang, Yi-Yung},
+  title   = {Bound-preserving and entropy stable enriched Galerkin methods for nonlinear hyperbolic equations},
+  journal = {Journal of Computational Physics},
+  year    = 2025,
+  volume  = 541,
+  pages   = 114323,
+  month   = nov,
+  issn    = {0021-9991},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0021999125006059},
+  doi     = {10.1016/j.jcp.2025.114323},
+  publisher = {Elsevier BV}
+}
+
 @PhDThesis{2025:kwagalakwe:investigating,
   author  = {Kwagalakwe, Asenath},
   title   = {Investigating the Kinematics and Dynamics of Strain Localization in the Northern Western Branch of the East African Rift System},
@@ -886,6 +914,19 @@
   title   = {Impact of Orogenic Inheritance on Rifted Margin Formation - A Numerical Modelling Perspective},
   year    = 2025,
   doi     = {10.17169/refubium-47184}
+}
+
+@Article{2025:liu.regenauer-lieb.ea:influence,
+  author  = {Liu, Chong and Regenauer-Lieb, Klaus and Hu, Manman},
+  title   = {Influence of geometry heterogeneity on Liesegang patterns in rocks},
+  journal = {Frontiers in Physics},
+  year    = 2025,
+  volume  = 13,
+  month   = aug,
+  issn    = {2296-424X},
+  url     = {https://www.frontiersin.org/journals/physics/articles/10.3389/fphy.2025.1628328/full},
+  doi     = {10.3389/fphy.2025.1628328},
+  publisher = {Frontiers Media SA}
 }
 
 @Article{2025:liu.sun:coupled,
@@ -1342,6 +1383,20 @@
   doi     = {10.1016/j.jcp.2024.113542},
   publisher = {Elsevier BV},
   preprint = {https://arxiv.org/abs/2402.13768}
+}
+
+@Article{2025:stankiewicz.dev.ea:configurational-force-driven,
+  author  = {Stankiewicz, Gabriel and Dev, Chaitanya and Steinmann, Paul},
+  title   = {Configurational-force-driven adaptive refinement and coarsening in topology optimization},
+  journal = {Structural and Multidisciplinary Optimization},
+  year    = 2025,
+  volume  = 68,
+  number  = 8,
+  month   = aug,
+  issn    = {1615-1488},
+  url     = {https://link.springer.com/article/10.1007/s00158-025-04096-7},
+  doi     = {10.1007/s00158-025-04096-7},
+  publisher = {Springer Science and Business Media LLC}
 }
 
 @Article{2025:syed-ansari.acharya.ea:experimentally,

--- a/publications-2025.bib
+++ b/publications-2025.bib
@@ -154,6 +154,16 @@
   publisher = {{\"O}sterreichische Akademie der Wissenschaften, Verlag}
 }
 
+@Misc{2025:beck.liu.ea:goal-oriented,
+  author  = {Beck, Joakim and Liu, Yang and von Schwerin, Erik and Tempone, Ra{\'u}l},
+  title   = {Goal-Oriented Adaptive Finite Element Multilevel Quasi-{M}onte {C}arlo},
+  year    = 2025,
+  doi     = {10.48550/ARXIV.2508.02925},
+  url     = {https://arxiv.org/abs/2508.02925},
+  publisher = {arXiv},
+  copyright = {Creative Commons Attribution 4.0 International}
+}
+
 @Misc{2025:becker.chouly.ea:dual,
   author  = {Becker, Roland and Chouly, Franz and Duprez, Michel and Richter, Thomas and Rohan, Christian Pierre-Yves and Wick, Thomas},
   title   = {Dual Weighted Residual-driven adaptive mesh refinement to enhance biomechanical simulations},
@@ -218,6 +228,26 @@
   doi     = {10.1137/24m1653689},
   publisher = {Society for Industrial \& Applied Mathematics (SIAM)},
   preprint = {https://arxiv.org/abs/2404.07911}
+}
+
+@Misc{2025:berry.islam.ea:efficient,
+  author  = {Berry, Brandiece N. and Islam, Md Mahmudul and Mohebujjaman, Muhammad and Raveendran, Neethu Suma},
+  title   = {Efficient and Optimally Accurate Numerical Algorithms for Stochastic Turbulent Flow Problems},
+  year    = 2025,
+  doi     = {10.48550/ARXIV.2508.10578},
+  url     = {https://arxiv.org/abs/2508.10578},
+  publisher = {arXiv},
+  copyright = {Creative Commons Attribution Non Commercial Share Alike 4.0 International}
+}
+
+@Misc{2025:bhatta.ghosh.ea:computational,
+  author  = {Bhatta, Dambaru and Ghosh, Saugata and Mallikarjunaiah, S. M.},
+  title   = {Computational investigation of crack-tip fields in a compressed nonlinear strain-limiting material},
+  year    = 2025,
+  doi     = {10.48550/ARXIV.2508.07175},
+  url     = {https://arxiv.org/abs/2508.07175},
+  publisher = {arXiv},
+  copyright = {Creative Commons Attribution 4.0 International}
 }
 
 @Article{2025:bosnjak.schussnig.ea:geometric,
@@ -1456,6 +1486,16 @@
   url     = {https://journals.aps.org/prfluids/abstract/10.1103/PhysRevFluids.10.030502},
   doi     = {10.1103/physrevfluids.10.030502},
   publisher = {American Physical Society (APS)}
+}
+
+@Misc{2025:wang:fuzzy,
+  author  = {Wang, Ke},
+  title   = {Fuzzy dark matter soliton as gravitational lens},
+  year    = 2025,
+  doi     = {10.48550/ARXIV.2507.20323},
+  url     = {https://arxiv.org/abs/2507.20323},
+  publisher = {arXiv},
+  copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
 @InProceedings{2025:weber:cut,

--- a/publications-2025.bib
+++ b/publications-2025.bib
@@ -525,16 +525,6 @@
   publisher = {Springer Science and Business Media LLC}
 }
 
-@Misc{2025:gerberding:high,
-  author  = {Gerberding, Seth},
-  title   = {A High Order IMEX Method for Generalized Korteweg de-Vries Equations},
-  year    = 2025,
-  doi     = {10.48550/ARXIV.2503.15397},
-  url     = {https://arxiv.org/abs/2503.15397},
-  publisher = {arXiv},
-  copyright = {Creative Commons Attribution 4.0 International}
-}
-
 @Misc{2025:ghosh.bhatta.ea:computational,
   author  = {Ghosh, Saugata and Bhatta, Dambaru and Mallikarjunaiah, S. M.},
   title   = {Computational Insights into Orthotropic Fracture: Crack-Tip Fields in Strain-Limiting Materials under Non-Uniform Loads},

--- a/publications-2026.bib
+++ b/publications-2026.bib
@@ -1,0 +1,18 @@
+% Encoding: US-ASCII
+
+@Article{2026:gerberding:high,
+  author  = {Gerberding, Seth},
+  title   = {A high order IMEX method for generalized Korteweg de-Vries equations},
+  journal = {Journal of Computational and Applied Mathematics},
+  year    = 2026,
+  volume  = 475,
+  pages   = 116991,
+  month   = mar,
+  issn    = {0377-0427},
+  url     = {https://www.sciencedirect.com/science/article/pii/S0377042725005059},
+  doi     = {10.1016/j.cam.2025.116991},
+  publisher = {Elsevier BV},
+  preprint = {https://arxiv.org/abs/2503.15397}
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
Unfortunately, the articles introduced in #645 were already part of the publication list. This patch removes them again.

This patch also introduces the first article for 2026. The histogram on the website has been adjusted with https://github.com/dealii/website/commit/15863a6624e83376e6064bd86e7f5a1141bb38ee.