### PR TITLE
Remove copyright field.

### DIFF
--- a/bibtool.rsc
+++ b/bibtool.rsc
@@ -1,5 +1,6 @@
-delete.field = {keywords}
 delete.field = {abstract}
+delete.field = {copyright}
+delete.field = {keywords}
 delete.field = {publisher}
 
 % generate citekeys using year, author, and title field

--- a/publications-2016.bib
+++ b/publications-2016.bib
@@ -1255,8 +1255,7 @@
   title   = {A computational approach for mode isolation for reaction-diffusion systems on arbitrary geometries},
   year    = 2016,
   doi     = {10.48550/ARXIV.1604.05653},
-  url     = {https://arxiv.org/abs/1604.05653},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/1604.05653}
 }
 
 @MastersThesis{2016:narayanan:parallel,

--- a/publications-2018.bib
+++ b/publications-2018.bib
@@ -644,8 +644,7 @@
   title   = {Bayesian approaches to modelling physical and socio-economic systems},
   year    = 2018,
   doi     = {10.25560/70367},
-  url     = {http://spiral.imperial.ac.uk/handle/10044/1/70367},
-  copyright = {Creative Commons Attribution NonCommercial Licence}
+  url     = {http://spiral.imperial.ac.uk/handle/10044/1/70367}
 }
 
 @MastersThesis{2018:ellowitz:dynamics,
@@ -752,8 +751,7 @@
   title   = {On the implementation of a locally modified finite element method for interface problems in deal.II},
   year    = 2018,
   doi     = {10.48550/ARXIV.1806.00999},
-  url     = {https://arxiv.org/abs/1806.00999},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/1806.00999}
 }
 
 @Article{2018:freund.kim.ea:field,

--- a/publications-2019.bib
+++ b/publications-2019.bib
@@ -169,8 +169,7 @@
   note    = {Bachelor's thesis},
   doi     = {10.25673/13842},
   url     = {https://opendata.uni-halle.de//handle/1981185920/13968},
-  language = {de},
-  copyright = {Creative Commons Attribution Share Alike 4.0 International}
+  language = {de}
 }
 
 @Article{2019:basak.levitas:finite,
@@ -1500,8 +1499,7 @@
   year    = 2019,
   doi     = {10.15488/5129},
   url     = {https://www.repo.uni-hannover.de/handle/123456789/5175},
-  language = {en},
-  copyright = {CC BY 3.0 DE}
+  language = {en}
 }
 
 @InProceedings{2019:mcbride.davydov.ea:modelling,

--- a/publications-2020.bib
+++ b/publications-2020.bib
@@ -1288,8 +1288,7 @@
   title   = {A numerical study of the jerky crack growth in elastoplastic materials with localized plasticity},
   year    = 2020,
   doi     = {10.48550/ARXIV.2004.12705},
-  url     = {https://arxiv.org/abs/2004.12705},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2004.12705}
 }
 
 @Article{2020:massa.schetz:hypersonic,
@@ -1527,8 +1526,7 @@
   year    = 2020,
   doi     = {10.25643/BAUHAUS-UNIVERSITAET.4286},
   url     = {https://e-pub.uni-weimar.de/opus4/4286},
-  language = {en},
-  copyright = {Creative Commons 4.0 - Namensnennung-Nicht kommerziell (CC BY-NC 4.0)}
+  language = {en}
 }
 
 @Article{2020:rajaonarison.stamps.ea:numerical,
@@ -1924,8 +1922,7 @@
   title   = {A computational study of viscoelastic blood flow in an arteriovenous fistula},
   year    = 2020,
   doi     = {10.48550/ARXIV.2003.08176},
-  url     = {https://arxiv.org/abs/2003.08176},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2003.08176}
 }
 
 @Article{2020:wakeling.ross.ea:energy,

--- a/publications-2021.bib
+++ b/publications-2021.bib
@@ -79,8 +79,7 @@
   year    = 2021,
   doi     = {10.15488/11629},
   url     = {https://www.repo.uni-hannover.de/handle/123456789/11722},
-  language = {en},
-  copyright = {CC BY-NC-ND 3.0 DE}
+  language = {en}
 }
 
 @Article{2021:anselmann.bause:higher,
@@ -190,8 +189,7 @@
   title   = {A novel relaxation scheme for the numerical approximation of Schr{\"o}dinger-Poisson type systems},
   year    = 2021,
   doi     = {10.48550/ARXIV.2103.04903},
-  url     = {https://arxiv.org/abs/2103.04903},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2103.04903}
 }
 
 @Article{2021:barrionuevo.liu.ea:influence,
@@ -741,8 +739,7 @@
   year    = 2021,
   doi     = {10.5445/IR/1000129214},
   url     = {https://publikationen.bibliothek.kit.edu/1000129214},
-  language = {en},
-  copyright = {Open Access}
+  language = {en}
 }
 
 @Article{2021:frei.richter.ea:locmodfe,
@@ -835,8 +832,7 @@
   title   = {An efficient FV-based Virtual Boundary Method for the simulation of fluid-solid interaction},
   year    = 2021,
   doi     = {10.48550/ARXIV.2110.11756},
-  url     = {https://arxiv.org/abs/2110.11756},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2110.11756}
 }
 
 @Article{2021:glerum.spakman.ea:sensitivity,
@@ -1445,8 +1441,7 @@
   year    = 2021,
   doi     = {10.5445/IR/1000130222},
   url     = {https://publikationen.bibliothek.kit.edu/1000130222},
-  language = {en},
-  copyright = {Open Access}
+  language = {en}
 }
 
 @Article{2021:leng.ardekani.ea:poro-viscoelastic,
@@ -1861,8 +1856,7 @@
   title   = {Parallel two-scale finite element implementation of a system with varying microstructures},
   year    = 2021,
   doi     = {10.48550/ARXIV.2103.17040},
-  url     = {https://arxiv.org/abs/2103.17040},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2103.17040}
 }
 
 @PhDThesis{2021:richardson:multiscale,
@@ -2111,8 +2105,7 @@
   year    = 2021,
   doi     = {10.22028/D291-35096},
   url     = {https://publikationen.sulb.uni-saarland.de/handle/20.500.11880/32102},
-  language = {en},
-  copyright = {http://creativecommons.org/licenses/by-nc-nd/3.0/de/}
+  language = {en}
 }
 
 @Article{2021:shi-dong.nadarajah:full-space,
@@ -2233,8 +2226,7 @@
   title   = {Li$_x$CoO$_2$ phase stability studied by machine learning-enabled scale bridging between electronic structure, statistical mechanics and phase field theories},
   year    = 2021,
   doi     = {10.48550/ARXIV.2104.08318},
-  url     = {https://arxiv.org/abs/2104.08318},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2104.08318}
 }
 
 @Article{2021:thiele.wick:space-time,

--- a/publications-2022.bib
+++ b/publications-2022.bib
@@ -5,8 +5,7 @@
   title   = {An open tool based on lifex for myofibers generation in cardiac computational models},
   year    = 2022,
   doi     = {10.48550/ARXIV.2201.03303},
-  url     = {https://arxiv.org/abs/2201.03303},
-  copyright = {Creative Commons Attribution Non Commercial Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2201.03303}
 }
 
 @Article{2022:africa:lifex,
@@ -194,8 +193,7 @@
   title   = {Physics-informed neural networks for modeling rate- and temperature-dependent plasticity},
   year    = 2022,
   doi     = {10.48550/ARXIV.2201.08363},
-  url     = {https://arxiv.org/abs/2201.08363},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2201.08363}
 }
 
 @Article{2022:bahadori.holt.ea:coupled,
@@ -264,8 +262,7 @@
   title   = {Pressure robust mixed methods for nearly incompressible elasticity},
   year    = 2022,
   doi     = {10.48550/ARXIV.2209.08916},
-  url     = {https://arxiv.org/abs/2209.08916},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2209.08916}
 }
 
 @Article{2022:beck.liu.ea:goal-oriented,
@@ -776,8 +773,7 @@
   year    = 2022,
   doi     = {10.17170/KOBRA-202305128014},
   url     = {https://kobra.uni-kassel.de/handle/123456789/14849},
-  language = {en},
-  copyright = {Creative Commons Attribution Non Commercial 4.0 International}
+  language = {en}
 }
 
 @Article{2022:drobny.friedmann:numerical,
@@ -1117,8 +1113,7 @@
   title   = {Robust preconditioning for a mixed formulation of phase-field fracture problems},
   year    = 2022,
   doi     = {10.48550/ARXIV.2202.04191},
-  url     = {https://arxiv.org/abs/2202.04191},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2202.04191}
 }
 
 @Article{2022:heyn.conrad:on,
@@ -1510,8 +1505,7 @@
   title   = {A practical algorithm to minimize the overall error in {FEM} computations},
   year    = 2022,
   doi     = {10.48550/ARXIV.2202.02572},
-  url     = {https://arxiv.org/abs/2202.02572},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2202.02572}
 }
 
 @Article{2022:liu.yang.ea:effects,
@@ -1659,8 +1653,7 @@
   title   = {Analytical investigation of {1D} {D}arcy-{F}orchheimer flow under local thermal nonequilibrium},
   year    = 2022,
   doi     = {10.48550/ARXIV.2208.13502},
-  url     = {https://arxiv.org/abs/2208.13502},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2208.13502}
 }
 
 @InProceedings{2022:munch.ljungkvist.ea:efficient,
@@ -1977,8 +1970,7 @@
   title   = {Amplitude modulation in binary gravitational lensing of gravitational waves},
   year    = 2022,
   doi     = {10.48550/ARXIV.2205.01682},
-  url     = {https://arxiv.org/abs/2205.01682},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2205.01682}
 }
 
 @Article{2022:quarteroni.dede.ea:modeling,
@@ -2029,8 +2021,7 @@
   title   = {Nonlinearity and wavelength control in ultrashort-pulse subsurface material processing},
   year    = 2022,
   doi     = {10.48550/ARXIV.2201.11199},
-  url     = {https://arxiv.org/abs/2201.11199},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2201.11199}
 }
 
 @PhDThesis{2022:richter:continental,
@@ -2403,8 +2394,7 @@
   title   = {Numerical Methods for Partial Differential Equations},
   year    = 2022,
   doi     = {10.15488/11709},
-  url     = {https://www.repo.uni-hannover.de/handle/123456789/11802},
-  copyright = {CC BY-NC-ND 3.0 DE}
+  url     = {https://www.repo.uni-hannover.de/handle/123456789/11802}
 }
 
 @MastersThesis{2022:wik:high-performance,

--- a/publications-2023.bib
+++ b/publications-2023.bib
@@ -18,8 +18,7 @@
   title   = {An A Posteriori Error Estimator for Electrically Coupled Liquid Crystal Equilibrium Configurations},
   year    = 2023,
   doi     = {10.48550/ARXIV.2304.02062},
-  url     = {https://arxiv.org/abs/2304.02062},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2304.02062}
 }
 
 @Article{2023:africa.piersanti.ea:lifex-ep,
@@ -389,8 +388,7 @@
   title   = {Mixed-dimensional modeling of vascular tissues with reduced Lagrange multipliers},
   year    = 2023,
   doi     = {10.48550/ARXIV.2309.06797},
-  url     = {https://arxiv.org/abs/2309.06797},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2309.06797}
 }
 
 @Article{2023:bennati.giambruno.ea:turbulence,
@@ -520,8 +518,7 @@
   title   = {Adaptive mesh refinement for the Landau-Lifshitz-Gilbert equation},
   year    = 2023,
   doi     = {10.48550/ARXIV.2303.07463},
-  url     = {https://arxiv.org/abs/2303.07463v2},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2303.07463v2}
 }
 
 @TechReport{2023:brillon.nadarajah:on,
@@ -1250,8 +1247,7 @@
   title   = {Coefficient Control of Variational Inequalities},
   year    = 2023,
   doi     = {10.48550/arXiv.2307.00869},
-  url     = {https://arxiv.org/abs/2307.00869},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2307.00869}
 }
 
 @Article{2023:heinz.munch.ea:high-order,
@@ -1536,8 +1532,7 @@
   title   = {Modeling, Discretization, Optimization, and Simulation of Phase-Field Fracture Problems},
   year    = 2023,
   doi     = {10.15488/15172},
-  url     = {https://www.repo.uni-hannover.de/handle/123456789/15291},
-  copyright = {CC BY-NC-ND 3.0 DE}
+  url     = {https://www.repo.uni-hannover.de/handle/123456789/15291}
 }
 
 @Article{2023:kiefer.pruger.ea:monolithic,
@@ -1723,8 +1718,7 @@
   title   = {FEcMD: A multi-physics and multi-scale computational program for electron emission characteristics dynamically coupled with atomic structure in metal nano-emitters},
   year    = 2023,
   doi     = {10.48550/ARXIV.2310.04751},
-  url     = {https://arxiv.org/abs/2310.04751},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2310.04751}
 }
 
 @Article{2023:li.liu.ea:multi-physics,
@@ -1821,8 +1815,7 @@
   title   = {Nonasymptotic Convergence Rate of Quasi-Monte Carlo: Applications to Linear Elliptic PDEs with Lognormal Coefficients and Importance Samplings},
   year    = 2023,
   doi     = {10.48550/ARXIV.2310.14351},
-  url     = {https://arxiv.org/abs/2310.14351},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2310.14351}
 }
 
 @Article{2023:liu.wei:novel,
@@ -2764,8 +2757,7 @@
   title   = {Space-time hybridizable discontinuous {G}alerkin method for advection-diffusion on deforming domains: The advection-dominated regime},
   year    = 2023,
   doi     = {10.48550/ARXIV.2308.12130},
-  url     = {https://arxiv.org/abs/2308.12130},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2308.12130}
 }
 
 @Article{2023:weerdesteijn.naliboff.ea:modeling,

--- a/publications-2024.bib
+++ b/publications-2024.bib
@@ -428,8 +428,7 @@
   title   = {A geometry aware arbitrary order collocation Boundary Element Method solver for the potential flow past three dimensional lifting surfaces},
   year    = 2024,
   doi     = {10.48550/ARXIV.2410.10529},
-  url     = {https://arxiv.org/abs/2410.10529},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2410.10529}
 }
 
 @Article{2024:cicchino.nadarajah:discretely,
@@ -486,8 +485,7 @@
   title   = {An implementation of tensor product patch smoothers on GPU},
   year    = 2024,
   doi     = {10.48550/ARXIV.2405.19004},
-  url     = {https://arxiv.org/abs/2405.19004},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2405.19004}
 }
 
 @Article{2024:dai.hou.ea:thermal-hydraulic-mechanical-chemical,
@@ -575,8 +573,7 @@
   title   = {Error analysis of {DGTD} for linear Maxwell equations with inhomogeneous interface conditions},
   year    = 2024,
   doi     = {10.48550/ARXIV.2408.01398},
-  url     = {https://arxiv.org/abs/2408.01398},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2408.01398}
 }
 
 @Article{2024:dorich.leibold.ea:maximum,
@@ -635,8 +632,7 @@
   title   = {CFD-DEM study of mixing in a monodispersed solid-liquid fluidized bed},
   year    = 2024,
   doi     = {10.48550/ARXIV.2406.15674},
-  url     = {https://arxiv.org/abs/2406.15674},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2406.15674}
 }
 
 @Article{2024:fischer.roth.ea:more-dwr,
@@ -933,8 +929,7 @@
   title   = {Coupling deal.II and FROSch: A Sustainable and Accessible (O)RAS Preconditioner},
   year    = 2024,
   doi     = {10.48550/ARXIV.2410.22871},
-  url     = {https://arxiv.org/abs/2410.22871},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+  url     = {https://arxiv.org/abs/2410.22871}
 }
 
 @Article{2024:heinzmann.carrara.ea:calibration,
@@ -1583,8 +1578,7 @@
   title   = {A Space-Time Multigrid Method for Space-Time Finite Element Discretizations of Parabolic and Hyperbolic PDEs},
   year    = 2024,
   doi     = {10.48550/ARXIV.2408.04372},
-  url     = {https://arxiv.org/abs/2408.04372},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2408.04372}
 }
 
 @Article{2024:martinez.rao.ea:approximation,
@@ -1615,8 +1609,7 @@
   title   = {Monolithic two-level Schwarz preconditioner for Biot's consolidation model in two space dimensions},
   year    = 2024,
   doi     = {10.48550/ARXIV.2404.16684},
-  url     = {https://arxiv.org/abs/2404.16684},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2404.16684}
 }
 
 @Article{2024:menon.das.ea:atomistic,
@@ -1783,8 +1776,7 @@
   title   = {A comparison of different approaches to compute surface tension contribution in incompressible two-phase flows},
   year    = 2024,
   doi     = {10.48550/ARXIV.2402.04670},
-  url     = {https://arxiv.org/abs/2402.04670},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2402.04670}
 }
 
 @Article{2024:orlando.benacchio.ea:impact,
@@ -1821,8 +1813,7 @@
   title   = {An asymptotic-preserving scheme for Euler equations I: non-ideal gases},
   year    = 2024,
   doi     = {10.48550/ARXIV.2402.09252},
-  url     = {https://arxiv.org/abs/2402.09252},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2402.09252}
 }
 
 @Article{2024:orlando:implicit,
@@ -2420,8 +2411,7 @@
   title   = {ideal.{II}: a Galerkin Space-Time Extension to the Finite Element Library deal.{II}},
   year    = 2024,
   url     = {https://arxiv.org/abs/2408.08840},
-  doi     = {10.48550/arXiv.2408.08840},
-  copyright = {Creative Commons Attribution 4.0 International}
+  doi     = {10.48550/arXiv.2408.08840}
 }
 
 @Article{2024:thieulot.bangerth:on,
@@ -2692,8 +2682,7 @@
   title   = {Challenging theories of dark energy with levitated force sensor},
   year    = 2024,
   doi     = {10.48550/ARXIV.2405.09791},
-  url     = {https://arxiv.org/abs/2405.09791},
-  copyright = {Creative Commons Attribution Non Commercial Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2405.09791}
 }
 
 @Article{2024:yuan.li.ea:coordination,

--- a/publications-2025.bib
+++ b/publications-2025.bib
@@ -53,8 +53,7 @@
   title   = {Multigrid Preconditioning for FD-DLM Method in Elliptic Interface Problems},
   year    = 2025,
   doi     = {10.48550/ARXIV.2503.00146},
-  url     = {https://arxiv.org/abs/2503.00146},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2503.00146}
 }
 
 @Article{2025:alshehri.boffi.ea:posteriori,
@@ -76,8 +75,7 @@
   title   = {Optimal pressure approximation for the nonstationary Stokes problem by a variational method in time with post-processing},
   year    = 2025,
   doi     = {10.48550/ARXIV.2505.06933},
-  url     = {https://arxiv.org/abs/2505.06933},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2505.06933}
 }
 
 @Article{2025:arndt.bangerth.ea:deal,
@@ -108,8 +106,7 @@
   title   = {Synthetic Datasets for Machine Learning on Spatio-Temporal Graphs using PDEs},
   year    = 2025,
   doi     = {10.48550/ARXIV.2502.04140},
-  url     = {https://arxiv.org/abs/2502.04140},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2502.04140}
 }
 
 @Misc{2025:arpaia.orlando.ea:high-order,
@@ -117,8 +114,7 @@
   title   = {High-order adaptive discontinuous finite elements for the shallow water equations with sub-grid irregular bathymetry},
   year    = 2025,
   doi     = {10.48550/ARXIV.2505.18743},
-  url     = {https://arxiv.org/abs/2505.18743},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2505.18743}
 }
 
 @Misc{2025:ashby.pryer.ea:modelling,
@@ -126,8 +122,7 @@
   title   = {Modelling and Analysis of Non-Contacting Mechanical Face Seals with Axial Disturbances and Misalignment},
   year    = 2025,
   doi     = {10.48550/ARXIV.2509.19993},
-  url     = {https://arxiv.org/abs/2509.19993},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2509.19993}
 }
 
 @Article{2025:baek.das.ea:quasicrystal,
@@ -169,8 +164,7 @@
   title   = {Experience converting a large mathematical software package written in C++ to C++20 modules},
   year    = 2025,
   doi     = {10.48550/ARXIV.2506.21654},
-  url     = {https://arxiv.org/abs/2506.21654},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2506.21654}
 }
 
 @InProceedings{2025:bause.anselmann:optimal,
@@ -193,8 +187,7 @@
   title   = {Anisotropic space-time goal-oriented error control and mesh adaptivity for convection-diffusion-reaction equations},
   year    = 2025,
   doi     = {10.48550/ARXIV.2504.04951},
-  url     = {https://arxiv.org/abs/2504.04951},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2504.04951}
 }
 
 @Article{2025:bause.franz.ea:structure-preserving,
@@ -269,8 +262,7 @@
   title   = {Efficient and Optimally Accurate Numerical Algorithms for Stochastic Turbulent Flow Problems},
   year    = 2025,
   doi     = {10.48550/ARXIV.2508.10578},
-  url     = {https://arxiv.org/abs/2508.10578},
-  copyright = {Creative Commons Attribution Non Commercial Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2508.10578}
 }
 
 @Article{2025:biondic.nadarajah:goal-oriented,
@@ -655,8 +647,7 @@
   title   = {Numerical Simulations of Fully Eulerian Fluid-Structure Contact Interaction using a Ghost-Penalty Cut Finite Element Approach},
   year    = 2025,
   doi     = {10.48550/ARXIV.2503.17145},
-  url     = {https://arxiv.org/abs/2503.17145},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+  url     = {https://arxiv.org/abs/2503.17145}
 }
 
 @Article{2025:fumagalli.dede.ea:reduced,
@@ -754,8 +745,7 @@
   title   = {A conservative invariant-domain preserving projection technique for hyperbolic systems under adaptive mesh refinement},
   year    = 2025,
   doi     = {10.48550/ARXIV.2507.18717},
-  url     = {https://arxiv.org/abs/2507.18717},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2507.18717}
 }
 
 @Article{2025:heron.dannberg.ea:impact,
@@ -969,8 +959,7 @@
   title   = {Influence of an external static magnetic field on prebreakdown electron emission and heating},
   year    = 2025,
   doi     = {10.48550/ARXIV.2510.09113},
-  url     = {https://arxiv.org/abs/2510.09113},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+  url     = {https://arxiv.org/abs/2510.09113}
 }
 
 @InProceedings{2025:kolditz.wick:matrix-free,
@@ -1193,8 +1182,7 @@
   title   = {On the best accuracy using the $h$-adaptive finite element refinement},
   year    = 2025,
   doi     = {10.48550/ARXIV.2503.18683},
-  url     = {https://arxiv.org/abs/2503.18683},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2503.18683}
 }
 
 @Article{2025:luo.huang.ea:full-wave,
@@ -1298,8 +1286,7 @@
   title   = {Structure-preserving finite element approximations of a hybrid relativistic cold fluid-particle model},
   year    = 2025,
   doi     = {10.48550/ARXIV.2510.11500},
-  url     = {https://arxiv.org/abs/2510.11500},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2510.11500}
 }
 
 @Article{2025:munshi.annavarapu.ea:modeling,
@@ -1320,8 +1307,7 @@
   title   = {Mercury Crustal Magnetization Indicates a Stronger Ancient Dynamo},
   year    = 2025,
   doi     = {10.48550/ARXIV.2510.02003},
-  url     = {https://arxiv.org/abs/2510.02003},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2510.02003}
 }
 
 @Article{2025:newton.basak:multiphase-field,
@@ -1447,8 +1433,7 @@
   title   = {Matrix-free algorithms for fast ab initio calculations on distributed CPU architectures using finite-element discretization},
   year    = 2025,
   doi     = {10.48550/ARXIV.2512.08571},
-  url     = {https://arxiv.org/abs/2512.08571},
-  copyright = {Creative Commons Zero v1.0 Universal}
+  url     = {https://arxiv.org/abs/2512.08571}
 }
 
 @Article{2025:pe-resty.soejono.ea:late,
@@ -1536,8 +1521,7 @@
   title   = {Numerical approximation of the first $p$-Laplace eigenpair},
   year    = 2025,
   doi     = {10.48550/ARXIV.2512.10122},
-  url     = {https://arxiv.org/abs/2512.10122},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2512.10122}
 }
 
 @Misc{2025:poudel.lee.ea:pressure-robust,
@@ -1545,8 +1529,7 @@
   title   = {Pressure-robust enriched Galerkin finite element methods for coupled Navier-Stokes and heat equations},
   year    = 2025,
   doi     = {10.48550/ARXIV.2512.16716},
-  url     = {https://arxiv.org/abs/2512.16716},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2512.16716}
 }
 
 @Article{2025:prieto-saavedra.archambault.ea:implicit,
@@ -1768,8 +1751,7 @@
   title   = {Higher-Oder Splitting Schemes for Fluids with Variable Viscosity},
   year    = 2025,
   doi     = {10.48550/ARXIV.2506.14424},
-  url     = {https://arxiv.org/abs/2506.14424},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2506.14424}
 }
 
 @Article{2025:schussnig.fehn.ea:matrix-free,
@@ -1872,8 +1854,7 @@
   title   = {Matrix-Free Evaluation Strategies for Continuous and Discontinuous Galerkin Discretizations on Unstructured Tetrahedral Grids},
   year    = 2025,
   doi     = {10.48550/ARXIV.2509.10226},
-  url     = {https://arxiv.org/abs/2509.10226},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2509.10226}
 }
 
 @Misc{2025:still.nebulishvili.ea:discontinuous,
@@ -1881,8 +1862,7 @@
   title   = {A Discontinuous Galerkin Consistent Splitting Method for the Incompressible Navier-Stokes Equations},
   year    = 2025,
   doi     = {10.48550/ARXIV.2512.05919},
-  url     = {https://arxiv.org/abs/2512.05919},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2512.05919}
 }
 
 @Article{2025:stoner.holt.ea:emergent,
@@ -1975,8 +1955,7 @@
   title   = {Mathematical modeling and simulation of two-phase magnetohydrodynamic flows at low magnetic Reynolds numbers},
   year    = 2025,
   doi     = {10.48550/ARXIV.2507.14518},
-  url     = {https://arxiv.org/abs/2507.14518},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2507.14518}
 }
 
 @Article{2025:wang.liu.ea:controls,
@@ -2066,8 +2045,7 @@
   title   = {A Geometric Multigrid Preconditioner for Discontinuous Galerkin Shifted Boundary Method},
   year    = 2025,
   doi     = {10.48550/ARXIV.2506.12899},
-  url     = {https://arxiv.org/abs/2506.12899},
-  copyright = {Creative Commons Attribution Non Commercial Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2506.12899}
 }
 
 @Misc{2025:wichrowski:local,
@@ -2075,8 +2053,7 @@
   title   = {Local Solvers for High-Order Patch Smoothers via p-Multigrid},
   year    = 2025,
   doi     = {10.48550/ARXIV.2510.17785},
-  url     = {https://arxiv.org/abs/2510.17785},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+  url     = {https://arxiv.org/abs/2510.17785}
 }
 
 @Article{2025:witte.cui.ea:tensor-product,

--- a/publications-2026.bib
+++ b/publications-2026.bib
@@ -84,8 +84,7 @@
   title   = {Risk-averse optimization under distributional uncertainty with Rockafellian relaxation},
   year    = 2026,
   doi     = {10.48550/ARXIV.2604.00226},
-  url     = {https://arxiv.org/abs/2604.00226},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2604.00226}
 }
 
 @Article{2026:antil.carney.ea:rockafellian,
@@ -141,8 +140,7 @@
   title   = {Massively parallel flow routing and drainage area determination},
   year    = 2026,
   doi     = {10.48550/ARXIV.2606.12800},
-  url     = {https://arxiv.org/abs/2606.12800},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2606.12800}
 }
 
 @Misc{2026:bao.shen.ea:walking,
@@ -150,8 +148,7 @@
   title   = {Walking on Heat Stars for Parabolic Heat Equations with Neumann Boundary Conditions},
   year    = 2026,
   doi     = {10.48550/ARXIV.2606.16578},
-  url     = {https://arxiv.org/abs/2606.16578},
-  copyright = {Creative Commons Attribution Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2606.16578}
 }
 
 @Article{2026:bause.bruchhauser.ea:multi-goal-oriented,
@@ -201,8 +198,7 @@
   title   = {Augmented Lagrangian preconditioners for fictitious domain formulations of elliptic interface problems},
   year    = 2026,
   doi     = {10.48550/ARXIV.2603.12993},
-  url     = {https://arxiv.org/abs/2603.12993},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2603.12993}
 }
 
 @Article{2026:benzi.feder.ea:scalable,
@@ -260,8 +256,7 @@
   title   = {Goal-oriented space-time adaptivity for the Navier--Stokes equations based on the dual weighted residual method},
   year    = 2026,
   doi     = {10.48550/ARXIV.2607.00686},
-  url     = {https://arxiv.org/abs/2607.00686},
-  copyright = {Creative Commons Attribution Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2607.00686}
 }
 
 @Article{2026:brunati.bucelli.ea:coupled,
@@ -420,8 +415,7 @@
   title   = {Multi-Solver Coupling for Parallel Adaptive Multi-Physics Simulations with Trixi.jl and deal.II},
   year    = 2026,
   doi     = {10.48550/ARXIV.2607.25871},
-  url     = {https://arxiv.org/abs/2607.25871},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2607.25871}
 }
 
 @Misc{2026:elshiaty.petra.ea:riemannian,
@@ -429,8 +423,7 @@
   title   = {Riemannian Multilevel Optimization with Application to Constrained Energy Minimization Problems},
   year    = 2026,
   doi     = {10.48550/ARXIV.2607.09517},
-  url     = {https://arxiv.org/abs/2607.09517},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2607.09517}
 }
 
 @Article{2026:faber.greiner.ea:poro-viscoelastic,
@@ -451,8 +444,7 @@
   title   = {Well-balanced second-order approximation of the compressible atmospheric Euler equations},
   year    = 2026,
   doi     = {10.48550/ARXIV.2606.19764},
-  url     = {https://arxiv.org/abs/2606.19764},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2606.19764}
 }
 
 @Misc{2026:feder.africa:agglomeration-based,
@@ -460,8 +452,7 @@
   title   = {An agglomeration-based multigrid solver for the discontinuous Galerkin discretization of cardiac electrophysiology},
   year    = 2026,
   doi     = {10.48550/ARXIV.2602.16312},
-  url     = {https://arxiv.org/abs/2602.16312},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+  url     = {https://arxiv.org/abs/2602.16312}
 }
 
 @Article{2026:feng.li:convergence,
@@ -592,8 +583,7 @@
   title   = {Scalability of the asynchronous discontinuous Galerkin method for compressible flow simulations},
   year    = 2026,
   doi     = {10.48550/ARXIV.2603.28710},
-  url     = {https://arxiv.org/abs/2603.28710},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2603.28710}
 }
 
 @Article{2026:guermond.tovar:invariant-domain,
@@ -610,8 +600,7 @@
   title   = {Surface-access limitation in catalytic porous monoliths: Performance diagnosis using pore-resolved CFD},
   year    = 2026,
   doi     = {10.48550/ARXIV.2604.03514},
-  url     = {https://arxiv.org/abs/2604.03514},
-  copyright = {Creative Commons Attribution Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2604.03514}
 }
 
 @Article{2026:hao.gong.ea:blackout,
@@ -647,8 +636,7 @@
   title   = {Efficient higher-order local time integration for Friedrichs' systems},
   year    = 2026,
   doi     = {10.48550/ARXIV.2607.15192},
-  url     = {https://arxiv.org/abs/2607.15192},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2607.15192}
 }
 
 @Article{2026:hochbruck.scheifinger:local,
@@ -766,8 +754,7 @@
   title   = {Adaptive Reduced-Basis Trust-Region Methods for Defect Identification in Elastic Materials},
   year    = 2026,
   doi     = {10.48550/ARXIV.2605.19896},
-  url     = {https://arxiv.org/abs/2605.19896},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2605.19896}
 }
 
 @Misc{2026:kodali.panigrahi.ea:towards,
@@ -775,8 +762,7 @@
   title   = {Towards exascale fully relativistic pseudopotential density functional theory calculations enabled by mixed-precision computation and compressed-communication using residual based subspace iteration},
   year    = 2026,
   doi     = {10.48550/ARXIV.2605.30128},
-  url     = {https://arxiv.org/abs/2605.30128},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2605.30128}
 }
 
 @Misc{2026:koitermaa.kyritsakis.ea:coupled,
@@ -784,8 +770,7 @@
   title   = {Coupled simulation of plasma-surface interactions during early stages of vacuum arcing},
   year    = 2026,
   doi     = {10.48550/ARXIV.2606.05893},
-  url     = {https://arxiv.org/abs/2606.05893},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+  url     = {https://arxiv.org/abs/2606.05893}
 }
 
 @Article{2026:koitermaa.toktaganova.ea:influence,
@@ -962,8 +947,7 @@
   title   = {Parameterization-driven arbitrary Lagrangian-Eulerian method for large-deformation isogeometric fluid-structure interaction},
   year    = 2026,
   doi     = {10.48550/ARXIV.2604.27537},
-  url     = {https://arxiv.org/abs/2604.27537},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2604.27537}
 }
 
 @Article{2026:li.liu.ea:four-dimensional,
@@ -1007,8 +991,7 @@
   title   = {Numerical solutions of an accurate diffuse interface model of the incompressible resistive MHD free surface flow},
   year    = 2026,
   doi     = {10.48550/ARXIV.2607.07025},
-  url     = {https://arxiv.org/abs/2607.07025},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2607.07025}
 }
 
 @Article{2026:lin.lin.ea:advances,
@@ -1101,8 +1084,7 @@
   title   = {Computational modeling of crack-tip fields in transversely isotropic strain-limiting solids subjected to piecewise linear slope loads},
   year    = 2026,
   doi     = {10.48550/ARXIV.2604.25919},
-  url     = {https://arxiv.org/abs/2604.25919},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2604.25919}
 }
 
 @Article{2026:mallikarjunaiah.venkatachalapthy:hp-adaptive,
@@ -1120,8 +1102,7 @@
   title   = {A Monolithic hp Space-Time Multigrid Preconditioned Newton-Krylov Solver for Space-Time FEM applied to the Incompressible Navier-Stokes Equations},
   year    = 2026,
   doi     = {10.48550/ARXIV.2602.13841},
-  url     = {https://arxiv.org/abs/2602.13841},
-  copyright = {Creative Commons Attribution Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2602.13841}
 }
 
 @Misc{2026:margenberg.bruchhauser.ea:anisotropic,
@@ -1129,8 +1110,7 @@
   title   = {Anisotropic hp space-time adaptivity and goal-oriented error control for convection-dominated problems},
   year    = 2026,
   doi     = {10.48550/ARXIV.2602.13843},
-  url     = {https://arxiv.org/abs/2602.13843},
-  copyright = {Creative Commons Attribution Share Alike 4.0 International}
+  url     = {https://arxiv.org/abs/2602.13843}
 }
 
 @Article{2026:martinez.s-n-rao.ea:numerical,
@@ -1205,8 +1185,7 @@
   title   = {Solving the (Navier-)Stokes equations with space and time adaptivity using deal.II},
   year    = 2026,
   doi     = {10.48550/ARXIV.2603.29621},
-  url     = {https://arxiv.org/abs/2603.29621},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2603.29621}
 }
 
 @Article{2026:munch.grayver:multi-scale,
@@ -1266,8 +1245,7 @@
   title   = {Gradient-robustness in optimization subject to stationary Navier-Stokes equations},
   year    = 2026,
   doi     = {10.48550/ARXIV.2603.12028},
-  url     = {https://arxiv.org/abs/2603.12028},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2603.12028}
 }
 
 @Misc{2026:nitzler.bergbauer.ea:scalable,
@@ -1275,8 +1253,7 @@
   title   = {Scalable High-Dimensional Bayesian Field Reconstruction with Finite Elements: Application to 3D Porous Media Flow},
   year    = 2026,
   doi     = {10.48550/ARXIV.2605.24682},
-  url     = {https://arxiv.org/abs/2605.24682},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2605.24682}
 }
 
 @Article{2026:nitzler.temur.ea:efficient,
@@ -1311,8 +1288,7 @@
   title   = {Numerical modeling of microstructure evolution in nanocrystalline alloys - grain boundary segregation, solute drag and mechanics},
   year    = 2026,
   doi     = {10.48550/ARXIV.2608.10048},
-  url     = {https://arxiv.org/abs/2608.10048},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2608.10048}
 }
 
 @Article{2026:papillon-laroche.alphonius.ea:geometric,
@@ -1381,8 +1357,7 @@
   title   = {Mosaic: A Benchmark Suite for Differentiable Physics Solvers},
   year    = 2026,
   doi     = {10.48550/ARXIV.2606.27895},
-  url     = {https://arxiv.org/abs/2606.27895},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2606.27895}
 }
 
 @Article{2026:romor.galarce.ea:shape-informed,
@@ -1700,8 +1675,7 @@
   title   = {Homogenization of rod-like metamaterials as a special Cosserat rod},
   year    = 2026,
   doi     = {10.48550/ARXIV.2605.10952},
-  url     = {https://arxiv.org/abs/2605.10952},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2605.10952}
 }
 
 @Article{2026:wang.brune.ea:dynamic,
@@ -1797,8 +1771,7 @@
   title   = {WING: A Simple Windowed Nonorthogonalized Initial Guess Procedure for Repeated Matrix Solves},
   year    = 2026,
   doi     = {10.48550/ARXIV.2606.10132},
-  url     = {https://arxiv.org/abs/2606.10132},
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+  url     = {https://arxiv.org/abs/2606.10132}
 }
 
 @Article{2026:wichrowski:matrix-free,
@@ -1831,8 +1804,7 @@
   title   = {Specimen design for material parameter identification using topology optimization},
   year    = 2026,
   doi     = {10.48550/ARXIV.2607.16865},
-  url     = {https://arxiv.org/abs/2607.16865},
-  copyright = {Creative Commons Attribution 4.0 International}
+  url     = {https://arxiv.org/abs/2607.16865}
 }
 
 @Misc{2026:xiao.li.ea:fecmd,
@@ -1840,8 +1812,7 @@
   title   = {FEcMD: A multi-physics and multi-scale computational program for dynamic coupling molecular dynamics simulations with transient electric field and heat conduction in metal nanostructures},
   year    = 2026,
   doi     = {10.48550/ARXIV.2601.14712},
-  url     = {https://arxiv.org/abs/2601.14712},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  url     = {https://arxiv.org/abs/2601.14712}
 }
 
 @Article{2026:yin.lin.ea:scalar,


### PR DESCRIPTION
We can easily instruct bibtool to remove the copyright field. I don't see any benefit in storing the copyright information.